### PR TITLE
chore: bump brand-content-design to v1.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom skills and tools for Claude Code development workflows",
-    "version": "1.0.7"
+    "version": "1.0.8"
   },
   "plugins": [
     {

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Create branded visual content (presentations, carousels) using a layered philosophy system with Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-12-09
+
+### Fixed
+- **AskUserQuestion option limits**: Split multi-option selections to respect 4-option limit
+  - Palette selection: 3 questions (basic harmony, advanced harmony, tonal)
+  - Japanese Zen styles: 2 questions (7 styles split into 3+4)
+  - All 10 palette types and 13 styles now accessible
+
+### Added
+- `/brand-palette` added to `/brand` command quick actions
+- `/brand-palette` added to SKILL.md commands table
+- Trigger phrases for "color palette" / "generate palette" / "alternative colors"
+- `style-constraints.md` and `color-palettes.md` added to SKILL.md references
+
 ## [1.2.0] - 2025-12-08
 
 ### Added


### PR DESCRIPTION
## Summary
- Bumps brand-content-design plugin version to 1.2.1
- Updates marketplace version to 1.0.8
- Documents the AskUserQuestion option limit fixes from PR #9

## Changes
- **CHANGELOG.md**: Added v1.2.1 section with fixes and additions
- **plugin.json**: Version 1.2.0 → 1.2.1
- **marketplace.json**: Version 1.0.7 → 1.0.8, brand-content-design 1.2.0 → 1.2.1

## Fixed in v1.2.1
- AskUserQuestion option limits: Split multi-option selections to respect 4-option limit
  - Palette selection: 3 questions (basic harmony, advanced harmony, tonal)
  - Japanese Zen styles: 2 questions (7 styles split into 3+4)
  - All 10 palette types and 13 styles now accessible

## Added in v1.2.1
- `/brand-palette` added to `/brand` command quick actions
- `/brand-palette` added to SKILL.md commands table
- Trigger phrases for "color palette" / "generate palette" / "alternative colors"
- `style-constraints.md` and `color-palettes.md` added to SKILL.md references

🤖 Generated with [Claude Code](https://claude.com/claude-code)