### PR TITLE
fix(drupal-dev-framework): v3.2.0 - User-configured project storage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "author": {
         "name": "camoa"
       },

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Create an agent that reviews code for security issues
 
 The skill triggers automatically when you mention creating plugins, skills, commands, agents, or hooks.
 
-### drupal-dev-framework (v3.1.0)
+### drupal-dev-framework (v3.2.0)
 
 Systematic Drupal development workflow. Enforces SOLID, TDD, DRY, security, and code purposefulness principles through 5 quality gates.
 

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-02-10
+
+### Changed
+- **Project storage**: Registry now stores `projectsBase` — user's preferred base path for all projects, asked once on first run
+- **Default path**: Removed hardcoded `../claude_projects/` default; new projects use saved `projectsBase/{name}/`
+- **Registry schema v1.1**: Removed `phase` field (phase is per-task, not per-project). Added `projectsBase` field
+- **project-initializer** v1.3.0: Reads `projectsBase` from registry, asks user on first run instead of assuming a path
+- **memory-manager**: No longer writes `phase` to registry
+
 ## [3.1.0] - 2026-02-07
 
 ### Added

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -295,7 +295,11 @@ This plugin builds on patterns and integrates with:
 
 See [CHANGELOG.md](./CHANGELOG.md) for full version history.
 
-### 3.1.0 (Current)
+### 3.2.0 (Current)
+- User-configured project storage: `projectsBase` saved in registry on first run, no hardcoded defaults
+- Registry schema v1.1: removed stale `phase` field (phase is per-task)
+
+### 3.1.0
 - Agent memory, model routing, tool restrictions across all agents and skills
 - Dynamic context injection, `.claude/rules/`, CLAUDE.md, PreCompact hook
 - Lean documentation: pruned v2.x migration content, condensed output templates

--- a/drupal-dev-framework/commands/new.md
+++ b/drupal-dev-framework/commands/new.md
@@ -18,7 +18,7 @@ Initialize a new development project with complete memory structure.
 ## What This Does
 
 1. Asks for project name (if not provided)
-2. Asks where to store project files (default: `~/workspace/claude_projects/{name}/`)
+2. Asks where to store project files (uses saved base path from registry, or asks on first run)
 3. Creates project folder structure:
    - `project_state.md`
    - `architecture/main.md`
@@ -43,16 +43,14 @@ Enter project name (lowercase, underscores only):
 > content_workflow
 
 Where should project files be stored?
-Default: ~/workspace/claude_projects/content_workflow/
+Default: ~/my/projects/content_workflow/    (from saved base path)
 Press Enter to accept or provide custom path:
 > [Enter]
 
 Creating project: content_workflow
-Location: ~/workspace/claude_projects/content_workflow/
+Location: ~/my/projects/content_workflow/
 
-✓ Directory structure created
-✓ Project registered
-✓ Initializing project...
+Structure created, project registered, initializing...
 
 Now gathering requirements...
 ```

--- a/drupal-dev-framework/skills/memory-manager/SKILL.md
+++ b/drupal-dev-framework/skills/memory-manager/SKILL.md
@@ -147,7 +147,6 @@ Update the registry at `~/.claude/drupal-dev-framework/active_projects.json`:
 2. Find this project by path
 3. Update:
    - `lastAccessed`: today's date
-   - `phase`: current detected phase
    - `status`: "active" or "archived" if all tasks complete
 4. Write the updated registry
 

--- a/drupal-dev-framework/skills/project-initializer/SKILL.md
+++ b/drupal-dev-framework/skills/project-initializer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-initializer
 description: Use when starting a new development project - creates memory folder structure with project_state.md, architecture scaffolding, and registers project
-version: 1.2.0
+version: 1.3.0
 ---
 
 # Project Initializer
@@ -29,12 +29,13 @@ Validate the name matches pattern `^[a-z][a-z0-9_]*$`. If invalid, ask again.
 
 ### 2. Get Storage Location
 
-Ask:
+Read the registry at `~/.claude/drupal-dev-framework/active_projects.json`. Check if `projectsBase` is set.
+
+**If `projectsBase` exists** — use it as default:
 ```
 Where should project files be stored?
 
-Default: ../claude_projects/{project_name}/
-(relative to current working directory)
+Default: {projectsBase}/{project_name}/
 
 Options:
 1. Accept default
@@ -42,6 +43,16 @@ Options:
 
 Your choice:
 ```
+
+**If `projectsBase` is NOT set** (first-time setup) — ask:
+```
+Where do you keep your project memory files?
+This folder will store architecture docs, task files, and project state.
+
+Enter the base path (all projects will be created as subfolders here):
+```
+
+Save the chosen base path as `projectsBase` in the registry (see Step 7).
 
 Convert relative paths to absolute. Store the full path.
 
@@ -130,23 +141,27 @@ Then read existing registry (or create new if doesn't exist) and add the project
 **Registry Schema:**
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
+  "projectsBase": "{user's chosen base path for all projects}",
   "projects": [
     {
       "name": "{project_name}",
       "path": "{full_path_to_project}",
       "created": "{YYYY-MM-DD}",
       "lastAccessed": "{YYYY-MM-DD}",
-      "phase": 1,
       "status": "active"
     }
   ]
 }
 ```
 
+- `projectsBase` — set once on first project creation, reused as default for all future projects
+- `path` — always the full absolute path to the specific project folder
+- No `phase` field — phase is tracked per-task in task files, not per-project
+
 Use `Read` to load existing registry, then `Write` to save updated version with new project appended.
 
-If registry doesn't exist, create it with just this project.
+If registry doesn't exist, create it with `projectsBase` and this project.
 
 ### 8. Invoke Requirements Gatherer
 


### PR DESCRIPTION
## Summary

- **`projectsBase` in registry** — user's preferred base path saved on first project creation, reused as default for all future projects. No more hardcoded `../claude_projects/` or `~/workspace/claude_projects/`
- **Registry schema v1.1** — removed stale `phase` field (phase is per-task, not per-project; was never kept up-to-date). Added `projectsBase` field
- **project-initializer v1.3.0** — reads `projectsBase` from registry on subsequent runs, asks user on first run
- **memory-manager** — no longer writes `phase` to registry entries
- **Version bump** — 3.1.0 → 3.2.0 across plugin.json, marketplace.json, README, CHANGELOG

### Local cleanup also done (not in this PR)
- Moved 5 scattered projects from `~/workspace/claude_memory/{name}/` into `~/workspace/claude_memory/projects/{name}/`
- Updated registry paths and project_state.md references
- Deleted empty `claude_projects/` folder and pre-framework `completed_tasks/` folder
- Set `projectsBase` in local registry

## Test plan

- [ ] Run `/drupal-dev-framework:new test_project` — should ask for base path on first run (if projectsBase not set) or use saved default
- [ ] Verify registry entry has no `phase` field
- [ ] Verify `projectsBase` is saved to registry after first project

🤖 Generated with [Claude Code](https://claude.com/claude-code)