### PR TITLE
chore: update marketplace.json for brand-content-design v1.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": ""
   },
   "metadata": {
-    "description": "Custom skills and tools for Claude Code development workflows",
-    "version": "1.0.10"
+    "description": "Claude Code plugins for Drupal development, brand content creation (presentations, carousels, infographics), code quality auditing, and plugin development",
+    "version": "1.1.0"
   },
   "plugins": [
     {
@@ -64,14 +64,14 @@
     {
       "name": "brand-content-design",
       "source": "./brand-content-design",
-      "description": "Create branded presentations and carousels with 13 visual styles, 17 color palettes, and Presentation Zen principles",
-      "version": "1.4.1",
+      "description": "Create branded visual content (presentations, carousels, infographics) with 114 templates, 13 visual styles, 17 color palettes, and Presentation Zen principles",
+      "version": "1.10.0",
       "author": {
         "name": "camoa"
       },
       "license": "MIT",
       "repository": "https://github.com/camoa/claude-skills",
-      "keywords": ["brand", "presentations", "carousels", "linkedin", "instagram", "design", "canvas", "zen"],
+      "keywords": ["brand", "presentations", "carousels", "infographics", "data-visualization", "timeline", "process-diagram", "linkedin", "instagram", "design", "canvas", "zen"],
       "strict": false
     }
   ]


### PR DESCRIPTION
## Summary

- Update brand-content-design version from 1.4.1 to 1.10.0
- Add infographics to description (114 templates)
- Add keywords: infographics, data-visualization, timeline, process-diagram

This syncs the marketplace.json with the actual plugin version after PR #21 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)