### PR TITLE
feat: add cross-platform hooks guide and example plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "author": {
         "name": "camoa"
       },

--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ This marketplace was built collaboratively by Carlos Ospina and Claude (Anthropi
 Patterns and insights drawn from:
 
 - [Anthropic Agent Skills](https://github.com/anthropics/skills) - Official skill-creator and best practices (Apache 2.0)
-- [Superpowers](https://github.com/obra/superpowers-marketplace) by Jesse Vincent - TDD approach and writing-skills methodology (MIT)
+- [Superpowers](https://github.com/obra/superpowers-marketplace) by Jesse Vincent - TDD approach, writing-skills methodology, and cross-platform hooks patterns (MIT)
+- [superpowers-developing-for-claude-code](https://github.com/obra/superpowers-marketplace) by Jesse Vincent - Polyglot hook wrapper technique, troubleshooting patterns, and example plugin structures
 - [Anthropic Platform Docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) - Official guidelines
+- [Claude Code Settings Docs](https://code.claude.com/docs/en/settings) - Settings hierarchy and configuration patterns
 
 ## License
 

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -195,6 +195,7 @@ Before creating a component, verify it's the right choice:
 - `references/04-commands/` - Command creation guides
 - `references/05-agents/` - Agent creation guides
 - `references/06-hooks/` - Hook creation guides
+- `references/06-hooks/cross-platform-hooks.md` - Windows/macOS/Linux support
 - `references/07-mcp/` - MCP overview
 
 ### Configuration
@@ -212,6 +213,12 @@ Before creating a component, verify it's the right choice:
 - `references/10-distribution/versioning.md` - Version strategy
 - `references/10-distribution/complete-examples.md` - Full plugin examples
 
+## Examples
+
+Working example plugins in `examples/`:
+- `examples/simple-greeter-plugin/` - Minimal plugin with one skill
+- `examples/full-featured-plugin/` - Complete plugin with skill, commands, hooks
+
 ## Templates
 
 All templates are in the `templates/` directory:
@@ -219,6 +226,7 @@ All templates are in the `templates/` directory:
 - `templates/command/command.md.template`
 - `templates/agent/agent.md.template`
 - `templates/hooks/hooks.json.template`
+- `templates/hooks/run-hook.cmd.template` - Cross-platform hook wrapper
 - `templates/plugin.json.template`
 - `templates/marketplace.json.template`
 - `templates/settings.json.template`

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/.claude-plugin/marketplace.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,9 @@
+{
+  "name": "full-featured-dev",
+  "plugins": [
+    {
+      "name": "full-featured-example",
+      "source": "./"
+    }
+  ]
+}

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "full-featured-example",
+  "version": "1.0.0",
+  "description": "Example plugin demonstrating all component types - skills, commands, hooks",
+  "author": {
+    "name": "Your Name"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/your-org/full-featured-example",
+  "keywords": ["example", "demo", "tutorial"]
+}

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/README.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/README.md
@@ -1,0 +1,109 @@
+# Full-Featured Example Plugin
+
+A complete example plugin demonstrating all component types: skills, commands, and hooks with cross-platform support.
+
+## Structure
+
+```
+full-featured-plugin/
+├── .claude-plugin/
+│   ├── plugin.json           # Plugin manifest
+│   └── marketplace.json      # For local testing
+├── skills/
+│   └── code-helper/
+│       ├── SKILL.md          # Main skill
+│       └── references/
+│           └── patterns.md   # Reference documentation
+├── commands/
+│   ├── status.md             # /status command
+│   └── review.md             # /review command
+├── hooks/
+│   ├── hooks.json            # Hook configuration
+│   ├── run-hook.cmd          # Cross-platform wrapper
+│   ├── session-start.sh      # SessionStart hook
+│   └── post-edit.sh          # PostToolUse hook
+└── README.md
+```
+
+## Components
+
+### Skill: code-helper
+- Triggers on code review requests
+- Uses reference files for patterns
+- Provides code quality guidance
+
+### Commands
+- `/status` - Show project status (git, TODOs)
+- `/review [file]` - Review code for issues
+
+### Hooks
+- `SessionStart` - Creates output directories, logs session
+- `PostToolUse (Write|Edit)` - Logs file operations
+
+## Cross-Platform Support
+
+The hooks use a polyglot wrapper (`run-hook.cmd`) that works on:
+- **Windows** - Uses Git Bash via CMD
+- **macOS/Linux** - Runs bash directly
+
+This pattern ensures the plugin works everywhere.
+
+## Installation (Local Testing)
+
+```bash
+# Add the plugin as a local marketplace
+/plugin marketplace add /path/to/full-featured-plugin
+
+# Install the plugin
+/plugin install full-featured-example@full-featured-dev
+
+# Restart Claude Code
+```
+
+## Usage
+
+### Use the skill
+Ask Claude to review code:
+```
+Review my code for quality issues
+```
+
+### Use commands
+```
+/status
+/review src/main.py
+```
+
+### Hooks run automatically
+- Session logs appear in `claude-outputs/logs/session.log`
+- Edit operations logged in `claude-outputs/logs/operations.log`
+
+## What This Example Demonstrates
+
+1. **Skill with references** - SKILL.md + references/ pattern
+2. **Commands with arguments** - Using `$1` and `$ARGUMENTS`
+3. **Cross-platform hooks** - The polyglot `.cmd` wrapper
+4. **Output directory setup** - SessionStart hook pattern
+5. **Operation logging** - PostToolUse hook pattern
+6. **Local development** - marketplace.json for testing
+
+## Extending This Example
+
+Ideas for customization:
+- Add MCP server for external integrations
+- Add more commands for your workflow
+- Add agents for specialized tasks
+- Customize the code patterns in references/
+- Add formatter script called by post-edit hook
+
+## Configuration
+
+Set environment variables in `.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "FULLFEATURE_LOG_LEVEL": "debug"
+  }
+}
+```

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/review.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/review.md
@@ -1,0 +1,43 @@
+---
+description: Review a file or recent changes for code quality issues
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: [file-path]
+---
+
+# Code Review
+
+Review the specified file or recent changes for code quality.
+
+## Arguments
+
+- `$1`: File path to review (optional, defaults to recent changes)
+- `$ARGUMENTS`: All arguments passed
+
+## Steps
+
+If file specified ($1):
+1. Read the file at $1
+2. Apply code-helper skill patterns
+3. Report findings
+
+If no file specified:
+1. Run `git diff --name-only HEAD~1` to find changed files
+2. Review each changed file
+3. Report findings per file
+
+## Output Format
+
+```
+## File: [filename]
+
+### Issues Found
+- [issue 1]
+- [issue 2]
+
+### Suggestions
+- [suggestion 1]
+- [suggestion 2]
+
+### Overall Assessment
+[brief assessment]
+```

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/status.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/status.md
@@ -1,0 +1,31 @@
+---
+description: Show project status including git state, recent changes, and pending tasks
+allowed-tools: Bash, Read, Glob
+---
+
+# Project Status
+
+Provide a comprehensive status report for the current project.
+
+## Steps
+
+1. Run `git status` to show working tree state
+2. Run `git log --oneline -5` to show recent commits
+3. Check for TODO comments in code: `grep -r "TODO" --include="*.py" --include="*.js" --include="*.ts" .`
+4. Summarize findings in a clear format
+
+## Output Format
+
+```
+## Git Status
+[git status output]
+
+## Recent Commits
+[last 5 commits]
+
+## Pending TODOs
+[list of TODO comments found]
+
+## Summary
+[brief summary of project state]
+```

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Example hooks demonstrating cross-platform setup",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-edit.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/post-edit.sh
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/post-edit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PostToolUse hook - runs after Write or Edit operations
+
+OUTPUT_DIR="${PLUGIN_OUTPUT_DIR:-${CLAUDE_PROJECT_DIR:-$(pwd)}/claude-outputs}"
+
+# Log the edit operation
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] File edited" >> "${OUTPUT_DIR}/logs/operations.log"
+
+# Optional: Run formatter here
+# Example: prettier, black, etc.
+# "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh" "${EDITED_FILE}"
+
+exit 0

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/run-hook.cmd
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/run-hook.cmd
@@ -1,0 +1,15 @@
+: << 'CMDBLOCK'
+@echo off
+REM Polyglot wrapper: runs .sh scripts cross-platform
+REM Usage: run-hook.cmd <script-name> [args...]
+REM Requires: Git for Windows (provides bash.exe)
+
+"C:\Program Files\Git\bin\bash.exe" -l "%~dp0%~1"
+exit /b
+CMDBLOCK
+
+# Unix shell runs from here
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+"${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/session-start.sh
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SessionStart hook - runs when Claude Code session begins
+
+OUTPUT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}/claude-outputs"
+
+# Create output directories
+mkdir -p "${OUTPUT_DIR}/logs"
+mkdir -p "${OUTPUT_DIR}/artifacts"
+
+# Log session start
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Session started" >> "${OUTPUT_DIR}/logs/session.log"
+
+# Persist environment variables for session
+if [ -n "${CLAUDE_ENV_FILE}" ]; then
+    cat >> "${CLAUDE_ENV_FILE}" <<EOF
+export PLUGIN_OUTPUT_DIR="${OUTPUT_DIR}"
+export PLUGIN_SESSION_START="$(date '+%Y-%m-%d %H:%M:%S')"
+EOF
+fi
+
+exit 0

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/skills/code-helper/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/skills/code-helper/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: code-helper
+description: Assists with code quality tasks. Use when reviewing code, checking for issues, or improving code quality.
+---
+
+# Code Helper
+
+Provides guidance for code quality improvements.
+
+## When to Use
+
+- User asks for code review
+- User wants to improve code quality
+- User mentions "clean code" or "refactor"
+- NOT for: writing new features from scratch
+
+## Quick Reference
+
+| Task | Action |
+|------|--------|
+| Review code | Read file, check patterns |
+| Find issues | Use Grep for anti-patterns |
+| Suggest fixes | Provide specific improvements |
+
+## Review Process
+
+1. Read the code file
+2. Check against references/patterns.md
+3. Identify issues
+4. Suggest improvements with examples
+
+## See Also
+
+- `references/patterns.md` - Code patterns to check

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/skills/code-helper/references/patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/skills/code-helper/references/patterns.md
@@ -1,0 +1,47 @@
+# Code Patterns to Check
+
+## Good Patterns
+
+### Single Responsibility
+- Functions do one thing
+- Classes have one reason to change
+- Modules have focused purpose
+
+### Clear Naming
+- Variables describe their content
+- Functions describe their action
+- Constants are SCREAMING_CASE
+
+### Error Handling
+- Errors are caught and handled
+- User-friendly error messages
+- Proper error propagation
+
+## Anti-Patterns to Flag
+
+### Code Smells
+- Functions longer than 50 lines
+- Deeply nested conditionals (>3 levels)
+- Magic numbers without explanation
+- Commented-out code blocks
+- Duplicate code blocks
+
+### Security Issues
+- Hardcoded credentials
+- SQL string concatenation
+- Unsanitized user input
+- Exposed API keys
+
+### Performance Issues
+- N+1 queries
+- Missing indexes
+- Unnecessary loops
+- Large objects in memory
+
+## Review Checklist
+
+- [ ] No hardcoded secrets
+- [ ] Error handling present
+- [ ] Functions are focused
+- [ ] Names are descriptive
+- [ ] No obvious duplications

--- a/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/.claude-plugin/marketplace.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,9 @@
+{
+  "name": "greeter-dev",
+  "plugins": [
+    {
+      "name": "simple-greeter",
+      "source": "./"
+    }
+  ]
+}

--- a/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "simple-greeter",
+  "version": "1.0.0",
+  "description": "A minimal example plugin with one skill",
+  "author": {
+    "name": "Your Name"
+  },
+  "license": "MIT"
+}

--- a/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/README.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/README.md
@@ -1,0 +1,51 @@
+# Simple Greeter Plugin
+
+A minimal example plugin demonstrating the basic plugin structure with one skill.
+
+## Structure
+
+```
+simple-greeter-plugin/
+├── .claude-plugin/
+│   ├── plugin.json        # Plugin manifest (required)
+│   └── marketplace.json   # For local testing
+├── skills/
+│   └── greeter/
+│       └── SKILL.md       # The skill
+└── README.md
+```
+
+## Installation (Local Testing)
+
+```bash
+# Add the plugin as a local marketplace
+/plugin marketplace add /path/to/simple-greeter-plugin
+
+# Install the plugin
+/plugin install simple-greeter@greeter-dev
+
+# Restart Claude Code
+```
+
+## Usage
+
+Just say hello:
+- "Hi!"
+- "Good morning"
+- "Hello there"
+
+The greeter skill will trigger and provide a friendly response.
+
+## What This Example Shows
+
+1. **Minimal structure** - Only required files
+2. **plugin.json** - Basic manifest with name, version, description
+3. **marketplace.json** - For local development testing
+4. **SKILL.md** - Simple skill with clear triggers
+
+## Customization Ideas
+
+- Add time-based greeting logic
+- Include user's name if known
+- Add seasonal greetings
+- Support multiple languages

--- a/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/skills/greeter/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/simple-greeter-plugin/skills/greeter/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: greeter
+description: Greets users warmly. Use when user says hello, hi, good morning, or wants a friendly greeting.
+---
+
+# Greeter
+
+A simple skill that provides friendly greetings.
+
+## When to Use
+
+- User says "hello", "hi", "hey"
+- User says "good morning/afternoon/evening"
+- User asks for a greeting
+- NOT for: formal business communications
+
+## Greeting Patterns
+
+### Casual Greeting
+When user says "hi" or "hello":
+- Respond warmly and ask how you can help
+- Keep it brief and friendly
+
+### Time-Based Greeting
+When user mentions time of day:
+- Good morning (before noon)
+- Good afternoon (noon to 5pm)
+- Good evening (after 5pm)
+
+### Enthusiastic Greeting
+When user seems excited:
+- Match their energy
+- Add an emoji if appropriate
+
+## Example Responses
+
+**Casual:**
+> Hello! How can I help you today?
+
+**Morning:**
+> Good morning! Ready to get started?
+
+**Enthusiastic:**
+> Hey there! Great to see you! What are we working on today?

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/cross-platform-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/cross-platform-hooks.md
@@ -1,0 +1,225 @@
+# Cross-Platform Hooks (Windows/macOS/Linux)
+
+Claude Code plugins need hooks that work across all operating systems. This guide explains the polyglot wrapper technique for cross-platform compatibility.
+
+## The Problem
+
+Claude Code runs hook commands through the system's default shell:
+- **Windows**: CMD.exe
+- **macOS/Linux**: bash or sh
+
+This creates challenges:
+
+| Issue | Windows | Unix |
+|-------|---------|------|
+| Script execution | CMD can't run `.sh` files directly | Works natively |
+| Path format | Backslashes (`C:\path`) | Forward slashes (`/path`) |
+| Environment variables | `%VAR%` syntax | `$VAR` syntax |
+| bash availability | Not in PATH by default | Always available |
+
+## The Solution: Polyglot `.cmd` Wrapper
+
+A polyglot script is valid syntax in multiple languages simultaneously. This wrapper works in both CMD and bash:
+
+```cmd
+: << 'CMDBLOCK'
+@echo off
+REM Polyglot wrapper: runs .sh scripts cross-platform
+REM Usage: run-hook.cmd <script-name> [args...]
+
+"C:\Program Files\Git\bin\bash.exe" -l "%~dp0%~1"
+exit /b
+CMDBLOCK
+
+# Unix shell runs from here
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+"${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
+```
+
+### How It Works
+
+**On Windows (CMD.exe):**
+1. `: << 'CMDBLOCK'` - CMD sees `:` as a label, ignores the rest
+2. `@echo off` - Suppresses command echoing
+3. Runs bash.exe with `-l` (login shell) for proper PATH
+4. `exit /b` - Exits batch script before Unix section
+
+**On Unix (bash/sh):**
+1. `: << 'CMDBLOCK'` - `:` is no-op, starts heredoc
+2. Everything until `CMDBLOCK` is consumed (ignored)
+3. Runs the actual script with Unix paths
+
+## File Structure
+
+```
+hooks/
+├── hooks.json           # Points to .cmd wrapper
+├── run-hook.cmd         # Polyglot wrapper (entry point)
+├── session-start.sh     # Actual hook logic (bash)
+├── post-edit.sh         # Another hook script
+└── cleanup.sh           # Cleanup script
+```
+
+## Implementation
+
+### Step 1: Create run-hook.cmd
+
+Save this as `hooks/run-hook.cmd`:
+
+```cmd
+: << 'CMDBLOCK'
+@echo off
+REM Polyglot wrapper: runs .sh scripts cross-platform
+REM Usage: run-hook.cmd <script-name> [args...]
+REM Requires: Git for Windows (provides bash.exe)
+
+"C:\Program Files\Git\bin\bash.exe" -l "%~dp0%~1"
+exit /b
+CMDBLOCK
+
+# Unix shell runs from here
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+"${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
+```
+
+**Note**: Uses `$0` instead of `${BASH_SOURCE[0]:-$0}` for POSIX compliance. The latter causes "Bad substitution" errors on Ubuntu/Debian where `/bin/sh` is dash.
+
+### Step 2: Create Your Hook Scripts
+
+Write your actual logic in `.sh` files:
+
+```bash
+#!/bin/bash
+# hooks/session-start.sh
+
+OUTPUT_DIR="${CLAUDE_PROJECT_DIR}/claude-outputs"
+mkdir -p "${OUTPUT_DIR}/logs"
+
+echo "[$(date)] Session started" >> "${OUTPUT_DIR}/logs/session.log"
+exit 0
+```
+
+### Step 3: Configure hooks.json
+
+Point to the `.cmd` wrapper, passing the script name:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-edit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Important**: Quote the path because `${CLAUDE_PLUGIN_ROOT}` may contain spaces (e.g., `C:\Program Files\...`).
+
+### Step 4: Set Permissions
+
+```bash
+chmod +x hooks/run-hook.cmd
+chmod +x hooks/*.sh
+```
+
+## Requirements
+
+### Windows
+- **Git for Windows** must be installed
+- Default path: `C:\Program Files\Git\bin\bash.exe`
+- If installed elsewhere, modify the wrapper path
+
+### Unix (macOS/Linux)
+- Standard bash or sh shell
+- `.cmd` file must have execute permission
+
+## Writing Cross-Platform Scripts
+
+### Do:
+- Use pure bash builtins when possible
+- Use `$(command)` instead of backticks
+- Quote all variable expansions: `"$VAR"`
+- Use `printf` for consistent output
+
+### Avoid:
+- External commands not in Git Bash PATH
+- Platform-specific paths
+- Assuming specific shell features
+
+### Example: Pure Bash JSON Escaping
+
+Instead of sed/awk (may not be available):
+
+```bash
+escape_for_json() {
+    local input="$1"
+    local output=""
+    local i char
+    for (( i=0; i<${#input}; i++ )); do
+        char="${input:$i:1}"
+        case "$char" in
+            $'\\') output+='\\\\' ;;
+            '"') output+='\\"' ;;
+            $'\n') output+='\\n' ;;
+            $'\r') output+='\\r' ;;
+            $'\t') output+='\\t' ;;
+            *) output+="$char" ;;
+        esac
+    done
+    printf '%s' "$output"
+}
+```
+
+## Troubleshooting
+
+### "bash is not recognized"
+CMD can't find bash. The wrapper uses full path `C:\Program Files\Git\bin\bash.exe`. Update if Git is installed elsewhere.
+
+### "cygpath: command not found"
+Bash isn't running as login shell. Ensure `-l` flag is used.
+
+### Script opens in text editor instead of running
+hooks.json points directly to `.sh` file. Point to `.cmd` wrapper instead.
+
+### Works in terminal but not as hook
+Test by simulating hook environment:
+```powershell
+$env:CLAUDE_PLUGIN_ROOT = "C:\path\to\plugin"
+cmd /c "C:\path\to\plugin\hooks\run-hook.cmd" session-start.sh
+```
+
+## Template
+
+Copy the complete `run-hook.cmd` from `templates/hooks/run-hook.cmd.template`.
+
+## Credits
+
+This polyglot pattern is adapted from [superpowers-developing-for-claude-code](https://github.com/obra/superpowers-marketplace) by Jesse Vincent, which documented cross-platform hook solutions for Claude Code plugins.
+
+## See Also
+
+- `hook-events.md` - All hook event types
+- `hook-patterns.md` - Common hook use cases
+- `writing-hooks.md` - Hook basics

--- a/plugin-creation-tools/skills/plugin-creation/templates/hooks/run-hook.cmd.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/hooks/run-hook.cmd.template
@@ -1,0 +1,20 @@
+: << 'CMDBLOCK'
+@echo off
+REM Polyglot wrapper: runs .sh scripts cross-platform
+REM Usage: run-hook.cmd <script-name> [args...]
+REM
+REM This file works on both Windows (CMD) and Unix (bash/sh).
+REM On Windows, requires Git for Windows (provides bash.exe).
+REM
+REM Example in hooks.json:
+REM   "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" my-hook.sh"
+
+"C:\Program Files\Git\bin\bash.exe" -l "%~dp0%~1"
+exit /b
+CMDBLOCK
+
+# Unix shell runs from here
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+"${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"


### PR DESCRIPTION
## Summary
- Added cross-platform hooks guide with polyglot wrapper technique for Windows/macOS/Linux compatibility
- Added `run-hook.cmd.template` for cross-platform hook execution
- Added two example plugins:
  - `simple-greeter-plugin` - minimal working plugin with one skill
  - `full-featured-plugin` - complete plugin with skill, commands, and cross-platform hooks
- Updated acknowledgements crediting superpowers-developing-for-claude-code and Jesse Vincent
- Version bump to `2.0.0-beta.2`

## Test plan
- [ ] Verify cross-platform hooks guide is readable and complete
- [ ] Verify example plugins have valid structure
- [ ] Confirm acknowledgements are properly attributed

🤖 Generated with [Claude Code](https://claude.com/claude-code)