### PR TITLE
feat(code-paper-test): v0.2.0 - Model routing and plugin conventions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,7 @@
       "name": "code-paper-test",
       "source": "./code-paper-test",
       "description": "Systematically test code through mental execution - trace code line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, and contract violations before deployment",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "author": {
         "name": "camoa"
       },

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-paper-test",
   "description": "Systematic code testing through mental execution - trace code line-by-line with concrete values to find bugs, missing logic, and edge cases before running",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/.claude/rules/skill-conventions.md
+++ b/code-paper-test/.claude/rules/skill-conventions.md
@@ -1,0 +1,15 @@
+# Skill Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — starts with "Use when...", includes trigger phrases
+- `version` — semver
+
+## Optional Frontmatter
+- `model` — sonnet for balanced tasks, opus for complex reasoning
+- `user-invocable` — false for internal-only skills
+
+## Body
+- Imperative voice — instructions, not documentation
+- Under 500 lines per SKILL.md
+- Reference supporting files for detailed content

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-02-09
+
+### Added
+- `model: sonnet` routing on paper-test skill for cost optimization
+- `CLAUDE.md` plugin conventions file
+- `.claude/rules/skill-conventions.md` for path-scoped skill standards
+- Version bumped to 0.2.0 in SKILL.md frontmatter
+
+### Changed
+- Aligned with camoa-skills plugin standards (model routing, rules, conventions)
+
+---
+
 ## [0.1.1] - 2025-12-26
 
 ### Added

--- a/code-paper-test/CLAUDE.md
+++ b/code-paper-test/CLAUDE.md
@@ -1,0 +1,12 @@
+# Code Paper Test - Plugin Conventions
+
+## Skills
+- Frontmatter must include: name, description, version, model
+- Description starts with "Use when..." and includes trigger phrases
+- Body uses imperative voice — instructions, not documentation
+- Under 500 lines per SKILL.md
+
+## General
+- Reference files instead of reproducing content
+- Current state only — no historical narratives
+- Language-agnostic examples preferred (PHP shown as primary)

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -196,7 +196,7 @@ Specific checks for AI-generated code:
 
 ## Version
 
-0.1.1
+0.2.0
 
 ## License
 

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: paper-test
 description: Use when testing code through mental execution - trace code line-by-line with concrete input values to find bugs, logic errors, missing code, edge cases, and contract violations before deployment
-version: 0.1.0
+version: 0.2.0
+model: sonnet
 ---
 
 # Paper Test


### PR DESCRIPTION
## Summary
- Added `model: sonnet` routing on paper-test skill for cost optimization
- Created `CLAUDE.md` plugin conventions file
- Added `.claude/rules/skill-conventions.md` for path-scoped skill standards
- Bumped version 0.1.1 → 0.2.0 across plugin.json, marketplace.json, SKILL.md, README

## Test plan
- [ ] Verify `paper-test` skill loads with sonnet model
- [ ] Confirm CLAUDE.md is picked up by Claude Code
- [ ] Validate rules file is scoped to skill paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)