### PR TITLE
feat(plugin-creation-tools): v2.1.0 - Commands, reference sync, exit beta

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,14 +25,14 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration",
-      "version": "2.0.0-beta.4",
+      "description": "Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration",
+      "version": "2.1.0",
       "author": {
         "name": "camoa"
       },
       "license": "MIT",
       "repository": "https://github.com/camoa/claude-skills",
-      "keywords": ["beta", "plugins", "skills", "commands", "agents", "hooks", "mcp", "development", "best-practices"],
+      "keywords": ["plugins", "skills", "commands", "agents", "hooks", "mcp", "development", "best-practices"],
       "strict": false
     },
     {

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "plugin-creation-tools",
-  "description": "[BETA] Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
-  "version": "2.0.0-beta.4",
+  "description": "Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
+  "version": "2.1.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["beta", "plugins", "skills", "commands", "agents", "hooks", "mcp", "development", "best-practices"]
+  "keywords": ["plugins", "skills", "commands", "agents", "hooks", "mcp", "development", "best-practices"]
 }

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-02-07
+
+### Added
+- **3 slash commands** for plugin discoverability:
+  - `commands/create.md` — create a new plugin with selected components
+  - `commands/validate.md` — validate plugin structure, frontmatter, and best practices
+  - `commands/add-component.md` — add a skill, command, agent, or hook to an existing plugin
+- **Lean documentation principle** added as 6th iron law in `core-philosophy.md`
+- **Plugin project setup guidance** in SKILL.md (`.claude/rules/`, CLAUDE.md, README/CHANGELOG placement)
+
+### Updated (references synced against comprehensive guides)
+- `writing-agents.md` — added memory field (user/project/local), model selection, disallowedTools, hooks in frontmatter
+- `agent-tools.md` — added disallowedTools, MCP tool access, expanded tool list
+- `hook-events.md` — expanded from 10 to 14 events, added MCP matcher syntax, matcher values per event
+- `writing-hooks.md` — corrected to 3 hook types (command/prompt/agent), added async hooks, MCP matchers
+- `writing-skillmd.md` — added model, context, disable-model-invocation, user-invocable, dynamic context injection, ultrathink
+- `component-comparison.md` — added CLAUDE.md and Agent Teams, context cost considerations, 6-step decision process
+- `plugin-json.md` — added mcpServers, lspServers, path substitution, installation scopes, plugin caching
+- `testing.md` — added CLI automation section (--output-format json, -p flag, session resumption, --allowedTools)
+
+### Changed
+- Exited beta — version 2.0.0-beta.4 → 2.1.0
+- Removed [BETA] prefix from plugin description
+- SKILL.md updated with guidance for new features: memory, model routing, context injection, hook handler types
+
 ## [2.0.0-beta.4] - 2026-01-09
 
 ### Fixed

--- a/plugin-creation-tools/commands/add-component.md
+++ b/plugin-creation-tools/commands/add-component.md
@@ -1,0 +1,63 @@
+---
+description: Add a skill, command, agent, or hook to an existing plugin
+allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
+argument-hint: <component-type> <name>
+---
+
+# Add Component
+
+Add a new component to an existing Claude Code plugin.
+
+## Steps
+
+1. Parse arguments: `$1` = component type, `$2` = component name
+2. If missing arguments, ask user for component type and name
+3. Find the plugin root (look for `.claude-plugin/plugin.json` in current or parent directories)
+4. Validate the component name (hyphen-case, max 64 chars)
+5. Scaffold the component from templates
+6. Guide user to complete the component
+
+## Component Types
+
+### `skill`
+1. Create `skills/$2/SKILL.md` from `templates/skill/SKILL.md.template`
+2. Create `skills/$2/references/` directory
+3. Remind: SKILL.md is instructions for Claude, not documentation
+4. Consider: `model:` field, dynamic context injection, `context: fork` for heavy ops
+
+### `command`
+1. Create `commands/$2.md` from `templates/command/command.md.template`
+2. Remind: set `allowed-tools` to minimum needed
+3. Remind: use `$ARGUMENTS`, `$1`, `$2` for argument handling
+
+### `agent`
+1. Create `agents/$2.md` from `templates/agent/agent.md.template`
+2. Remind: description must include delegation triggers ("Use proactively when...")
+3. Consider: `memory: project` for cross-session learning
+4. Consider: `model:` matched to task complexity (haiku for simple, opus for complex)
+5. Consider: `tools` restriction to minimum needed
+6. Consider: `hooks` in agent frontmatter for scoped validation
+
+### `hook`
+1. If `hooks/hooks.json` exists, add new event entry
+2. If not, create from `templates/hooks/hooks.json.template`
+3. Ask which event(s) to handle
+4. Consider all three handler types: `command`, `prompt`, `agent`
+5. For cross-platform support, use `templates/hooks/run-hook.cmd.template`
+
+### `mcp`
+1. Create or update `.mcp.json` from `templates/mcp.json.template`
+2. Guide user to configure server command and args
+
+## After Adding
+
+1. Update `.claude-plugin/plugin.json` if component paths need explicit configuration
+2. Test the new component: `claude --debug` to verify loading
+3. For skills: verify auto-trigger by asking matching questions
+4. For commands: verify `/plugin-name:command-name` works
+5. For agents: verify in `/agents` listing
+
+## Arguments
+
+- `$1`: Component type (skill, command, agent, hook, mcp)
+- `$2`: Component name (hyphen-case)

--- a/plugin-creation-tools/commands/create.md
+++ b/plugin-creation-tools/commands/create.md
@@ -1,0 +1,49 @@
+---
+description: Create a new Claude Code plugin or standalone skill with selected components
+allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
+argument-hint: <plugin-name> [--skill|--command|--agent|--hook|--mcp]
+---
+
+# Create Plugin
+
+Create a new Claude Code plugin with any combination of components.
+
+## Steps
+
+1. Parse arguments: `$1` = plugin name, remaining = component flags
+2. If no arguments, ask the user for plugin name and desired components
+3. Validate plugin name (lowercase, hyphens, max 64 chars)
+4. Ask user for target directory if not obvious from context
+5. Run the init script:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/skills/plugin-creation/scripts/init_plugin.py $1 --path <target> --components <list>
+   ```
+6. After scaffolding, load the plugin-creation skill for guidance on completing each component
+7. Read `references/02-philosophy/core-philosophy.md` for design principles
+
+## Component Selection Guide
+
+If user doesn't specify components, ask which they need:
+
+| Component | Choose when... |
+|-----------|---------------|
+| Skill | Complex workflow, auto-triggered by context, needs reference files |
+| Command | User-triggered via `/name`, quick prompts, explicit invocation |
+| Agent | Specialized expertise, own context window, auto-delegated |
+| Hook | Event-based automation, validation, logging, no LLM involved |
+| MCP | External API/database integration, custom tools |
+
+## Post-Creation Guidance
+
+After creating, guide the user to:
+1. Edit `.claude-plugin/plugin.json` - update description and metadata
+2. Complete each component file using the plugin-creation skill's references
+3. Set up `.claude/rules/` if the plugin needs path-scoped rules
+4. Consider agent `memory:` and `model:` settings for agents
+5. Consider `model:` for cost optimization on skills
+6. Test locally: `/plugin marketplace add <path> && /plugin install`
+
+## Arguments
+
+- `$1`: Plugin name (hyphen-case, e.g., `my-tools`)
+- `$ARGUMENTS`: All arguments including component flags

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -1,0 +1,84 @@
+---
+description: Validate plugin structure, frontmatter, and best practices
+allowed-tools: Read, Glob, Grep
+argument-hint: [plugin-path]
+---
+
+# Validate Plugin
+
+Validate a plugin's structure and components against best practices.
+
+## Steps
+
+1. Determine plugin path: use `$1` if provided, otherwise detect from current directory
+2. Find `.claude-plugin/plugin.json` to confirm it's a plugin root
+3. Run all validation checks below
+4. Report results as a structured checklist
+
+## Validation Checks
+
+### Plugin Structure
+- [ ] `.claude-plugin/plugin.json` exists and is valid JSON
+- [ ] `name` field present in plugin.json
+- [ ] `version` follows semver
+- [ ] `description` present and not placeholder text
+- [ ] README.md exists at plugin root
+- [ ] CHANGELOG.md exists at plugin root
+
+### Skills (for each skill in `skills/*/`)
+- [ ] `SKILL.md` exists with valid YAML frontmatter
+- [ ] Frontmatter has `name` (hyphen-case, max 64 chars)
+- [ ] Frontmatter has `description` (starts with "Use when", max 1024 chars)
+- [ ] Description uses third person (no "you")
+- [ ] Body is instructions, not documentation (imperative voice)
+- [ ] Body under 500 lines
+- [ ] Referenced files in `references/` exist
+- [ ] Referenced scripts in `scripts/` exist
+- [ ] No README.md inside skill directories (belongs at plugin root)
+
+### Commands (for each `commands/*.md`)
+- [ ] Valid YAML frontmatter
+- [ ] `description` field present
+- [ ] `allowed-tools` field present
+- [ ] No inline code with backtick+exclamation or backtick+at-sign that could trigger execution
+
+### Agents (for each `agents/*.md`)
+- [ ] Valid YAML frontmatter
+- [ ] `name` field present
+- [ ] `description` field present (includes delegation triggers)
+- [ ] `tools` field present
+- [ ] `model` field present (haiku, sonnet, opus, or inherit)
+
+### Hooks (`hooks/hooks.json`)
+- [ ] Valid JSON structure
+- [ ] Each event name is a recognized event
+- [ ] Each hook entry has `type` (command, prompt, or agent) and matching field
+- [ ] Command hooks reference executable files
+- [ ] Timeouts are reasonable (< 120s for sync hooks)
+
+### Best Practices (warnings, not errors)
+- [ ] Skills use progressive disclosure (references for details)
+- [ ] Agents specify `model:` for cost optimization
+- [ ] Skills consider `model:` field
+- [ ] Hook scripts are executable (chmod +x)
+
+## Output Format
+
+```
+## Plugin Validation: {name} v{version}
+
+### Errors (must fix)
+- ...
+
+### Warnings (should fix)
+- ...
+
+### Info
+- {n} skills, {n} commands, {n} agents, hooks: {yes/no}, MCP: {yes/no}
+
+### Result: PASS / FAIL
+```
+
+## Arguments
+
+- `$1`: Path to plugin directory (optional, defaults to current directory)

--- a/plugin-creation-tools/skills/plugin-creation/README.md
+++ b/plugin-creation-tools/skills/plugin-creation/README.md
@@ -13,10 +13,23 @@ This skill activates when you say:
 - "Configure plugin" / "Setup plugin.json"
 - "Package for marketplace"
 
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/plugin-creation-tools:create` | Create a new plugin with selected components |
+| `/plugin-creation-tools:validate` | Validate plugin structure and best practices |
+| `/plugin-creation-tools:add-component` | Add a skill, command, agent, or hook to an existing plugin |
+
 ## Quick Start
 
 ### Create a New Plugin
 
+```
+/plugin-creation-tools:create my-tools --skill --command
+```
+
+Or describe what you need:
 ```
 Create a plugin called "my-tools" with a command and a skill
 ```
@@ -31,11 +44,18 @@ The skill will guide you through:
 ### Add Components to Existing Plugin
 
 ```
-Add a new command to my plugin that deploys to staging
+/plugin-creation-tools:add-component agent security-reviewer
 ```
 
+Or describe what you need:
 ```
 Add a hook that formats code after every write
+```
+
+### Validate a Plugin
+
+```
+/plugin-creation-tools:validate ./my-plugin
 ```
 
 ## What This Skill Covers
@@ -45,7 +65,7 @@ Add a hook that formats code after every write
 | **Skills** | Model-invoked workflows with supporting files |
 | **Commands** | User-invoked slash commands (`/command`) |
 | **Agents** | Specialized assistants with own context |
-| **Hooks** | Event-triggered automation (10 event types) |
+| **Hooks** | Event-triggered automation (14 event types, 3 handler types) |
 | **MCP Servers** | External tool integration |
 | **Settings** | Configuration hierarchy and permissions |
 | **Output** | Directory setup and logging patterns |
@@ -62,7 +82,7 @@ plugin-creation/
 │   ├── agent/
 │   ├── hooks/
 │   └── *.template
-├── references/        # Detailed guides (37 files)
+├── references/        # Detailed guides (38 files)
 │   ├── 01-overview/   # What each component is
 │   ├── 02-philosophy/ # Design principles
 │   ├── 03-skills/     # Skill-specific guides

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -31,6 +31,21 @@ Create complete Claude Code plugins with any combination of components.
 1. Read `references/01-overview/component-comparison.md` to decide which components needed
 2. Determine if this should be a new plugin or add to existing
 
+## Plugin Project Setup
+
+When creating any plugin, also consider:
+- `.claude/rules/` with modular project rules (path-scoped if needed for different component directories)
+- `CLAUDE.md` at plugin root for project conventions
+- README.md and CHANGELOG.md at plugin root (for humans — never inside skill directories)
+
+## Documentation Principles
+
+All plugin documentation should follow lean principles:
+- **Current truth only** — no historical narratives or "previously we did X"
+- **Replace, don't append** — superseded content gets replaced entirely
+- **Delete what's irrelevant** — every edit is a chance to prune
+- Read `references/02-philosophy/core-philosophy.md` for full philosophy
+
 ## Plugin Initialization
 
 When user says "create plugin", "initialize plugin", "new plugin":
@@ -80,6 +95,16 @@ When user says "add skill", "create skill", "make skill":
 | "This skill helps with PDF processing" | "Process PDF files using this workflow" |
 | "The description field is important" | "Write the description starting with 'Use when...'" |
 
+**Consider these optional frontmatter fields:**
+- `model: haiku` for simple lookup/formatting skills, `opus` for complex reasoning
+- `context: fork` with `agent: <type>` for heavy operations that would pollute main context
+- `disable-model-invocation: true` for command-only skills (no auto-trigger)
+- `user-invocable: false` for skills only triggered by other skills/agents
+
+**Dynamic context injection**: Use `` !`command` `` in the skill body to inject runtime state (git status, file contents, etc.) when the skill loads.
+
+**Extended thinking**: Include "ultrathink" in the skill body for tasks requiring deep reasoning.
+
 ## Creating Commands
 
 When user says "add command", "create command", "slash command":
@@ -103,19 +128,39 @@ When user says "add agent", "create agent", "make agent":
    - Description should include "Use proactively" for auto-delegation
    - One agent = one clear responsibility
 
+**Consider these agent-specific features:**
+- `memory: project` for agents that benefit from cross-session learning (architecture decisions, code review patterns)
+- `memory: user` for personal preferences that carry across projects
+- `model:` matched to task complexity — `haiku` for lookup/formatting, `sonnet` for balanced tasks, `opus` for complex reasoning
+- `tools` restriction to minimum needed (reduces cost and attack surface)
+- `disallowedTools` to block specific tools (e.g., `Edit`, `Write` for read-only agents)
+- `hooks` in agent frontmatter for scoped validation (runs only when that agent is active)
+
 ## Creating Hooks
 
 When user says "add hooks", "setup hooks", "event handlers":
 
 1. Read `references/06-hooks/writing-hooks.md`
-2. Read `references/06-hooks/hook-events.md` for event types
+2. Read `references/06-hooks/hook-events.md` for all 14 events
 3. Copy template from `templates/hooks/hooks.json.template`
 4. Key events:
-   - `PreToolUse` - before tool execution
+   - `PreToolUse` - before tool execution (can block)
    - `PostToolUse` - after tool execution (formatting, logging)
    - `SessionStart` - setup, output directories
    - `SessionEnd` - cleanup
-   - `UserPromptSubmit` - validation, context injection
+   - `UserPromptSubmit` - validation, context injection (can block)
+   - `SubagentStart`/`SubagentStop` - agent lifecycle
+   - `PreCompact` - inject context before compaction
+   - `Notification`, `Stop`, `TaskCompleted`, `TeammateIdle`
+
+**Three handler types** — choose the right one:
+- `command` — shell script, fastest, no LLM cost. Use for logging, file ops, env setup.
+- `prompt` — single-turn LLM evaluation, zero script overhead. Use for lightweight validation.
+- `agent` — multi-turn subagent with tools (Read, Grep, Glob). Use for complex verification.
+
+**Async execution**: Add `"async": true` on command hooks for background operations (logging, analytics) that shouldn't block the main flow.
+
+**MCP tool matching**: Use `mcp__<server>__<tool>` pattern in matchers for PreToolUse/PostToolUse.
 
 ## Configuring Plugin
 

--- a/plugin-creation-tools/skills/plugin-creation/references/01-overview/component-comparison.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/01-overview/component-comparison.md
@@ -4,33 +4,63 @@
 
 | Component | Location | Invocation | Best For |
 |-----------|----------|------------|----------|
+| CLAUDE.md | `.claude/CLAUDE.md` | Always loaded | Project conventions, always-on rules |
 | Skills | `skills/name/SKILL.md` | Model-invoked (auto) | Complex workflows with resources |
 | Commands | `commands/name.md` | User (`/command`) | Quick, frequently used prompts |
-| Agents | `agents/name.md` | Auto + Manual | Task-specific expertise |
+| Agents | `agents/name.md` | Auto + Manual | Task-specific expertise (subagents) |
+| Agent Teams | Multiple agents | Parallel sessions | Independent parallel workstreams (experimental) |
 | Hooks | `hooks/hooks.json` | Event-triggered | Automation and validation |
 | MCP | `.mcp.json` | Auto startup | External tool integration |
 
+## Context Cost Considerations
+
+Understanding when each feature loads and its context cost helps you choose the right component.
+
+| Component | When Loaded | Context Cost | Stays in Context |
+|-----------|-------------|--------------|------------------|
+| CLAUDE.md | Every session, always | Low-medium (entire file) | Yes, always present |
+| Skills | On-demand when model matches intent | Medium-high (SKILL.md + referenced files) | Yes, for duration of use |
+| Commands | On user invocation | Low-medium (command content) | Yes, for that turn |
+| Agents (Subagents) | On delegation | None in parent (own context window) | No, returns result only |
+| Agent Teams | On orchestration | None in parent per agent | No, each has own context |
+| Hooks | On event trigger | None (runs outside context) | No, side-effect only |
+| MCP | Session startup | Low (tool definitions only) | Tool schemas always, results per-call |
+
+**Key insight**: CLAUDE.md costs tokens every session. Skills cost tokens only when triggered. Choose accordingly.
+
 ## Decision Tree
 
-### Start Here: What triggers this capability?
+### 6-Step Decision Process
 
 ```
-1. Should the USER explicitly trigger it?
-   └── YES → COMMAND
+1. Always-on conventions or project rules?
+   └── YES → CLAUDE.md
 
-2. Should Claude trigger it automatically based on context?
-   └── YES → SKILL or AGENT
-       ├── Needs own context window? → AGENT
-       └── Shares conversation context? → SKILL
+2. Reference material, workflows, or complex guidance?
+   └── YES → SKILL
 
-3. Should it run automatically on events?
-   └── YES → HOOK
-
-4. Does it need external tools/APIs?
+3. External services, APIs, or databases?
    └── YES → MCP SERVER
+
+4. Isolated execution with own context?
+   └── YES → SUBAGENT (Agent)
+
+5. Parallel independent workstreams?
+   └── YES → AGENT TEAM (experimental)
+
+6. Predictable automation on events?
+   └── YES → HOOK
 ```
+
+**Still unsure?** Ask: should the USER explicitly trigger it? Then use a COMMAND.
 
 ### Detailed Decision Questions
+
+**Use CLAUDE.md when:**
+- Rules apply to every session in this project
+- Conventions should always be enforced
+- Content is small enough to justify always-on cost
+- Project-specific patterns Claude must always follow
 
 **Use a SKILL when:**
 - Complex workflow with multiple steps
@@ -46,12 +76,18 @@
 - No supporting resources needed
 - Explicit trigger is important
 
-**Use an AGENT when:**
+**Use an AGENT (Subagent) when:**
 - Task requires specialized expertise
 - Benefits from fresh context window
 - Needs different tool permissions than main
 - Should be delegated to automatically
-- Complex multi-step operations
+- Complex multi-step operations needing isolation
+
+**Use an AGENT TEAM when (experimental):**
+- Multiple independent tasks can run in parallel
+- Each task needs its own context window
+- Tasks don't depend on each other's intermediate results
+- Workload benefits from parallelism
 
 **Use a HOOK when:**
 - Should run on specific events
@@ -66,15 +102,85 @@
 - Custom tools beyond Claude's built-ins
 - Third-party service integration
 
+## Key Comparisons
+
+### CLAUDE.md vs Skill
+
+| Aspect | CLAUDE.md | Skill |
+|--------|-----------|-------|
+| Loading | Every session, always | On-demand when matched |
+| Context cost | Constant, every turn | Only when triggered |
+| Best for | Short rules, conventions | Complex workflows, references |
+| Size guidance | Keep small (< 200 lines) | Can be large with references |
+| Flexibility | One file, flat | Directory with supporting files |
+| Trigger | Automatic, always | Model decides based on description |
+
+**Rule of thumb**: If it's a short rule that always applies, use CLAUDE.md. If it's a detailed workflow or reference, use a Skill.
+
+### Subagent vs Agent Team
+
+| Aspect | Subagent | Agent Team |
+|--------|----------|------------|
+| Execution | Sequential, one at a time | Parallel, independent sessions |
+| Coordination | Parent delegates, child returns | Orchestrator coordinates multiple |
+| Context | Own window, returns result | Each agent has own window |
+| Use case | Focused single task | Multiple independent tasks |
+| Maturity | Stable | Experimental |
+| Communication | Parent-child | No inter-agent communication |
+
+### MCP vs Skill
+
+MCP provides **connection**; Skill provides **knowledge**.
+
+| Aspect | MCP Server | Skill |
+|--------|------------|-------|
+| Purpose | Connect to external tools/services | Provide context, workflows, guidance |
+| What it adds | New tool capabilities | Knowledge and decision frameworks |
+| Context cost | Tool schemas (low) | Content (medium-high) |
+| Runtime | Persistent process | Loaded into context |
+| Example | Notion API, database access | "How to write good docs" workflow |
+
+**Pattern**: MCP gives Claude new abilities. Skills tell Claude when and how to use those abilities effectively.
+
+## Combination Patterns
+
+Components work best in combination. Common effective patterns:
+
+### Skill + MCP
+Skill provides the workflow knowledge; MCP provides the tool connection.
+```
+Example: Documentation skill that knows HOW to write docs + Notion MCP that can CREATE pages
+```
+
+### Skill + Subagent
+Skill orchestrates the workflow; subagent handles isolated subtasks.
+```
+Example: Code review skill delegates security analysis to a security-focused agent
+```
+
+### CLAUDE.md + Skills
+CLAUDE.md sets the always-on rules; skills provide on-demand detailed guidance.
+```
+Example: CLAUDE.md says "always use BEM methodology" + CSS skill provides full BEM workflow
+```
+
+### Hook + MCP
+Hook triggers on events; MCP executes external actions.
+```
+Example: PostToolUse hook detects file save → MCP server pushes notification to Slack
+```
+
 ## Comparison by Characteristic
 
 ### Context Management
 
 | Component | Context |
 |-----------|---------|
+| CLAUDE.md | Always in system prompt |
 | Skill | Shares main conversation context |
 | Command | Adds to main conversation |
 | Agent | Own separate context window |
+| Agent Team | Each agent has own context |
 | Hook | Runs independently, no conversation |
 | MCP | Tool calls, results in context |
 
@@ -82,19 +188,20 @@
 
 | Low | Medium | High |
 |-----|--------|------|
-| Commands | Skills, Hooks | Agents, MCP |
+| CLAUDE.md, Commands | Skills, Hooks | Agents, Agent Teams, MCP |
 
 ### Discovery
 
 | Component | How User Finds It |
 |-----------|-------------------|
+| CLAUDE.md | Invisible (always active) |
 | Command | `/help`, autocomplete |
 | Skill | Automatic (model decides) |
 | Agent | `/agents`, automatic delegation |
 | Hook | Invisible (event-based) |
 | MCP | Shows as available tools |
 
-## Common Combinations
+## Common Plugin Combinations
 
 ### Code Quality Plugin
 ```
@@ -138,6 +245,8 @@
 | Multi-purpose agents | Confused delegation | One agent = one task |
 | Global hook matchers | Performance impact | Specific matchers |
 | MCP for simple things | Over-engineering | Use commands/skills |
+| CLAUDE.md as encyclopedia | Token waste every session | Move detailed content to skills |
+| Skill for simple rules | Unnecessary complexity | Use CLAUDE.md for short rules |
 
 ## See Also
 

--- a/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/core-philosophy.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/core-philosophy.md
@@ -9,6 +9,7 @@ Unified philosophy combining Anthropic's skill-creator principles with the guide
 3. **Decision-focused, not tutorial-focused** - "When to use X vs Y" not "How to install X"
 4. **One excellent example beats many mediocre ones** - Quality over quantity
 5. **Context window is a public good** - Every token must justify its cost
+6. **Documentation reflects current truth** - Docs describe what IS, not how we got here
 
 ## Content Strategy
 
@@ -87,6 +88,31 @@ Before including content, ask:
 3. **Is this decision-focused or tutorial-focused?** → Keep only decisions
 4. **Is one example enough?** → Remove extras
 5. **Does this justify its token cost?** → Remove if doubtful
+
+## Lean Documentation
+
+Documentation must reflect the current state of the system, not its history.
+
+### Principles
+
+- **Replace, don't append**: When content is superseded, remove the old version entirely. Do not keep both old and new alongside each other.
+- **Delete irrelevant content**: Every doc edit is an opportunity to prune. If surrounding content no longer applies, remove it during the same edit.
+- **Current state only**: Document what the system does now. No historical narratives about how it evolved, no version migration stories, no changelogs embedded in reference docs.
+- **No "Previously..." or "In v1.x..." language**: If a reader needs history, that belongs in git history or a dedicated changelog file, not in reference documentation.
+
+### Applying Lean Documentation
+
+| Situation | Action |
+|-----------|--------|
+| New version replaces old behavior | Rewrite the section to describe current behavior only |
+| Feature removed | Delete the section entirely |
+| Two docs describe the same thing differently | Pick the correct one, delete the other |
+| Doc mentions old versions for context | Remove version references, describe current state |
+| Section is half-outdated | Rewrite fully or delete, never leave partial truths |
+
+### Why This Matters
+
+Stale documentation is worse than no documentation. It teaches Claude wrong patterns, wastes context tokens on irrelevant history, and creates confusion about what is actually true. Keeping docs lean and current is not just style preference; it directly impacts Claude's ability to help effectively.
 
 ## Summary
 

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
@@ -111,6 +111,8 @@ description: Use when [triggers] - [what it does]
 ---
 name: processing-pdfs
 description: Extracts text and tables from PDF files, fills forms. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+model: sonnet
+context: fork
 ---
 ```
 
@@ -118,11 +120,52 @@ description: Extracts text and tables from PDF files, fills forms. Use when work
 |-------|----------|-------------|
 | `name` | Yes | Lowercase, numbers, hyphens only. Max 64 chars. No "anthropic" or "claude". |
 | `description` | Yes | Max 1024 chars. Must include WHAT and WHEN. Third person only. |
-| `allowed-tools` | No | Restricts available tools when skill active |
-| `license` | No | License for the skill |
-| `metadata` | No | Custom key-value pairs |
+| `model` | No | Override model for this skill. Values: `haiku`, `sonnet`, `opus`. Use for cost optimization -- `haiku` for simple/repetitive tasks, `opus` for complex reasoning. |
+| `allowed-tools` | No | Restricts available tools when skill is active. |
+| `context` | No | Set to `fork` to run skill in an isolated context (own context window). Use for heavy operations that would pollute the main context. |
+| `agent` | No | When `context: fork`, specify agent type for the forked context. |
+| `disable-model-invocation` | No | Set to `true` to prevent Claude from auto-invoking. User must call explicitly via `/name`. Reduces context cost to zero for triggered-only skills. |
+| `user-invocable` | No | Set to `false` to make skill only auto-invocable (Claude triggers it, user cannot call directly). Default is `true`. |
+| `license` | No | License for the skill. |
+| `metadata` | No | Custom key-value pairs. |
 
-**Do not add other fields.** Only these are recognized.
+### Model Selection Guidelines
+
+| Model | Use When |
+|-------|----------|
+| `haiku` | Simple formatting, file listing, repetitive transforms, boilerplate generation |
+| `sonnet` | Standard coding tasks, most skills (default behavior) |
+| `opus` | Complex multi-step reasoning, architecture decisions, nuanced analysis |
+
+### Context and Invocation Examples
+
+**Forked context** -- prevents heavy skill output from consuming main context:
+```yaml
+---
+name: analyzing-codebase
+description: Deep analysis of codebase architecture. Use when asked to audit or analyze overall code structure.
+context: fork
+agent: researcher
+---
+```
+
+**Triggered-only skill** -- zero context cost until explicitly called:
+```yaml
+---
+name: resetting-environment
+description: Resets development environment to clean state.
+disable-model-invocation: true
+---
+```
+
+**Auto-only skill** -- Claude decides when to invoke, user cannot call directly:
+```yaml
+---
+name: formatting-output
+description: Formats command output for readability. Use when command output exceeds 50 lines.
+user-invocable: false
+---
+```
 
 ### Naming Convention
 
@@ -135,6 +178,63 @@ description: Extracts text and tables from PDF files, fills forms. Use when work
 | `managing-git` | `git-manager` | `tools` |
 
 Reserved words not allowed: `anthropic`, `claude`
+
+## Dynamic Context Injection
+
+Skill body text supports dynamic context injection using the exclamation mark prefix with backtick-wrapped commands. Lines using this syntax run the command at invocation time and inject the output into the skill context.
+
+### Syntax
+
+A line starting with exclamation mark followed by a backtick-wrapped command:
+```
+!`command here`
+```
+
+### Examples
+
+Inject current git status when the skill loads:
+```
+!`git status`
+```
+
+Inject file contents at runtime:
+```
+!`cat .env.example`
+```
+
+Inject project structure:
+```
+!`ls -la src/`
+```
+
+### When to Use
+
+- Skill needs awareness of current project state (git status, branch, changed files)
+- Skill references configuration that varies per project
+- Skill needs to adapt behavior based on runtime environment
+
+### Guidelines
+
+- Keep injected commands fast -- slow commands delay skill loading
+- Avoid commands with large output; they consume context unnecessarily
+- Use targeted commands (`git diff --stat` over `git diff`) to minimize output size
+
+## Extended Thinking with Ultrathink
+
+Skills can include the word "ultrathink" in their body text to encourage Claude to use extended thinking on complex tasks. This is particularly useful for skills that involve:
+
+- Multi-step architectural reasoning
+- Complex code refactoring decisions
+- Weighing multiple trade-offs before acting
+- Tasks where getting it right the first time matters
+
+Place "ultrathink" in a natural instruction, such as:
+```markdown
+## Workflow
+Before making changes, ultrathink about the implications across the codebase.
+```
+
+This signals Claude to engage deeper reasoning before responding, which improves quality on complex tasks at the cost of slightly longer response times.
 
 ## Section Guidelines
 
@@ -300,6 +400,7 @@ Build at least 3 test scenarios before finalizing:
 - [ ] No unnecessary content
 - [ ] No time-sensitive information
 - [ ] Consistent terminology throughout
+- [ ] Current state only -- no historical narratives. Replace outdated content, don't keep it alongside new.
 
 ### Frontmatter
 - [ ] Name uses gerund form (preferred)

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
@@ -12,6 +12,21 @@ tools: Read, Grep, Glob, Bash
 
 If omitted, agent inherits all available tools.
 
+## The disallowedTools Field
+
+Explicitly deny specific tools. Takes precedence over `tools`:
+
+```yaml
+# Allow all tools except Bash and Write
+disallowedTools: Bash, Write
+
+# Combined: allow a set, but deny specific ones
+tools: Read, Write, Edit, Bash, Glob, Grep
+disallowedTools: Bash
+```
+
+Use `disallowedTools` when it is easier to exclude a few tools than to list all allowed ones.
+
 ## Available Tools
 
 ### File Operations
@@ -23,6 +38,7 @@ If omitted, agent inherits all available tools.
 | Edit | Modify existing files | Medium |
 | Glob | Find files by pattern | Low |
 | Grep | Search file contents | Low |
+| NotebookEdit | Edit Jupyter notebook cells | Medium |
 
 ### System Operations
 
@@ -32,12 +48,43 @@ If omitted, agent inherits all available tools.
 | WebFetch | Fetch URLs | Medium |
 | WebSearch | Search the web | Low |
 
-### Meta Operations
+### Agent and Task Operations
 
 | Tool | Purpose | Risk Level |
 |------|---------|------------|
-| Task | Spawn subagents | Medium |
-| TodoWrite | Manage task lists | Low |
+| Task | Spawn subagents (legacy) | Medium |
+| TaskCreate | Create a new subagent task | Medium |
+| TaskUpdate | Update an existing task | Medium |
+| TaskList | List active tasks | Low |
+| TaskGet | Get task details and output | Low |
+| Skill | Invoke a preloaded skill | Low |
+| AskUserQuestion | Prompt the user for input | Low |
+
+### Planning and Discovery
+
+| Tool | Purpose | Risk Level |
+|------|---------|------------|
+| EnterPlanMode | Switch agent to read-only planning | Low |
+| ExitPlanMode | Leave planning mode | Low |
+| ToolSearch | Discover and load deferred tools | Low |
+| ListMcpResourcesTool | List available MCP resources | Low |
+| ReadMcpResourceTool | Read a specific MCP resource | Low |
+
+## MCP Tool Access
+
+Reference MCP tools using the `mcp__server__tool` format:
+
+```yaml
+# Allow specific MCP tools
+tools: Read, Grep, mcp__slack__send_message, mcp__github__create_issue
+
+# Deny MCP tools
+disallowedTools: mcp__slack__send_message
+```
+
+Pattern: `mcp__<server-name>__<tool-name>`
+
+The server name matches the key in your MCP configuration. Use `ToolSearch` or `ListMcpResourcesTool` at runtime to discover available MCP tools.
 
 ## Tool Restriction Patterns
 
@@ -137,7 +184,16 @@ Load specific skills into agent context:
 skills: code-review, testing-patterns
 ```
 
-Skills are loaded when agent activates, providing specialized knowledge.
+Skills are preloaded when the agent activates, injecting specialized knowledge and instructions into the agent's context window. This gives the agent domain expertise without requiring it in the system prompt body.
+
+```yaml
+# Agent with skill-provided expertise
+name: drupal-reviewer
+tools: Read, Grep, Glob
+skills: drupal-best-practices, security-review
+```
+
+The agent receives all skill content at activation, so keep skill references focused and relevant to avoid context bloat.
 
 ## Example Configurations
 
@@ -146,6 +202,7 @@ Skills are loaded when agent activates, providing specialized knowledge.
 ```yaml
 name: security-auditor
 tools: Read, Grep, Glob
+disallowedTools: Bash, Write
 permissionMode: default
 ```
 
@@ -178,28 +235,30 @@ Can write tests and run npm test commands.
 ```yaml
 name: doc-writer
 tools: Read, Write, Glob
+disallowedTools: Bash
 permissionMode: default
 ```
 
-Can read code and write documentation files.
+Can read code and write documentation files. Bash explicitly denied.
 
 ### DevOps Agent
 
 ```yaml
 name: devops
-tools: Read, Bash, Glob
+tools: Read, Bash, Glob, mcp__github__create_issue
 permissionMode: default
 ```
 
-Bash access for infrastructure commands.
+Bash access plus specific MCP tool for GitHub integration.
 
 ## Best Practices
 
 1. **Principle of Least Privilege**: Only grant needed tools
-2. **Consider Risk**: Bash and Write are higher risk
-3. **Document Choices**: Explain why tools are included
-4. **Test Thoroughly**: Verify agent works with limited tools
-5. **Review Permissions**: bypassPermissions should be rare
+2. **Prefer disallowedTools for broad access**: When an agent needs most tools but not a few, use `disallowedTools` instead of listing every allowed tool
+3. **Consider Risk**: Bash and Write are higher risk
+4. **Use MCP patterns for integrations**: Reference MCP tools explicitly rather than granting blanket access
+5. **Test Thoroughly**: Verify agent works with limited tools
+6. **Review Permissions**: bypassPermissions should be rare
 
 ## Tool Access Troubleshooting
 
@@ -207,8 +266,9 @@ Bash access for infrastructure commands.
 
 If agent fails on an operation:
 1. Check if tool is in `tools` list
-2. Verify permission mode allows it
-3. Check project-level permissions
+2. Check if tool is in `disallowedTools` list (takes precedence)
+3. Verify permission mode allows it
+4. Check project-level permissions
 
 ### Unexpected Permission Prompts
 

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
@@ -49,16 +49,19 @@ Or inline in `plugin.json`:
 |-------|------|----------|-------------|
 | matcher | string | No | Pattern to match (regex, exact, or `*`) |
 | hooks | array | **Yes** | Array of hook actions |
-| type | string | **Yes** | Hook type (command, validation, notification, prompt) |
-| command | string | Depends | Shell command to execute |
-| timeout | number | No | Timeout in seconds (default varies) |
-| prompt | string | Depends | LLM prompt (for prompt type) |
+| type | string | **Yes** | Hook handler type: `command`, `prompt`, or `agent` |
+| command | string | For command | Shell command to execute |
+| prompt | string | For prompt/agent | LLM prompt (`$ARGUMENTS` for context) |
+| timeout | number | No | Timeout in seconds (default varies by type) |
+| async | boolean | No | Run in background (command type only) |
 
-## Hook Types
+## Hook Handler Types
 
-### Command Hook
+Three handler types are available. Each serves a different complexity level.
 
-Execute a bash script:
+### 1. Command Hook
+
+Execute a shell script. Receives JSON on stdin with event context. Returns exit code + stdout.
 
 ```json
 {
@@ -68,31 +71,15 @@ Execute a bash script:
 }
 ```
 
-### Validation Hook
+**Stdin JSON** includes: `hook_event_name`, `tool_name`, `tool_input`, `tool_output` (varies by event).
 
-Validate input/output:
+**Exit codes**: 0 = success/allow, non-zero = failure/block (for blocking events).
 
-```json
-{
-  "type": "validation",
-  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/lint-check.py"
-}
-```
+**Stdout**: Returned as hook result. For blocking events, specific strings like `approve`, `deny`, or `continue` control behavior.
 
-### Notification Hook
+### 2. Prompt Hook
 
-Send alerts:
-
-```json
-{
-  "type": "notification",
-  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/notify.sh"
-}
-```
-
-### Prompt Hook
-
-LLM-based decision:
+Single-turn LLM evaluation. Uses Haiku by default for fast, cheap yes/no decisions. Zero script overhead -- no shell process spawned.
 
 ```json
 {
@@ -102,14 +89,61 @@ LLM-based decision:
 }
 ```
 
+**`$ARGUMENTS`**: Replaced with event context (tool input/output, conversation state). Always include this placeholder so the LLM has context.
+
+**Response handling**: The LLM's response is returned as the hook result. For blocking events, the response determines the action (e.g., returning `continue` from a Stop hook).
+
+### 3. Agent Hook
+
+Multi-turn subagent with access to tools (Read, Grep, Glob). Up to 50 turns of autonomous reasoning. Use for complex verification requiring file inspection.
+
+```json
+{
+  "type": "agent",
+  "prompt": "Verify all test files exist and have proper structure for: $ARGUMENTS",
+  "timeout": 120
+}
+```
+
+**Available tools**: Read, Grep, Glob (read-only file access).
+
+**Turns**: Up to 50 turns of tool use and reasoning.
+
+**When to use**: When a prompt hook cannot answer without reading files -- e.g., verifying code changes, checking file existence, validating cross-file consistency.
+
+## Async Hooks
+
+Command hooks can run asynchronously in the background.
+
+```json
+{
+  "type": "command",
+  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/slow-lint.sh",
+  "timeout": 120,
+  "async": true
+}
+```
+
+**Behavior**:
+- Claude continues immediately without waiting
+- Results are delivered on the next conversation turn
+- Cannot block tool calls or return decisions (blocking return values are ignored)
+- Only available for `command` type (not prompt or agent)
+
+**Use cases**: Long-running linters, external API calls, background logging, notifications to external systems.
+
 ## Matcher Patterns
 
 | Pattern | Behavior | Example |
 |---------|----------|---------|
-| Exact | Matches exactly | `Write` |
-| Regex | Pattern match | `Write\|Edit` |
-| Wildcard | All events | `*` |
-| Omit | Global (no filter) | Don't include field |
+| Exact match | Matches tool name exactly | `Write` |
+| Regex | Pattern match on tool name | `Write\|Edit` |
+| Wildcard | Matches all | `*` |
+| Path pattern | Tool + path constraint | `Read(./docs/**)` |
+| MCP tool | Server + tool pattern | `mcp__memory__.*` |
+| MCP wildcard | Any server, matching tool | `mcp__.*__write.*` |
+| Compound | Multiple patterns combined | `Write\|Edit\|mcp__fs__write` |
+| Omitted | No filter (fires for all) | Don't include the field |
 
 Examples:
 ```json
@@ -119,11 +153,20 @@ Examples:
 // Match Write OR Edit
 "matcher": "Write|Edit"
 
-// Match all tools
-"matcher": "*"
-
 // Match Bash commands starting with git
 "matcher": "Bash(git:*)"
+
+// Match all tools from memory MCP server
+"matcher": "mcp__memory__.*"
+
+// Match any write tool from any MCP server
+"matcher": "mcp__.*__write.*"
+
+// Built-in and MCP tools together
+"matcher": "Write|Edit|mcp__fs__write_file"
+
+// Read tool scoped to docs directory
+"matcher": "Read(./docs/**)"
 ```
 
 ## Environment Variables
@@ -144,11 +187,23 @@ Available in hook scripts:
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-bash.sh"
           }
         ]
       }
@@ -161,6 +216,27 @@ Available in hook scripts:
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check if all tasks from the original request are complete. Return 'continue' if more work is needed. $ARGUMENTS"
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "Verify the completed task by inspecting relevant files. Check that changes are correct and complete. $ARGUMENTS",
+            "timeout": 120
           }
         ]
       }
@@ -187,11 +263,9 @@ Available in hook scripts:
 ```bash
 #!/bin/bash
 # ${CLAUDE_PLUGIN_ROOT}/scripts/format.sh
-
-# Exit on error
 set -e
 
-# Read input from stdin if available
+# Read JSON input from stdin
 if [ -t 0 ]; then
   INPUT=""
 else
@@ -226,22 +300,25 @@ sys.exit(0)
 
 ## Timeout Configuration
 
-| Use Case | Recommended Timeout |
-|----------|---------------------|
-| Quick validation | 10-15 seconds |
-| Formatting | 30 seconds |
-| Long-running tasks | 60+ seconds |
-| Network operations | 30-60 seconds |
+| Handler Type | Default | Recommended Range |
+|-------------|---------|-------------------|
+| command | 30s | 10-60s |
+| command (async) | 120s | 30-300s |
+| prompt | 30s | 10-60s |
+| agent | 120s | 60-300s |
 
 ## Best Practices
 
-1. **Use specific matchers** - Avoid `*` for performance
-2. **Set appropriate timeouts** - Don't block too long
-3. **Handle errors gracefully** - Return meaningful messages
-4. **Log for debugging** - Include logging in scripts
-5. **Test in isolation** - Run scripts manually first
+1. **Use specific matchers** -- avoid `*` for performance
+2. **Set appropriate timeouts** -- don't block the user unnecessarily
+3. **Handle errors gracefully** -- return meaningful messages on failure
+4. **Use prompt hooks for simple decisions** -- faster and cheaper than command hooks
+5. **Use agent hooks only when file inspection is needed** -- they are the most expensive
+6. **Use async for slow operations** -- background logging, linting, external calls
+7. **Include `$ARGUMENTS`** in prompt/agent hooks -- without it the LLM has no context
+8. **Test scripts in isolation** -- run command hooks manually before wiring them up
 
 ## See Also
 
-- `hook-events.md` - all available events
-- `hook-patterns.md` - common patterns and examples
+- `hook-events.md` -- all 14 available events with return values
+- `hook-patterns.md` -- common patterns and examples


### PR DESCRIPTION
## Summary

- **3 new slash commands** for plugin discoverability: `/create`, `/validate`, `/add-component`
- **9 reference files synced** against comprehensive source guides (agents, hooks, skills, comparison, philosophy, plugin config, testing)
- **SKILL.md updated** with guidance for memory, model routing, context injection, hook handler types, and lean documentation
- **Exited beta** — version 2.0.0-beta.4 → 2.1.0, removed [BETA] from description and marketplace

## Changes (17 files: 3 new, 14 modified)

### New Commands
| Command | Purpose |
|---------|---------|
| `commands/create.md` | Create a new plugin with selected components |
| `commands/validate.md` | Validate plugin structure, frontmatter, best practices |
| `commands/add-component.md` | Add skill, command, agent, or hook to existing plugin |

### Reference Updates
| File | Key Changes |
|------|-------------|
| `writing-agents.md` | Added memory (user/project/local), model selection, disallowedTools, hooks in frontmatter |
| `agent-tools.md` | Added disallowedTools, MCP tool access, expanded tool list |
| `hook-events.md` | Expanded 10 → 14 events, MCP matcher syntax, matcher values per event |
| `writing-hooks.md` | Corrected to 3 hook types (command/prompt/agent), async hooks, MCP matchers |
| `writing-skillmd.md` | Added model, context, disable-model-invocation, user-invocable, dynamic context injection, ultrathink |
| `component-comparison.md` | Added CLAUDE.md + Agent Teams, context costs, 6-step decision process |
| `core-philosophy.md` | Added lean documentation as 6th iron law |
| `plugin-json.md` | Added mcpServers, lspServers, path substitution, installation scopes, caching |
| `testing.md` | Added CLI automation section (-p flag, --output-format, session resumption) |

### Other Updates
- `SKILL.md` — new feature guidance (memory, model, context injection, hooks, lean docs)
- `plugin.json` — v2.1.0, removed [BETA]
- `marketplace.json` — synced version and description
- `README.md` — added commands table, updated event count to 14
- `CHANGELOG.md` — v2.1.0 entry

## Test plan

- [ ] Verify `/plugin-creation-tools:create` appears in command list
- [ ] Verify `/plugin-creation-tools:validate` runs against a plugin directory
- [ ] Verify `/plugin-creation-tools:add-component` scaffolds components
- [ ] Verify skill auto-triggers on "create a plugin" queries
- [ ] Spot-check reference files for accuracy against source guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)