### PR TITLE
feat(plugin-creation-tools): v2.0.0-beta.3 - Enhanced skill creation guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.3] - 2025-12-31
+
+### Added
+- **6-step creation process**: Structured workflow for manual skill creation
+  - Added to `references/03-skills/creation-approaches.md`
+  - Step 1: Understand skill with concrete examples
+  - Step 2: Plan reusable skill contents
+  - Step 3: Initialize skill (run init_skill.py)
+  - Step 4: Edit skill (implement resources + write SKILL.md)
+  - Step 5: Package skill (run package_skill.py with validation)
+  - Step 6: Iterate based on real usage
+  - Includes decision matrices, examples, and completion criteria for each step
+
+### Enhanced
+- **Plugin vs skill level distinction**: Clarified README/CHANGELOG placement
+  - Updated `references/02-philosophy/anti-patterns.md`
+  - ✅ README.md, CHANGELOG.md, LICENSE **required** at plugin root (for humans)
+  - ❌ README.md, CHANGELOG.md **forbidden** inside skills (AI-only files)
+  - Added visual examples showing correct vs incorrect structure
+  - Explains why: Plugin docs for humans, skill SKILL.md for AI
+
+### Attribution
+- 6-step creation process adapted from Anthropic's `skill-creator` skill (document-skills@anthropic-agent-skills)
+- Plugin vs skill level distinction concept from Anthropic's skill-creator best practices
+- We preserve unique value: multi-component coverage (commands, agents, hooks, MCP) not in Anthropic's skill-creator
+
+### Context
+Aligned with Anthropic's official skill-creator guidance while preserving our multi-component (skills, commands, agents, hooks, MCP) coverage. The core philosophy (Claude is already smart, context window as public good, degrees of freedom) was already present in v2.0.0-beta.2.
+
 ## [2.0.0-beta.2] - 2025-12-08
 
 ### Added

--- a/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/anti-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/anti-patterns.md
@@ -72,12 +72,59 @@ Before including any code, ask: **"Can I reference existing code instead?"**
 
 ## What NOT to Include
 
+> **Attribution**: The plugin vs skill level distinction is based on best practices from Anthropic's `skill-creator` skill (document-skills@anthropic-agent-skills).
+
+**Critical distinction: Plugin level vs Skill level**
+
+### ❌ NEVER in Skills (skills/skill-name/)
+
 Skills should ONLY contain essential files for AI execution:
 
 | Don't Include | Why |
 |---------------|-----|
-| README.md | Use SKILL.md instead |
+| README.md | Use SKILL.md instead - README is for humans, SKILL.md is for AI |
 | INSTALLATION_GUIDE.md | Not needed for AI execution |
-| CHANGELOG.md | Historical clutter |
+| CHANGELOG.md | Historical clutter - skills version with their plugin |
 | QUICK_REFERENCE.md | Put in SKILL.md or references/ |
 | User-facing documentation | Skills are for AI, not humans |
+| LICENSE files | License belongs at plugin root |
+
+**Bad (skill has human docs):**
+```
+skills/my-skill/
+├── SKILL.md
+├── README.md       ❌ NO - redundant with SKILL.md
+├── CHANGELOG.md    ❌ NO - skills version with plugin
+└── LICENSE         ❌ NO - belongs at plugin root
+```
+
+**Good (skill has only AI files):**
+```
+skills/my-skill/
+├── SKILL.md        ✅ AI instructions
+├── scripts/        ✅ Bundled resources
+├── references/     ✅ Loaded as needed
+└── assets/         ✅ Used in output
+```
+
+### ✅ Required at Plugin Level (plugin root)
+
+Plugins (the overall package) SHOULD have human-facing documentation:
+
+```
+my-plugin/
+├── README.md           ✅ User-facing docs, GitHub visibility
+├── CHANGELOG.md        ✅ Version history, marketplace updates
+├── LICENSE             ✅ Legal clarity
+├── .claude-plugin/
+│   └── plugin.json
+└── skills/
+    └── my-skill/
+        └── SKILL.md    ✅ AI instructions only
+```
+
+**Why the distinction?**
+- **Plugin README/CHANGELOG**: For humans (GitHub visitors, marketplace users)
+- **Skill SKILL.md**: For AI agents only (no human-facing fluff)
+
+The skill is Claude's "onboarding guide" - it should contain ONLY what Claude needs to execute the task, nothing more.

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/creation-approaches.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/creation-approaches.md
@@ -2,6 +2,196 @@
 
 Choosing the right tool for creating skills based on source material and requirements.
 
+## The 6-Step Creation Process
+
+> **Attribution**: This process is adapted from Anthropic's `skill-creator` skill (document-skills@anthropic-agent-skills). We've enhanced it with our scripts and templates while preserving the core workflow.
+
+When creating skills manually (recommended for custom workflows and domain expertise), follow this structured process:
+
+### Step 1: Understand the Skill with Concrete Examples
+
+**Goal**: Clearly understand how the skill will be used.
+
+Skip this step only when usage patterns are already crystal clear.
+
+**Actions**:
+- Gather concrete examples from users or create validated examples
+- Ask clarifying questions:
+  - "What functionality should this skill support?"
+  - "Can you give examples of how this would be used?"
+  - "What would trigger this skill?"
+- Document 3-5 real usage scenarios
+
+**Example questions for an image-editor skill**:
+- "What functionality: editing, rotating, resizing, filters?"
+- "Example uses: 'Remove red-eye', 'Rotate 90 degrees', 'Resize to 800x600'?"
+- "What triggers it: 'edit image', 'process photo', 'fix picture'?"
+
+**Completion criteria**: Clear sense of functionality the skill should support.
+
+### Step 2: Plan Reusable Skill Contents
+
+**Goal**: Identify what bundled resources (scripts, references, assets) would be helpful.
+
+For each concrete example, analyze:
+1. How to execute from scratch
+2. What would make repeated execution easier
+
+**Decision matrix**:
+
+| If task requires... | Include... |
+|---------------------|------------|
+| Same code rewritten each time | `scripts/` - Executable code |
+| Re-discovering schemas/APIs each time | `references/` - Documentation |
+| Same boilerplate HTML/templates each time | `assets/` - Template files |
+
+**Examples**:
+
+**PDF rotation** → Requires rewriting code each time → `scripts/rotate_pdf.py`
+
+**BigQuery queries** → Requires re-discovering schemas → `references/schema.md`
+
+**Frontend apps** → Requires same boilerplate → `assets/hello-world/` template
+
+**Output**: List of bundled resources needed (scripts, references, assets).
+
+### Step 3: Initialize the Skill
+
+**Goal**: Create skill directory structure.
+
+Skip this step only if the skill already exists and needs iteration.
+
+**Always use the init script**:
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+The script automatically:
+- Creates skill directory structure
+- Generates SKILL.md template with frontmatter
+- Creates example `scripts/`, `references/`, `assets/` directories
+- Adds example files you can customize or delete
+
+**After initialization**: Customize or remove generated example files as needed.
+
+### Step 4: Edit the Skill
+
+**Goal**: Implement bundled resources and write SKILL.md instructions.
+
+#### 4a. Implement Bundled Resources
+
+Start with the reusable resources identified in Step 2:
+
+**For scripts/**:
+- Write and test by actually running them
+- Ensure no bugs, output matches expectations
+- Test representative samples if many similar scripts
+
+**For references/**:
+- Gather documentation, schemas, API docs
+- May require user input (brand assets, templates, documentation)
+- Organize by domain or framework for large skills
+
+**For assets/**:
+- Collect templates, images, boilerplate code
+- Store files that will be used in output
+
+**Delete** any example files not needed for the skill.
+
+#### 4b. Write SKILL.md
+
+**Remember**: SKILL.md is INSTRUCTIONS for Claude, not documentation.
+
+**Frontmatter**:
+```yaml
+---
+name: skill-name
+description: Use when [triggers] - [what it does]. Include specific contexts: (1) scenario, (2) scenario, (3) scenario
+---
+```
+
+**Body**:
+- Use imperative/infinitive form
+- Tell Claude what to DO, not what things ARE
+- Keep under 500 lines (split to references/ if larger)
+- Link to bundled resources: "See references/file.md for..."
+- One excellent example per pattern
+
+**See also**: `writing-skillmd.md` for complete guidance.
+
+### Step 5: Package the Skill
+
+**Goal**: Validate and create distributable .skill file.
+
+**Always use the package script**:
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory:
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The script automatically:
+1. **Validates** the skill:
+   - YAML frontmatter format
+   - Required fields present
+   - Naming conventions
+   - File organization
+   - Description quality
+2. **Packages** if validation passes:
+   - Creates .skill file (zip with .skill extension)
+   - Includes all files with proper structure
+
+**If validation fails**: Fix errors and rerun.
+
+**Output**: Distributable `skill-name.skill` file.
+
+### Step 6: Iterate Based on Real Usage
+
+**Goal**: Improve skill based on actual performance.
+
+After testing the skill on real tasks:
+
+1. **Notice** struggles or inefficiencies
+2. **Identify** how SKILL.md or bundled resources should change
+3. **Implement** changes
+4. **Test** again
+
+**Common iteration patterns**:
+
+| Observation | Solution |
+|-------------|----------|
+| Claude asks same question repeatedly | Add to SKILL.md or references/ |
+| Rewriting similar code each time | Extract to scripts/ |
+| Missing edge cases | Add to references/troubleshooting.md |
+| Confusing instructions | Simplify SKILL.md, add examples |
+| Too verbose, loads slowly | Move details to references/, use progressive disclosure |
+
+### See Also: Anthropic's skill-creator
+
+For an alternative approach to skill creation, see Anthropic's official `skill-creator` skill:
+
+```bash
+# Install Anthropic's example-skills plugin
+/plugin marketplace add anthropics/skills
+/plugin install example-skills@anthropic-agent-skills
+```
+
+**When to use Anthropic's skill-creator vs this skill:**
+
+| Use Anthropic's skill-creator | Use plugin-creation (this skill) |
+|------------------------------|----------------------------------|
+| Creating standalone skills only | Creating plugins with multiple components |
+| Prefer Anthropic's official approach | Need commands, agents, hooks, or MCP servers |
+| Want minimal, focused guidance | Want comprehensive templates and scripts |
+| - | Need cross-platform hooks or output management |
+
+**Both approaches are valid** - Anthropic's is more focused, ours is more comprehensive. Choose based on your needs.
+
+---
+
 ## Approach Comparison
 
 | Approach | Best For | Speed | Quality |


### PR DESCRIPTION
## Summary

Enhanced plugin-creation-tools by comparing with Anthropic's official skill-creator and adding the missing pieces while preserving our unique multi-component (skills, commands, agents, hooks, MCP) coverage.

## Added

### 6-Step Creation Process (`references/03-skills/creation-approaches.md`)

Added structured workflow for manual skill creation:

1. **Understand Skill with Concrete Examples**
   - Gather 3-5 real usage scenarios
   - Ask clarifying questions
   - Example questions provided for image-editor skill

2. **Plan Reusable Skill Contents**
   - Decision matrix: When to use scripts/ vs references/ vs assets/
   - Real examples: PDF rotation → scripts, BigQuery schemas → references, Frontend boilerplate → assets

3. **Initialize Skill**
   - Always use `init_skill.py` script
   - Auto-generates proper structure

4. **Edit Skill**
   - 4a: Implement bundled resources (test scripts, gather docs, collect assets)
   - 4b: Write SKILL.md (instructions for Claude, not documentation)

5. **Package Skill**
   - Always use `package_skill.py` (validates + packages)
   - Validation ensures quality before distribution

6. **Iterate Based on Real Usage**
   - Common iteration patterns table
   - Systematic improvement process

## Enhanced

### Plugin vs Skill Level Distinction (`references/02-philosophy/anti-patterns.md`)

Clarified the critical distinction for README/CHANGELOG files:

**❌ NEVER in Skills** (`skills/skill-name/`):
- No README.md (use SKILL.md instead)
- No CHANGELOG.md (skills version with their plugin)
- No LICENSE (belongs at plugin root)
- Only AI-execution files: SKILL.md + bundled resources

**✅ Required at Plugin Level** (plugin root):
- README.md - User-facing docs, GitHub visibility
- CHANGELOG.md - Version history, marketplace updates
- LICENSE - Legal clarity

**Why**: Plugin docs are for humans (GitHub visitors, marketplace users), while skill SKILL.md is for AI agents only.

Added visual examples showing correct vs incorrect structure.

## Comparison Analysis

Reviewed Anthropic's official `skill-creator` skill and found our existing content already had:

✅ **Already Excellent** (no changes needed):
- "Claude is already smart" principle (`core-philosophy.md`)
- Context window as public good (`core-philosophy.md`)
- Degrees of freedom concept (`core-philosophy.md`)
- Progressive disclosure patterns (`bundled-resources.md`, `writing-skillmd.md`)
- Clear scripts/references/assets distinction (`bundled-resources.md`)
- Strong <500 line limits (`writing-skillmd.md`)

❌ **Gaps Identified** (now fixed):
- Missing structured 6-step creation process → Added
- Plugin vs skill level README/CHANGELOG confusion → Clarified

## Our Unique Strengths (Preserved)

What we have that Anthropic's skill-creator doesn't:
- ✅ Multi-component coverage (skills, commands, agents, hooks, MCP)
- ✅ Component comparison tables
- ✅ Cross-platform hooks guidance
- ✅ The "5-10 Rule" decision framework
- ✅ More comprehensive templates

## Files Changed

- `plugin-creation-tools/skills/plugin-creation/references/02-philosophy/anti-patterns.md` - Added plugin vs skill distinction
- `plugin-creation-tools/skills/plugin-creation/references/03-skills/creation-approaches.md` - Added 6-step process
- `plugin-creation-tools/CHANGELOG.md` - Added v2.0.0-beta.3 entry
- `plugin-creation-tools/.claude-plugin/plugin.json` - Version bump
- `.claude-plugin/marketplace.json` - Version bump

## Testing

- ✅ Verified examples already follow best practices (no README in skills)
- ✅ Confirmed core philosophy files already excellent
- ✅ Validated bundled resources guidance already comprehensive

## Impact

This update makes plugin-creation-tools the most comprehensive Claude Code plugin creation guide available, combining:
- Anthropic's official best practices
- Our unique multi-component coverage
- Structured, actionable workflows
- Clear anti-patterns and decision frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)