### PR TITLE
fix(drupal-dev-framework): task creation flow after requirements gathering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom skills and tools for Claude Code development workflows",
-    "version": "1.0.9"
+    "version": "1.0.10"
   },
   "plugins": [
     {
@@ -39,7 +39,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2025-12-10
+
+### Fixed
+- requirements-gatherer now has Step 7 to handle task creation after user provides task name
+- Previously, after requirements gathering, the flow could skip straight to research without creating a task
+- Now explicitly: validates task name → asks for description → waits for confirmation → invokes `/research`
+
+### Changed
+- SessionStart hook now runs `session-start.sh` script that:
+  - Checks registry for existing projects
+  - Shows project count and directs user to run `/next`
+  - Provides clear entry point for new sessions
+
 ## [1.3.0] - 2025-12-06
 
 ### Added

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -24,22 +24,20 @@ A **project** is a collection of related development tasks. It might include:
 
 Projects are organized by **goal**, not by file type. The plugin tracks each project in a dedicated folder with requirements, architecture documents, and implementation tasks.
 
-### Phases
-Development happens in three phases, each with a clear purpose:
-
-| Phase | What Happens | Code Written? |
-|-------|--------------|---------------|
-| **1. Research** | Gather requirements, study contrib modules, find patterns | No |
-| **2. Architecture** | Design components, choose patterns, document decisions | No |
-| **3. Implementation** | Build features interactively with TDD | Yes (with approval) |
-
-You don't write code until Phase 3. This prevents wasted effort on wrong approaches.
-
 ### Tasks
-A **task** is a single implementable unit of work (e.g., "create settings form", "build entity type"). Each task has:
-- Acceptance criteria
-- TDD steps (test first)
-- Pattern references
+A **task** is a single implementable unit of work (e.g., "create settings form", "build entity type"). Tasks are created after requirements gathering - you define what you want to work on, and the framework guides you through building it.
+
+Each task independently cycles through **three phases**:
+
+| Phase | Command | What Happens | Code Written? |
+|-------|---------|--------------|---------------|
+| **1. Research** | `/research <task>` | Study contrib modules, find core patterns | No |
+| **2. Architecture** | `/design <task>` | Design approach, choose patterns, set criteria | No |
+| **3. Implementation** | `/implement <task>` | Build with TDD, user approval at each step | Yes |
+
+**Key insight:** Phases apply to TASKS, not projects. A project can have multiple tasks, each at different phases. You don't write code until a task reaches Phase 3.
+
+Task files are stored in `implementation_process/in_progress/` and moved to `completed/` when done.
 
 ### Memory
 The plugin stores project state in markdown files, allowing:
@@ -91,63 +89,69 @@ The path is saved in `project_state.md`, so the plugin remembers it across sessi
 ### Starting a New Project
 
 ```bash
-# 1. Create project structure
+# 1. Create project and gather requirements
 /drupal-dev-framework:new my_project
 
-# 2. Answer requirements questions when prompted
-# (scope, integrations, constraints, etc.)
+# 2. Answer requirements questions (scope, integrations, constraints)
 
-# 3. Research existing solutions
-/drupal-dev-framework:research content workflow
-/drupal-dev-framework:research entity references
+# 3. When asked "Enter your first task:", provide a task name
+#    Example: "settings_form" or "content_entity"
 
-# 4. Design architecture (Phase 2)
-/drupal-dev-framework:design
+# 4. The framework automatically starts research for your task
+```
 
-# 5. Get pattern recommendations
-/drupal-dev-framework:pattern settings form
-/drupal-dev-framework:pattern content entity
+### Working on Tasks
 
-# 6. Validate architecture before coding
-/drupal-dev-framework:validate
+Each task goes through 3 phases:
 
-# 7. Start implementing (Phase 3)
+```bash
+# Phase 1: Research (automatic after task creation)
+# - Searches contrib modules, finds core patterns
+# - Review findings, then proceed to design
+
+# Phase 2: Design architecture
+/drupal-dev-framework:design settings_form
+
+# Phase 3: Implement with TDD
 /drupal-dev-framework:implement settings_form
 
-# 8. Mark task complete when done
-/drupal-dev-framework:complete
+# Mark complete when done
+/drupal-dev-framework:complete settings_form
+
+# Start next task
+/drupal-dev-framework:research api_integration
 ```
 
 ### Resuming Work
 
 ```bash
-# Check current status
-/drupal-dev-framework:status
-
-# Get recommendation for next action
+# Get intelligent recommendation for next action
 /drupal-dev-framework:next
+
+# Or check current status
+/drupal-dev-framework:status
 ```
 
-### Typical Workflow
+### Typical Session Flow
 
 ```
-Phase 1: Research (no code)
-├── /drupal-dev-framework:new <project>
-├── /drupal-dev-framework:research <topic>
-└── Review findings, decide approach
-
-Phase 2: Architecture (no code)
-├── /drupal-dev-framework:design
-├── /drupal-dev-framework:pattern <use-case>
-├── /drupal-dev-framework:validate
-└── Review designs, approve before Phase 3
-
-Phase 3: Implementation (interactive coding)
-├── /drupal-dev-framework:implement <task>
-├── Write code piece-by-piece with approval
-├── /drupal-dev-framework:validate
-├── /drupal-dev-framework:complete
-└── Repeat for each task
+/next (no argument)
+     │
+     ▼
+"Found 2 projects..."  →  Select project
+     │
+     ▼
+"Found 2 tasks..."     →  Select task or create new
+     │
+     ▼
+"Task: settings_form (Phase 2)"
+"Recommended: /design settings_form"
+     │
+     ▼
+Work on task through phases → /complete when done
+     │
+     ▼
+Back to task selection
 ```
 
 ## Commands
@@ -223,27 +227,28 @@ This plugin builds on patterns and integrates with:
 
 ## Changelog
 
-### 1.1.3
-- Fixed assumptions that projects are always modules
-- Changed "module" references to "project" in commands, skills, agents
-- Updated examples to use generic project names instead of module names
-- Removed "Must be valid Drupal module name format" requirement from `/new` command
+See [CHANGELOG.md](./CHANGELOG.md) for full version history.
+
+### 1.3.1
+- Fixed task creation flow after requirements gathering
+- Added Step 7 to requirements-gatherer: validates task name, asks for description, then invokes `/research`
+
+### 1.3.0
+- Added WORKFLOW.md with complete workflow documentation
+- Phases now apply to TASKS, not projects
+- Each task independently cycles through Research → Architecture → Implementation
+- Added project registry at `~/.claude/drupal-dev-framework/active_projects.json`
+
+### 1.2.0
+- Projects contain requirements (gathered once) + multiple tasks
+- Task-based workflow with files in `implementation_process/in_progress/`
 
 ### 1.1.0
-- **Rewrote all 15 skills** to use imperative instructions instead of documentation style
-- Changed "Triggers" sections to "Activation" with active voice
-- Changed "Human Control Points" to "Stop Points" with actionable instructions
-- Added specific tool calls (`Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`)
-- Added numbered workflow steps with clear actions
-- Created `hooks/hooks.json` with SessionStart message
+- Rewrote all 15 skills to use imperative instructions
 - Skills now tell Claude what to do, not explain what the skill is
 
 ### 1.0.0
-- Initial release
-- 5 agents, 15 skills, 9 commands
-- 3-phase workflow (Research → Architecture → Implementation)
-- Configurable project paths
-- Optional guides integration
+- Initial release with 5 agents, 15 skills, 9 commands
 
 ## License
 

--- a/drupal-dev-framework/hooks/hooks.json
+++ b/drupal-dev-framework/hooks/hooks.json
@@ -5,8 +5,9 @@
         "matcher": "*",
         "hooks": [
           {
-            "type": "message",
-            "message": "Drupal Development Framework active. Use /drupal-dev-framework:status to check project state or /drupal-dev-framework:new to start a new project."
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 5
           }
         ]
       }

--- a/drupal-dev-framework/hooks/session-start.sh
+++ b/drupal-dev-framework/hooks/session-start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Session start hook for drupal-dev-framework
+# Checks for registered projects and outputs context
+
+REGISTRY="$HOME/.claude/drupal-dev-framework/active_projects.json"
+
+echo "## Drupal Development Framework"
+echo ""
+
+if [ -f "$REGISTRY" ]; then
+  # Count projects
+  PROJECT_COUNT=$(jq -r '.projects | length' "$REGISTRY" 2>/dev/null || echo "0")
+
+  if [ "$PROJECT_COUNT" -gt 0 ]; then
+    echo "Found $PROJECT_COUNT registered project(s)."
+    echo ""
+    echo "**Run \`/drupal-dev-framework:next\` to:**"
+    echo "1. Select a project"
+    echo "2. Choose or create a task"
+    echo "3. Get recommended next action"
+  else
+    echo "No projects registered yet."
+    echo ""
+    echo "**Run \`/drupal-dev-framework:new <project-name>\` to start a new project.**"
+  fi
+else
+  echo "No projects registered yet."
+  echo ""
+  echo "**Run \`/drupal-dev-framework:new <project-name>\` to start a new project.**"
+fi
+
+exit 0

--- a/drupal-dev-framework/skills/requirements-gatherer/SKILL.md
+++ b/drupal-dev-framework/skills/requirements-gatherer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: requirements-gatherer
 description: Use when gathering project requirements - asks structured questions about project type, scope, integrations, and constraints to populate project_state.md
-version: 1.2.0
+version: 1.3.1
 ---
 
 # Requirements Gatherer
@@ -186,10 +186,37 @@ Enter your first task:
 
 **IMPORTANT:** Do NOT suggest `/research` or `/design` at the project level. Tasks are what go through phases, not the project.
 
+### 7. Create First Task
+
+When user provides a task name:
+
+1. **Validate task name** - convert to lowercase with underscores (e.g., "Add settings form" → `settings_form`)
+
+2. **Confirm task creation:**
+   ```
+   Creating task: {task_name}
+
+   Brief description (one sentence - what does this task accomplish?):
+   ```
+
+3. **Wait for user to provide description**
+
+4. **Invoke research phase:**
+   ```
+   Starting research phase for: {task_name}
+   ```
+   Then invoke `/drupal-dev-framework:research {task_name}`
+
+**CRITICAL:** Do NOT start research until:
+- Task name is confirmed
+- User provides a description
+- Task creation is acknowledged
+
 ## Stop Points
 
 STOP and wait for user after:
 - Each category question
 - Showing summary for confirmation
 - Asking for first task
+- After asking for task description (Step 7.2)
 - User says "add more"


### PR DESCRIPTION
## Summary

- Fixed task creation flow after requirements gathering - previously the flow could skip straight to research without creating a task
- Added Step 7 to `requirements-gatherer` skill: validates task name → asks description → waits for confirmation → invokes `/research`
- Updated SessionStart hook to check registry and direct users to `/next` as the entry point
- Fixed README to correctly explain task-based phases (phases apply to TASKS, not projects)

## Changes

| File | Description |
|------|-------------|
| `requirements-gatherer/SKILL.md` | Added Step 7 for handling task creation after user provides task name |
| `hooks/hooks.json` | Now runs `session-start.sh` script instead of passive message |
| `hooks/session-start.sh` | New script that checks registry and shows project count |
| `README.md` | Fixed Tasks section, Quick Start, and changelog |
| `CHANGELOG.md` | Added v1.3.1 entry |
| `marketplace.json` | Version bump to 1.3.1 |

## Test plan

- [ ] Run `/drupal-dev-framework:new test_project` and verify it asks for first task after requirements
- [ ] Verify Step 7 waits for task description before invoking `/research`
- [ ] Start new Claude session and verify SessionStart shows project count and `/next` directive
- [ ] Verify README accurately describes task-based workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)