### PR TITLE
fix: Resolve skill initialization error in plugin-creation-tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.4] - 2026-01-09
+
+### Fixed
+- **Skill initialization error**: Fixed parsing issue in SKILL.md where inline code containing special characters (backtick + exclamation mark, backtick + at-sign) was causing bash command execution errors during skill loading
+  - Changed `` `!` prefix`` to "exclamation mark"
+  - Changed `` `@` prefix`` to "at-sign"
+  - This resolves the "command not found: prefix" error on skill invocation
+
 ## [2.0.0-beta.3] - 2025-12-31
 
 ### Added

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -89,8 +89,8 @@ When user says "add command", "create command", "slash command":
 3. Key requirements:
    - Frontmatter: description, allowed-tools, argument-hint
    - Support `$ARGUMENTS`, `$1`, `$2` for arguments
-   - Use `!` prefix for bash execution
-   - Use `@` prefix for file references
+   - Prefix lines with exclamation mark for bash execution
+   - Prefix lines with at-sign for file references
 
 ## Creating Agents
 


### PR DESCRIPTION
## Summary

Fixes skill initialization error where inline code containing special characters was being incorrectly parsed as bash commands.

**Error message:**
```
Error: Bash command failed for pattern "!` prefix for bash execution - Use `": [stderr]
(eval):1: command not found: prefix
```

## Root Cause

The SKILL.md contained inline code like:
```markdown
- Use `!` prefix for bash execution
- Use `@` prefix for file references
```

The backtick + special character pattern was being interpreted as a command during skill loading.

## Fix

Changed to plain text descriptions:
```markdown
- Prefix lines with exclamation mark for bash execution
- Prefix lines with at-sign for file references
```

## Test Plan

- [ ] Invoke `/plugin-creation-tools:plugin-creation` skill
- [ ] Verify no initialization errors
- [ ] Verify skill content still provides correct guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)