### PR TITLE
feat: expand palette system to 18 types with branching selection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom skills and tools for Claude Code development workflows",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "plugins": [
     {
@@ -64,8 +64,8 @@
     {
       "name": "brand-content-design",
       "source": "./brand-content-design",
-      "description": "Create branded presentations and carousels with 13 visual styles, color palettes, and Presentation Zen principles",
-      "version": "1.2.0",
+      "description": "Create branded presentations and carousels with 13 visual styles, 18 color palettes, and Presentation Zen principles",
+      "version": "1.3.0",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Create branded visual content (presentations, carousels) using a layered philosophy system with Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2025-12-09
+
+### Added
+- **Expanded Palette System**: 18 palette types (up from 10)
+  - **Derived palettes** (color theory): 11 types
+    - Harmony: Monochromatic, Analogous, Complementary, Split-Complementary, Triadic, Tetradic, Extended Harmony
+    - Tonal: Tints, Shades, Tones, Interpolation
+  - **Alternative palettes** (mood-based): 7 types
+    - Pastel, Bold, Earthy, Vibrant, Muted, Monochrome, Custom
+- **Branching palette selection**: Choose "Derived" or "Alternative" first, then specific options
+- **Multi-color source support**: Derived palettes can use full brand palette (not just primary)
+- **Extended Harmony**: Generates harmonies from all brand colors, merges results
+- **Interpolation**: Creates gradient colors between brand colors
+- **Mood-based alternatives**: Generate completely different colors that maintain brand feeling
+
+### Changed
+- `/brand-palette` now uses branching workflow (category → options)
+- `color-palettes.md` reorganized with Derived vs Alternative sections
+- Quick decision guide updated with all 18 palette types
+
 ## [1.2.1] - 2025-12-09
 
 ### Fixed

--- a/brand-content-design/commands/brand-palette.md
+++ b/brand-content-design/commands/brand-palette.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Write, Glob, Bash, AskUserQuestion
 
 # Brand Palette Command
 
-Generate alternative color palettes derived from brand primary colors.
+Generate alternative color palettes - either derived from brand colors (color theory) or completely different colors with the same brand feeling (mood-based).
 
 ## Prerequisites
 
@@ -21,8 +21,7 @@ Generate alternative color palettes derived from brand primary colors.
 
 2. **Extract brand colors**
    - Read brand-philosophy.md
-   - Find primary color (first color listed, or labeled "primary")
-   - Find any secondary/accent colors already defined
+   - Find all colors: primary, secondary, accent, neutrals
    - If no colors found: Tell user to run `/brand-extract` first and stop
 
 3. **Show current colors**
@@ -31,106 +30,174 @@ Generate alternative color palettes derived from brand primary colors.
    echo -e "\033[48;2;R;G;Bm     \033[0m #HEX - Color Name"
    ```
 
-4. **Ask palette selection (three questions to show all 10 types)**
-
-   **Question 1: Basic harmony palettes**
-   Use AskUserQuestion with multiSelect: true
-   - Header: "Basic"
-   - Question: "Which basic harmony palettes? (most common)"
+4. **Ask palette category (branching question)**
+   Use AskUserQuestion:
+   - Header: "Category"
+   - Question: "What type of palette do you want?"
    - Options:
-     - **Monochromatic** - Same hue, varying lightness (safe, cohesive)
-     - **Analogous** - Adjacent colors (harmonious, comfortable)
-     - **Complementary** - Opposite colors (high contrast, attention)
+     - **Derived** - Colors mathematically related to your brand (harmonies, tints)
+     - **Alternative** - Completely different colors, same brand feeling
 
-   **Question 2: Advanced harmony palettes**
-   Use AskUserQuestion with multiSelect: true
-   - Header: "Advanced"
-   - Question: "Which advanced harmony palettes?"
-   - Options:
-     - **Split-Complementary** - Contrast with less tension
-     - **Triadic** - Three balanced colors (vibrant, energetic)
-     - **Tetradic** - Four colors in rectangle (rich, complex)
+---
 
-   **Question 3: Tonal variations**
-   Use AskUserQuestion with multiSelect: true
-   - Header: "Tonal"
-   - Question: "Which tonal variations?"
-   - Options:
-     - **Tints** - Lighter variations (soft backgrounds)
-     - **Shades** - Darker variations (bold emphasis)
-     - **Tones** - Muted variations (sophisticated, subtle)
-     - **Custom** - Describe what you need
+## DERIVED BRANCH (Color Theory)
 
-   Reference: `references/color-palettes.md` for decision guidance
+If user selected "Derived":
 
-5. **If Custom selected, ask for description**
-   Ask: "Describe the mood or purpose for your custom palette:"
-   Examples: "summer campaign", "professional but warm", "bold and innovative"
+5a. **Ask harmony type**
+    Use AskUserQuestion with multiSelect: true
+    - Header: "Harmony"
+    - Question: "Which harmony palettes? (1/2)"
+    - Options:
+      - **Monochromatic** - Same hue, varying lightness (safe, cohesive)
+      - **Analogous** - Adjacent colors on wheel (harmonious)
+      - **Complementary** - Opposite colors (high contrast)
+      - **More harmonies...** - See advanced options
 
-6. **Generate palettes**
-   For each selected type, calculate colors from primary:
+6a. **If "More harmonies..." selected, ask advanced**
+    Use AskUserQuestion with multiSelect: true
+    - Header: "Advanced"
+    - Question: "Which advanced harmony palettes? (2/2)"
+    - Options:
+      - **Split-Complementary** - Contrast with less tension
+      - **Triadic** - Three balanced colors (vibrant)
+      - **Tetradic** - Four colors in rectangle (complex)
+      - **Extended Harmony** - Harmonies from all brand colors merged
 
-   **Harmony calculations (from color wheel):**
-   - Monochromatic: Same hue, lightness at 30%, 50%, 70%, 90%
-   - Analogous: Primary ± 30° on wheel
-   - Complementary: Primary + 180°
-   - Split-Complementary: Primary + 150°, Primary + 210°
-   - Triadic: Primary + 120°, Primary + 240°
-   - Tetradic: Primary + 90°, Primary + 180°, Primary + 270°
+7a. **Ask tonal variations**
+    Use AskUserQuestion with multiSelect: true
+    - Header: "Tonal"
+    - Question: "Which tonal variations?"
+    - Options:
+      - **Tints** - Lighter variations (soft backgrounds)
+      - **Shades** - Darker variations (bold emphasis)
+      - **Tones** - Muted with gray (sophisticated)
+      - **Interpolation** - Gradients between brand colors
 
-   **Tonal calculations:**
-   - Tints: Mix with white at 25%, 50%, 75%
-   - Shades: Mix with black at 25%, 50%, 75%
-   - Tones: Mix with gray at 25%, 50%, 75%
+8a. **Generate derived palettes**
+    For each selected type, calculate colors from brand palette:
 
-   **Custom:**
-   - Interpret user description
-   - Generate 3-4 colors matching the mood
-   - Stay adjacent to brand colors when possible
+    **Harmony calculations (from color wheel):**
+    - Monochromatic: Same hue, lightness at 30%, 50%, 70%, 90%
+    - Analogous: Primary ± 30° on wheel
+    - Complementary: Primary + 180°
+    - Split-Complementary: Primary + 150°, Primary + 210°
+    - Triadic: Primary + 120°, Primary + 240°
+    - Tetradic: Primary + 90°, Primary + 180°, Primary + 270°
+    - Extended Harmony: Apply Triadic to each brand color, merge unique results
 
-7. **Display generated palettes**
+    **Tonal calculations:**
+    - Tints: Mix with white at 25%, 50%, 75%
+    - Shades: Mix with black at 25%, 50%, 75%
+    - Tones: Mix with gray at 25%, 50%, 75%
+    - Interpolation: Blend primary → secondary at 25%, 50%, 75%
+
+    → Continue to step 9
+
+---
+
+## ALTERNATIVE BRANCH (Mood-Based)
+
+If user selected "Alternative":
+
+5b. **Ask mood style**
+    Use AskUserQuestion with multiSelect: true
+    - Header: "Mood"
+    - Question: "Which mood palettes? (1/2)"
+    - Options:
+      - **Pastel** - Soft, light, airy (gentle campaigns)
+      - **Bold** - High saturation, strong contrast (impact)
+      - **Earthy** - Natural, warm, grounded (sustainable)
+      - **More moods...** - See additional options
+
+6b. **If "More moods..." selected, ask additional**
+    Use AskUserQuestion with multiSelect: true
+    - Header: "Mood"
+    - Question: "Which mood palettes? (2/2)"
+    - Options:
+      - **Vibrant** - Bright, energetic (youth, excitement)
+      - **Muted** - Desaturated, refined (luxury, sophistication)
+      - **Monochrome** - Grayscale + one accent (editorial, dramatic)
+      - **Custom** - Describe what you need
+
+7b. **If Custom selected, ask for description**
+    Ask: "Describe the mood or purpose for your custom palette:"
+    Examples: "summer festival", "winter elegance", "tech startup energy"
+
+8b. **Generate alternative palettes**
+    For each selected mood:
+
+    1. **Analyze brand personality** from brand-philosophy.md
+       - What emotions does the current palette evoke?
+       - What's the brand energy level (calm, energetic, sophisticated)?
+
+    2. **Generate mood-matched colors**
+       - Pastel: Light, desaturated versions maintaining brand feeling
+       - Bold: High saturation, strong contrast, same energy
+       - Earthy: Map to natural palette (browns, greens, terracotta)
+       - Vibrant: Bright, saturated alternatives
+       - Muted: Desaturated, sophisticated versions
+       - Monochrome: Convert to grayscale, keep one brand accent
+       - Custom: Interpret description, maintain brand relationships
+
+    3. **Preserve brand characteristics**
+       - If brand has high contrast, maintain in alternative
+       - If brand is warm, keep warmth in new palette
+       - Match number of colors (3-color brand = 3-color alternative)
+
+    → Continue to step 9
+
+---
+
+## COMMON STEPS (Both Branches)
+
+9. **Display generated palettes**
    Show each palette with color boxes:
    ```
-   Generated from primary #2563EB:
+   Generated palettes:
 
-   ██ ██ ██  Monochromatic   #1E40AF #2563EB #60A5FA #BFDBFE
-   ██ ██ ██  Complementary   #2563EB #EB8225 #F59E0B
-   ██ ██ ██  Triadic         #2563EB #EB2563 #63EB25
+   ██ ██ ██ ██  Complementary (Derived)    #1E40AF #2563EB #EB8225 #F59E0B
+   ██ ██ ██     Pastel (Alternative)       #E0E7FF #FCE7F3 #D1FAE5
    ```
 
    Use Bash with ANSI codes:
    ```bash
-   echo -e "\033[48;2;37;99;235m  \033[0m \033[48;2;235;130;37m  \033[0m \033[48;2;245;158;11m  \033[0m  Complementary   #2563EB #EB8225 #F59E0B"
+   echo -e "\033[48;2;37;99;235m  \033[0m \033[48;2;235;130;37m  \033[0m  Complementary   #2563EB #EB8225"
    ```
 
-8. **Ask to save (multi-select)**
-   Use AskUserQuestion with multiSelect: true
-   - Header: "Save"
-   - Question: "Which palettes would you like to save?"
-   - Options: List each generated palette by name
+10. **Ask to save (multi-select)**
+    Use AskUserQuestion with multiSelect: true
+    - Header: "Save"
+    - Question: "Which palettes would you like to save?"
+    - Options: List each generated palette by name
 
-9. **Ask for custom names (if saving Custom)**
-   If Custom palette is being saved:
-   Ask: "What should we call this palette?" (e.g., "Summer Campaign", "Q4 Launch")
+11. **Ask for custom names (if saving Custom)**
+    If Custom palette is being saved:
+    Ask: "What should we call this palette?" (e.g., "Summer Festival", "Q4 Launch")
 
-10. **Save selected palettes**
+12. **Save selected palettes**
     Append to brand-philosophy.md under `## Alternative Palettes`:
 
     ```markdown
     ## Alternative Palettes
 
-    ### Complementary
+    ### Complementary (Derived)
     - Primary: #2563EB
     - Complement: #EB8225
     - Accent: #F59E0B
 
-    ### Summer Campaign (Custom)
+    ### Pastel (Alternative)
+    - Base: #E0E7FF
+    - Secondary: #FCE7F3
+    - Accent: #D1FAE5
+
+    ### Summer Festival (Custom)
     - Base: #F59E0B
     - Secondary: #10B981
     - Accent: #EC4899
     ```
 
-11. **Confirm and suggest usage**
+13. **Confirm and suggest usage**
     Show:
     - "Saved X palettes to brand-philosophy.md"
     - "Use these when creating content:"
@@ -142,9 +209,18 @@ Generate alternative color palettes derived from brand primary colors.
 - Updated: `brand-philosophy.md` with Alternative Palettes section
 - Terminal display of generated palettes with color boxes
 
+## Reference
+
+See `references/color-palettes.md` for:
+- Full list of 18 palette types
+- Decision guide for which to use
+- Calculation formulas
+- Storage format
+
 ## Notes
 
 - Multiple palettes can be selected and saved
 - Custom palettes need a name for saving
-- Palettes are derived from the primary brand color
+- Derived palettes use mathematical color theory
+- Alternative palettes maintain brand feeling with different colors
 - Content commands can reference saved palettes

--- a/brand-content-design/skills/brand-content-design/references/color-palettes.md
+++ b/brand-content-design/skills/brand-content-design/references/color-palettes.md
@@ -4,9 +4,13 @@ Reference for generating alternative color palettes from brand colors.
 
 ---
 
-## Palette Types
+## Palette Categories
 
-### Harmony-Based (Color Wheel)
+### Derived Palettes (Color Theory)
+
+Mathematical derivations from existing brand colors.
+
+#### Harmony-Based (Color Wheel)
 
 | Type | When to Use | Character | Learn More |
 |------|-------------|-----------|------------|
@@ -16,36 +20,85 @@ Reference for generating alternative color palettes from brand colors.
 | **Split-Complementary** | Contrast with less visual tension | Base + two adjacent to complement | [Wikipedia](https://en.wikipedia.org/wiki/Color_scheme#Split-complementary) |
 | **Triadic** | Balanced, vibrant, energetic | Three equally spaced | [Wikipedia](https://en.wikipedia.org/wiki/Color_scheme#Triadic) |
 | **Tetradic** | Rich, complex, multi-element designs | Four colors (rectangle) | [Wikipedia](https://en.wikipedia.org/wiki/Color_scheme#Tetradic) |
+| **Extended Harmony** | Rich palette from existing brand colors | Harmonies from all brand colors merged | - |
 
-### Tonal Variations
+#### Tonal Variations
 
 | Type | When to Use | Character | Learn More |
 |------|-------------|-----------|------------|
 | **Tints** | Lighter backgrounds, softer feel | Base + white | [Wikipedia](https://en.wikipedia.org/wiki/Tint,_shade_and_tone) |
 | **Shades** | Darker accents, emphasis, depth | Base + black | [Wikipedia](https://en.wikipedia.org/wiki/Tint,_shade_and_tone) |
 | **Tones** | Muted, sophisticated, subtle | Base + gray | [Wikipedia](https://en.wikipedia.org/wiki/Tint,_shade_and_tone) |
+| **Interpolation** | Gradients, data viz, smooth transitions | Blend between brand colors | [Color Interpolation](https://en.wikipedia.org/wiki/Color_gradient) |
 
-### Custom
+---
 
-| Type | When to Use | Character |
-|------|-------------|-----------|
-| **Custom** | Specific mood or campaign | User describes, AI generates |
+### Alternative Palettes (Mood-Based)
+
+Completely different colors that capture the same brand feeling/energy.
+
+| Type | When to Use | Character | Example Transformation |
+|------|-------------|-----------|------------------------|
+| **Pastel** | Soft campaigns, gentle messaging | Light, airy, delicate | Professional blue → soft lavender, mint |
+| **Bold** | Impact, announcements, CTAs | High saturation, strong contrast | Calm blue → deep navy, gold |
+| **Earthy** | Natural, sustainable, authentic | Warm browns, greens, terracotta | Corporate → olive, sienna, cream |
+| **Vibrant** | Energy, youth, excitement | Bright, saturated, dynamic | Reserved → coral, electric blue, lime |
+| **Muted** | Sophistication, luxury, subtlety | Desaturated, refined | Bright → dusty rose, sage, taupe |
+| **Monochrome** | Dramatic, editorial, focused | Grayscale + one accent color | Full palette → B&W + brand accent |
+| **Custom** | Specific mood or campaign | User describes, AI generates | "Summer festival" → your interpretation |
 
 ---
 
 ## Quick Decision Guide
 
-| Need | Recommended Palette |
-|------|---------------------|
-| Professional, safe | Monochromatic |
-| Warm, inviting | Analogous (warm side) |
-| Call-to-action pop | Complementary |
-| Vibrant but balanced | Triadic |
-| Complex infographic | Tetradic |
-| Subtle backgrounds | Tints |
-| Bold headlines | Shades |
-| Sophisticated muted | Tones |
-| "Summer campaign feel" | Custom |
+| Need | Category | Recommended |
+|------|----------|-------------|
+| Expand existing colors mathematically | Derived | Complementary, Triadic |
+| Professional, safe variation | Derived | Monochromatic, Tones |
+| Subtle backgrounds | Derived | Tints |
+| Bold headlines | Derived | Shades |
+| Complex infographic | Derived | Tetradic, Extended Harmony |
+| Smooth gradients | Derived | Interpolation |
+| Completely different look, same feel | Alternative | Pastel, Bold, Earthy |
+| Seasonal campaign | Alternative | Custom |
+| Premium/luxury feel | Alternative | Muted, Monochrome |
+| Youth/energy campaign | Alternative | Vibrant, Bold |
+
+---
+
+## Derived Palette Calculations
+
+### Harmony (from color wheel)
+
+```
+Monochromatic: Same hue, lightness at 30%, 50%, 70%, 90%
+Analogous: Primary ± 30° on wheel
+Complementary: Primary + 180°
+Split-Complementary: Primary + 150°, Primary + 210°
+Triadic: Primary + 120°, Primary + 240°
+Tetradic: Primary + 90°, Primary + 180°, Primary + 270°
+Extended Harmony: Apply Triadic to each brand color, merge unique results
+```
+
+### Tonal
+
+```
+Tints: Mix with white at 25%, 50%, 75%
+Shades: Mix with black at 25%, 50%, 75%
+Tones: Mix with gray at 25%, 50%, 75%
+Interpolation: Blend primary → secondary at 25%, 50%, 75%
+```
+
+---
+
+## Alternative Palette Generation
+
+For mood-based alternatives, analyze brand personality and translate to new colors:
+
+1. **Extract brand feeling** - What emotions does the current palette evoke?
+2. **Map to new colors** - Find colors that evoke the same emotions in the target mood
+3. **Maintain relationships** - If brand has high contrast, maintain that in alternative
+4. **Test coherence** - Ensure the alternative still "feels like" the brand
 
 ---
 
@@ -71,10 +124,15 @@ Save selected palettes to `brand-philosophy.md` under:
 ```markdown
 ## Alternative Palettes
 
-### Complementary
+### Complementary (Derived)
 - Primary: #2563EB
 - Complement: #EB8225
 - Accent: #F59E0B
+
+### Pastel (Alternative)
+- Base: #E0E7FF
+- Secondary: #FCE7F3
+- Accent: #D1FAE5
 
 ### Summer Campaign (Custom)
 - Base: #F59E0B


### PR DESCRIPTION
## Summary
- Expands color palette system from 10 to 18 types
- Adds branching selection: Derived (color theory) vs Alternative (mood-based)
- Users can now generate completely different palettes that maintain brand feeling

## Changes

### New Palette Types (18 total)

**Derived Palettes (11 types)** - Mathematical derivations from brand colors:
- Harmony: Monochromatic, Analogous, Complementary, Split-Complementary, Triadic, Tetradic, **Extended Harmony** (NEW)
- Tonal: Tints, Shades, Tones, **Interpolation** (NEW)

**Alternative Palettes (7 types)** - Different colors, same brand feeling:
- **Pastel** - Soft, light, airy
- **Bold** - High saturation, strong contrast
- **Earthy** - Natural, warm, grounded
- **Vibrant** - Bright, energetic
- **Muted** - Sophisticated, subtle
- **Monochrome** - Grayscale + one accent
- **Custom** - Describe what you need

### Branching Workflow
```
Q1: What type? → Derived / Alternative
├── Derived → Harmony options → Tonal options
└── Alternative → Mood options
```

### Files Modified
- `brand-palette.md` - Branching workflow with both paths
- `color-palettes.md` - Reorganized with all 18 types documented
- `plugin.json` - Version 1.2.1 → 1.3.0
- `marketplace.json` - Version 1.0.8 → 1.0.9
- `CHANGELOG.md` - Added v1.3.0 entry

## Test Plan
- [ ] Run `/brand-palette` and select "Derived" path
- [ ] Run `/brand-palette` and select "Alternative" path
- [ ] Verify all 18 options are accessible via branching questions
- [ ] Test saving palettes to brand-philosophy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)