### PR TITLE
fix(brand-content-design): bug fixes for palette and template workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -65,7 +65,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded presentations and carousels with 13 visual styles, 17 color palettes, and Presentation Zen principles",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Create branded visual content (presentations, carousels) using a layered philosophy system with Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2025-12-09
+
+### Fixed
+- **`/brand-init` next steps**: Now shows `/brand-palette` and `/template-*` commands after init
+- **Alternative palette menu**: Both mood questions now marked "ALWAYS ASK" (sequential, not conditional)
+- **Palette confirmation message**: Now correctly mentions `/template-presentation` and `/template-carousel` (not `/presentation`)
+- **Template purpose question**: Now shows examples and asks for 2-4 word description instead of limited menu options
+
 ## [1.3.1] - 2025-12-09
 
 ### Added

--- a/brand-content-design/commands/brand-init.md
+++ b/brand-content-design/commands/brand-init.md
@@ -53,7 +53,9 @@ Initialize a new brand project with the required folder structure.
    - Project folder created successfully
    - Next steps:
      1. Add brand assets to input/ folder
-     2. Run `/brand-extract` when ready
+     2. Run `/brand-extract` to analyze and generate brand philosophy
+     3. Run `/brand-palette` (optional) to generate alternative color palettes
+     4. Run `/template-presentation` or `/template-carousel` to create your first template
 
 ## Output
 

--- a/brand-content-design/commands/brand-palette.md
+++ b/brand-content-design/commands/brand-palette.md
@@ -126,7 +126,7 @@ If user selected "Derived":
 
 If user selected "Alternative":
 
-5. **Ask mood style (1/2)**
+5. **Ask mood style (1/2)** - ALWAYS ASK
     Use AskUserQuestion with multiSelect: true
     - Header: "Mood"
     - Question: "Which mood palettes? (1/2)"
@@ -136,7 +136,7 @@ If user selected "Alternative":
       - **Earthy** - Natural, warm, grounded (sustainable)
       - **Vibrant** - Bright, energetic (youth, excitement)
 
-6. **Ask mood style (2/2)**
+6. **Ask mood style (2/2)** - ALWAYS ASK (immediately after step 5)
     Use AskUserQuestion with multiSelect: true
     - Header: "Mood"
     - Question: "Which mood palettes? (2/2)"
@@ -145,7 +145,7 @@ If user selected "Alternative":
       - **Monochrome** - Grayscale + one accent (editorial, dramatic)
       - **Custom** - Describe what you need
 
-7. **If Custom selected, ask for description**
+7. **If Custom selected in step 5 or 6, ask for description**
     Ask: "Describe the mood or purpose for your custom palette:"
     Examples: "summer festival", "winter elegance", "tech startup energy"
 
@@ -232,9 +232,9 @@ If user selected "Alternative":
 14. **Confirm and suggest usage**
     Show:
     - "Saved X palettes to brand-philosophy.md"
-    - "Use these when creating content:"
-    - "  - `/presentation` or `/carousel` will ask which palette to use"
-    - "  - Or specify in your content brief"
+    - "Use these when creating templates:"
+    - "  - `/template-presentation` or `/template-carousel` will ask which palette to use"
+    - "  - Templates lock in style + palette for consistent content creation"
 
 ## Output
 

--- a/brand-content-design/commands/template-carousel.md
+++ b/brand-content-design/commands/template-carousel.md
@@ -140,9 +140,11 @@ Create a new carousel template or edit an existing one.
    - Options: LinkedIn (4:5 portrait), Instagram (1:1 square), Instagram (4:5 portrait)
 
 8. **Ask template purpose** (CREATE MODE only)
-   Use AskUserQuestion:
-   - "What is this carousel template for?"
-   - Options: Educational/Tips, Storytelling, Data/Statistics, Listicle, Other (describe)
+   Ask user directly (not AskUserQuestion):
+   "What is this template for? (2-4 words)
+   Examples: tips carousel, story series, data highlights, how-to guide, listicle, case study"
+
+   User provides short description like "tips carousel" or "weekly insights"
 
 9. **Load carousels guide**
    - Read plugin `references/carousels-guide.md` for card type options

--- a/brand-content-design/commands/template-presentation.md
+++ b/brand-content-design/commands/template-presentation.md
@@ -134,9 +134,11 @@ Create a new presentation template or edit an existing one.
    **Store selected palette** for use in canvas-philosophy.md generation.
 
 7. **Ask template purpose** (CREATE MODE only)
-   Use AskUserQuestion:
-   - "What is this presentation template for?"
-   - Options: Technical/Product, Sales/Pitch, Educational/Training, Other (describe)
+   Ask user directly (not AskUserQuestion):
+   "What is this template for? (2-4 words)
+   Examples: sales pitch, product demo, quarterly update, team training, investor deck, tech overview"
+
+   User provides short description like "sales pitch" or "product launch"
 
 8. **Load presentations guide**
    - Read plugin `references/presentations-guide.md` for slide type options


### PR DESCRIPTION
## Summary

Bug fixes for palette and template workflows - version 1.3.2

## Fixes

1. **`/brand-init` next steps**: Now shows `/brand-palette` and `/template-*` commands after init
2. **Alternative palette menu**: Both mood questions now marked "ALWAYS ASK" (sequential, not conditional)
3. **Palette confirmation message**: Now correctly mentions `/template-presentation` and `/template-carousel` (not `/presentation`)
4. **Template purpose question**: Now shows examples and asks for 2-4 word description instead of limited menu options

## Files Changed

- `commands/brand-init.md` - Updated next steps
- `commands/brand-palette.md` - Fixed mood questions and confirmation message
- `commands/template-presentation.md` - Fixed purpose question
- `commands/template-carousel.md` - Fixed purpose question
- `CHANGELOG.md` - Added 1.3.2 entry
- `plugin.json` - Version bump
- `marketplace.json` - Version bump

## Test plan

- [ ] Run `/brand-init` - verify next steps show palette and template commands
- [ ] Run `/brand-palette` with Alternative - verify both mood questions appear sequentially
- [ ] After saving palettes - verify message mentions template commands
- [ ] Run `/template-presentation` - verify purpose asks for 2-4 word description with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)