### PR TITLE
chore(brand-content-design): bump version to 1.11.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -65,7 +65,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics) with 114 templates, 13 visual styles, visual components (cards, icons, gradients), 17 color palettes, and Presentation Zen principles",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Create branded visual content (presentations, carousels, infographics) with visual components (cards, icons, gradients) using a layered philosophy system with Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2025-12-11
+
+### Fixed
+- **Gradient rendering bug**: Fixed `AttributeError: 'PDFPathObject' object has no attribute 'closePath'` - reportlab uses `p.close()` not `p.closePath()`
+- **Icons fallback paths**: Added fallback plugin directory detection when `BRAND_CONTENT_DESIGN_DIR` env var not set by hook
+
+### Added
+- **Intelligent usage guidelines**: Visual components now have decision framework for smart usage
+  - When to use/avoid cards, icons, gradients based on content type
+  - Slide-type recommendation matrix
+  - Quality checklist and common mistakes
+- **Outline command**: `/outline` now includes visual components in generated AI prompts
+
 ## [1.11.0] - 2025-12-11
 
 ### Added


### PR DESCRIPTION
## Summary

Version bump to 1.11.1 with changelog updates.

## Changes in 1.11.1

### Fixed
- **Gradient rendering bug**: Fixed `AttributeError: 'PDFPathObject' object has no attribute 'closePath'` - reportlab uses `p.close()` not `p.closePath()`
- **Icons fallback paths**: Added fallback plugin directory detection when `BRAND_CONTENT_DESIGN_DIR` env var not set by hook

### Added
- **Intelligent usage guidelines**: Visual components now have decision framework for smart usage
- **Outline command**: `/outline` now includes visual components in generated AI prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)