### PR TITLE
chore: update marketplace.json for brand-content-design v1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom skills and tools for Claude Code development workflows",
-    "version": "1.0.6"
+    "version": "1.0.7"
   },
   "plugins": [
     {
@@ -64,8 +64,8 @@
     {
       "name": "brand-content-design",
       "source": "./brand-content-design",
-      "description": "Create branded presentations and carousels with consistent visual identity using Presentation Zen principles",
-      "version": "1.0.0",
+      "description": "Create branded presentations and carousels with 13 visual styles, color palettes, and Presentation Zen principles",
+      "version": "1.2.0",
       "author": {
         "name": "camoa"
       },


### PR DESCRIPTION
## Summary

Update marketplace.json to reflect brand-content-design v1.2.0 changes.

## Changes

- `brand-content-design` version: 1.0.0 → 1.2.0
- Updated description: "13 visual styles, color palettes, and Presentation Zen principles"
- Marketplace version: 1.0.6 → 1.0.7

## Context

PR #6 added visual styles (v1.1.0) and PR #7 added brand-analyst agent integration (v1.2.0), but marketplace.json wasn't updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)