### PR TITLE
fix(marketplace): update drupal-dev-framework to v2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,14 +38,14 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands",
-      "version": "1.3.1",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
+      "version": "2.0.0",
       "author": {
         "name": "camoa"
       },
       "license": "MIT",
       "repository": "https://github.com/camoa/claude-skills",
-      "keywords": ["drupal", "development", "workflow", "architecture", "tdd"],
+      "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security"],
       "strict": false
     },
     {


### PR DESCRIPTION
## Summary
- Updates marketplace.json version from 1.3.1 to 2.0.0 to match plugin.json
- Enhanced description with enforced principles
- Added solid, dry, security keywords

## Problem
After PR #31 merged drupal-dev-framework v2.0.0, the marketplace.json was not updated, causing Claude Code to not detect the plugin update.

## Changes
- `.claude-plugin/marketplace.json`: Updated drupal-dev-framework version to 2.0.0
- Enhanced description to reflect enforced SOLID, TDD, DRY, and security principles
- Added missing keywords

## Test Plan
- [x] Verify marketplace.json version matches plugin.json
- [ ] After merge, verify Claude Code detects version 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)