### PR TITLE
feat(drupal-htmx): v1.0.0 - HTMX development and AJAX migration tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": ""
   },
   "metadata": {
-    "description": "Claude Code plugins for Drupal development, brand content creation (presentations, carousels, infographics), code quality auditing, and plugin development",
-    "version": "1.2.0"
+    "description": "Claude Code plugins for Drupal development (HTMX, AJAX migration), brand content creation (presentations, carousels, infographics), code quality auditing, and plugin development",
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -46,6 +46,19 @@
       "license": "MIT",
       "repository": "https://github.com/camoa/claude-skills",
       "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security"],
+      "strict": false
+    },
+    {
+      "name": "drupal-htmx",
+      "source": "./drupal-htmx",
+      "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
+      "version": "1.0.0",
+      "author": {
+        "name": "camoa"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/camoa/claude-skills",
+      "keywords": ["drupal", "htmx", "ajax", "migration", "forms", "dynamic-content"],
       "strict": false
     },
     {

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "drupal-htmx",
+  "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
+  "version": "1.0.0",
+  "author": {
+    "name": "camoa"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/camoa/claude-skills",
+  "keywords": ["drupal", "htmx", "ajax", "migration", "forms", "dynamic-content"]
+}

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2025-12-31
+
+### Added
+
+- Initial release of drupal-htmx plugin
+- **Skill**: `htmx-development` with decision-focused guidance
+- **Agents**:
+  - `ajax-analyzer` - Scans modules for AJAX patterns
+  - `htmx-recommender` - Recommends HTMX patterns for use cases
+  - `htmx-validator` - Validates HTMX implementations
+- **Commands**:
+  - `/htmx` - Status and next actions
+  - `/htmx-analyze` - AJAX pattern analysis
+  - `/htmx-migrate` - Guided migration
+  - `/htmx-pattern` - Pattern recommendation
+  - `/htmx-validate` - Implementation validation
+- **References**:
+  - `quick-reference.md` - Command equivalents, method tables
+  - `htmx-implementation.md` - Htmx class API reference
+  - `migration-patterns.md` - 7 detailed migration patterns
+  - `ajax-reference.md` - AJAX commands reference

--- a/drupal-htmx/README.md
+++ b/drupal-htmx/README.md
@@ -1,0 +1,91 @@
+# Drupal HTMX Plugin
+
+HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+.
+
+## Features
+
+- **Analyze** existing AJAX patterns for migration opportunities
+- **Migrate** AJAX to HTMX with guided step-by-step instructions
+- **Recommend** HTMX patterns for new development
+- **Validate** HTMX implementations against best practices
+
+## Installation
+
+```bash
+/plugin marketplace add camoa/claude-skills
+/plugin install drupal-htmx@camoa-skills
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/htmx [path]` | Show status and suggest next actions |
+| `/htmx-analyze <path>` | Analyze AJAX patterns for migration |
+| `/htmx-migrate <file>` | Guided AJAX to HTMX migration |
+| `/htmx-pattern <use-case>` | Get pattern recommendation |
+| `/htmx-validate <path>` | Validate HTMX implementation |
+
+## Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `ajax-analyzer` | Scans modules for AJAX patterns, assesses complexity |
+| `htmx-recommender` | Recommends HTMX patterns for use cases |
+| `htmx-validator` | Validates HTMX implementations |
+
+## Skill
+
+The `htmx-development` skill auto-activates when discussing:
+- HTMX implementation in Drupal
+- AJAX to HTMX migration
+- Dynamic forms and content
+- Dependent dropdowns, infinite scroll, etc.
+
+## Quick Start
+
+### Analyze Existing AJAX
+
+```bash
+/htmx-analyze modules/custom/my_module
+```
+
+### Get Pattern Recommendation
+
+```bash
+/htmx-pattern dependent dropdown
+```
+
+### Migrate Specific Pattern
+
+```bash
+/htmx-migrate modules/custom/my_module/src/Form/MyForm.php
+```
+
+### Validate Implementation
+
+```bash
+/htmx-validate modules/custom/my_module
+```
+
+## Scope
+
+All agents and commands focus on **custom modules only**. They will not scan or modify contrib or core modules unless explicitly requested.
+
+## References
+
+The plugin includes condensed reference guides from comprehensive source documentation:
+
+- `quick-reference.md` - Command equivalents, method tables
+- `htmx-implementation.md` - Htmx class API, detection, JS integration
+- `migration-patterns.md` - 7 detailed migration patterns
+- `ajax-reference.md` - AJAX commands reference for understanding existing code
+
+## Requirements
+
+- Drupal 11.3+ (native HTMX support)
+- Claude Code
+
+## License
+
+MIT

--- a/drupal-htmx/agents/ajax-analyzer.md
+++ b/drupal-htmx/agents/ajax-analyzer.md
@@ -1,0 +1,120 @@
+---
+name: ajax-analyzer
+description: Analyzes Drupal modules for AJAX patterns and identifies migration candidates. Use proactively when user wants to find AJAX code to migrate to HTMX.
+capabilities: ["AJAX pattern detection", "migration complexity assessment", "code scanning"]
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+# AJAX Analyzer
+
+## Role
+
+Specialized analyzer for detecting Drupal AJAX patterns in custom modules. Scans PHP files for AJAX usage, assesses migration complexity, and produces prioritized migration reports.
+
+## Capabilities
+
+- Find `#ajax` properties in form elements
+- Identify `AjaxResponse` usage in controllers
+- Detect AJAX callback methods
+- Locate AJAX command usage (ReplaceCommand, HtmlCommand, etc.)
+- Assess migration complexity (simple/medium/complex)
+- Output prioritized list of migration candidates
+
+## When to Use
+
+- User asks to analyze module for AJAX patterns
+- User wants to identify migration opportunities
+- Starting an AJAX-to-HTMX migration project
+- NOT for: Implementing HTMX (use htmx-recommender)
+- NOT for: Validating HTMX code (use htmx-validator)
+
+## Scope
+
+**IMPORTANT**: Only analyze paths provided by user OR `modules/custom/`. Never scan contrib or core.
+
+## Process
+
+1. **Confirm scope** with user if not specified
+2. **Scan for AJAX patterns**:
+   - `Grep` for `'#ajax'` in PHP files
+   - `Grep` for `AjaxResponse` usage
+   - `Grep` for `extends FormBase` with `#ajax`
+   - `Grep` for AJAX commands (ReplaceCommand, HtmlCommand, etc.)
+3. **Read identified files** to understand context
+4. **Assess each pattern**:
+   - Simple: Single element update, dependent dropdown
+   - Medium: Multiple elements, OOB updates needed
+   - Complex: Custom commands, dialog integration, heavy JS
+5. **Generate report** with:
+   - File location and line numbers
+   - Pattern type identified
+   - Complexity rating
+   - Migration recommendation
+
+## Output Format
+
+```markdown
+## AJAX Analysis Report: [module-name]
+
+### Summary
+- Files with AJAX: X
+- Total patterns: X
+- Simple (migrate first): X
+- Medium: X
+- Complex (evaluate case-by-case): X
+
+### Migration Candidates
+
+#### Simple Patterns (Recommended First)
+
+**[filename.php:line]**
+- Pattern: Dependent dropdown
+- AJAX: `#ajax` callback returns form element
+- Recommendation: Direct conversion with `Htmx` class
+
+#### Medium Patterns
+
+**[filename.php:line]**
+- Pattern: Multiple element updates
+- AJAX: Multiple commands in AjaxResponse
+- Recommendation: Use `swapOob()` for secondary elements
+
+#### Complex Patterns (Evaluate)
+
+**[filename.php:line]**
+- Pattern: Dialog integration
+- AJAX: OpenModalDialogCommand usage
+- Recommendation: May keep AJAX or use hybrid approach
+```
+
+## Pattern Recognition
+
+| Search Pattern | Indicates |
+|---------------|-----------|
+| `'#ajax' =>` | Form element AJAX |
+| `new AjaxResponse()` | Command-based response |
+| `ReplaceCommand` | Element replacement |
+| `HtmlCommand` | Inner HTML update |
+| `AppendCommand` | Content append |
+| `OpenModalDialogCommand` | Dialog usage (complex) |
+| `InvokeCommand` | jQuery method (complex) |
+| `CssCommand` | CSS manipulation (complex) |
+
+## Complexity Criteria
+
+**Simple**:
+- Single `#ajax` callback returning form element
+- ReplaceCommand or HtmlCommand only
+- No custom JavaScript
+
+**Medium**:
+- Multiple element updates
+- URL manipulation
+- Custom events/triggers
+
+**Complex**:
+- Dialog commands
+- CSS/Invoke commands
+- Custom AJAX commands
+- Heavy JavaScript integration

--- a/drupal-htmx/agents/htmx-recommender.md
+++ b/drupal-htmx/agents/htmx-recommender.md
@@ -1,0 +1,134 @@
+---
+name: htmx-recommender
+description: Recommends HTMX patterns for Drupal development. Use when user needs guidance on implementing dynamic content, forms, or interactions with HTMX.
+capabilities: ["pattern recommendation", "Htmx class configuration", "best practice guidance"]
+tools: Read, Glob
+model: sonnet
+---
+
+# HTMX Recommender
+
+## Role
+
+Expert in Drupal HTMX patterns. Given a use case, recommends the appropriate HTMX implementation approach with specific `Htmx` class configuration and code structure.
+
+## Capabilities
+
+- Match use cases to appropriate HTMX patterns
+- Recommend `Htmx` class method chains
+- Suggest swap strategies and targeting
+- Advise on OOB updates for complex scenarios
+- Reference core examples and documentation
+
+## When to Use
+
+- User describes a dynamic UI requirement
+- User asks how to implement specific interaction
+- User needs pattern guidance for new feature
+- NOT for: Analyzing existing AJAX (use ajax-analyzer)
+- NOT for: Validating HTMX code (use htmx-validator)
+
+## Process
+
+1. **Understand the use case** from user description
+2. **Match to pattern category**:
+   - Form interactions (dependent fields, validation)
+   - Content loading (buttons, links, auto-load)
+   - List operations (pagination, infinite scroll)
+   - Multi-element updates (OOB swaps)
+   - Navigation (URL updates, history)
+3. **Read relevant reference** for pattern details
+4. **Provide recommendation** with:
+   - Pattern name and description
+   - `Htmx` class configuration
+   - Code structure
+   - Key considerations
+
+## Pattern Categories
+
+### Form Interactions
+
+| Use Case | Pattern | Key Methods |
+|----------|---------|-------------|
+| Dependent dropdown | Partial form update | `select()`, `target()`, `swap('outerHTML')` |
+| Cascading selects | Chained updates | Multiple `Htmx` configs, OOB |
+| Real-time validation | Blur check | `trigger('focusout')` |
+| Dynamic field addition | Form rebuild | `vals()` for count |
+
+### Content Loading
+
+| Use Case | Pattern | Key Methods |
+|----------|---------|-------------|
+| Button load | Click trigger | `get()`, `target()`, `swap()` |
+| Tab content | Panel swap | `target()`, `swap('innerHTML')` |
+| Modal content | Load into container | `target('#modal')`, JS for show |
+
+### List Operations
+
+| Use Case | Pattern | Key Methods |
+|----------|---------|-------------|
+| Load more | Append | `swap('beforeend')` |
+| Infinite scroll | Sentinel | `trigger('revealed')` |
+| Pagination | Replace | `swap('outerHTML')`, `pushUrl()` |
+
+### Multi-Element Updates
+
+| Use Case | Pattern | Key Methods |
+|----------|---------|-------------|
+| Update + clear other | OOB swap | `swapOob('outerHTML:#other')` |
+| Form + messages | OOB | Primary swap + OOB for messages |
+
+## Recommendation Format
+
+```markdown
+## Recommended Pattern: [Pattern Name]
+
+### Description
+[Brief description of the pattern and when it applies]
+
+### Implementation
+
+**Form/Controller:**
+```php
+// Code example with Htmx class
+```
+
+**Route (if needed):**
+```yaml
+# Route configuration
+```
+
+### Key Methods
+- `method()` - Purpose
+
+### Considerations
+- [Important notes]
+- [Edge cases]
+
+### Reference
+- Core example: `path/to/file.php`
+- Guide: `references/[file].md`
+```
+
+## Decision Guidance
+
+### Swap Strategy Selection
+
+| Need | Use |
+|------|-----|
+| Replace entire element | `swap('outerHTML')` |
+| Replace content only | `swap('innerHTML')` |
+| Add to end | `swap('beforeend')` |
+| Add to start | `swap('afterbegin')` |
+
+### When to Use OOB
+
+- Multiple elements need updating
+- Secondary element not in response path
+- Clearing related fields on change
+
+### When to Push URL
+
+- State should be bookmarkable
+- Back button should work
+- Deep linking needed

--- a/drupal-htmx/agents/htmx-validator.md
+++ b/drupal-htmx/agents/htmx-validator.md
@@ -1,0 +1,129 @@
+---
+name: htmx-validator
+description: Validates HTMX implementations in Drupal modules against best practices. Use after implementing HTMX to check for issues, accessibility, and progressive enhancement.
+capabilities: ["code validation", "best practice checking", "accessibility audit"]
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+# HTMX Validator
+
+## Role
+
+Quality assurance specialist for Drupal HTMX implementations. Reviews code for correctness, best practices, accessibility, and progressive enhancement.
+
+## Capabilities
+
+- Verify proper `Htmx` class usage
+- Check swap strategies and targeting
+- Validate accessibility (aria-live, focus management)
+- Assess progressive enhancement (works without JS)
+- Identify missing `onlyMainContent()` or route options
+- Check for common mistakes and anti-patterns
+
+## When to Use
+
+- After implementing HTMX features
+- Before code review/merge
+- When HTMX isn't working as expected
+- NOT for: Finding AJAX to migrate (use ajax-analyzer)
+- NOT for: Choosing patterns (use htmx-recommender)
+
+## Scope
+
+**IMPORTANT**: Only validate paths provided by user OR `modules/custom/`. Never scan contrib or core.
+
+## Process
+
+1. **Confirm scope** with user if not specified
+2. **Scan for HTMX usage**:
+   - `Grep` for `new Htmx()` in PHP files
+   - `Grep` for `data-hx-` attributes
+   - `Grep` for `HtmxRequestInfoTrait`
+3. **Read identified files** to analyze
+4. **Check each implementation** against checklist
+5. **Generate report** with findings and recommendations
+
+## Validation Checklist
+
+### Required Checks
+
+- [ ] **Htmx class used** (not raw `data-hx-` attributes)
+- [ ] **`onlyMainContent()` called** for partial responses
+- [ ] **Proper swap strategy** for use case
+- [ ] **Target selector exists** in DOM
+- [ ] **Select selector matches** response content
+
+### Best Practice Checks
+
+- [ ] **OOB used** for multiple element updates
+- [ ] **`getHtmxTriggerName()`** for conditional logic
+- [ ] **Route has `_htmx_route`** or uses `onlyMainContent()`
+- [ ] **No raw attribute strings** in PHP
+
+### Accessibility Checks
+
+- [ ] **`aria-live` regions** for dynamic content areas
+- [ ] **Focus management** considered
+- [ ] **Screen reader announcements** via `triggerHeader()` if needed
+- [ ] **Loading indicators** for slow operations
+
+### Progressive Enhancement Checks
+
+- [ ] **Form works without JavaScript**
+- [ ] **Semantic HTML structure**
+- [ ] **Fallback for non-JS users**
+
+## Output Format
+
+```markdown
+## HTMX Validation Report: [module-name]
+
+### Summary
+- Files checked: X
+- Issues found: X
+- Passed checks: X
+
+### Issues
+
+#### Critical
+
+**[filename.php:line]**
+- Issue: Missing `onlyMainContent()` - full page returned
+- Fix: Add `->onlyMainContent()` to Htmx chain
+
+#### Warnings
+
+**[filename.php:line]**
+- Issue: No `aria-live` on dynamic region
+- Fix: Add `'aria-live' => 'polite'` to container attributes
+
+#### Suggestions
+
+**[filename.php:line]**
+- Suggestion: Consider `pushUrlHeader()` for bookmarkable state
+
+### Passed Checks
+- [x] Htmx class used properly
+- [x] Swap strategies appropriate
+- [x] Trigger detection implemented
+```
+
+## Common Issues
+
+| Issue | Severity | Fix |
+|-------|----------|-----|
+| Missing `onlyMainContent()` | Critical | Add to Htmx chain |
+| Raw `data-hx-*` attributes | Warning | Use Htmx class |
+| Missing target element | Critical | Verify selector |
+| No OOB for multiple updates | Warning | Add `swapOob()` |
+| Missing accessibility | Warning | Add `aria-live` |
+| No progressive enhancement | Info | Consider fallback |
+
+## Anti-Patterns to Flag
+
+1. **Mixing AJAX and HTMX** on same element
+2. **Hardcoded URLs** instead of `Url::fromRoute()`
+3. **Missing error handling** for failed requests
+4. **Overusing OOB** when single swap would work
+5. **Not using trigger detection** in buildForm

--- a/drupal-htmx/commands/htmx-analyze.md
+++ b/drupal-htmx/commands/htmx-analyze.md
@@ -1,0 +1,74 @@
+---
+description: Analyze Drupal module for AJAX patterns and identify HTMX migration candidates
+allowed-tools: Read, Glob, Grep, Task
+argument-hint: <module-path>
+---
+
+# Analyze AJAX Patterns
+
+Scan a Drupal module for AJAX usage and generate a migration report.
+
+## Usage
+
+`/htmx-analyze <module-path>`
+
+## Parameters
+
+- `$1` - **Required**. Path to module (e.g., `modules/custom/my_module`)
+
+## Steps
+
+1. **Validate path exists**
+   - If missing, prompt user for path
+
+2. **Invoke ajax-analyzer agent**
+   - Use Task tool with `subagent_type: "drupal-htmx:ajax-analyzer"`
+   - Pass the module path
+
+3. **Present results**
+   - Show summary of patterns found
+   - List migration candidates by complexity
+   - Suggest next steps
+
+## Example
+
+```
+/htmx-analyze modules/custom/my_module
+```
+
+## Agent Invocation
+
+```
+Use the Task tool to invoke the ajax-analyzer agent:
+- subagent_type: "drupal-htmx:ajax-analyzer"
+- prompt: "Analyze [module-path] for AJAX patterns and generate migration report"
+```
+
+## Expected Output
+
+```markdown
+## AJAX Analysis Report: my_module
+
+### Summary
+- Files with AJAX: 3
+- Total patterns: 5
+- Simple: 3
+- Medium: 1
+- Complex: 1
+
+### Migration Candidates
+
+#### Simple (Start Here)
+1. `src/Form/MyForm.php:45` - Dependent dropdown
+2. `src/Form/MyForm.php:89` - Real-time validation
+3. `src/Controller/MyController.php:123` - Content load button
+
+#### Medium
+1. `src/Form/WizardForm.php:67` - Multi-step with URL
+
+#### Complex (Evaluate)
+1. `src/Controller/DialogController.php:34` - Modal dialog
+
+### Next Steps
+- Run `/htmx-migrate src/Form/MyForm.php` for guided migration
+```

--- a/drupal-htmx/commands/htmx-migrate.md
+++ b/drupal-htmx/commands/htmx-migrate.md
@@ -1,0 +1,102 @@
+---
+description: Guide migration of a specific AJAX pattern to HTMX with step-by-step instructions
+allowed-tools: Read, Edit, Glob, Grep
+argument-hint: <file-path> [pattern-type]
+---
+
+# Migrate AJAX to HTMX
+
+Guided migration of an AJAX pattern to HTMX.
+
+## Usage
+
+`/htmx-migrate <file-path> [pattern-type]`
+
+## Parameters
+
+- `$1` - **Required**. File path containing AJAX pattern
+- `$2` - Pattern type (optional). Auto-detected if not provided.
+  - `dropdown` - Dependent dropdown
+  - `cascade` - Cascading selects
+  - `button` - Button-triggered content
+  - `wizard` - Multi-step form
+  - `validation` - Real-time validation
+  - `loadmore` - Load more / infinite scroll
+  - `fields` - Dynamic field addition
+
+## Steps
+
+1. **Read the file** to understand current AJAX implementation
+
+2. **Identify pattern type**:
+   - If provided, use specified type
+   - Otherwise, analyze code to determine pattern
+
+3. **Show current implementation**:
+   - Highlight the AJAX-specific code
+   - Explain what it does
+
+4. **Show HTMX equivalent**:
+   - Reference `references/migration-patterns.md`
+   - Present the converted code
+
+5. **Guide migration**:
+   - Step 1: Remove `#ajax` property
+   - Step 2: Add `Htmx` class configuration
+   - Step 3: Move callback logic to `buildForm()` (if applicable)
+   - Step 4: Add trigger detection with `getHtmxTriggerName()`
+   - Step 5: Update route if needed
+
+6. **Verify changes**:
+   - Run `/htmx-validate` on the file
+
+## Example
+
+```
+/htmx-migrate modules/custom/my_module/src/Form/MyForm.php dropdown
+```
+
+## Migration Workflow
+
+```markdown
+## Migrating: MyForm.php
+
+### Current AJAX Pattern
+```php
+$form['category'] = [
+  '#type' => 'select',
+  '#ajax' => [
+    'callback' => '::categoryCallback',
+    'wrapper' => 'subcategory-wrapper',
+  ],
+];
+```
+
+### HTMX Equivalent
+```php
+$form['category'] = ['#type' => 'select'];
+
+(new Htmx())
+  ->post(Url::fromRoute('<current>'))
+  ->onlyMainContent()
+  ->select('#edit-subcategory--wrapper')
+  ->target('#edit-subcategory--wrapper')
+  ->swap('outerHTML')
+  ->applyTo($form['category']);
+```
+
+### Migration Steps
+1. [ ] Remove `#ajax` from `$form['category']`
+2. [ ] Add `use Drupal\Core\Htmx\Htmx;`
+3. [ ] Add Htmx configuration after element
+4. [ ] Move callback logic to buildForm()
+5. [ ] Delete unused callback method
+
+### Ready to Apply?
+```
+
+## Notes
+
+- Always backup before migrating
+- Test without JavaScript after migration
+- Run `/htmx-validate` to check result

--- a/drupal-htmx/commands/htmx-pattern.md
+++ b/drupal-htmx/commands/htmx-pattern.md
@@ -1,0 +1,122 @@
+---
+description: Get HTMX pattern recommendation for a specific use case in Drupal
+allowed-tools: Read, Glob, Task
+argument-hint: <use-case>
+---
+
+# Pattern Recommendation
+
+Get the recommended HTMX pattern for a use case.
+
+## Usage
+
+`/htmx-pattern <use-case>`
+
+## Parameters
+
+- `$ARGUMENTS` - Use case description. Examples:
+  - `dependent dropdown`
+  - `infinite scroll`
+  - `real-time validation`
+  - `multi-step wizard`
+  - `load more button`
+  - `cascading selects`
+  - `modal content`
+  - `dynamic field addition`
+
+## Steps
+
+1. **Parse use case** from arguments
+
+2. **Invoke htmx-recommender agent**
+   - Use Task tool with `subagent_type: "drupal-htmx:htmx-recommender"`
+   - Pass the use case
+
+3. **Present recommendation**:
+   - Pattern name and description
+   - Code example with Htmx class
+   - Key configuration options
+   - Considerations and edge cases
+
+## Example
+
+```
+/htmx-pattern dependent dropdown
+```
+
+## Agent Invocation
+
+```
+Use the Task tool to invoke the htmx-recommender agent:
+- subagent_type: "drupal-htmx:htmx-recommender"
+- prompt: "Recommend HTMX pattern for: [use-case]"
+```
+
+## Expected Output
+
+```markdown
+## Recommended Pattern: Dependent Dropdown
+
+### Description
+Updates a secondary select field based on the value of a primary select.
+Classic use case: Category → Subcategory.
+
+### Implementation
+
+```php
+public function buildForm(array $form, FormStateInterface $form_state) {
+  $form_url = Url::fromRoute('<current>');
+
+  $form['category'] = [
+    '#type' => 'select',
+    '#title' => $this->t('Category'),
+    '#options' => $this->getCategories(),
+  ];
+
+  (new Htmx())
+    ->post($form_url)
+    ->onlyMainContent()
+    ->select('#edit-subcategory--wrapper')
+    ->target('#edit-subcategory--wrapper')
+    ->swap('outerHTML')
+    ->applyTo($form['category']);
+
+  $category = $form_state->getValue('category');
+  $form['subcategory'] = [
+    '#type' => 'select',
+    '#title' => $this->t('Subcategory'),
+    '#options' => $category ? $this->getSubcategories($category) : [],
+  ];
+
+  return $form;
+}
+```
+
+### Key Methods
+- `post()` - Submit form data
+- `onlyMainContent()` - Minimal response
+- `select()` - Extract specific element from response
+- `target()` - Where to swap
+- `swap('outerHTML')` - Replace entire wrapper
+
+### Considerations
+- Wrapper ID format: `#edit-[field-name]--wrapper`
+- No callback method needed - logic stays in buildForm()
+- Use `getHtmxTriggerName()` for conditional logic
+
+### Reference
+- Core example: `core/modules/config/src/Form/ConfigSingleExportForm.php`
+```
+
+## Common Use Cases
+
+| Use Case | Pattern |
+|----------|---------|
+| dependent dropdown | Form partial update |
+| cascading selects | Chained updates with OOB |
+| real-time validation | Blur trigger validation |
+| load more | Append with beforeend |
+| infinite scroll | Revealed trigger |
+| multi-step wizard | URL-based steps |
+| modal content | Target modal container |
+| dynamic fields | vals() with count |

--- a/drupal-htmx/commands/htmx-validate.md
+++ b/drupal-htmx/commands/htmx-validate.md
@@ -1,0 +1,103 @@
+---
+description: Validate HTMX implementation in Drupal module against best practices
+allowed-tools: Read, Glob, Grep, Task
+argument-hint: <module-path>
+---
+
+# Validate HTMX Implementation
+
+Check HTMX code for issues, best practices, and accessibility.
+
+## Usage
+
+`/htmx-validate <module-path>`
+
+## Parameters
+
+- `$1` - **Required**. Path to module (e.g., `modules/custom/my_module`)
+
+## Steps
+
+1. **Validate path exists**
+   - If missing, prompt user for path
+
+2. **Invoke htmx-validator agent**
+   - Use Task tool with `subagent_type: "drupal-htmx:htmx-validator"`
+   - Pass the module path
+
+3. **Present results**:
+   - Summary of checks
+   - Issues found (critical, warnings, suggestions)
+   - Passed checks
+   - Recommendations
+
+## Example
+
+```
+/htmx-validate modules/custom/my_module
+```
+
+## Agent Invocation
+
+```
+Use the Task tool to invoke the htmx-validator agent:
+- subagent_type: "drupal-htmx:htmx-validator"
+- prompt: "Validate HTMX implementation in [module-path]"
+```
+
+## Expected Output
+
+```markdown
+## HTMX Validation Report: my_module
+
+### Summary
+- Files checked: 4
+- Issues found: 2
+- Passed checks: 8
+
+### Issues
+
+#### Critical (Must Fix)
+
+**src/Form/MyForm.php:67**
+- Issue: Missing `onlyMainContent()` - full page HTML returned
+- Fix: Add `->onlyMainContent()` to the Htmx chain
+- Impact: Large response size, potential display issues
+
+#### Warnings (Should Fix)
+
+**src/Form/MyForm.php:89**
+- Issue: No `aria-live` attribute on dynamic region
+- Fix: Add `'#attributes' => ['aria-live' => 'polite']` to container
+- Impact: Screen readers won't announce changes
+
+### Suggestions
+
+**src/Form/WizardForm.php:45**
+- Suggestion: Consider using `pushUrlHeader()` for bookmarkable wizard steps
+- Benefit: Users can bookmark/share specific steps
+
+### Passed Checks
+- [x] Htmx class used (not raw attributes)
+- [x] Proper swap strategies
+- [x] Target selectors valid
+- [x] Trigger detection implemented
+- [x] Progressive enhancement possible
+- [x] Route configuration correct
+- [x] Form works without JavaScript
+- [x] No mixed AJAX/HTMX on same elements
+
+### Recommendations
+1. Fix critical issue in MyForm.php first
+2. Add accessibility improvements
+3. Consider URL state for wizard
+```
+
+## Validation Categories
+
+| Category | Checks |
+|----------|--------|
+| Critical | Missing onlyMainContent, invalid selectors, broken swaps |
+| Warnings | Missing accessibility, suboptimal patterns |
+| Suggestions | Performance improvements, UX enhancements |
+| Passed | Correct usage, best practices followed |

--- a/drupal-htmx/commands/htmx.md
+++ b/drupal-htmx/commands/htmx.md
@@ -1,0 +1,68 @@
+---
+description: Show HTMX development status and suggest next actions for a Drupal module
+allowed-tools: Read, Glob, Grep
+argument-hint: [module-path]
+---
+
+# HTMX Status
+
+Show current HTMX/AJAX usage and suggest next actions.
+
+## Usage
+
+`/htmx [module-path]`
+
+## Parameters
+
+- `$1` - Module path (optional). Defaults to `modules/custom/`
+
+## Steps
+
+1. If module path provided:
+   - Quick scan for AJAX patterns (`#ajax`, `AjaxResponse`)
+   - Quick scan for HTMX usage (`new Htmx()`, `HtmxRequestInfoTrait`)
+   - Summarize findings
+   - Suggest appropriate next command
+
+2. If no path provided:
+   - Show available commands
+   - Explain when to use each
+
+## Output
+
+### With Module Path
+
+```markdown
+## HTMX Status: [module-name]
+
+### Current State
+- AJAX patterns found: X
+- HTMX implementations: X
+
+### Suggested Actions
+- [Based on findings]
+
+### Available Commands
+- `/htmx-analyze [path]` - Full AJAX analysis
+- `/htmx-migrate [file]` - Migrate specific pattern
+- `/htmx-pattern [use-case]` - Get pattern recommendation
+- `/htmx-validate [path]` - Validate HTMX code
+```
+
+### Without Module Path
+
+```markdown
+## HTMX Development Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/htmx [path]` | Quick status scan |
+| `/htmx-analyze <path>` | Analyze AJAX for migration |
+| `/htmx-migrate <file>` | Guided migration |
+| `/htmx-pattern <use-case>` | Pattern recommendation |
+| `/htmx-validate <path>` | Validate implementation |
+
+### Getting Started
+1. Run `/htmx-analyze modules/custom/my_module` to find migration candidates
+2. Run `/htmx-pattern dependent dropdown` for new implementations
+```

--- a/drupal-htmx/skills/htmx-development/SKILL.md
+++ b/drupal-htmx/skills/htmx-development/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: htmx-development
+description: Use when developing HTMX features in Drupal 11.3+ or migrating AJAX to HTMX. Covers Htmx class usage, form patterns, migration strategies, and validation. Triggers on "htmx", "ajax to htmx", "dynamic form", "dependent dropdown".
+---
+
+# HTMX Development
+
+Drupal 11.3+ HTMX implementation and AJAX migration guidance.
+
+## When to Use
+
+- Implementing dynamic content updates in Drupal
+- Building forms with dependent fields
+- Migrating existing AJAX to HTMX
+- Adding infinite scroll, load more, real-time validation
+- NOT for: Traditional AJAX maintenance (use ajax-reference.md)
+
+## Decision: HTMX vs AJAX
+
+| Choose HTMX | Choose AJAX |
+|-------------|-------------|
+| New features | Existing AJAX code |
+| Declarative HTML preferred | Complex command sequences |
+| Returns HTML fragments | Dialog commands needed |
+| Progressive enhancement needed | Contrib expects AJAX |
+
+**Hybrid OK**: Both systems coexist. Migrate incrementally.
+
+## Quick Start
+
+### 1. Basic HTMX Element
+
+```php
+use Drupal\Core\Htmx\Htmx;
+use Drupal\Core\Url;
+
+$build['button'] = [
+  '#type' => 'button',
+  '#value' => t('Load'),
+];
+
+(new Htmx())
+  ->get(Url::fromRoute('my.content'))
+  ->onlyMainContent()
+  ->target('#result')
+  ->swap('innerHTML')
+  ->applyTo($build['button']);
+```
+
+### 2. Controller Returns Render Array
+
+```php
+public function content() {
+  return ['#markup' => '<p>Content loaded</p>'];
+}
+```
+
+### 3. Route (Optional HTMX-Only)
+
+```yaml
+my.content:
+  path: '/my/content'
+  options:
+    _htmx_route: TRUE  # Always minimal response
+```
+
+## Core Patterns
+
+### Pattern Selection
+
+| Use Case | Pattern | Key Methods |
+|----------|---------|-------------|
+| Dependent dropdown | Form partial update | `select()`, `target()`, `swap('outerHTML')` |
+| Load more | Append content | `swap('beforeend')`, `trigger('click')` |
+| Infinite scroll | Auto-load | `swap('beforeend')`, `trigger('revealed')` |
+| Real-time validation | Blur check | `trigger('focusout')`, field update |
+| Multi-step wizard | URL-based steps | `pushUrl()`, route parameters |
+| Multiple updates | OOB swap | `swapOob('outerHTML:#selector')` |
+
+### Dependent Dropdown
+
+```php
+public function buildForm(array $form, FormStateInterface $form_state) {
+  $form['category'] = ['#type' => 'select', '#options' => $this->getCategories()];
+
+  (new Htmx())
+    ->post(Url::fromRoute('<current>'))
+    ->onlyMainContent()
+    ->select('#edit-subcategory--wrapper')
+    ->target('#edit-subcategory--wrapper')
+    ->swap('outerHTML')
+    ->applyTo($form['category']);
+
+  $form['subcategory'] = ['#type' => 'select', '#options' => []];
+
+  // Handle trigger
+  if ($this->getHtmxTriggerName() === 'category') {
+    $form['subcategory']['#options'] = $this->getSubcategories(
+      $form_state->getValue('category')
+    );
+  }
+
+  return $form;
+}
+```
+
+Reference: `core/modules/config/src/Form/ConfigSingleExportForm.php`
+
+### Multiple Element Updates
+
+```php
+// Primary element updates via target
+// Secondary element updates via OOB
+(new Htmx())
+  ->swapOob('outerHTML:[data-secondary]')
+  ->applyTo($form['secondary'], '#wrapper_attributes');
+```
+
+### URL History
+
+```php
+(new Htmx())
+  ->pushUrlHeader(Url::fromRoute('my.route', $params))
+  ->applyTo($form);
+```
+
+## Htmx Class Reference
+
+### Request Methods
+- `get(Url)` / `post(Url)` / `put(Url)` / `patch(Url)` / `delete(Url)`
+
+### Control Methods
+- `target(selector)` - Where to swap
+- `select(selector)` - What to extract from response
+- `swap(strategy)` - How to swap (outerHTML, innerHTML, beforeend, etc.)
+- `swapOob(selector)` - Out-of-band updates
+- `trigger(event)` - When to trigger
+- `vals(array)` - Additional values
+- `onlyMainContent()` - Minimal response
+
+### Response Headers
+- `pushUrlHeader(Url)` - Update browser URL
+- `redirectHeader(Url)` - Full redirect
+- `triggerHeader(event)` - Fire client event
+- `reswapHeader(strategy)` - Change swap
+- `retargetHeader(selector)` - Change target
+
+See: `references/quick-reference.md` for complete tables
+
+## Detecting HTMX Requests
+
+In forms (trait included automatically):
+
+```php
+if ($this->isHtmxRequest()) {
+  $trigger = $this->getHtmxTriggerName();
+}
+```
+
+In controllers (add trait):
+
+```php
+use Drupal\Core\Htmx\HtmxRequestInfoTrait;
+
+class MyController extends ControllerBase {
+  use HtmxRequestInfoTrait;
+  protected function getRequest() { return \Drupal::request(); }
+}
+```
+
+## Migration from AJAX
+
+### Quick Conversion
+
+| AJAX | HTMX |
+|------|------|
+| `'#ajax' => ['callback' => '::cb']` | `(new Htmx())->post()->applyTo()` |
+| `'wrapper' => 'id'` | `->target('#id')` |
+| `return $form['element']` | Logic in `buildForm()` |
+| `new AjaxResponse()` | Return render array |
+| `ReplaceCommand` | `->swap('outerHTML')` |
+| `HtmlCommand` | `->swap('innerHTML')` |
+| `AppendCommand` | `->swap('beforeend')` |
+| `MessageCommand` | Auto-included |
+
+### Migration Steps
+
+1. Identify `#ajax` properties
+2. Replace with `Htmx` class
+3. Move callback logic to `buildForm()`
+4. Use `getHtmxTriggerName()` for conditional logic
+5. Replace `AjaxResponse` with render arrays
+6. Test progressive enhancement
+
+See: `references/migration-patterns.md` for detailed examples
+
+## Validation Checklist
+
+When reviewing HTMX implementations:
+
+- [ ] `Htmx` class used (not raw attributes)
+- [ ] `onlyMainContent()` for minimal response
+- [ ] Proper swap strategy selected
+- [ ] OOB used for multiple updates
+- [ ] Trigger element detection works
+- [ ] Works without JavaScript (progressive)
+- [ ] Accessibility: `aria-live` for dynamic regions
+- [ ] URL updates for bookmarkable states
+
+## Common Issues
+
+| Problem | Solution |
+|---------|----------|
+| Content not swapping | Check `target()` selector exists |
+| Wrong content extracted | Check `select()` selector |
+| JS not running | Verify `htmx:drupal:load` fires |
+| Form not submitting | Check `post()` and URL |
+| Multiple swaps fail | Add `swapOob('true')` to elements |
+| History broken | Use `pushUrlHeader()` |
+
+## References
+
+- `references/quick-reference.md` - Command equivalents, method tables
+- `references/htmx-implementation.md` - Full Htmx class API, detection, JS
+- `references/migration-patterns.md` - 7 patterns with before/after code
+- `references/ajax-reference.md` - AJAX commands for understanding existing code
+
+## Key Files in Drupal Core
+
+- `core/lib/Drupal/Core/Htmx/Htmx.php` - Main API
+- `core/lib/Drupal/Core/Htmx/HtmxRequestInfoTrait.php` - Request detection
+- `core/lib/Drupal/Core/Render/MainContent/HtmxRenderer.php` - Response renderer
+- `core/modules/config/src/Form/ConfigSingleExportForm.php` - Production example
+- `core/modules/system/tests/modules/test_htmx/` - Test examples

--- a/drupal-htmx/skills/htmx-development/references/ajax-reference.md
+++ b/drupal-htmx/skills/htmx-development/references/ajax-reference.md
@@ -1,0 +1,237 @@
+# AJAX Reference
+
+Drupal AJAX system reference for understanding existing patterns before migration.
+
+## AJAX Configuration
+
+### Form Element AJAX Settings
+
+```php
+$form['element'] = [
+  '#type' => 'select',
+  '#ajax' => [
+    'callback' => '::ajaxCallback',      // Required: PHP callback
+    'wrapper' => 'target-wrapper',        // Target element ID
+    'method' => 'replaceWith',            // jQuery method
+    'effect' => 'fade',                   // Animation
+    'event' => 'change',                  // Trigger event
+    'progress' => [
+      'type' => 'throbber',               // throbber, bar, fullscreen
+      'message' => t('Loading...'),
+    ],
+  ],
+];
+```
+
+### Common #ajax Properties
+
+| Property | Purpose | Values |
+|----------|---------|--------|
+| `callback` | PHP method | `'::method'` or `[class, 'method']` |
+| `wrapper` | Target ID | HTML ID without `#` |
+| `method` | Insert method | `replaceWith`, `html`, `append`, `prepend`, `before`, `after` |
+| `event` | Trigger event | `change`, `click`, `keyup`, `focusout` |
+| `effect` | Animation | `fade`, `slide`, `none` |
+| `progress` | Indicator | `['type' => 'throbber']` |
+
+## AJAX Commands
+
+### Content Manipulation
+
+| Command | Purpose | HTMX Equivalent |
+|---------|---------|-----------------|
+| `ReplaceCommand('#sel', $content)` | Replace element | `swap('outerHTML')` |
+| `HtmlCommand('#sel', $content)` | Replace inner HTML | `swap('innerHTML')` |
+| `AppendCommand('#sel', $content)` | Append inside | `swap('beforeend')` |
+| `PrependCommand('#sel', $content)` | Prepend inside | `swap('afterbegin')` |
+| `BeforeCommand('#sel', $content)` | Insert before | `swap('beforebegin')` |
+| `AfterCommand('#sel', $content)` | Insert after | `swap('afterend')` |
+| `RemoveCommand('#sel')` | Remove element | Empty + `swap('outerHTML')` |
+| `InsertCommand('#sel', $content)` | Generic insert | Various swaps |
+
+### CSS and Styling
+
+| Command | Purpose | Notes |
+|---------|---------|-------|
+| `CssCommand('#sel', ['prop' => 'val'])` | Set CSS | No direct HTMX equivalent |
+| `AddCssCommand($library)` | Add CSS | Auto-handled by HTMX |
+| `InvokeCommand('#sel', 'method', $args)` | jQuery method | Use JS events |
+
+### Dialog Commands
+
+| Command | Purpose |
+|---------|---------|
+| `OpenModalDialogCommand($title, $content, $opts)` | Open modal |
+| `OpenDialogCommand('#sel', $title, $content)` | Open dialog |
+| `OpenOffCanvasDialogCommand($title, $content)` | Slide-in panel |
+| `CloseModalDialogCommand()` | Close modal |
+| `CloseDialogCommand('#sel')` | Close specific dialog |
+| `SetDialogOptionCommand('#sel', 'option', $val)` | Modify dialog |
+| `SetDialogTitleCommand('#sel', $title)` | Update title |
+
+### Feedback Commands
+
+| Command | Purpose | HTMX Equivalent |
+|---------|---------|-----------------|
+| `MessageCommand($msg, null, ['type' => 'status'])` | Status message | Auto-included |
+| `AnnounceCommand($text, 'polite')` | Screen reader | `triggerHeader()` + JS |
+| `AlertCommand($msg)` | Browser alert | `triggerHeader()` + JS |
+| `ScrollTopCommand('#sel')` | Scroll to element | CSS/JS |
+
+### Navigation Commands
+
+| Command | Purpose | HTMX Equivalent |
+|---------|---------|-----------------|
+| `RedirectCommand($url)` | Redirect | `redirectHeader(Url)` |
+
+### State Commands
+
+| Command | Purpose |
+|---------|---------|
+| `ChangedCommand('#el', '#asterisk')` | Mark changed |
+| `UpdateBuildIdCommand($old, $new)` | Update form token |
+| `RestripeCommand('#table')` | Re-stripe table |
+| `SettingsCommand($settings, true)` | Update drupalSettings |
+| `FocusFirstCommand('#wrapper')` | Focus first tabbable |
+
+## Callback Patterns
+
+### Return Render Array
+```php
+public function callback(array &$form, FormStateInterface $form_state) {
+  return $form['subcategory'];
+}
+```
+
+### Return AjaxResponse
+```php
+public function callback(array &$form, FormStateInterface $form_state) {
+  $response = new AjaxResponse();
+  $response->addCommand(new ReplaceCommand('#target', $content));
+  $response->addCommand(new MessageCommand('Updated!'));
+  return $response;
+}
+```
+
+### Handling Errors
+```php
+public function callback(array &$form, FormStateInterface $form_state) {
+  if ($form_state->hasAnyErrors()) {
+    return $form; // Return entire form to show errors
+  }
+  return $form['result'];
+}
+```
+
+## Security
+
+### CSRF Protection
+Drupal automatically handles AJAX CSRF via `X-Drupal-Ajax-Token` header.
+
+### Route-Level Access
+```yaml
+my_module.ajax:
+  path: '/ajax/endpoint'
+  requirements:
+    _permission: 'access content'
+    _csrf_token: 'TRUE'
+```
+
+### Callback Access Check
+```php
+public function callback(...) {
+  if (!$this->currentUser->hasPermission('edit content')) {
+    $response = new AjaxResponse();
+    $response->addCommand(new AlertCommand('Access denied'));
+    return $response;
+  }
+}
+```
+
+### Input Sanitization
+```php
+$sanitized = Html::escape($form_state->getValue('field'));
+```
+
+## JavaScript API
+
+### Creating AJAX Instance
+```javascript
+var ajax = Drupal.ajax({
+  url: '/my/endpoint',
+  event: 'click',
+  selector: '#button',
+  wrapper: 'result',
+  submit: { extraKey: 'value' },
+});
+ajax.execute();
+```
+
+### Lifecycle Hooks
+```javascript
+var ajax = Drupal.ajax['element-id'];
+ajax.beforeSerialize = function(element, options) { /* ... */ };
+ajax.beforeSubmit = function(formValues, element, options) { /* ... */ };
+ajax.success = function(response, status) { /* ... */ };
+ajax.error = function(xhr, uri, message) { /* ... */ };
+```
+
+### Custom Command Handler
+```javascript
+Drupal.AjaxCommands.prototype.myCommand = function(ajax, response, status) {
+  // response contains data from command's render() method
+  console.log(response.data);
+};
+```
+
+## Detecting AJAX Requests
+
+### In Controller
+```php
+if ($request->isXmlHttpRequest()) {
+  return new AjaxResponse();
+}
+```
+
+### Using AjaxHelperTrait
+```php
+use Drupal\Core\Ajax\AjaxHelperTrait;
+
+class MyController extends ControllerBase {
+  use AjaxHelperTrait;
+
+  public function content() {
+    if ($this->isAjax()) {
+      return new AjaxResponse();
+    }
+  }
+}
+```
+
+## Common Patterns to Migrate
+
+### Pattern Recognition
+
+| If You See | It's | Migration |
+|------------|------|-----------|
+| `'#ajax' => [...]` | Form AJAX | Use `Htmx` class |
+| `new AjaxResponse()` | Command response | Return render array |
+| `::callback` method | AJAX callback | Logic in `buildForm()` |
+| `ReplaceCommand` | Content replace | `swap('outerHTML')` |
+| `HtmlCommand` | Inner HTML | `swap('innerHTML')` |
+| `AppendCommand` | Append | `swap('beforeend')` |
+| `MessageCommand` | Status message | Auto-included |
+| `'wrapper' => 'id'` | Target ID | `target('#id')` |
+| `'event' => 'change'` | Trigger | Default for select |
+| `'event' => 'focusout'` | Blur trigger | `trigger('focusout')` |
+
+### Complexity Assessment
+
+| Pattern | Complexity | Notes |
+|---------|------------|-------|
+| Single element update | Simple | Direct conversion |
+| Dependent dropdowns | Simple | Use `select()` + `target()` |
+| Multiple element updates | Medium | Use `swapOob()` |
+| Custom commands | Medium | Use `triggerHeader()` + JS |
+| Dialog integration | Complex | May keep AJAX |
+| Heavy JS processing | Complex | Evaluate case-by-case |

--- a/drupal-htmx/skills/htmx-development/references/htmx-implementation.md
+++ b/drupal-htmx/skills/htmx-development/references/htmx-implementation.md
@@ -1,0 +1,277 @@
+# HTMX Implementation Guide
+
+Drupal 11.3+ native HTMX support reference.
+
+## Core Architecture
+
+### Key Files
+- `core/lib/Drupal/Core/Htmx/Htmx.php` - Main API (30+ attribute methods, 11 header methods)
+- `core/lib/Drupal/Core/Htmx/HtmxRequestInfoTrait.php` - Request detection (8 methods)
+- `core/lib/Drupal/Core/Render/MainContent/HtmxRenderer.php` - Minimal HTML renderer
+- `core/misc/htmx/htmx-assets.js` - Asset loading, settings merging
+- `core/misc/htmx/htmx-behaviors.js` - Drupal behaviors integration
+
+### Request/Response Flow
+1. User interacts with HTMX element
+2. JS adds `_wrapper_format`, `ajax_page_state`, triggering element
+3. Server routes to controller/form, detects HTMX request
+4. Controller returns render array with HTMX headers
+5. HtmxRenderer creates minimal HTML response
+6. JS loads new CSS/JS assets
+7. HTMX swaps content
+8. Drupal behaviors attach (`htmx:drupal:load`)
+
+## The Htmx Class
+
+### Basic Usage
+```php
+use Drupal\Core\Htmx\Htmx;
+use Drupal\Core\Url;
+
+$htmx = new Htmx();
+$htmx->post(Url::fromRoute('my.route'))
+  ->onlyMainContent()
+  ->target('#result')
+  ->swap('innerHTML')
+  ->applyTo($element);
+```
+
+### Request Attributes
+
+```php
+$htmx->get(Url::fromRoute('my.get'));     // GET request
+$htmx->post(Url::fromRoute('my.post'));   // POST request
+$htmx->put(Url::fromRoute('my.put'));     // PUT request
+$htmx->patch(Url::fromRoute('my.patch')); // PATCH request
+$htmx->delete(Url::fromRoute('my.del'));  // DELETE request
+```
+
+### Control Attributes
+
+```php
+$htmx->target('#element-id');        // Where to swap content
+$htmx->select('.content-class');     // What to extract from response
+$htmx->swap('outerHTML');            // How to swap (default ignoreTitle:true)
+$htmx->swap('beforeend', 'scroll:bottom'); // With modifiers
+$htmx->swapOob('true');              // Mark for out-of-band swap
+$htmx->swapOob('outerHTML:#other');  // OOB with selector
+$htmx->trigger('click');             // Trigger event
+$htmx->trigger(['load', 'revealed']); // Multiple triggers
+$htmx->vals(['key' => 'value']);     // Additional values as JSON
+$htmx->onlyMainContent();            // Request minimal response
+```
+
+### Response Headers
+
+```php
+$htmx->pushUrlHeader(Url::fromRoute('my.route')); // Push to history
+$htmx->replaceUrlHeader($url);        // Replace current URL
+$htmx->redirectHeader($url);          // Full page redirect
+$htmx->refreshHeader(true);           // Force page refresh
+$htmx->reswapHeader('innerHTML');     // Change swap strategy
+$htmx->retargetHeader('#new-target'); // Change target
+$htmx->reselectHeader('.new-select'); // Change content selector
+$htmx->triggerHeader('eventName');    // Fire client event
+$htmx->triggerHeader(['event' => ['data' => 'value']]); // With data
+$htmx->triggerAfterSwapHeader('event'); // After swap completes
+$htmx->triggerAfterSettleHeader('event'); // After settle
+```
+
+### Additional Attributes
+
+```php
+$htmx->boost(true);           // Progressive enhancement
+$htmx->confirm('Are you sure?'); // Confirmation dialog
+$htmx->indicator('#spinner'); // Loading indicator
+$htmx->include('#other-form'); // Include additional elements
+$htmx->pushUrl(true);         // Push URL attribute
+$htmx->preserve();            // Keep element unchanged
+$htmx->validate(true);        // Validate before submit
+$htmx->on('::afterSwap', 'myHandler()'); // Event handler
+```
+
+### Applying to Elements
+
+```php
+// Apply to #attributes
+$htmx->applyTo($form['element']);
+
+// Apply to specific attribute key
+$htmx->applyTo($form['element'], '#wrapper_attributes');
+
+// Apply headers to entire form
+$htmx->pushUrlHeader($url)->applyTo($form);
+```
+
+## Detecting HTMX Requests
+
+### In Forms (HtmxRequestInfoTrait included)
+
+```php
+class MyForm extends FormBase {
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    if ($this->isHtmxRequest()) {
+      $trigger = $this->getHtmxTriggerName();
+      if ($trigger === 'category') {
+        // Handle category change
+      }
+    }
+  }
+}
+```
+
+### In Controllers
+
+```php
+use Drupal\Core\Htmx\HtmxRequestInfoTrait;
+
+class MyController extends ControllerBase {
+  use HtmxRequestInfoTrait;
+
+  protected function getRequest() {
+    return \Drupal::request();
+  }
+
+  public function content() {
+    if ($this->isHtmxRequest()) {
+      // Return partial content
+    }
+  }
+}
+```
+
+### Available Methods
+
+| Method | Purpose |
+|--------|---------|
+| `isHtmxRequest()` | TRUE if HX-Request header present |
+| `isHtmxBoosted()` | TRUE if HX-Boosted header present |
+| `getHtmxCurrentUrl()` | Current page URL |
+| `isHtmxHistoryRestoration()` | History restore request |
+| `getHtmxPrompt()` | Prompt value if set |
+| `getHtmxTarget()` | Target element ID |
+| `getHtmxTrigger()` | Triggering element ID |
+| `getHtmxTriggerName()` | Triggering element name |
+
+## Route Configuration
+
+### HTMX-Only Route
+```yaml
+my_module.htmx_content:
+  path: '/my-module/htmx-content'
+  defaults:
+    _controller: '\Drupal\my_module\Controller\MyController::content'
+  options:
+    _htmx_route: TRUE
+```
+
+### Dual-Purpose Route
+```php
+// Use onlyMainContent() instead - adds ?_wrapper_format=drupal_htmx
+$htmx->onlyMainContent()->applyTo($element);
+```
+
+## Form Patterns
+
+### Dependent Dropdowns
+Reference: `core/modules/config/src/Form/ConfigSingleExportForm.php`
+
+```php
+public function buildForm(array $form, FormStateInterface $form_state) {
+  $form_url = Url::fromRoute('<current>');
+
+  $form['category'] = [
+    '#type' => 'select',
+    '#options' => $this->getCategories(),
+  ];
+
+  (new Htmx())
+    ->post($form_url)
+    ->onlyMainContent()
+    ->select('#edit-subcategory--wrapper')
+    ->target('#edit-subcategory--wrapper')
+    ->swap('outerHTML')
+    ->applyTo($form['category']);
+
+  $form['subcategory'] = [
+    '#type' => 'select',
+    '#options' => $this->getSubcategories($form_state->getValue('category')),
+  ];
+
+  return $form;
+}
+```
+
+### OOB Updates for Multiple Elements
+```php
+// When category changes, also clear export
+$trigger = $this->getHtmxTriggerName();
+if ($trigger === 'category') {
+  (new Htmx())
+    ->swapOob('outerHTML:[data-export-wrapper]')
+    ->applyTo($form['export'], '#wrapper_attributes');
+}
+```
+
+### Auto form_build_id Updates
+FormBuilder automatically updates form_build_id via OOB swap during HTMX requests. No action needed.
+
+Reference: `core/lib/Drupal/Core/Form/FormBuilder.php:782-790`
+
+## JavaScript Integration
+
+### Drupal Behaviors
+```javascript
+Drupal.behaviors.myBehavior = {
+  attach(context, settings) {
+    // context = HTMX-swapped element
+  },
+  detach(context, settings, trigger) {
+    // trigger = 'unload' for HTMX removals
+  }
+};
+```
+
+### HTMX Events
+```javascript
+htmx.on('htmx:beforeRequest', (e) => console.log('Request', e.detail));
+htmx.on('htmx:afterSwap', (e) => console.log('Swapped', e.detail));
+htmx.on('htmx:drupal:load', (e) => console.log('Behaviors attached'));
+```
+
+### Triggering Custom Events
+```php
+// Server-side
+$htmx->triggerHeader(['showNotification' => ['msg' => 'Saved!']]);
+
+// Client-side
+htmx.on('showNotification', (e) => alert(e.detail.msg));
+```
+
+## Best Practices
+
+### Progressive Enhancement
+- Forms should POST normally without JavaScript
+- Use semantic HTML, add HTMX attributes
+- Test with JavaScript disabled
+
+### Performance
+- Use `onlyMainContent()` for minimal responses
+- Drupal sends only new CSS/JS (via ajax_page_state)
+- Configure proper cache contexts on render arrays
+
+### Accessibility
+- Status messages auto-included via HtmxRenderer
+- Add `aria-live` regions for dynamic content
+- Use `Drupal.announce()` via trigger headers
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Attributes not working | Verify `core/drupal.htmx` library attached |
+| Content not swapping | Check target/select selectors exist |
+| JS not executing | Ensure behaviors implement `attach` |
+| Form not submitting | Verify `post()` and form URL routing |
+| Multiple swaps failing | Use `swapOob('true')` on response elements |
+| History not updating | Use `pushUrlHeader()` |

--- a/drupal-htmx/skills/htmx-development/references/migration-patterns.md
+++ b/drupal-htmx/skills/htmx-development/references/migration-patterns.md
@@ -1,0 +1,405 @@
+# Migration Patterns
+
+AJAX to HTMX migration patterns with side-by-side comparisons.
+
+## Pattern 1: Dependent Dropdown
+
+### AJAX
+```php
+$form['category'] = [
+  '#type' => 'select',
+  '#ajax' => [
+    'callback' => '::categoryCallback',
+    'wrapper' => 'subcategory-wrapper',
+  ],
+];
+
+$form['subcategory'] = [
+  '#prefix' => '<div id="subcategory-wrapper">',
+  '#suffix' => '</div>',
+];
+
+public function categoryCallback(array &$form, FormStateInterface $form_state) {
+  return $form['subcategory'];
+}
+```
+
+### HTMX
+```php
+$form['category'] = ['#type' => 'select'];
+
+(new Htmx())
+  ->post(Url::fromRoute('<current>'))
+  ->onlyMainContent()
+  ->select('#edit-subcategory--wrapper')
+  ->target('#edit-subcategory--wrapper')
+  ->swap('outerHTML')
+  ->applyTo($form['category']);
+
+$form['subcategory'] = ['#type' => 'select'];
+
+// Check trigger in buildForm - no callback needed
+$trigger = $this->getHtmxTriggerName();
+if ($trigger === 'category') {
+  $form['subcategory']['#options'] = $this->getSubcategories($form_state->getValue('category'));
+}
+```
+
+**Key Changes:**
+- No `#ajax` property → `Htmx` class
+- No callback method → logic in `buildForm()`
+- Wrapper ID → CSS selector
+- Use `getHtmxTriggerName()` for trigger detection
+
+Reference: `core/modules/config/src/Form/ConfigSingleExportForm.php`
+
+---
+
+## Pattern 2: Cascading Selects with URL Update
+
+### AJAX
+```php
+$form['type']['#ajax'] = ['callback' => '::updateName', 'wrapper' => 'name-wrapper'];
+$form['name']['#ajax'] = ['callback' => '::updateExport', 'wrapper' => 'export-wrapper'];
+
+public function updateName(...) { return $form['name']; }
+public function updateExport(...) { return $form['export']; }
+```
+
+### HTMX
+```php
+// Type updates name
+(new Htmx())
+  ->post($form_url)
+  ->onlyMainContent()
+  ->select('*:has(>select[name="name"])')
+  ->target('*:has(>select[name="name"])')
+  ->swap('outerHTML')
+  ->applyTo($form['type']);
+
+// Name updates export
+(new Htmx())
+  ->post($form_url)
+  ->onlyMainContent()
+  ->select('[data-export-wrapper]')
+  ->target('[data-export-wrapper]')
+  ->swap('outerHTML')
+  ->applyTo($form['name']);
+
+// Handle trigger and URL push
+$trigger = $this->getHtmxTriggerName();
+if ($trigger === 'type') {
+  // Also clear export via OOB
+  (new Htmx())
+    ->swapOob('outerHTML:[data-export-wrapper]')
+    ->applyTo($form['export'], '#wrapper_attributes');
+
+  $pushUrl = Url::fromRoute('my.form', ['type' => $form_state->getValue('type')]);
+}
+
+if ($pushUrl) {
+  (new Htmx())->pushUrlHeader($pushUrl)->applyTo($form);
+}
+```
+
+**Key Changes:**
+- Use `swapOob()` for multiple element updates
+- Use `pushUrlHeader()` for URL management
+- Route parameters enable bookmarkable URLs
+
+---
+
+## Pattern 3: Button-Triggered Content Load
+
+### AJAX
+```php
+// Controller
+public function loadContent() {
+  $response = new AjaxResponse();
+  $response->addCommand(new ReplaceCommand('#wrapper', $content));
+  $response->addCommand(new MessageCommand('Loaded!'));
+  return $response;
+}
+
+// Form
+$form['button'] = [
+  '#type' => 'button',
+  '#ajax' => ['callback' => '::loadCallback', 'wrapper' => 'wrapper'],
+];
+```
+
+### HTMX
+```php
+// Controller - returns render array, not AjaxResponse
+public function loadContent() {
+  return [
+    '#theme' => 'my_content',
+    '#data' => $this->getData(),
+  ];
+}
+
+// Form
+$form['button'] = [
+  '#type' => 'html_tag',
+  '#tag' => 'button',
+  '#value' => t('Load'),
+  '#attributes' => ['type' => 'button'],
+];
+
+(new Htmx())
+  ->get(Url::fromRoute('my.load'))
+  ->onlyMainContent()
+  ->target('#wrapper')
+  ->swap('innerHTML')
+  ->applyTo($form['button']);
+```
+
+**Key Changes:**
+- Controller returns render array, not `AjaxResponse`
+- No `MessageCommand` → auto-included by HtmxRenderer
+- `select()` filters response, `target()` specifies destination
+
+---
+
+## Pattern 4: Multi-Step Wizard
+
+### AJAX
+```php
+$form['next'] = [
+  '#type' => 'submit',
+  '#submit' => ['::nextStep'],
+  '#ajax' => ['callback' => '::stepCallback', 'wrapper' => 'form-wrapper'],
+];
+
+public function nextStep(...) {
+  $form_state->set('step', $step + 1);
+  $form_state->setRebuild();
+}
+public function stepCallback(...) { return $form; }
+```
+
+### HTMX
+```php
+public function buildForm(..., $step = 1) {
+  $nextUrl = Url::fromRoute('my.wizard', ['step' => $step + 1]);
+
+  $form['next'] = ['#type' => 'button', '#value' => t('Next')];
+
+  (new Htmx())
+    ->post($nextUrl)
+    ->onlyMainContent()
+    ->target('#wizard-form')
+    ->swap('outerHTML')
+    ->pushUrl($nextUrl)
+    ->applyTo($form['next']);
+
+  $form['#attributes']['id'] = 'wizard-form';
+  return $form;
+}
+```
+
+**Key Changes:**
+- Step is route parameter, not form state
+- Each step has own URL (bookmarkable, back button works)
+- No submit handlers for navigation
+
+---
+
+## Pattern 5: Real-time Validation
+
+### AJAX
+```php
+$form['email'] = [
+  '#type' => 'email',
+  '#ajax' => [
+    'callback' => '::validateEmail',
+    'wrapper' => 'email-validation',
+    'event' => 'focusout',
+    'progress' => ['type' => 'none'],
+  ],
+];
+
+public function validateEmail(...) {
+  // Build and return validation message
+  return $form['email_validation'];
+}
+```
+
+### HTMX
+```php
+$form['email'] = ['#type' => 'email'];
+
+(new Htmx())
+  ->post(Url::fromRoute('<current>'))
+  ->onlyMainContent()
+  ->trigger('focusout')
+  ->select('#email-validation')
+  ->target('#email-validation')
+  ->swap('outerHTML')
+  ->applyTo($form['email']);
+
+// In buildForm
+$trigger = $this->getHtmxTriggerName();
+if ($trigger === 'email') {
+  $email = $form_state->getValue('email');
+  $form['email_validation']['#markup'] = $this->emailExists($email)
+    ? '<span class="error">Taken</span>'
+    : '<span class="success">Available</span>';
+}
+```
+
+---
+
+## Pattern 6: Infinite Scroll / Load More
+
+### AJAX
+```php
+$form['load_more'] = [
+  '#ajax' => ['callback' => '::loadMore', 'wrapper' => 'list', 'method' => 'append'],
+];
+```
+
+### HTMX
+```php
+// Click trigger
+(new Htmx())
+  ->get(Url::fromRoute('my.items', ['page' => $nextPage]))
+  ->onlyMainContent()
+  ->select('.item-list')
+  ->target('#content-list')
+  ->swap('beforeend')
+  ->applyTo($form['load_more']);
+
+// Scroll trigger (sentinel at bottom)
+(new Htmx())
+  ->get(Url::fromRoute('my.items', ['page' => $nextPage]))
+  ->trigger('revealed')
+  ->select('.item-list')
+  ->target('#content-list')
+  ->swap('beforeend')
+  ->applyTo($form['sentinel']);
+```
+
+---
+
+## Pattern 7: Dynamic Field Addition
+
+### AJAX
+```php
+$form['add_item'] = [
+  '#type' => 'submit',
+  '#submit' => ['::addItem'],
+  '#ajax' => ['callback' => '::itemsCallback', 'wrapper' => 'items-wrapper'],
+];
+
+public function addItem(...) {
+  $form_state->set('item_count', $count + 1);
+  $form_state->setRebuild();
+}
+```
+
+### HTMX
+```php
+$item_count = $form_state->getValue('item_count', 1);
+$form['item_count'] = ['#type' => 'hidden', '#value' => $item_count];
+
+$form['add_item'] = ['#type' => 'button', '#value' => t('Add Item')];
+
+(new Htmx())
+  ->post(Url::fromRoute('<current>'))
+  ->onlyMainContent()
+  ->vals(['item_count' => $item_count + 1])
+  ->select('#items-wrapper')
+  ->target('#items-wrapper')
+  ->swap('outerHTML')
+  ->applyTo($form['add_item']);
+```
+
+**Key Changes:**
+- Use `vals()` to send incremented count
+- Hidden field tracks count instead of form state
+- No submit handler needed
+
+---
+
+## JavaScript Migration
+
+### Event Mapping
+
+| AJAX Hook | HTMX Event |
+|-----------|------------|
+| `beforeSerialize` | `htmx:configRequest` |
+| `beforeSubmit` | `htmx:beforeRequest` |
+| `success` | `htmx:afterSwap` |
+| `error` | `htmx:responseError` |
+| After behaviors | `htmx:drupal:load` |
+| Before removal | `htmx:drupal:unload` |
+
+### Custom AJAX Command → HTMX Trigger
+
+**AJAX:**
+```php
+$response->addCommand(new NotificationCommand('Hello!'));
+
+// JS
+Drupal.AjaxCommands.prototype.showNotification = function(ajax, response) {
+  alert(response.message);
+};
+```
+
+**HTMX:**
+```php
+(new Htmx())
+  ->triggerHeader(['showNotification' => ['message' => 'Hello!']])
+  ->applyTo($build);
+
+// JS
+htmx.on('showNotification', (e) => alert(e.detail.message));
+```
+
+---
+
+## When NOT to Migrate
+
+Keep AJAX for:
+- Complex command sequences
+- `CssCommand`, `InvokeCommand` for jQuery methods
+- `OpenModalDialogCommand`, `CloseDialogCommand`
+- `DataCommand` for jQuery data API
+- Contrib modules expecting AJAX callbacks
+
+### Hybrid Approach
+
+Both systems coexist. AJAX can insert HTMX-enabled content:
+
+```php
+public function ajaxCallback(...) {
+  $build = ['#type' => 'container'];
+
+  $build['htmx_button'] = ['#type' => 'button', '#value' => t('Refresh')];
+
+  (new Htmx())
+    ->get(Url::fromRoute('my.refresh'))
+    ->target('#wrapper')
+    ->applyTo($build['htmx_button']);
+
+  return $build;
+}
+```
+
+`Drupal.behaviors.htmx` ensures HTMX processes content inserted by AJAX.
+
+---
+
+## Migration Checklist
+
+- [ ] Identify all `#ajax` properties
+- [ ] Replace with `Htmx` class configuration
+- [ ] Convert callbacks to `buildForm()` logic
+- [ ] Replace `AjaxResponse` with render arrays
+- [ ] Update routes with `_htmx_route: TRUE` if needed
+- [ ] Migrate JS event handlers to HTMX events
+- [ ] Test behaviors attach/detach
+- [ ] Test browser history (back/forward)
+- [ ] Verify accessibility
+- [ ] Test with JavaScript disabled

--- a/drupal-htmx/skills/htmx-development/references/quick-reference.md
+++ b/drupal-htmx/skills/htmx-development/references/quick-reference.md
@@ -1,0 +1,140 @@
+# Quick Reference
+
+## AJAX to HTMX Command Equivalents
+
+| AJAX Command | HTMX Equivalent | Notes |
+|--------------|-----------------|-------|
+| `ReplaceCommand` | `swap('outerHTML')` | Replace entire element |
+| `HtmlCommand` | `swap('innerHTML')` | Replace inner content |
+| `AppendCommand` | `swap('beforeend')` | Append inside element |
+| `PrependCommand` | `swap('afterbegin')` | Prepend inside element |
+| `BeforeCommand` | `swap('beforebegin')` | Insert before element |
+| `AfterCommand` | `swap('afterend')` | Insert after element |
+| `RemoveCommand` | Empty + `swap('outerHTML')` | Remove element |
+| `RedirectCommand` | `redirectHeader(Url)` | Full page redirect |
+| `MessageCommand` | Auto-included | Via HtmxRenderer |
+| `SettingsCommand` | Auto-merged | Via htmx-assets.js |
+| Multiple commands | `swapOob()` | Out-of-band swaps |
+
+## Htmx Class Methods
+
+### Request Methods
+| Method | Result |
+|--------|--------|
+| `get(Url)` | `data-hx-get` |
+| `post(Url)` | `data-hx-post` |
+| `put(Url)` | `data-hx-put` |
+| `patch(Url)` | `data-hx-patch` |
+| `delete(Url)` | `data-hx-delete` |
+
+### Control Methods
+| Method | Result | Purpose |
+|--------|--------|---------|
+| `target(selector)` | `data-hx-target` | Where to swap |
+| `select(selector)` | `data-hx-select` | What to extract from response |
+| `swap(strategy)` | `data-hx-swap` | How to swap |
+| `swapOob(true\|selector)` | `data-hx-swap-oob` | Out-of-band updates |
+| `trigger(event)` | `data-hx-trigger` | When to trigger |
+| `vals(array)` | `data-hx-vals` | Additional values as JSON |
+| `onlyMainContent()` | Adds `_wrapper_format` | Minimal response |
+
+### Response Headers
+| Method | Header | Purpose |
+|--------|--------|---------|
+| `pushUrlHeader(Url)` | `HX-Push-Url` | Update browser URL |
+| `redirectHeader(Url)` | `HX-Redirect` | Full page redirect |
+| `triggerHeader(event)` | `HX-Trigger` | Fire client event |
+| `reswapHeader(strategy)` | `HX-Reswap` | Change swap strategy |
+| `retargetHeader(selector)` | `HX-Retarget` | Change target |
+
+## Swap Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `innerHTML` | Replace inner content (default) |
+| `outerHTML` | Replace entire element |
+| `beforebegin` | Insert before element |
+| `afterbegin` | Prepend inside element |
+| `beforeend` | Append inside element |
+| `afterend` | Insert after element |
+| `delete` | Remove element |
+| `none` | No swap (headers only) |
+
+## Common Patterns
+
+### Dependent Dropdown
+```php
+(new Htmx())
+  ->post($form_url)
+  ->onlyMainContent()
+  ->select('#subcategory-wrapper')
+  ->target('#subcategory-wrapper')
+  ->swap('outerHTML')
+  ->applyTo($form['category']);
+```
+
+### Load More / Infinite Scroll
+```php
+(new Htmx())
+  ->get(Url::fromRoute('my.items', ['page' => $next]))
+  ->trigger('revealed')  // or 'click'
+  ->select('.item-list')
+  ->target('#content-list')
+  ->swap('beforeend')
+  ->applyTo($element);
+```
+
+### Multiple Element Updates (OOB)
+```php
+// Primary target updates normally
+// Secondary element uses OOB
+(new Htmx())
+  ->swapOob('outerHTML:[data-export-wrapper]')
+  ->applyTo($form['export'], '#wrapper_attributes');
+```
+
+### URL History Update
+```php
+(new Htmx())
+  ->pushUrlHeader(Url::fromRoute('my.route', $params))
+  ->applyTo($form);
+```
+
+## Detection Methods (HtmxRequestInfoTrait)
+
+Available in `FormBase` and any class using the trait:
+
+| Method | Returns |
+|--------|---------|
+| `isHtmxRequest()` | TRUE if HX-Request header present |
+| `getHtmxTriggerName()` | Triggering element name |
+| `getHtmxTarget()` | Target element ID |
+| `getHtmxCurrentUrl()` | Current page URL |
+
+## Route Configuration
+
+```yaml
+# Always returns minimal HTML
+my_module.htmx_endpoint:
+  path: '/my-module/htmx-content'
+  options:
+    _htmx_route: TRUE
+```
+
+## JavaScript Events
+
+| Event | When |
+|-------|------|
+| `htmx:drupal:load` | After swap + assets loaded |
+| `htmx:drupal:unload` | Before content removal |
+| `htmx:beforeRequest` | Before AJAX request |
+| `htmx:afterSwap` | After content swapped |
+
+## Decision: HTMX vs AJAX
+
+| Use HTMX | Use AJAX |
+|----------|----------|
+| New features | Maintaining existing AJAX |
+| Declarative HTML preferred | Complex command sequences |
+| Returns HTML | Heavy JS processing |
+| Progressive enhancement important | Contrib expects AJAX callbacks |


### PR DESCRIPTION
## Summary

New plugin for Drupal 11.3+ HTMX development and AJAX-to-HTMX migration:

- **Skill**: `htmx-development` with decision-focused guidance
- **3 Agents**: ajax-analyzer, htmx-recommender, htmx-validator
- **5 Commands**: /htmx, /htmx-analyze, /htmx-migrate, /htmx-pattern, /htmx-validate
- **4 Reference files**: Condensed from source guides (4,550 → 1,293 lines, 72% reduction)

## Features

| Component | Purpose |
|-----------|---------|
| `/htmx-analyze` | Scan modules for AJAX migration candidates |
| `/htmx-migrate` | Guided step-by-step migration |
| `/htmx-pattern` | Get pattern recommendation for use case |
| `/htmx-validate` | Validate implementation against best practices |

## Source Guides

Based on three comprehensive guides:
- `drupal_htmx_implementation_guide.md` (~850 lines)
- `drupal_ajax_to_htmx_migration_guide.md` (~1,100 lines)
- `Comprehensive Drupal AJAX Usage Guide.md` (~2,600 lines)

## Test plan

- [ ] Install plugin: `/plugin install drupal-htmx@camoa-skills`
- [ ] Run `/htmx` to see available commands
- [ ] Test `/htmx-pattern dependent dropdown`
- [ ] Test agents trigger on relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)