### PR TITLE
feat(drupal-htmx): v1.1.0 - Tool restrictions, version fields, rules

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
       "name": "drupal-htmx",
       "source": "./drupal-htmx",
       "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/.claude/rules/agent-conventions.md
+++ b/drupal-htmx/.claude/rules/agent-conventions.md
@@ -1,0 +1,20 @@
+---
+globs: agents/**
+---
+
+# Agent Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — includes delegation triggers
+- `version` — semver
+- `model` — haiku, sonnet, or opus
+
+## Optional Frontmatter
+- `tools` — comma-separated allowlist
+- `disallowedTools` — comma-separated denylist
+
+## Body
+- Imperative voice: "Analyze...", "Scan...", "Validate..."
+- Read-only agents must not modify files
+- Return findings to caller, don't write directly

--- a/drupal-htmx/.claude/rules/command-conventions.md
+++ b/drupal-htmx/.claude/rules/command-conventions.md
@@ -1,0 +1,16 @@
+---
+globs: commands/**
+---
+
+# Command Conventions
+
+## Required Frontmatter
+- `description` — clear, concise action description
+- `allowed-tools` — minimum needed tools
+
+## Optional Frontmatter
+- `argument-hint` — when command accepts arguments
+
+## Body
+- Step-by-step workflow with numbered steps
+- Include error handling for missing prerequisites

--- a/drupal-htmx/.claude/rules/skill-conventions.md
+++ b/drupal-htmx/.claude/rules/skill-conventions.md
@@ -1,0 +1,19 @@
+---
+globs: skills/**
+---
+
+# Skill Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — starts with "Use when...", includes trigger phrases
+- `version` — semver
+
+## Optional Frontmatter
+- `model` — sonnet for balanced tasks
+- `user-invocable` — false for internal-only skills
+
+## Body
+- Imperative voice — instructions, not documentation
+- Under 500 lines per SKILL.md
+- Reference supporting files for detailed content

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2026-02-09
+
+### Added
+- **Tool restrictions**: All 3 agents have `disallowedTools` for read-only enforcement
+- **Version fields**: Added `version` to all agents and skill
+- **Model routing**: htmx-development skill set to `model: sonnet`
+- **CLAUDE.md**: Plugin conventions at plugin root
+- **Path-scoped rules**: `.claude/rules/` with agent, skill, and command conventions
+
 ## [1.0.0] - 2025-12-31
 
 ### Added

--- a/drupal-htmx/CLAUDE.md
+++ b/drupal-htmx/CLAUDE.md
@@ -1,0 +1,22 @@
+# Drupal HTMX - Plugin Conventions
+
+## Agents
+- Frontmatter must include: name, description, version, model
+- All agents are read-only analyzers — use `disallowedTools` to enforce
+- Description starts with action phrases for auto-delegation
+
+## Skills
+- Frontmatter must include: name, description, version
+- Add `model:` matched to complexity
+- Body uses imperative voice — instructions, not documentation
+- Under 500 lines per SKILL.md
+
+## Commands
+- Frontmatter must include: description, allowed-tools
+- Use `argument-hint:` when command accepts arguments
+- Restrict `allowed-tools` to minimum needed
+
+## General
+- Drupal 11.3+ HTMX patterns only — no legacy AJAX guidance
+- Reference files instead of reproducing content
+- Current state only — no historical narratives

--- a/drupal-htmx/README.md
+++ b/drupal-htmx/README.md
@@ -28,11 +28,11 @@ HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+.
 
 ## Agents
 
-| Agent | Purpose |
-|-------|---------|
-| `ajax-analyzer` | Scans modules for AJAX patterns, assesses complexity |
-| `htmx-recommender` | Recommends HTMX patterns for use cases |
-| `htmx-validator` | Validates HTMX implementations |
+| Agent | Model | Features |
+|-------|-------|----------|
+| `ajax-analyzer` | sonnet | Read-only (`disallowedTools: Edit, Write`), scans AJAX patterns |
+| `htmx-recommender` | sonnet | Read-only (`disallowedTools: Edit, Write, Bash`), recommends patterns |
+| `htmx-validator` | sonnet | Read-only (`disallowedTools: Edit, Write`), validates implementations |
 
 ## Skill
 

--- a/drupal-htmx/agents/ajax-analyzer.md
+++ b/drupal-htmx/agents/ajax-analyzer.md
@@ -2,8 +2,10 @@
 name: ajax-analyzer
 description: Analyzes Drupal modules for AJAX patterns and identifies migration candidates. Use proactively when user wants to find AJAX code to migrate to HTMX.
 capabilities: ["AJAX pattern detection", "migration complexity assessment", "code scanning"]
-tools: Read, Grep, Glob
+version: 1.0.0
 model: sonnet
+tools: Read, Grep, Glob
+disallowedTools: Edit, Write
 ---
 
 # AJAX Analyzer

--- a/drupal-htmx/agents/htmx-recommender.md
+++ b/drupal-htmx/agents/htmx-recommender.md
@@ -2,8 +2,10 @@
 name: htmx-recommender
 description: Recommends HTMX patterns for Drupal development. Use when user needs guidance on implementing dynamic content, forms, or interactions with HTMX.
 capabilities: ["pattern recommendation", "Htmx class configuration", "best practice guidance"]
-tools: Read, Glob
+version: 1.0.0
 model: sonnet
+tools: Read, Glob
+disallowedTools: Edit, Write, Bash
 ---
 
 # HTMX Recommender

--- a/drupal-htmx/agents/htmx-validator.md
+++ b/drupal-htmx/agents/htmx-validator.md
@@ -2,8 +2,10 @@
 name: htmx-validator
 description: Validates HTMX implementations in Drupal modules against best practices. Use after implementing HTMX to check for issues, accessibility, and progressive enhancement.
 capabilities: ["code validation", "best practice checking", "accessibility audit"]
-tools: Read, Grep, Glob
+version: 1.0.0
 model: sonnet
+tools: Read, Grep, Glob
+disallowedTools: Edit, Write
 ---
 
 # HTMX Validator

--- a/drupal-htmx/skills/htmx-development/SKILL.md
+++ b/drupal-htmx/skills/htmx-development/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: htmx-development
 description: Use when developing HTMX features in Drupal 11.3+ or migrating AJAX to HTMX. Covers Htmx class usage, form patterns, migration strategies, and validation. Triggers on "htmx", "ajax to htmx", "dynamic form", "dependent dropdown".
+version: 1.0.0
+model: sonnet
 ---
 
 # HTMX Development


### PR DESCRIPTION
## Summary

- **Tool restrictions**: All 3 agents have `disallowedTools` for read-only enforcement (ajax-analyzer, htmx-recommender, htmx-validator)
- **Version fields**: Added `version: 1.0.0` to all agents and skill
- **Model routing**: htmx-development skill set to `model: sonnet`
- **CLAUDE.md**: Plugin conventions at plugin root
- **`.claude/rules/`**: 3 path-scoped rule files (agent, skill, command conventions)

## Files changed (12)

| Category | Files |
|----------|-------|
| Agents (3) | ajax-analyzer, htmx-recommender, htmx-validator |
| Skills (1) | htmx-development |
| New files (4) | CLAUDE.md, .claude/rules/{agent,skill,command}-conventions.md |
| Config (4) | plugin.json, marketplace.json, CHANGELOG.md, README.md |

## Test plan

- [ ] Verify agents have correct disallowedTools in frontmatter
- [ ] Verify existing htmx commands still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)