### PR TITLE
fix: correct hooks.json structure for drupal-dev-framework

### DIFF
--- a/drupal-dev-framework/hooks/hooks.json
+++ b/drupal-dev-framework/hooks/hooks.json
@@ -1,9 +1,15 @@
 {
-  "hooks": [
-    {
-      "event": "SessionStart",
-      "type": "message",
-      "message": "Drupal Development Framework active. Use /drupal-dev-framework:status to check project state or /drupal-dev-framework:new to start a new project."
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "message",
+            "message": "Drupal Development Framework active. Use /drupal-dev-framework:status to check project state or /drupal-dev-framework:new to start a new project."
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Fixes the hooks.json structure for drupal-dev-framework plugin. The `hooks` field must be an object with event names as keys, not an array.

## Error Fixed

```
Failed to load hooks: Expected object, received array
```

## Changes

**Before (incorrect):**
```json
{
  "hooks": [
    { "event": "SessionStart", "type": "message", ... }
  ]
}
```

**After (correct):**
```json
{
  "hooks": {
    "SessionStart": [
      {
        "matcher": "*",
        "hooks": [
          { "type": "message", ... }
        ]
      }
    ]
  }
}
```

## Test Plan

- [ ] Reinstall/refresh drupal-dev-framework plugin
- [ ] Verify no hooks loading error on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)