### PR TITLE
feat(brand-content-design): v2.0.0 - Agent memory, model routing, rules, hooks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -91,7 +91,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics) with 114 templates, 13 visual styles, visual components (cards, icons, gradients), 17 color palettes, and Presentation Zen principles",
-      "version": "1.11.3",
+      "version": "2.0.0",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "1.11.3",
+  "version": "2.0.0",
   "description": "Create branded visual content (presentations, carousels, infographics) with visual components (cards, icons, gradients) using a layered philosophy system with Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/.claude/rules/agent-conventions.md
+++ b/brand-content-design/.claude/rules/agent-conventions.md
@@ -1,0 +1,22 @@
+---
+globs: agents/**
+---
+
+# Agent Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — includes delegation triggers
+- `version` — semver
+- `model` — haiku, sonnet, or opus
+
+## Optional Frontmatter
+- `memory` — project for brand pattern learning
+- `tools` — comma-separated allowlist
+- `disallowedTools` — comma-separated denylist
+- `hooks` — scoped lifecycle hooks
+
+## Body
+- Imperative voice: "Analyze...", "Extract...", "Return..."
+- Read-only agents must not modify files
+- Return findings to caller, don't write directly

--- a/brand-content-design/.claude/rules/command-conventions.md
+++ b/brand-content-design/.claude/rules/command-conventions.md
@@ -1,0 +1,19 @@
+---
+globs: commands/**
+---
+
+# Command Conventions
+
+## Required Frontmatter
+- `description` — clear, concise action description
+- `allowed-tools` — minimum needed tools
+
+## Optional Frontmatter
+- `argument-hint` — when command accepts arguments
+- `model` — override model for this command
+
+## Body
+- Step-by-step workflow with numbered steps
+- Use AskUserQuestion for interactive choices
+- Include error handling for missing prerequisites
+- Reference skills via Skill tool, not inline duplication

--- a/brand-content-design/.claude/rules/skill-conventions.md
+++ b/brand-content-design/.claude/rules/skill-conventions.md
@@ -1,0 +1,21 @@
+---
+globs: skills/**
+---
+
+# Skill Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — starts with "Use when...", includes trigger phrases
+- `version` — semver
+
+## Optional Frontmatter
+- `model` — sonnet for routing, opus for creative/artistic work
+- `user-invocable` — false for skills only called by commands
+- `context` — fork for heavy operations
+
+## Body
+- Imperative voice — instructions, not documentation
+- Under 500 lines per SKILL.md
+- Accessibility requirements are MANDATORY sections
+- Reference supporting files instead of inlining large content

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-02-09
+
+### Added
+- **Agent memory**: brand-analyst uses `memory: project` for cross-session brand pattern learning
+- **Model routing**: opus for visual-content (creative complexity), sonnet for brand-content-design and infographic-generator
+- **Tool restrictions**: brand-analyst has `disallowedTools: Edit, Write, Bash` for explicit read-only enforcement
+- **Invocation control**: visual-content and infographic-generator set `user-invocable: false` (called by commands only)
+- **PreCompact hook**: preserves active brand project context before context compaction
+- **CLAUDE.md**: plugin conventions at plugin root
+- **Path-scoped rules**: `.claude/rules/` with agent, skill, and command conventions
+- **Version fields**: added `version` to all agents and skills
+
 ## [1.11.3] - 2025-12-11
 
 ### Added

--- a/brand-content-design/CLAUDE.md
+++ b/brand-content-design/CLAUDE.md
@@ -1,0 +1,26 @@
+# Brand Content Design - Plugin Conventions
+
+## Agents
+- Frontmatter must include: name, description, version, model
+- Description starts with action phrases for auto-delegation
+- Read-only agents must have `disallowedTools: Edit, Write, Bash`
+- Agents that learn brand patterns across sessions should have `memory: project`
+
+## Skills
+- Frontmatter must include: name, description, version
+- Add `model:` matched to complexity (sonnet for routing, opus for creative/artistic)
+- Internal skills called only by commands should have `user-invocable: false`
+- Body uses imperative voice — instructions for Claude, not documentation
+- Under 500 lines per SKILL.md
+
+## Commands
+- Frontmatter must include: description, allowed-tools
+- Use `argument-hint:` when command accepts arguments
+- Restrict `allowed-tools` to minimum needed
+- Interactive commands use AskUserQuestion for user input
+
+## General
+- Accessibility (WCAG AA) is mandatory — never skip contrast validation
+- Three-layer philosophy: brand → content type → template
+- Current state only — no historical narratives
+- Reference files instead of reproducing content

--- a/brand-content-design/README.md
+++ b/brand-content-design/README.md
@@ -170,6 +170,20 @@ Generates two files for your template:
 | `/infographic-quick` | Create infographic (quick) |
 | `/content-type-new` | Add new content type |
 
+## Components
+
+### Agent
+| Agent | Model | Features |
+|-------|-------|----------|
+| `brand-analyst` | sonnet | `memory: project`, read-only (`disallowedTools: Edit, Write, Bash`) |
+
+### Skills (3)
+| Skill | Model | Invocation |
+|-------|-------|------------|
+| `brand-content-design` | sonnet | User + Claude (main router) |
+| `visual-content` | opus | Claude only (`user-invocable: false`) — artistic output |
+| `infographic-generator` | sonnet | Claude only (`user-invocable: false`) — template generation |
+
 ## Visual Style System
 
 Choose from **13 distinct visual styles** across 4 aesthetic families when creating templates:

--- a/brand-content-design/agents/brand-analyst.md
+++ b/brand-content-design/agents/brand-analyst.md
@@ -1,8 +1,11 @@
 ---
 name: brand-analyst
 description: Analyze brand assets (screenshots, documents, logos, websites) to extract brand elements including color palettes with color theory analysis. Use proactively when user provides assets for brand analysis.
-tools: Read, Glob, WebFetch
+version: 1.11.3
 model: sonnet
+memory: project
+tools: Read, Glob, WebFetch
+disallowedTools: Edit, Write, Bash
 ---
 
 # Brand Analyst Agent

--- a/brand-content-design/hooks/hooks.json
+++ b/brand-content-design/hooks/hooks.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/brand-content-design/hooks/pre-compact.sh
+++ b/brand-content-design/hooks/pre-compact.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Pre-compaction context preservation for brand-content-design plugin
+# Outputs active brand project state so it survives context compaction
+
+echo "## Pre-Compaction Context (brand-content-design)"
+
+# Find active brand project by looking for brand-philosophy.md in recent directories
+BRAND_PROJECT=""
+for dir in */; do
+  if [ -f "${dir}brand-philosophy.md" ]; then
+    BRAND_PROJECT="$dir"
+    break
+  fi
+done
+
+if [ -z "$BRAND_PROJECT" ]; then
+  echo "No active brand project found in current directory."
+  exit 0
+fi
+
+echo "### Active Brand Project: ${BRAND_PROJECT}"
+
+# Output brand philosophy summary (first 20 lines)
+if [ -f "${BRAND_PROJECT}brand-philosophy.md" ]; then
+  echo "#### Brand Philosophy"
+  head -20 "${BRAND_PROJECT}brand-philosophy.md"
+  echo "..."
+fi
+
+# List available templates
+if [ -d "${BRAND_PROJECT}templates" ]; then
+  echo "#### Templates"
+  ls "${BRAND_PROJECT}templates/" 2>/dev/null
+fi
+
+# List recent outputs
+if [ -d "${BRAND_PROJECT}output" ]; then
+  echo "#### Recent Outputs"
+  ls -t "${BRAND_PROJECT}output/" 2>/dev/null | head -5
+fi

--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: brand-content-design
 description: Use when user says "create presentation", "make carousel", "setup brand", "brand init", "extract brand", "get outline", or wants to create visual content with consistent branding. Creates branded presentations and carousels using a layered philosophy system.
+version: 1.11.3
+model: sonnet
 ---
 
 # Brand Content Design

--- a/brand-content-design/skills/infographic-generator/SKILL.md
+++ b/brand-content-design/skills/infographic-generator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: generating-infographics
 description: Use when creating infographics, data visualizations, process diagrams, timelines, or comparisons - generates branded infographics using @antv/infographic with 114 templates across 7 categories. Triggers on "create infographic", "make infographic", "visualize data", "timeline", "process diagram".
+version: 1.11.3
+model: sonnet
+user-invocable: false
 ---
 
 # Generating Infographics

--- a/brand-content-design/skills/visual-content/SKILL.md
+++ b/brand-content-design/skills/visual-content/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: visual-content
 description: Use when creating branded presentations or carousels. Generates museum-quality visual output from canvas philosophy, enforcing style constraints. Outputs PDF first, then converts to PPTX for editability.
+version: 1.11.3
+model: opus
+user-invocable: false
 ---
 
 # Visual Content Skill


### PR DESCRIPTION
## Summary

- **Agent memory**: brand-analyst uses `memory: project` for cross-session brand pattern learning
- **Model routing**: opus for visual-content (creative complexity), sonnet for brand-content-design and infographic-generator
- **Tool restrictions**: brand-analyst has `disallowedTools: Edit, Write, Bash` for read-only enforcement
- **Invocation control**: visual-content and infographic-generator set `user-invocable: false` (called by commands only)
- **PreCompact hook**: preserves active brand project context before compaction
- **CLAUDE.md**: plugin conventions at plugin root
- **`.claude/rules/`**: 3 path-scoped rule files (agent, skill, command conventions)
- **Version fields**: added to all agents and skills

## Files changed (14)

| Category | Files |
|----------|-------|
| Agent (1) | brand-analyst |
| Skills (3) | brand-content-design, visual-content, infographic-generator |
| New files (5) | CLAUDE.md, .claude/rules/{agent,skill,command}-conventions.md, hooks/pre-compact.sh |
| Config (5) | hooks.json, plugin.json, marketplace.json, CHANGELOG.md, README.md |

## Test plan

- [ ] Verify brand-analyst agent has correct model, memory, and tool restrictions
- [ ] Verify visual-content and infographic-generator hidden from `/` menu
- [ ] Verify PreCompact hook outputs brand project context
- [ ] Verify existing brand workflows (presentation, carousel, infographic) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)