### PR TITLE
fix(plugin-creation-tools): Clarify user-invocable and disallowedTools docs

### DIFF
--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -99,7 +99,7 @@ When user says "add skill", "create skill", "make skill":
 - `model: haiku` for simple lookup/formatting skills, `opus` for complex reasoning
 - `context: fork` with `agent: <type>` for heavy operations that would pollute main context
 - `disable-model-invocation: true` for command-only skills (no auto-trigger)
-- `user-invocable: false` for skills only triggered by other skills/agents
+- `user-invocable: false` to hide from `/` menu (Claude can still invoke via Skill tool)
 
 **Dynamic context injection**: Use `` !`command` `` in the skill body to inject runtime state (git status, file contents, etc.) when the skill loads.
 

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
@@ -125,7 +125,7 @@ context: fork
 | `context` | No | Set to `fork` to run skill in an isolated context (own context window). Use for heavy operations that would pollute the main context. |
 | `agent` | No | When `context: fork`, specify agent type for the forked context. |
 | `disable-model-invocation` | No | Set to `true` to prevent Claude from auto-invoking. User must call explicitly via `/name`. Reduces context cost to zero for triggered-only skills. |
-| `user-invocable` | No | Set to `false` to make skill only auto-invocable (Claude triggers it, user cannot call directly). Default is `true`. |
+| `user-invocable` | No | Set to `false` to hide from `/` menu. Claude can still invoke via Skill tool. For background knowledge users shouldn't invoke directly. Default is `true`. |
 | `license` | No | License for the skill. |
 | `metadata` | No | Custom key-value pairs. |
 
@@ -158,7 +158,7 @@ disable-model-invocation: true
 ---
 ```
 
-**Auto-only skill** -- Claude decides when to invoke, user cannot call directly:
+**Auto-only skill** -- hidden from `/` menu, Claude decides when to invoke:
 ```yaml
 ---
 name: formatting-output
@@ -166,6 +166,10 @@ description: Formats command output for readability. Use when command output exc
 user-invocable: false
 ---
 ```
+
+> **Note:** `user-invocable: false` only controls `/` menu visibility. Claude can still invoke via the Skill tool. To block Claude from auto-invoking, use `disable-model-invocation: true` instead. These serve opposite purposes:
+> - `user-invocable: false` — user cannot call, Claude can
+> - `disable-model-invocation: true` — Claude cannot call, user can
 
 ### Naming Convention
 

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
@@ -14,7 +14,7 @@ If omitted, agent inherits all available tools.
 
 ## The disallowedTools Field
 
-Explicitly deny specific tools. Takes precedence over `tools`:
+Explicitly deny specific tools. Removed from inherited or specified tool list:
 
 ```yaml
 # Allow all tools except Bash and Write
@@ -26,6 +26,8 @@ disallowedTools: Bash
 ```
 
 Use `disallowedTools` when it is easier to exclude a few tools than to list all allowed ones.
+
+> **Note:** `disallowedTools` applies when Claude auto-delegates to the agent based on its description. It does not apply when an agent is spawned explicitly via the Task tool from the main conversation.
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary

- Clarified `user-invocable: false` only controls `/` menu visibility, not Skill tool access
- Clarified `disallowedTools` applies on auto-delegation, not explicit Task tool spawning
- Added note explaining `user-invocable: false` vs `disable-model-invocation: true` distinction

Verified against official Claude Code docs at code.claude.com during drupal-dev-framework v3.1.0 runtime validation.

## Test plan

- [ ] Review clarifications match official docs at https://code.claude.com/docs/en/skills and https://code.claude.com/docs/en/sub-agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)