### PR TITLE
fix: correct hooks.json schema for SessionStart

### DIFF
--- a/brand-content-design/hooks/hooks.json
+++ b/brand-content-design/hooks/hooks.json
@@ -2,9 +2,13 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/setup-env.sh",
-        "timeout": 5
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/setup-env.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/drupal-dev-framework/hooks/hooks.json
+++ b/drupal-dev-framework/hooks/hooks.json
@@ -2,7 +2,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Fix plugin loading errors caused by incorrect hooks.json schema.

## Errors Fixed

**brand-content-design:**
```
"expected": "array", "received": "undefined"
"path": ["hooks", "SessionStart", 0, "hooks"]
```

**drupal-dev-framework:**
```
"expected": "object", "received": "array"
```

## Changes

SessionStart hooks require an inner `"hooks"` array wrapper:

```json
// Wrong ❌
{
  "hooks": {
    "SessionStart": [
      { "type": "command", "command": "..." }
    ]
  }
}

// Correct ✓
{
  "hooks": {
    "SessionStart": [
      {
        "hooks": [
          { "type": "command", "command": "..." }
        ]
      }
    ]
  }
}
```

Also removed invalid `"matcher": "*"` from drupal-dev-framework - SessionStart doesn't use matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)