### PR TITLE
feat(brand-content-design): add Lucide inline SVG icons to HTML generator

### DIFF
--- a/brand-content-design/commands/html-page-quick.md
+++ b/brand-content-design/commands/html-page-quick.md
@@ -1,6 +1,6 @@
 ---
 description: Create a branded HTML page quickly with minimal questions
-allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Skill
+allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, Skill
 ---
 
 # HTML Page Quick Command

--- a/brand-content-design/commands/html-page.md
+++ b/brand-content-design/commands/html-page.md
@@ -1,6 +1,6 @@
 ---
 description: Create a branded HTML page by selecting components from a design system
-allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Skill
+allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, Skill
 ---
 
 # HTML Page Command

--- a/brand-content-design/scripts/html-icons.js
+++ b/brand-content-design/scripts/html-icons.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for Lucide icons — outputs inline SVG for HTML embedding.
+ *
+ * Reuses icons.js from infographic-generator for icon loading.
+ *
+ * Usage:
+ *   node scripts/html-icons.js get rocket lightbulb shield
+ *   node scripts/html-icons.js search chart
+ *   node scripts/html-icons.js category business
+ *   node scripts/html-icons.js categories
+ */
+
+const path = require('path');
+
+// Resolve plugin root from BRAND_CONTENT_DESIGN_DIR or script location
+const pluginDir = process.env.BRAND_CONTENT_DESIGN_DIR || path.resolve(__dirname, '..');
+const iconsLib = require(path.join(pluginDir, 'skills', 'infographic-generator', 'lib', 'icons.js'));
+
+const [command, ...args] = process.argv.slice(2);
+
+switch (command) {
+  case 'get': {
+    if (args.length === 0) {
+      console.error('Usage: html-icons.js get <name> [name2] [name3] ...');
+      process.exit(1);
+    }
+    for (const name of args) {
+      const svg = iconsLib.getIcon(name);
+      if (svg) {
+        console.log(`<!-- icon: ${name} -->`);
+        console.log(svg);
+      } else {
+        console.error(`Icon not found: ${name}`);
+      }
+    }
+    break;
+  }
+
+  case 'search': {
+    if (args.length === 0) {
+      console.error('Usage: html-icons.js search <keyword>');
+      process.exit(1);
+    }
+    const results = iconsLib.searchIcons(args[0]);
+    if (results.length === 0) {
+      console.error(`No icons matching "${args[0]}"`);
+    } else {
+      console.log(results.join('\n'));
+    }
+    break;
+  }
+
+  case 'category': {
+    if (args.length === 0) {
+      console.error('Usage: html-icons.js category <name>');
+      process.exit(1);
+    }
+    const icons = iconsLib.getIconsByCategory(args[0]);
+    if (icons.length === 0) {
+      console.error(`Unknown category: ${args[0]}`);
+      console.error(`Available: ${iconsLib.listCategories().join(', ')}`);
+    } else {
+      console.log(icons.join('\n'));
+    }
+    break;
+  }
+
+  case 'categories': {
+    console.log(iconsLib.listCategories().join('\n'));
+    break;
+  }
+
+  default:
+    console.error('Commands: get, search, category, categories');
+    console.error('  get <name> [...]    — output inline SVG for named icons');
+    console.error('  search <keyword>    — find icons matching keyword');
+    console.error('  category <name>     — list icons in a category');
+    console.error('  categories          — list all category names');
+    process.exit(1);
+}

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -158,6 +158,70 @@ Components reference design tokens (not hardcoded values):
 
 ---
 
+## Part 3.5: Icon Integration
+
+Lucide icons (1,500+ icons) are available as inline SVG via a CLI script.
+
+### Fetching Icons
+
+```bash
+# Get inline SVG for one or more icons
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" get rocket lightbulb shield
+
+# Search by keyword
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" search chart
+
+# List icons in a category
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" category business
+
+# List all categories
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" categories
+```
+
+The `get` command outputs each SVG on its own line prefixed with `<!-- icon: {name} -->`.
+
+### Embedding Pattern
+
+Icons use `currentColor` for stroke and inherit size from the parent container:
+
+```html
+<div class="feature-grid__icon" aria-hidden="true">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <!-- paths from script output -->
+  </svg>
+</div>
+```
+
+### CSS Styling
+
+Control icon size and color through the container:
+
+```css
+.feature-grid__icon {
+  width: 48px;
+  height: 48px;
+  color: var(--color-primary);
+}
+.feature-grid__icon svg {
+  width: 100%;
+  height: 100%;
+}
+```
+
+### When to Use Icons
+
+- Use icons when a clear visual metaphor exists (rocket for launch, shield for security)
+- Pair icons with text labels — never use icons alone for meaning
+- Skip icons when no good match exists; forced icons weaken the design
+
+### Accessibility
+
+- **Decorative icons** (paired with text): `aria-hidden="true"` on the SVG
+- **Meaningful icons** (convey info alone): `role="img" aria-label="Description"` on the SVG
+
+---
+
 ## Part 4: Style Enforcement
 
 Read `references/web-style-constraints.md` for the selected style and enforce:
@@ -395,7 +459,7 @@ Design components for future conversion to other frameworks:
 <!-- prop: section-title type: string -->
 <!-- prop: section-subtitle type: string -->
 <!-- slot: features -->
-  <!-- prop: feature-icon type: string -->
+  <!-- prop: feature-icon type: string (Lucide icon name) -->
   <!-- prop: feature-title type: string -->
   <!-- prop: feature-description type: string -->
 <!-- /slot: features -->

--- a/brand-content-design/skills/html-generator/references/html-components.md
+++ b/brand-content-design/skills/html-generator/references/html-components.md
@@ -164,7 +164,7 @@ Feature or benefit showcase in a grid layout.
 <!-- prop: section-title type: string -->
 <!-- prop: section-subtitle type: string (optional) -->
 <!-- slot: features -->
-  <!-- prop: feature-icon type: string (CSS class or emoji) -->
+  <!-- prop: feature-icon type: string (Lucide icon name, e.g. "rocket") -->
   <!-- prop: feature-title type: string -->
   <!-- prop: feature-description type: string -->
 <!-- /slot: features -->
@@ -178,7 +178,9 @@ Feature or benefit showcase in a grid layout.
     <p class="feature-grid__subtitle">Section subtitle</p>
     <div class="feature-grid__grid">
       <div class="feature-grid__item">
-        <div class="feature-grid__icon">Icon</div>
+        <div class="feature-grid__icon" aria-hidden="true">
+          <!-- inline SVG from html-icons.js -->
+        </div>
         <h3 class="feature-grid__item-title">Feature</h3>
         <p class="feature-grid__item-desc">Description</p>
       </div>
@@ -300,7 +302,7 @@ Key numbers or metrics displayed prominently.
 <!-- slot: stats -->
   <!-- prop: stat-value type: string -->
   <!-- prop: stat-label type: string -->
-  <!-- prop: stat-icon type: string (optional) -->
+  <!-- prop: stat-icon type: string (optional, Lucide icon name) -->
 <!-- /slot: stats -->
 ```
 
@@ -478,7 +480,7 @@ Step-by-step flow showing a process, timeline, or journey.
   <!-- prop: step-number type: string -->
   <!-- prop: step-title type: string -->
   <!-- prop: step-description type: string -->
-  <!-- prop: step-icon type: string (optional) -->
+  <!-- prop: step-icon type: string (optional, Lucide icon name) -->
 <!-- /slot: steps -->
 ```
 

--- a/brand-content-design/skills/html-generator/references/html-technical.md
+++ b/brand-content-design/skills/html-generator/references/html-technical.md
@@ -199,6 +199,68 @@ Since Claude cannot generate actual images, create visual placeholders:
 
 ---
 
+## Icon Integration
+
+Lucide icons are available as inline SVG via a CLI script. Use Bash to fetch icons during generation.
+
+### Fetching Icons
+
+```bash
+# Get SVG for specific icons
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" get rocket shield lightbulb
+
+# Search by keyword
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" search chart
+
+# List icons in a category
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" category business
+
+# List all categories
+node "$BRAND_CONTENT_DESIGN_DIR/scripts/html-icons.js" categories
+```
+
+### Inline SVG Embedding
+
+Paste the SVG output directly into the HTML. Icons use `currentColor` for stroke, so they inherit color from CSS:
+
+```html
+<div class="feature-grid__icon" aria-hidden="true">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <!-- SVG paths from script output -->
+  </svg>
+</div>
+```
+
+### Icon Container CSS
+
+Control size and color through the parent element:
+
+```css
+.feature-grid__icon {
+  width: 48px;
+  height: 48px;
+  color: var(--color-primary);
+}
+.feature-grid__icon svg {
+  width: 100%;
+  height: 100%;
+}
+```
+
+### Accessibility
+
+| Context | Attribute |
+|---------|-----------|
+| Decorative (next to text label) | `aria-hidden="true"` on `<svg>` |
+| Meaningful (conveys info alone) | `role="img" aria-label="Description"` on `<svg>` |
+
+### Available Categories
+
+Categories are defined in `skills/infographic-generator/lib/icons.js` — `ICON_CATEGORIES` object. Run `categories` command to list them. Common ones: business, growth, technology, security, actions, misc.
+
+---
+
 ## Vanilla JS Patterns
 
 Use only when CSS cannot achieve the desired effect. Always progressive enhancement.


### PR DESCRIPTION
## Summary

- **New script** `scripts/html-icons.js` — CLI wrapper for inline SVG output, reuses existing `icons.js` from infographic generator
- **Commands** — Added `Bash` to allowed-tools for `html-page` and `html-page-quick` so the generator can call the icon script
- **SKILL.md** — Added Part 3.5: Icon Integration with fetching, embedding, CSS styling, and accessibility patterns
- **html-components.md** — Changed icon prop types from `string (CSS class or emoji)` to `string (Lucide icon name)` for feature-grid, stats-bar, and process-steps
- **html-technical.md** — Added Icon Integration section with script usage, inline SVG embedding, container CSS, and accessibility rules

## Test plan

- [ ] Run `node scripts/html-icons.js get rocket` — outputs clean inline SVG
- [ ] Run `node scripts/html-icons.js search chart` — lists matching icon names
- [ ] Run `node scripts/html-icons.js category business` — lists business icons
- [ ] Run `node scripts/html-icons.js categories` — lists all category names
- [ ] Invoke `/html-page-quick` on a test project and verify icons appear as inline SVGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)