### PR TITLE
feat(brand-content-design): v2.2.0 - HTML-to-Drupal Radix/SDC converter

### DIFF
--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brand-content-design",
-  "version": "2.1.0",
-  "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
+  "version": "2.2.0",
+  "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, Presentation Zen principles, and HTML-to-Drupal Radix/SDC converter",
   "author": {
     "name": "camoa"
   },
@@ -26,6 +26,12 @@
     "zen",
     "cards",
     "icons",
-    "gradients"
+    "gradients",
+    "drupal",
+    "radix",
+    "sdc",
+    "layout-builder",
+    "converter",
+    "theme"
   ]
 }

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-02-11
+
+### Added
+- **HTML-to-Drupal Radix/SDC Converter**: Metadata-driven converter that parses HTML component comments to generate Drupal themes
+  - `/convert-to-radix` command: Guided 7-phase wizard with 6 AskUserQuestion points for full control
+  - `/convert-to-radix-quick` command: Quick mode with 3 questions and auto-resolved ambiguities
+  - `html-to-radix-analyzer` skill: Shared analysis layer (HTML metadata parsing, pattern classification, design token extraction, Drupal backend inventory, atomic classification)
+  - `radix-sdc-generator` skill: Generates complete Radix 6.0.2 sub-theme with SDC components, Bootstrap SCSS mapping, Layout Builder config, and icon packs
+  - `scripts/extract-icons.js`: CLI tool to extract inline SVGs from HTML for Drupal Icon API
+  - 7 reference files: pattern-classification, atomic-classification, drupal-backend-inventory, radix-theme-scaffold, token-to-bootstrap-mapping, sdc-patterns, layout-builder-config
+- **Architecture**: Shared analysis layer + target-specific generators (Radix first, Canvas and Node.js future)
+- **Metadata-driven**: Parses `<!-- component: -->` / `<!-- prop: -->` / `<!-- slot: -->` comments dynamically, not hardcoded to 15 component types
+- **6px threshold framework**: Design token to Bootstrap SCSS variable mapping (Accommodate/Extend/Customize/Create)
+- **Drupal backend inventory**: Scans `config/sync/` for content types, views, block types, menus to maximize reuse
+- **Atomic classification**: Dynamic atom/molecule/organism heuristics with Radix base component reuse detection
+- **Per-project config**: `converter/radix-sdc.yml` stores all conversion decisions for reproducibility
+
+### Changed
+- **SKILL.md**: Added converter trigger phrases and command routing
+- **plugin.json**: Version bump to 2.2.0, added Drupal/Radix/SDC keywords
+
 ## [2.1.0] - 2026-02-09
 
 ### Added

--- a/brand-content-design/commands/convert-to-radix-quick.md
+++ b/brand-content-design/commands/convert-to-radix-quick.md
@@ -1,0 +1,139 @@
+---
+description: Quick-convert branded HTML pages to a Drupal Radix sub-theme
+allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, Skill
+---
+
+# Convert to Radix Quick Command
+
+Quick-convert branded HTML pages into a Drupal Radix sub-theme with minimal interaction. Auto-resolves all ambiguities using sensible defaults: components with few instances become block types, components with many instances become views, icons always generate a pack, and all recommended modules are included.
+
+## Prerequisites
+
+- A brand project with `brand-philosophy.md`
+- At least one HTML design system with `design-system.md` and `canvas-philosophy.md`
+- At least one HTML page in `html-pages/` containing metadata comments
+- The `html-to-radix-analyzer` and `radix-sdc-generator` skills
+
+---
+
+## Workflow
+
+### Step 1: Find Project and HTML Pages
+
+Search for `brand-philosophy.md` using standard project detection order:
+
+1. Current directory — check `./brand-philosophy.md`
+2. Parent directory — check `../brand-philosophy.md`
+3. Subdirectories — `find . -maxdepth 2 -name "brand-philosophy.md"`
+4. If multiple found — ask user which project
+5. If none found — tell user to run `/brand-init` first
+
+Set `PROJECT_PATH` to the directory containing `brand-philosophy.md`.
+
+Search for HTML files with metadata comments:
+```
+find {PROJECT_PATH}/html-pages -name "*.html" -type f 2>/dev/null
+```
+
+Verify each file contains `<!-- component:` markers. If none found — tell user to run `/html-page` first and ensure pages include metadata comments.
+
+If exactly one page found — auto-select it.
+
+### Step 2: Select Pages
+
+Only ask if multiple pages exist.
+
+**AskUserQuestion**: "Which pages to convert?"
+
+If 4 or fewer pages, list each plus "All pages". If more than 4, show the 3 most recent (by directory date prefix) plus "All pages".
+
+- **{page-name}** — {date}, {component count} components
+- **All pages** — Convert all {count} pages
+
+Store as `SELECTED_PAGES`.
+
+### Step 3: Drupal Path
+
+**AskUserQuestion**: "Drupal codebase path?"
+- **None — green-field** — "Generate complete structure from scratch"
+- **Provide path** — "I'll scan config/sync/ for existing backend to reuse"
+
+If path provided, verify `config/sync/` exists. Warn if missing but continue.
+
+Store as `DRUPAL_PATH` (path string or `null`).
+
+### Step 4: Theme Name
+
+Read `brand-philosophy.md` to extract the brand name. Derive a machine name: lowercase, replace spaces/hyphens with underscores, remove special characters.
+
+**AskUserQuestion**: "Theme machine name?"
+- **{suggested_name}** — Based on brand name
+- **{suggested_name}_theme** — With _theme suffix
+- **Custom** — Enter your own
+
+Validate: lowercase letters, digits, underscores; starts with a letter. Re-ask if invalid.
+
+Store as `THEME_NAME`.
+
+### Step 5: Auto-Analyze and Generate
+
+Read all required files:
+- Each selected HTML page
+- Design system: `{PROJECT_PATH}/templates/html/*/design-system.md`
+- Canvas philosophy: `{PROJECT_PATH}/templates/html/*/canvas-philosophy.md`
+- Brand philosophy: `{PROJECT_PATH}/brand-philosophy.md`
+
+Invoke the `html-to-radix-analyzer` skill via the Skill tool with HTML contents, design system files, brand philosophy, and `DRUPAL_PATH` if provided.
+
+Apply quick-mode auto-resolution rules to the analysis result:
+- **Ambiguous components with 1-3 instances** — classify as `block_type`
+- **Ambiguous components with 4+ instances** — classify as `view_content_type`
+- **Icons** — always generate an icon pack (`ICON_STRATEGY = "generate_pack"`)
+- **Modules** — accept all recommended modules
+
+Invoke the `radix-sdc-generator` skill via the Skill tool with:
+- Analysis output (with auto-resolved classifications)
+- `THEME_NAME`
+- `DRUPAL_PATH` (if provided)
+- Icon strategy: `generate_pack` if icons exist, `none` otherwise
+- Full recommended module list
+- Design system and brand philosophy contents
+
+Save conversion config to `{PROJECT_PATH}/converter/radix-sdc.yml` (create `converter/` directory if needed).
+
+### Step 6: Display Summary
+
+Present the results:
+
+```
+-- Theme Generated --
+
+Theme: {THEME_NAME}
+Location: {PROJECT_PATH}/converter/{THEME_NAME}/
+
+Components: {count} ({atoms} atoms, {molecules} molecules, {organisms} organisms)
+Config exports: {count}
+Icons: {count} (if applicable)
+
+Commands to run:
+  composer require drupal/radix drupal/layout_builder_styles {other modules}
+  drush en {module_list}
+  drush theme:enable {THEME_NAME}
+  drush config:set system.theme default {THEME_NAME}
+  cd {theme_path} && npm install && npm run build
+
+Next steps:
+  1. Copy theme to your Drupal themes/custom/ directory
+  2. Import config exports with drush config:import
+  3. Configure Layout Builder on target content types
+
+Conversion config: {PROJECT_PATH}/converter/radix-sdc.yml
+```
+
+---
+
+## Output
+
+- Created: `{PROJECT_PATH}/converter/radix-sdc.yml` (conversion configuration)
+- Created: `{PROJECT_PATH}/converter/{THEME_NAME}/` (complete Radix sub-theme)
+- Created: SDC components, SCSS, config exports, and optional icon pack within theme directory

--- a/brand-content-design/commands/convert-to-radix.md
+++ b/brand-content-design/commands/convert-to-radix.md
@@ -1,0 +1,343 @@
+---
+description: Convert branded HTML pages to a Drupal Radix sub-theme with SDC components and Layout Builder composition
+allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, Skill
+---
+
+# Convert to Radix Command
+
+Convert branded HTML pages (with metadata comments) into a Drupal Radix sub-theme featuring SDC components, SCSS tokens, Layout Builder configuration, and optional icon packs. The converter is metadata-driven — it parses `<!-- component: ... -->` annotations dynamically, not hardcoded to specific component types.
+
+## Prerequisites
+
+- A brand project with `brand-philosophy.md`
+- At least one HTML design system with `design-system.md` and `canvas-philosophy.md`
+- At least one HTML page in `html-pages/` containing metadata comments
+- The `html-to-radix-analyzer` and `radix-sdc-generator` skills
+
+---
+
+## Workflow
+
+### Phase 1: Discovery
+
+#### Step 1: Find Project
+
+Search for `brand-philosophy.md` using standard project detection order:
+
+1. Current directory — check `./brand-philosophy.md`
+2. Parent directory — check `../brand-philosophy.md`
+3. Subdirectories — `find . -maxdepth 2 -name "brand-philosophy.md"`
+4. If multiple found — ask user which project
+5. If none found — tell user to run `/brand-init` first
+
+Set `PROJECT_PATH` to the directory containing `brand-philosophy.md`.
+
+#### Step 2: Find HTML Pages
+
+Search for HTML files with metadata comments:
+```
+find {PROJECT_PATH}/html-pages -name "*.html" -type f 2>/dev/null
+```
+
+For each file found, check for metadata comment markers (`<!-- component:`) to confirm they are annotated pages. List found pages with their directory dates (extracted from the `YYYY-MM-DD` prefix in directory names).
+
+If none found — tell user to run `/html-page` or `/html-page-quick` first, and ensure pages contain metadata comments.
+
+#### Step 3: Select Pages
+
+**AskUserQuestion**: "Which HTML pages should we convert?"
+
+If 4 or fewer pages exist, list each as an option plus "All pages".
+
+If more than 4 pages exist, show the 3 most recent (by directory date) plus "All pages".
+
+Options format:
+- **{page-name}** — {date}, {component count} components detected
+- **All pages** — Convert everything found ({count} pages)
+
+Store selected pages as `SELECTED_PAGES`.
+
+---
+
+### Phase 2: Drupal Context
+
+#### Step 4: Drupal Codebase
+
+**AskUserQuestion**: "Do you have an existing Drupal codebase to target?"
+- **Yes — provide path** — "I'll scan config/sync/ for existing content types, views, and modules"
+- **No — green-field** — "I'll generate a complete recommended structure from scratch"
+
+If user selects "Yes", ask for the Drupal root path. Verify the path exists and contains `config/sync/`:
+```
+ls {DRUPAL_PATH}/config/sync/ 2>/dev/null
+```
+
+If `config/sync/` is missing, warn the user and ask whether to continue without backend inventory or provide a corrected path.
+
+Store result as `DRUPAL_PATH` (path string or `null` for green-field).
+
+#### Step 5: Theme Name
+
+Read `brand-philosophy.md` to extract the brand name. Derive a suggested machine name:
+- Lowercase the brand name
+- Replace spaces and hyphens with underscores
+- Remove special characters
+- Truncate to 32 characters if needed
+
+**AskUserQuestion**: "What should the Radix sub-theme be called?"
+- **{suggested_name}** — Based on brand name "{brand name}"
+- **{suggested_name}_theme** — Longer variant with _theme suffix
+- **Custom** — Enter your own machine name
+
+Validate the chosen name: lowercase letters, digits, and underscores only; must start with a letter; must be a valid Drupal machine name. If invalid, explain the constraints and ask again.
+
+Store as `THEME_NAME`.
+
+---
+
+### Phase 3: Analysis
+
+#### Step 6: Run Analysis
+
+Read the following files:
+- Each selected HTML page from `SELECTED_PAGES`
+- `{PROJECT_PATH}/templates/html/*/design-system.md` (find the design system associated with the pages)
+- `{PROJECT_PATH}/templates/html/*/canvas-philosophy.md`
+- `{PROJECT_PATH}/brand-philosophy.md`
+
+Invoke the `html-to-radix-analyzer` skill via the Skill tool with this context:
+- HTML file paths and their contents
+- `DRUPAL_PATH` (if provided, for config/sync scanning)
+- Design system and canvas philosophy contents
+- Brand philosophy contents
+
+The skill parses metadata comments (`<!-- component: ... -->`, `<!-- prop: ... -->`, `<!-- slot: ... -->`) from each HTML page and returns:
+- **components** — List of components with names, variants, props, slots, nesting
+- **design_tokens** — Extracted from `:root { --color-*: ...; --font-*: ...; }` blocks
+- **classifications** — Each component classified as: block_type, view_content_type, menu, form, or ambiguous
+- **icons** — Icon references found in metadata or inline SVGs
+- **inventory** — If DRUPAL_PATH provided: existing content types, views, vocabularies, modules, and reuse matches
+- **atomic_levels** — Each component assigned: atom, molecule, organism
+- **warnings** — Issues, conflicts, or items needing attention
+
+Store the full analysis result as `ANALYSIS`.
+
+---
+
+### Phase 4: Review Plan
+
+#### Step 7: Display Analysis Summary
+
+Present the analysis to the user in a structured summary:
+
+```
+-- Conversion Analysis --
+
+Components: {count} found across {page_count} pages
+  Atoms: {count}  |  Molecules: {count}  |  Organisms: {count}
+
+Classifications:
+  Block types:          {count}
+  Views + content type: {count}
+  Menus:                {count}
+  Forms:                {count}
+  Ambiguous:            {count}
+
+Design Tokens: {count} total
+  Colors: {count}  |  Typography: {count}  |  Spacing: {count}  |  Other: {count}
+
+Icons: {count} unique icons referenced
+```
+
+If `DRUPAL_PATH` was provided, also show:
+```
+Backend Inventory:
+  Existing content types: {count} ({list reuse matches})
+  Existing views:         {count} ({list reuse matches})
+  Modules enabled:        {count relevant}
+  Reusable:               {count} components match existing backend
+  New:                    {count} components need new backend config
+```
+
+If warnings exist, list each one clearly.
+
+#### Step 8: Review Plan
+
+**AskUserQuestion**: "Here is the conversion plan. How would you like to proceed?"
+- **Approve and continue** — "Generate the theme with these settings"
+- **Modify classifications** — "I want to change how some components are handled"
+- **Start over** — "Let me reconfigure from the beginning"
+
+If **Start over**: return to Step 3.
+
+If **Modify classifications**: for each component, show its current classification and ask the user to confirm or override. Use follow-up AskUserQuestion calls, grouping up to 4 components per question where practical:
+- "{component_name}: currently classified as {classification}. Change to?"
+- Options: Block type, View + content type, Menu, Form, Skip
+
+After modifications, update `ANALYSIS` with the overrides and return to Step 7 to re-display the summary.
+
+If **Approve and continue**: proceed to Phase 5.
+
+---
+
+### Phase 5: Resolve Ambiguities
+
+#### Step 9: Handle Ambiguous Items
+
+Only execute this step if `ANALYSIS` contains components flagged as `ambiguous: true`.
+
+For each ambiguous component:
+
+**AskUserQuestion**: "How should we handle '{component_name}'? (appears {count} times across pages)"
+- **Custom block type** — "Static curated content, managed per-block in Layout Builder"
+- **View + content type** — "Dynamic listing, each item is a content node"
+- **Skip** — "Do not convert this component"
+
+Update `ANALYSIS` with each resolution.
+
+#### Step 10: Icon Strategy
+
+If icons were found in `ANALYSIS`:
+
+Display: "{count} unique icons referenced across components."
+
+Check if `DRUPAL_PATH` has an existing icon module or icon pack configuration:
+```
+find {DRUPAL_PATH}/config/sync -name "ui_icons*" 2>/dev/null
+ls {DRUPAL_PATH}/modules/custom/*/icons/ 2>/dev/null
+```
+
+If existing icon infrastructure found:
+- Report what was found and suggest reusing it
+- Store `ICON_STRATEGY = "reuse_existing"`
+
+If no existing icons:
+- Store `ICON_STRATEGY = "generate_pack"` (generate a Drupal Icon API pack using `extractor: svg`)
+
+If no icons found in analysis, store `ICON_STRATEGY = "none"`.
+
+#### Step 11: Module Review
+
+Compile a list of recommended Drupal modules based on the analysis:
+- **Required**: `drupal/radix`, `drupal/layout_builder` (core)
+- **Recommended**: `drupal/layout_builder_styles` (section styling)
+- **If icons**: `drupal/ui_icons` (Drupal Core Icon API)
+- **If views detected**: `drupal/views` (core, usually enabled)
+- **If forms detected**: `drupal/webform` or `drupal/contact` depending on complexity
+- Any additional modules identified by the analyzer
+
+**AskUserQuestion**: "These Drupal modules are recommended for this conversion:"
+Show the compiled list with brief purpose for each.
+- **Accept all** — "Install all recommended modules"
+- **Customize** — "Let me review and adjust the module list"
+- **Minimal** — "Only essential modules (radix + layout_builder)"
+
+If **Customize**: show each module and let user toggle on/off via follow-up questions.
+
+Store final module list as `MODULES`.
+
+#### Step 12: Save Configuration
+
+Write all collected decisions to `{PROJECT_PATH}/converter/radix-sdc.yml`:
+
+```yaml
+converter:
+  target: radix-sdc
+  created: {ISO date}
+  theme_name: {THEME_NAME}
+  drupal_path: {DRUPAL_PATH or null}
+
+pages:
+  - {list of selected page paths}
+
+analysis:
+  component_count: {count}
+  token_count: {count}
+  icon_count: {count}
+
+classifications:
+  {component_name}: {classification}
+  # ... for each component
+
+icon_strategy: {ICON_STRATEGY}
+
+modules:
+  - {module list}
+
+ambiguity_resolutions:
+  {component_name}: {resolution}
+  # ... for each resolved ambiguity
+```
+
+Create the `converter/` directory if it does not exist.
+
+---
+
+### Phase 6: Generation
+
+#### Step 13: Generate Theme
+
+Invoke the `radix-sdc-generator` skill via the Skill tool with:
+- Full `ANALYSIS` output from Step 6 (with any user modifications from Steps 8-9)
+- `THEME_NAME` from Step 5
+- `DRUPAL_PATH` (if provided)
+- `ICON_STRATEGY` from Step 10
+- `MODULES` list from Step 11
+- Classification overrides and ambiguity resolutions
+- Design system and brand philosophy contents
+
+The skill generates:
+- Theme directory structure under `{PROJECT_PATH}/converter/{THEME_NAME}/`
+- `{THEME_NAME}.info.yml` — theme definition with Radix base theme
+- `{THEME_NAME}.libraries.yml` — asset libraries
+- SDC component directories under `components/` — each with `.twig`, `.yml` (schema), `.scss`
+- Global SCSS with design tokens mapped to Bootstrap variables
+- Layout Builder config exports under `config/` — section layouts with styles
+- Icon pack directory (if `ICON_STRATEGY` is `generate_pack`)
+- `package.json` with build tooling (Webpack or Vite)
+
+---
+
+### Phase 7: Completion
+
+#### Step 14: Display Summary
+
+Present the generation results:
+
+```
+-- Theme Generated --
+
+Theme: {THEME_NAME}
+Location: {PROJECT_PATH}/converter/{THEME_NAME}/
+
+Files created: {total count}
+  Theme config:    {count} (.info.yml, .libraries.yml, etc.)
+  SDC components:  {count} ({list names with atomic levels})
+  SCSS files:      {count}
+  Config exports:  {count}
+  Icon pack:       {count} icons (if applicable)
+
+Module installation:
+  composer require drupal/radix drupal/layout_builder_styles {other modules}
+  drush en {module_list}
+  drush theme:enable {THEME_NAME}
+  drush config:set system.theme default {THEME_NAME}
+
+Next steps:
+  1. Copy theme to {DRUPAL_PATH}/themes/custom/{THEME_NAME}/ (if Drupal path provided)
+  2. Run: cd {theme_path} && npm install
+  3. Run: npm run build (production) or npm run dev (watch mode)
+  4. Import config exports: drush config:import --partial --source={config_path}
+  5. Configure Layout Builder on target content types
+  6. Place SDC components in Layout Builder sections
+
+Conversion config saved: {PROJECT_PATH}/converter/radix-sdc.yml
+```
+
+---
+
+## Output
+
+- Created: `{PROJECT_PATH}/converter/radix-sdc.yml` (conversion configuration)
+- Created: `{PROJECT_PATH}/converter/{THEME_NAME}/` (complete Radix sub-theme)
+- Created: SDC components, SCSS, config exports, and optional icon pack within theme directory

--- a/brand-content-design/scripts/extract-icons.js
+++ b/brand-content-design/scripts/extract-icons.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Extract inline SVGs from HTML files for Drupal Icon API.
+ *
+ * Finds `<!-- icon: {name} -->` comments followed by `<svg>...</svg>` blocks
+ * and extracts the inner SVG content (paths, circles, lines) to individual files.
+ *
+ * Usage:
+ *   node scripts/extract-icons.js list <html-file>
+ *   node scripts/extract-icons.js extract <html-file> <output-dir>
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const [command, ...args] = process.argv.slice(2);
+
+/**
+ * Parse HTML and return an array of { name, innerSvg } objects.
+ * Matches `<!-- icon: {name} -->` followed by an `<svg ...>...</svg>` block.
+ * Deduplicates by icon name (keeps first occurrence).
+ */
+function parseIcons(html) {
+  const pattern = /<!--\s*icon:\s*([\w-]+)\s*-->\s*<svg[^>]*>([\s\S]*?)<\/svg>/gi;
+  const seen = new Set();
+  const icons = [];
+  let match;
+
+  while ((match = pattern.exec(html)) !== null) {
+    const name = match[1].toLowerCase();
+    const innerSvg = match[2].trim();
+
+    if (!seen.has(name)) {
+      seen.add(name);
+      icons.push({ name, innerSvg });
+    }
+  }
+
+  return icons;
+}
+
+/**
+ * Read an HTML file and return its contents.
+ */
+function readHtmlFile(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    console.error(`File not found: ${resolved}`);
+    process.exit(1);
+  }
+  return fs.readFileSync(resolved, 'utf-8');
+}
+
+switch (command) {
+  case 'list': {
+    if (args.length === 0) {
+      console.error('Usage: extract-icons.js list <html-file>');
+      process.exit(1);
+    }
+    const html = readHtmlFile(args[0]);
+    const icons = parseIcons(html);
+
+    if (icons.length === 0) {
+      console.error('No icon comments found in the HTML file.');
+      console.error('Expected format: <!-- icon: name --> followed by <svg>...</svg>');
+      process.exit(1);
+    }
+
+    for (const icon of icons) {
+      console.log(icon.name);
+    }
+    break;
+  }
+
+  case 'extract': {
+    if (args.length < 2) {
+      console.error('Usage: extract-icons.js extract <html-file> <output-dir>');
+      process.exit(1);
+    }
+
+    const html = readHtmlFile(args[0]);
+    const outputDir = path.resolve(args[1]);
+    const icons = parseIcons(html);
+
+    if (icons.length === 0) {
+      console.error('No icon comments found in the HTML file.');
+      console.error('Expected format: <!-- icon: name --> followed by <svg>...</svg>');
+      process.exit(1);
+    }
+
+    // Create output directory if it does not exist
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    let count = 0;
+    for (const icon of icons) {
+      const outPath = path.join(outputDir, icon.name + '.svg');
+      fs.writeFileSync(outPath, icon.innerSvg + '\n', 'utf-8');
+      count++;
+    }
+
+    console.log('Extracted ' + count + ' icons to ' + outputDir);
+    break;
+  }
+
+  default:
+    console.error('Commands: list, extract');
+    console.error('  list <html-file>                — list icon names found in HTML');
+    console.error('  extract <html-file> <output-dir> — extract SVG inner content to files');
+    process.exit(1);
+}

--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brand-content-design
-description: Use when user says "create presentation", "make carousel", "create HTML page", "make landing page", "build web page", "html design system", "design system", "setup brand", "brand init", "extract brand", "get outline", or wants to create visual content with consistent branding. Creates branded presentations, carousels, and HTML pages using a layered philosophy system.
-version: 2.1.0
+description: Use when user says "create presentation", "make carousel", "create HTML page", "make landing page", "build web page", "html design system", "design system", "setup brand", "brand init", "extract brand", "get outline", "convert to drupal", "convert to radix", "html to drupal", "generate theme", or wants to create visual content with consistent branding. Creates branded presentations, carousels, and HTML pages using a layered philosophy system, with conversion to Drupal Radix sub-themes.
+version: 2.2.0
 model: sonnet
 ---
 
@@ -19,6 +19,8 @@ Create branded visual content (presentations, LinkedIn carousels, HTML pages) wi
 - "create template" / "new template"
 - "get outline" / "outline for template" / "prepare content"
 - "color palette" / "generate palette" / "alternative colors"
+- "convert to drupal" / "convert to radix" / "html to drupal" / "generate theme"
+- "convert html" / "radix theme" / "SDC components" / "layout builder"
 - NOT for: General design questions, non-branded content
 
 ## Project Detection
@@ -98,6 +100,8 @@ Route user requests to the appropriate command:
 | Create HTML design system | `/design-html` |
 | Create HTML page (guided) | `/html-page` |
 | Create HTML page (quick) | `/html-page-quick` |
+| Convert HTML to Drupal Radix (guided) | `/convert-to-radix` |
+| Convert HTML to Drupal Radix (quick) | `/convert-to-radix-quick` |
 | Add new content type | `/content-type-new` |
 
 ## Underlying Skills
@@ -108,6 +112,8 @@ Use these skills during content generation:
 |-------|-------------|
 | **visual-content** | Generate visual output from canvas philosophy (bundled) |
 | **html-generator** | Generate HTML pages and components from design system (bundled) |
+| **html-to-radix-analyzer** | Analyze HTML metadata for Drupal conversion (bundled) |
+| **radix-sdc-generator** | Generate Radix sub-theme with SDC components (bundled) |
 | **pptx** | Convert presentation PDFs to PowerPoint |
 | **pdf** | Create multi-page carousel PDFs |
 

--- a/brand-content-design/skills/html-to-radix-analyzer/SKILL.md
+++ b/brand-content-design/skills/html-to-radix-analyzer/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: html-to-radix-analyzer
+description: Use when analyzing HTML pages for conversion to Drupal. Parses HTML metadata comments, classifies patterns, extracts design tokens, inventories Drupal backend, and produces target-agnostic analysis output.
+version: 2.2.0
+model: sonnet
+user-invocable: false
+---
+
+# HTML-to-Radix Analyzer
+
+Analyze HTML pages produced by the brand-content-design workflow and produce a structured, target-agnostic analysis. This analysis feeds into target-specific generators (Radix, Canvas, etc.) that handle the actual Drupal implementation.
+
+## Inputs
+
+- `HTML_FILE` -- Path to the HTML file to analyze (required)
+- `DRUPAL_PATH` -- Path to an existing Drupal codebase (optional; enables backend inventory)
+- `QUICK_MODE` -- When true, auto-resolve ambiguous classifications without prompting (default: false)
+
+## Part 1: HTML Metadata Parsing
+
+Read the HTML file at `HTML_FILE`.
+
+### Extract Components
+
+Find all component blocks delimited by metadata comments:
+
+```html
+<!-- component: {type} variant: {variant} -->
+  ...component HTML...
+<!-- /component: {type} -->
+```
+
+For each component, extract:
+
+1. **Type and variant** from the opening comment
+2. **Props** -- all `<!-- prop: {name} type: {type} -->` entries within the component
+3. **Slots** -- all `<!-- slot: {name} -->` / `<!-- /slot: {name} -->` blocks, including:
+   - Nested props within each slot item
+   - Count of items in the slot (number of repeated structures)
+   - Whether items share identical prop structures (same names and types)
+4. **CSS classes** -- collect all `class="..."` values from the component's HTML elements
+5. **Raw HTML** -- the HTML between the component open/close comments (trimmed)
+6. **HTML semantic elements** -- note presence of `<nav>`, `<footer>`, `<form>`, `<details>`, `<summary>`, `<header>`, `<main>`, `<section>`, `<article>`
+
+### Extract Design Token Block
+
+Find the `<style>` block containing `:root { ... }` CSS custom property declarations. Store the raw CSS text for Part 2.
+
+### Extract Google Fonts
+
+Find any `<link>` tags with `href` containing `fonts.googleapis.com`. Extract the font family names and weights.
+
+### Component List Output
+
+Build a structured list:
+
+```yaml
+components:
+  - type: hero
+    variant: centered
+    props:
+      - { name: heading, type: string }
+      - { name: subheadline, type: string }
+      - { name: cta-text, type: string }
+      - { name: cta-url, type: string }
+    slots: []
+    cssClasses: [hero, hero--centered, container, text-center]
+    semanticElements: [section]
+    html: "<section class=\"hero hero--centered\">..."
+  - type: features
+    variant: grid
+    props:
+      - { name: heading, type: string }
+    slots:
+      - name: items
+        count: 3
+        uniformStructure: true
+        itemProps:
+          - { name: icon, type: string }
+          - { name: title, type: string }
+          - { name: description, type: string }
+    cssClasses: [features, features--grid, container, row]
+    semanticElements: [section]
+    html: "<section class=\"features features--grid\">..."
+```
+
+## Part 2: Design Token Extraction
+
+Parse the `:root { }` CSS custom property declarations extracted in Part 1.
+
+### Categorize Each Token
+
+Group tokens by their prefix and purpose:
+
+**Color tokens** -- `--color-*`:
+- Primary, secondary, accent colors
+- Background colors (`--color-bg-*`)
+- Text colors (`--color-text-*`)
+- Semantic colors (`--color-error`, `--color-success`, `--color-warning`, `--color-info`)
+- Border colors
+
+**Typography tokens** -- `--font-*`, `--font-size-*`, `--line-height-*`, `--letter-spacing-*`:
+- Font families (`--font-heading`, `--font-body`)
+- Font sizes per level
+- Line heights
+- Letter spacing
+- Font weights (`--font-weight-*`)
+
+**Spacing tokens** -- `--space-*`:
+- Spacing scale values
+- Section padding
+- Component gaps
+
+**Layout tokens** -- structural measurements:
+- `--max-width` (container width)
+- `--border-radius` variants
+- `--min-tap-target` (accessibility)
+
+**Interaction tokens** -- animation/transition:
+- `--timing-*` (durations)
+- `--easing-*` (curves)
+
+**Form tokens** -- form-specific:
+- `--color-error`, `--color-success`
+- Input-related tokens
+
+### Bootstrap Variable Mapping
+
+For each token, determine the closest Bootstrap SCSS variable using the 6px threshold:
+- If a token value is within 6px of a Bootstrap default, map to that Bootstrap variable
+- If outside 6px, flag as a custom override
+- Record both the token name and its Bootstrap equivalent (or "custom")
+
+### Google Fonts
+
+Include the extracted Google Fonts information:
+- Font family names
+- Weights requested
+- The full Google Fonts URL for inclusion
+
+### Design Token Output
+
+```yaml
+designTokens:
+  colors:
+    - { token: "--color-primary", value: "#2563eb", bootstrapVar: "$primary", action: "override" }
+    - { token: "--color-bg-dark", value: "#1e293b", bootstrapVar: "$gray-900", action: "map" }
+    - { token: "--color-error", value: "#dc2626", bootstrapVar: "$danger", action: "override" }
+  typography:
+    - { token: "--font-heading", value: "Inter", bootstrapVar: "$headings-font-family", action: "override" }
+    - { token: "--font-body", value: "Inter", bootstrapVar: "$font-family-base", action: "override" }
+    - { token: "--font-size-xl", value: "3rem", bootstrapVar: "$h1-font-size", action: "map", within6px: true }
+  spacing:
+    - { token: "--space-lg", value: "2rem", bootstrapVar: "$spacer-4", action: "map" }
+  layout:
+    - { token: "--max-width", value: "1280px", bootstrapVar: "$container-max-widths(xxl)", action: "override" }
+    - { token: "--border-radius", value: "0.5rem", bootstrapVar: "$border-radius", action: "override" }
+  interaction:
+    - { token: "--timing-normal", value: "200ms", bootstrapVar: null, action: "custom" }
+  googleFonts:
+    families: [{ name: "Inter", weights: [400, 500, 600, 700] }]
+    url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+```
+
+## Part 3: Pattern Classification
+
+For each component from Part 1, apply the decision tree in `references/pattern-classification.md`.
+
+### Classification Steps
+
+1. **Check semantic elements first:**
+   - `<nav>` or `<header>` with nav links --> `navigation` pattern
+   - `<footer>` --> `footer` pattern
+   - `<form>` --> `form` pattern
+   - `<details>`/`<summary>` --> `accordion` pattern
+
+2. **Check slot structure:**
+   - Slots with 4+ uniform items --> `repeating_content` (content type + view)
+   - Slots with 2-3 uniform items --> `curated_content` (block type with multi-value fields)
+   - No slots or non-uniform slots --> continue to step 3
+
+3. **Check prop patterns:**
+   - Numeric/stat-like props (stat-value, stat-label, number) --> `statistics`
+   - Heading + body + CTA combination --> `single_promotional`
+
+4. **Flag ambiguous cases:**
+   - Set `ambiguous: true` when item count is borderline (3-4 testimonials, 4-6 team members)
+   - Include both possible classifications (`pattern` and `alt_pattern`)
+   - If `QUICK_MODE` is true, auto-resolve using the quick-mode rules in the reference file
+
+5. **Attach reasoning** for each classification explaining why this pattern was chosen.
+
+### Classification Output
+
+```yaml
+classifications:
+  - component: hero
+    variant: centered
+    pattern: single_promotional
+    drupal_type: block_type
+    ambiguous: false
+    reasoning: "Single section with heading, subheadline, CTA -- promotional block"
+  - component: features
+    variant: grid
+    pattern: curated_content
+    drupal_type: block_type
+    ambiguous: false
+    reasoning: "3 feature items, small curated set -- block type with multi-value fields"
+  - component: testimonials
+    variant: slider
+    pattern: curated_content
+    drupal_type: block_type
+    ambiguous: true
+    alt_pattern: repeating_content
+    alt_drupal_type: content_type_with_view
+    reasoning: "4 testimonials -- borderline, could be curated or dynamic"
+```
+
+## Part 4: Drupal Backend Inventory
+
+Only run Part 4 if `DRUPAL_PATH` is provided and `{DRUPAL_PATH}/config/sync/` exists.
+
+### If Config Exists: Run Inventory Scan
+
+Follow the scan rules in `references/drupal-backend-inventory.md`:
+
+1. **Scan config files** in `{DRUPAL_PATH}/config/sync/`:
+   - `node.type.*.yml` --> content types
+   - `block_content.type.*.yml` --> block types
+   - `views.view.*.yml` --> views
+   - `system.menu.*.yml` --> menus
+   - `taxonomy.vocabulary.*.yml` --> taxonomies
+   - `core.extension.yml` --> enabled modules
+   - `field.storage.*.*.yml` + `field.field.*.*.*.yml` --> field definitions
+   - `image.style.*.yml` --> image styles
+   - `responsive_image.styles.*.yml` --> responsive image styles
+
+2. **Build inventory** of all discovered entities with their fields, types, and relationships.
+
+3. **Match each classified component** to existing backend:
+   - Step 1: Direct name match (component type == entity machine name)
+   - Step 2: Field structure match (80%+ prop-to-field similarity)
+   - Step 3: View match (if repeating content, check for existing view)
+   - Step 4: No match --> generate create_new recommendation
+
+4. **Record match details**: action (reuse/extend/create_new), confidence, field mapping, fields to add.
+
+### If No Config: Green-Field Mode
+
+Return:
+
+```yaml
+inventory:
+  greenField: true
+  content_types: []
+  block_types: []
+  menus: []
+  modules: []
+  views: []
+  taxonomies: []
+  recommended_modules:
+    - layout_builder
+    - layout_builder_styles
+    # Add based on detected patterns:
+    # webform (if forms detected)
+    # ui_icons (if icons detected)
+    # media_library (if images detected)
+
+matches: []
+
+warnings:
+  - "Green-field analysis -- all config generated from scratch, no existing backend to reuse"
+```
+
+## Part 5: Icon Extraction
+
+Find all icon comments and their paired SVG elements in the HTML.
+
+### Extraction Steps
+
+1. Find all `<!-- icon: {name} -->` comments
+2. For each, extract the immediately following `<svg>` element (the complete SVG markup)
+3. Deduplicate by icon name (if same icon appears multiple times, keep one copy)
+4. Record which components use each icon
+
+### Icon Output
+
+```yaml
+icons:
+  - name: rocket
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/></svg>'
+    usedBy: [features, hero]
+  - name: check
+    svg: '<svg>...</svg>'
+    usedBy: [pricing]
+```
+
+## Part 6: Atomic Classification
+
+For each component, determine its atomic design level and Radix reuse status.
+
+### Classification Steps
+
+1. Apply the heuristics from `references/atomic-classification.md`:
+   - Props only, <= 3 props --> atom
+   - Props only or simple slots, 2-6 props --> molecule
+   - Slots with repeated items or section-level structure --> organism
+
+2. Check each component against the Radix base component reuse table:
+   - If Radix has a matching component --> `action: "extend"`
+   - If no Radix match --> `action: "create_new"`
+   - Record what changes are needed to extend the Radix base
+
+3. Determine SDC directory placement based on atomic level:
+   - `components/atoms/{name}/`
+   - `components/molecules/{name}/`
+   - `components/organisms/{name}/`
+
+### Atomic Classification Output
+
+```yaml
+atomicLevels:
+  - component: hero
+    level: organism
+    directory: components/organisms/hero
+    reasoning: "Page section with heading slot, CTA, background -- section-level structure"
+  - component: card
+    level: molecule
+    directory: components/molecules/card
+    reasoning: "Combines image, heading, text into self-contained unit"
+  - component: button
+    level: atom
+    directory: components/atoms/button
+    reasoning: "Single element, label + url props, no slots"
+
+radixReuse:
+  - component: navbar
+    radixBase: navbar
+    action: extend
+    changes: "Add brand colors, custom mobile breakpoint, dropdown styling"
+  - component: card
+    radixBase: card
+    action: extend
+    changes: "Add image-top variant, custom hover effect"
+  - component: hero
+    radixBase: null
+    action: create_new
+    changes: "No Radix equivalent -- create custom organism with full-width background"
+  - component: accordion
+    radixBase: accordion
+    action: extend
+    changes: "Style summary with brand typography, add expand/collapse icons"
+```
+
+---
+
+## Analysis Output Format
+
+Return the combined analysis as a single structured result. See `references/analysis-output-schema.md` for the complete YAML schema with all fields documented.
+
+The top-level keys are: `components[]`, `designTokens{}`, `classifications[]`, `inventory{}`, `matches[]`, `icons[]`, `atomicLevels[]`, `radixReuse[]`, `warnings[]`.
+
+---
+
+## Examples
+
+### Example 1: Landing Page (Green-Field)
+
+**Input:** A brand HTML page with hero, feature-grid (3 items), testimonials (4 items), and CTA sections. No Drupal codebase.
+
+**Analysis result:**
+- 4 components extracted with props/slots from metadata comments
+- 12 design tokens (5 colors, 3 typography, 3 spacing, 1 layout)
+- Classifications: hero = `single_promotional`, feature-grid = `curated_content`, testimonials = `ambiguous` (4 items, borderline), CTA = `single_promotional`
+- Green-field mode: all components get `create_new` action
+- 3 icons extracted (rocket, shield, star)
+- Atomic: hero = organism, feature-card = molecule, CTA = organism
+
+### Example 2: Blog Redesign (Existing Codebase)
+
+**Input:** HTML page with nav, hero, article-grid (6 items), and footer. Drupal codebase at `/var/www/html` with existing article content type and frontpage view.
+
+**Analysis result:**
+- 4 components extracted
+- Inventory: article content type (5 fields), frontpage view, main menu, footer menu
+- Matches: article-grid reuses existing article + frontpage view (85% field match), nav reuses main menu
+- Classifications: nav = `navigation`, hero = `single_promotional` (create_new), article-grid = `repeating_content` (reuse), footer = `footer`
+- 0 icons
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| No components found | HTML file lacks `<!-- component: -->` metadata comments | Generate the page with `/html-page` which adds metadata automatically |
+| No design tokens extracted | Missing `:root { }` CSS block in the HTML | Ensure the HTML was generated from a design system with tokens |
+| config/sync/ not found | Drupal path incorrect or config not exported | Run `drush config:export` in the Drupal codebase first |
+| Field match below 80% | Existing content type has different field structure | Analyzer flags as create_new; user can override to reuse if appropriate |
+| All components flagged ambiguous | Borderline item counts (3-4 items in most slots) | Use quick mode for auto-resolution, or guided mode to decide each one |
+
+## References
+
+- `references/pattern-classification.md` -- Decision tree for HTML pattern to Drupal implementation mapping
+- `references/atomic-classification.md` -- Atom/molecule/organism heuristics and Radix reuse table
+- `references/drupal-backend-inventory.md` -- Config scan rules and backend matching algorithm
+- `references/analysis-output-schema.md` -- Complete YAML output schema with field documentation

--- a/brand-content-design/skills/html-to-radix-analyzer/references/analysis-output-schema.md
+++ b/brand-content-design/skills/html-to-radix-analyzer/references/analysis-output-schema.md
@@ -1,0 +1,181 @@
+# Analysis Output Schema
+
+## Contents
+
+- Complete output structure
+- Metadata fields
+- Components array
+- Design tokens map
+- Classifications array
+- Inventory and matches
+- Icons array
+- Atomic levels and Radix reuse
+- Warnings array
+
+## Complete Output Structure
+
+Combine all parts into a single structured analysis result. This is the complete output schema that the analyzer returns to calling commands and the generator skill consumes.
+
+```yaml
+analysis:
+  # Metadata
+  sourceFile: "{HTML_FILE}"
+  analyzedAt: "{timestamp}"
+  quickMode: false
+  greenField: false
+
+  # Part 1: Parsed components
+  components:
+    - type: hero
+      variant: centered
+      props:
+        - { name: heading, type: string }
+        - { name: subheadline, type: string }
+        - { name: cta-text, type: string }
+        - { name: cta-url, type: string }
+      slots: []
+      cssClasses: [hero, hero--centered, container]
+      semanticElements: [section]
+      html: "<section class=\"hero\">..."
+    - type: features
+      variant: grid
+      props:
+        - { name: heading, type: string }
+      slots:
+        - name: items
+          count: 3
+          uniformStructure: true
+          itemProps:
+            - { name: icon, type: string }
+            - { name: title, type: string }
+            - { name: description, type: string }
+      cssClasses: [features, features--grid, row]
+      semanticElements: [section]
+      html: "<section class=\"features\">..."
+
+  # Part 2: Design tokens
+  designTokens:
+    colors:
+      - { token: "--color-primary", value: "#2563eb", bootstrapVar: "$primary", action: "override" }
+    typography:
+      - { token: "--font-heading", value: "Inter", bootstrapVar: "$headings-font-family", action: "override" }
+    spacing:
+      - { token: "--space-lg", value: "2rem", bootstrapVar: "$spacer-4", action: "map" }
+    layout:
+      - { token: "--max-width", value: "1280px", bootstrapVar: "$container-max-widths(xxl)", action: "override" }
+    interaction:
+      - { token: "--timing-normal", value: "200ms", bootstrapVar: null, action: "custom" }
+    googleFonts:
+      families: [{ name: "Inter", weights: [400, 500, 600, 700] }]
+      url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+
+  # Part 3: Pattern classifications
+  classifications:
+    - component: hero
+      variant: centered
+      pattern: single_promotional
+      drupal_type: block_type
+      ambiguous: false
+      reasoning: "Single section with heading, subheadline, CTA"
+    - component: features
+      variant: grid
+      pattern: curated_content
+      drupal_type: block_type
+      ambiguous: false
+      reasoning: "3 uniform items -- curated block with multi-value fields"
+
+  # Part 4: Backend inventory and matches
+  inventory:
+    greenField: false
+    content_types:
+      - name: article
+        label: Article
+        fields: [{ name: body, type: text_with_summary }, { name: field_image, type: image }]
+        has_view: true
+        view_id: content_recent
+    block_types:
+      - name: hero
+        label: Hero
+        fields: [{ name: field_headline, type: string }, { name: field_link, type: link }]
+    menus: [{ id: main, label: "Main navigation" }, { id: footer, label: "Footer" }]
+    modules: [layout_builder, views, media_library]
+    views:
+      - { id: content_recent, base_table: node_field_data, content_type: article }
+    taxonomies:
+      - { name: tags, label: Tags, used_by: [article] }
+
+  matches:
+    - component: hero
+      action: reuse
+      entity_type: block_content
+      entity_name: hero
+      confidence: 1.0
+      field_mapping: { heading: field_headline, cta-url: field_link }
+    - component: blog
+      action: create_new
+      recommendations:
+        entity_type: node
+        machine_name: blog_post
+        fields:
+          - { name: field_summary, type: text_long }
+          - { name: field_featured_image, type: image }
+
+  # Part 5: Icons
+  icons:
+    - name: rocket
+      svg: "<svg>...</svg>"
+      usedBy: [features]
+    - name: check
+      svg: "<svg>...</svg>"
+      usedBy: [pricing]
+
+  # Part 6: Atomic levels and Radix reuse
+  atomicLevels:
+    - { component: hero, level: organism, directory: "components/organisms/hero" }
+    - { component: card, level: molecule, directory: "components/molecules/card" }
+    - { component: button, level: atom, directory: "components/atoms/button" }
+
+  radixReuse:
+    - { component: card, radixBase: card, action: extend, changes: "Add brand variants" }
+    - { component: hero, radixBase: null, action: create_new, changes: "Custom full-width organism" }
+
+  # Warnings and notes
+  warnings:
+    - "Testimonials section flagged as ambiguous (4 items, borderline count)"
+    - "No webform module detected -- form component will need webform installed"
+```
+
+## Field Details
+
+### Component Props
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Prop name from `<!-- prop: {name} -->` |
+| `type` | string | Prop type from `<!-- prop: ... type: {type} -->` |
+
+### Slot Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Slot name from `<!-- slot: {name} -->` |
+| `count` | integer | Number of items found in the slot |
+| `uniformStructure` | boolean | Whether all items share identical prop names/types |
+| `itemProps` | array | Props common to each item in the slot |
+
+### Classification Actions
+
+| Action | Meaning |
+|---|---|
+| `reuse` | Existing backend entity matches, reuse it |
+| `extend` | Existing entity partially matches, add missing fields |
+| `create_new` | No match found, generate new config |
+
+### Token Mapping Actions
+
+| Action | Meaning |
+|---|---|
+| `accommodate` | Within 6px of Bootstrap default, use as-is |
+| `map` | Close to a Bootstrap variable, map directly |
+| `override` | Override Bootstrap variable with custom value |
+| `custom` | No Bootstrap equivalent, create custom variable |

--- a/brand-content-design/skills/html-to-radix-analyzer/references/atomic-classification.md
+++ b/brand-content-design/skills/html-to-radix-analyzer/references/atomic-classification.md
@@ -1,0 +1,180 @@
+# Atomic Classification Heuristics
+
+Use these rules to classify each component as atom, molecule, or organism, and to determine Radix base component reuse.
+
+## Contents
+
+- Classification Heuristics
+  - Atom -- Single-purpose element
+  - Molecule -- Small composed group
+  - Organism -- Complex section
+- Dynamic Classification Algorithm
+  - Edge Cases
+- Radix Base Component Reuse Table
+  - Reuse Workflow
+  - SDC Directory Convention
+  - Classification Output Format
+
+## Classification Heuristics
+
+### Atom -- Single-purpose element
+
+- Has props only (no slots)
+- Renders one visual unit
+- Contains no other components
+- Typically 1-3 props
+
+**Test:** Does it contain or compose other components? No --> atom.
+
+**Examples:** heading, button, icon, image, badge, link, input, label, separator
+
+### Molecule -- Small composed group
+
+- Combines 2-3 atomic-level elements into a functional unit
+- Has props AND/OR simple slots (no repeated items in slots)
+- Self-contained: meaningful on its own but not a full page section
+
+**Test:** Is it a self-contained group of atoms that works as a unit? Yes --> molecule.
+
+**Examples:** card, stat-item, form-group, nav-link-with-icon, section-heading (title + subtitle), media-object (image + text), price-tag (amount + period + label)
+
+### Organism -- Complex section
+
+- Has slots containing collections of repeated items
+- Wraps multiple molecules or provides page-section-level structure
+- Represents a distinct section of the page
+
+**Test:** Does it organize other components into a page section? Yes --> organism.
+
+**Examples:** navbar, hero, feature-grid, testimonials, footer, pricing-table, blog-listing, contact-section, accordion, stats-row
+
+## Dynamic Classification Algorithm
+
+Apply this logic for each component:
+
+```
+function classifyComponent(component):
+  # No slots, few props --> atom
+  if component.slots.length == 0 and component.props.length <= 3:
+    return "atom"
+
+  # No slots, moderate props --> molecule
+  if component.slots.length == 0 and component.props.length <= 6:
+    return "molecule"
+
+  # No slots, many props --> likely molecule (complex but self-contained)
+  if component.slots.length == 0 and component.props.length > 6:
+    return "molecule"
+
+  # Has slots --> check slot contents
+  if component.slots.length > 0:
+    # Slots with repeated items --> organism
+    if any slot contains repeated items (same-structure children):
+      return "organism"
+
+    # Many nested elements --> organism
+    if total nested component references > 3:
+      return "organism"
+
+    # Simple slots (1-2 children, no repetition) --> molecule
+    return "molecule"
+
+  # Fallback
+  return "molecule"
+```
+
+### Edge Cases
+
+- A component with 0 props and 1 slot containing free HTML: classify as "molecule" (wrapper)
+- A component that is purely structural (grid, container): classify as "organism"
+- A component with a single slot for a CTA button: classify as "molecule" (the slot holds an atom)
+
+## Radix Base Component Reuse Table
+
+Before creating a new SDC from scratch, check if Radix provides a base component to extend.
+
+| Radix Component | Reuse When | Extend By |
+|---|---|---|
+| `navbar` | Nav with links + brand logo | Add theme colors, mobile breakpoint, dropdown behavior |
+| `button` | CTA buttons, form submits, link buttons | Add brand color variants, size modifiers |
+| `card` | Any content card pattern | Add custom card variants, image positions |
+| `accordion` | FAQ, expandable sections | Style summary/content, add icons |
+| `badge` | Status labels, tags, counters | Brand colors, size variants |
+| `breadcrumb` | Breadcrumb navigation | Custom separator, styling |
+| `alert` | Notification banners, callouts | Brand styles, dismissible behavior |
+| `modal` | Overlay dialogs, popups | Custom modal content layout |
+| `carousel` | Sliding content, testimonials | Navigation style, autoplay |
+| `tabs` | Tabbed content sections | Tab styling, vertical variant |
+| `dropdown` | Menu dropdowns, select-like UI | Custom trigger, menu styling |
+| `toast` | Temporary notifications | Position, auto-dismiss timing |
+
+### Reuse Workflow
+
+When Radix has a matching component, extend it instead of creating from scratch:
+
+1. Copy Radix component to sub-theme: `npx drupal-radix-cli component`
+2. Modify the copy to match the brand design
+3. Keep the same `component.yml` schema structure
+4. Override only the Twig template and CSS, not the data model
+
+When no Radix match exists, create a new SDC:
+
+1. Place in the appropriate atomic directory
+2. Follow Radix component.yml conventions for schema
+3. Use Bootstrap utility classes as the base styling layer
+
+### SDC Directory Convention
+
+```
+components/
+  atoms/
+    heading/
+      heading.component.yml
+      heading.twig
+      heading.css
+    button/
+    icon/
+    image/
+  molecules/
+    card/
+      card.component.yml
+      card.twig
+      card.css
+    stat-item/
+    section-heading/
+  organisms/
+    navbar/
+      navbar.component.yml
+      navbar.twig
+      navbar.css
+    hero/
+    feature-grid/
+    footer/
+```
+
+### Classification Output Format
+
+Return atomic level per component:
+
+```yaml
+atomicLevels:
+  - component: hero
+    level: organism
+    reasoning: "Has heading slot, CTA slot, organizes page section"
+  - component: card
+    level: molecule
+    reasoning: "Combines image, heading, text -- self-contained group"
+  - component: button
+    level: atom
+    reasoning: "Single element, 2 props (label, url), no slots"
+
+radixReuse:
+  - component: card
+    radixBase: card
+    action: extend
+    changes: "Add image-top variant, brand color scheme"
+  - component: hero
+    radixBase: null
+    action: create_new
+    changes: "No Radix equivalent, create custom organism"
+```

--- a/brand-content-design/skills/html-to-radix-analyzer/references/drupal-backend-inventory.md
+++ b/brand-content-design/skills/html-to-radix-analyzer/references/drupal-backend-inventory.md
@@ -1,0 +1,280 @@
+# Drupal Backend Inventory
+
+Rules for scanning `config/sync/` to build an inventory of existing Drupal backend entities and matching HTML components to them.
+
+## Contents
+
+- Config Scan Rules
+  - Content Types
+  - Views
+  - Block Types
+  - Menus
+  - Taxonomies
+  - Enabled Modules
+  - Image Styles
+  - Responsive Image Styles
+- Matching Algorithm
+  - Step 1: Direct Name Match
+  - Step 2: Field Structure Match
+  - Step 3: View Match
+  - Step 4: No Match
+- Field Type Mapping
+- Inventory Output Format
+- Green-Field Mode
+
+## Config Scan Rules
+
+Scan `{DRUPAL_PATH}/config/sync/` for these YAML file patterns.
+
+### Content Types
+
+**Files:** `node.type.*.yml`
+
+Extract:
+- Machine name (id field)
+- Label (name field)
+- Description
+
+**Related field discovery:**
+- `field.storage.node.*.yml` -- field storage definitions (type, cardinality, settings)
+- `field.field.node.{type}.*.yml` -- field instance on this content type (label, required, settings)
+
+Build field list per content type: field name, field type, cardinality, required flag.
+
+### Views
+
+**Files:** `views.view.*.yml`
+
+Extract:
+- View ID
+- Base table (usually `node_field_data`)
+- Label
+- Display plugins: page, block, attachment, feed
+- For each display: path, pager type, items_per_page, sorts, filters, fields/formatters
+- Content type filter (if filtered to a specific node type)
+
+### Block Types
+
+**Files:** `block_content.type.*.yml`
+
+Extract:
+- Machine name (id field)
+- Label (name field)
+- Description
+
+**Related field discovery:**
+- `field.storage.block_content.*.yml`
+- `field.field.block_content.{type}.*.yml`
+
+Build field list per block type, same structure as content types.
+
+### Menus
+
+**Files:** `system.menu.*.yml`
+
+Extract:
+- Menu ID (id field)
+- Label
+- Note which are Drupal defaults (main, footer, account, admin, tools) vs custom
+
+### Taxonomies
+
+**Files:** `taxonomy.vocabulary.*.yml`
+
+Extract:
+- Vocabulary machine name
+- Label
+- Related fields via `field.field.taxonomy_term.{vocab}.*.yml`
+- Which content types reference this vocabulary (scan entity_reference fields)
+
+### Enabled Modules
+
+**File:** `core.extension.yml`
+
+Extract the `module:` key to get the full enabled module list.
+
+**Key module checks:**
+| Module | Significance |
+|---|---|
+| `layout_builder` | Layout Builder available for page composition |
+| `layout_builder_styles` | Section/block styling in LB |
+| `views` | Views available (almost always enabled) |
+| `media` / `media_library` | Media handling for images, videos |
+| `webform` | Form building available |
+| `ui_icons` | Drupal Core Icon API available |
+| `paragraphs` | Paragraphs module for structured content |
+| `field_group` | Field groups for compound fields |
+| `metatag` | SEO metadata |
+| `pathauto` | URL alias patterns |
+| `focal_point` | Image focal point cropping |
+
+### Image Styles
+
+**Files:** `image.style.*.yml`
+
+Extract available image styles (thumbnail, medium, large, custom). Useful for mapping image props to appropriate responsive image handling.
+
+### Responsive Image Styles
+
+**Files:** `responsive_image.styles.*.yml`
+
+Extract responsive image style sets if available.
+
+## Matching Algorithm
+
+For each HTML component classified in the pattern classification step, try to match it to an existing backend entity.
+
+### Step 1: Direct Name Match
+
+Check if `component.type` (or a normalized version) matches any existing entity:
+- `hero` matches `block_content.type.hero`
+- `blog` or `article` matches `node.type.article`
+- Normalize: strip hyphens, underscores; compare lowercased
+
+If direct match found: `{ action: "reuse", confidence: 1.0 }`
+
+### Step 2: Field Structure Match
+
+Compare the component's props to each candidate entity's fields:
+
+```
+function compareFields(componentProps, entityFields):
+  matchCount = 0
+  for prop in componentProps:
+    bestFieldMatch = findClosestField(prop, entityFields)
+    if bestFieldMatch.similarity >= 0.7:
+      matchCount += 1
+
+  return matchCount / max(len(componentProps), len(entityFields))
+```
+
+Field similarity considers:
+- Name similarity (fuzzy string match on field name vs prop name)
+- Type compatibility (prop type maps to an acceptable Drupal field type)
+- Cardinality match (multi-value prop matches unlimited cardinality field)
+
+If field match >= 0.8: `{ action: "reuse", confidence: fieldMatch }`
+If field match 0.5-0.79: `{ action: "extend", fieldsToAdd: [...], confidence: fieldMatch }`
+If field match < 0.5: no match, proceed to Step 3.
+
+### Step 3: View Match
+
+If a component was classified as `repeating_content` and matched a content type in Step 2:
+- Check if any View already displays that content type
+- If yes: `{ action: "reuse_view", view: view.id }`
+- If no: `{ action: "create_view", base_content_type: matched.id }`
+
+### Step 4: No Match
+
+```
+{ action: "create_new", recommendations: generateRecommendations(component) }
+```
+
+Recommendations include:
+- Suggested machine name
+- Suggested fields with types
+- Whether to use block_content or node (based on pattern classification)
+- Related View config if repeating content
+
+## Field Type Mapping
+
+Map HTML prop types to Drupal field types:
+
+| HTML Prop Type | Drupal Field Type | Notes |
+|---|---|---|
+| `string` (short, < 255 chars) | `string` | Plain text, single line |
+| `string` (long, paragraphs) | `text_long` | Formatted long text |
+| `string` (rich text with HTML) | `text_with_summary` | For body-like fields |
+| `string` (URL pattern) | `link` | External or internal link |
+| `string` (icon name) | `string` | With icon widget if `ui_icons` enabled |
+| `string` (email pattern) | `email` | Email field |
+| `string` (phone pattern) | `telephone` | Telephone field |
+| `boolean` | `boolean` | On/off toggle |
+| `string` (image path + alt) | `image` | Image with alt text |
+| `string` (image path, media) | `entity_reference` (media) | If `media_library` enabled |
+| `slot` (repeated items) | Entity reference or multi-value field | Depends on pattern |
+| `string` (date pattern) | `datetime` | Date/time field |
+| `string` (number pattern) | `integer` or `decimal` | Numeric field |
+
+## Inventory Output Format
+
+Return the full inventory in this structure:
+
+```yaml
+inventory:
+  content_types:
+    - name: article
+      label: Article
+      fields:
+        - { name: field_tags, type: entity_reference, target: tags, cardinality: -1 }
+        - { name: field_image, type: image, cardinality: 1 }
+        - { name: body, type: text_with_summary, cardinality: 1 }
+      has_view: true
+      view_id: frontpage
+  block_types:
+    - name: hero
+      label: Hero
+      fields:
+        - { name: field_headline, type: string, cardinality: 1 }
+        - { name: field_body, type: text_long, cardinality: 1 }
+        - { name: field_link, type: link, cardinality: 1 }
+  menus:
+    - { id: main, label: Main navigation, custom: false }
+    - { id: footer, label: Footer, custom: false }
+  modules: [layout_builder, views, media_library, webform, ui_icons]
+  views:
+    - id: frontpage
+      label: Frontpage
+      base_table: node_field_data
+      content_type: article
+      displays: [page_1, feed_1]
+  taxonomies:
+    - name: tags
+      label: Tags
+      used_by: [article]
+  image_styles: [thumbnail, medium, large, wide]
+
+matches:
+  - component: hero
+    action: reuse
+    entity_type: block_content
+    entity_name: hero
+    confidence: 1.0
+    field_mapping:
+      heading: field_headline
+      body: field_body
+      cta_url: field_link
+  - component: blog
+    action: reuse
+    entity_type: node
+    entity_name: article
+    confidence: 0.85
+    view_id: frontpage
+    fields_to_add: []
+  - component: pricing
+    action: create_new
+    recommendations:
+      entity_type: block_content
+      machine_name: pricing
+      fields:
+        - { name: field_tier_name, type: string }
+        - { name: field_price, type: string }
+        - { name: field_features, type: text_long, cardinality: -1 }
+        - { name: field_cta_link, type: link }
+```
+
+## Green-Field Mode
+
+When no `DRUPAL_PATH` is provided or `config/sync/` does not exist:
+
+- Skip the entire inventory scan
+- Set `greenField: true` in the output
+- All components get `action: "create_new"`
+- Generate complete config recommendations for every component
+- Recommend a full module list based on detected patterns:
+  - Forms detected --> recommend `webform`
+  - Icons detected --> recommend `ui_icons`
+  - Images detected --> recommend `media_library`
+  - Repeating content --> recommend `views` (usually already core)
+  - Layout sections --> recommend `layout_builder`, `layout_builder_styles`
+- Include a warning: "Green-field analysis -- all config generated from scratch, no existing backend to reuse"

--- a/brand-content-design/skills/html-to-radix-analyzer/references/pattern-classification.md
+++ b/brand-content-design/skills/html-to-radix-analyzer/references/pattern-classification.md
@@ -1,0 +1,213 @@
+# Pattern Classification Decision Tree
+
+Use this decision tree to map each HTML component to its Drupal implementation pattern. The converter is metadata-driven -- it reads `<!-- component: {type} variant: {variant} -->` comments, not hardcoded component names. Apply these rules based on HTML structure and slot/prop analysis.
+
+## Contents
+
+- Navigation Detection
+- Footer Detection
+- Form Detection
+- Repeating Content Detection
+- Curated Content Detection
+- Single Promotional Section
+- Accordion / FAQ Detection
+- Statistics / Metrics
+- Ambiguity Resolution
+- Quick-Mode Auto-Resolution Rules
+- Classification Output Format
+
+## 1. Navigation Detection
+
+**Signals:**
+- `<nav>` element present
+- `role="navigation"` attribute
+- `<header>` containing anchor links or menu-like lists
+- Component type hints: navbar, navigation, header, main-menu
+
+**Drupal mapping:**
+- Use Menu system (`main_menu`, `footer_menu`, or custom menu)
+- NEVER create a custom block for navigation
+- Rendered in theme region (outside Layout Builder)
+- SDC: Navbar organism wrapping Drupal menu render array
+
+**Config output:**
+- Menu entity if custom menu needed
+- Menu link content entities for items
+- Block placement in theme region
+
+## 2. Footer Detection
+
+**Signals:**
+- `<footer>` element present
+- `role="contentinfo"` attribute
+- Component at bottom of page with copyright, social links, secondary nav
+
+**Drupal mapping:**
+- Footer region with blocks (outside Layout Builder)
+- SDC: Footer organism
+- May contain sub-components: footer menu, social links block, copyright block
+
+**Config output:**
+- Block placements in footer region
+- Footer menu if separate from main menu
+
+## 3. Form Detection
+
+**Signals:**
+- `<form>` element present
+- `<input>`, `<textarea>`, `<select>` elements
+- Component type hints: contact, form, subscribe, newsletter, signup
+
+**Drupal mapping:**
+- Webform module block placed in Layout Builder section
+- SDC: Form styling component (wraps Webform output)
+- Do NOT recreate form logic in SDC -- Webform handles submission
+
+**Config output:**
+- `webform.webform.{name}.yml` with field definitions
+- Block placement in LB section
+- Webform handler config (email, submission storage)
+
+## 4. Repeating Content Detection
+
+**Signals:**
+- Slot (`<!-- slot: {name} -->`) containing 4+ items
+- All items share identical prop structures (same prop names and types)
+- Content likely to grow over time: articles, blog posts, team members (5+), portfolio items, events, products
+
+**Drupal mapping:**
+- Content type with fields derived from item props
+- View with responsive display (block or page display)
+- SDC: Card molecule (teaser view mode) + Grid organism (View wrapper)
+
+**Config output:**
+- `node.type.{name}.yml`
+- `field.storage.node.field_*.yml` + `field.field.node.{type}.field_*.yml` for each prop
+- `views.view.{name}.yml` with appropriate display, pager, sort
+- View mode config for teaser display
+
+## 5. Curated Content Detection
+
+**Signals:**
+- Slot with 2-3 items sharing the same prop structure
+- Content unlikely to grow: feature highlights, pricing tiers, key benefits
+- Small fixed collection, editorially curated
+
+**Drupal mapping:**
+- Custom block type with multi-value fields (one field per prop, cardinality unlimited)
+- Placed in Layout Builder section
+- SDC: Block organism with embedded molecules
+
+**Config output:**
+- `block_content.type.{name}.yml`
+- `field.storage.block_content.field_*.yml` + `field.field.block_content.{type}.field_*.yml`
+- Multi-value field cardinality set to unlimited
+
+## 6. Single Promotional Section
+
+**Signals:**
+- Section with heading prop, body text prop, CTA (link prop or slot)
+- No repeating items
+- One-off promotional or informational section: hero, CTA banner, about section
+
+**Drupal mapping:**
+- Custom block type in Layout Builder section
+- SDC: Section organism
+
+**Config output:**
+- `block_content.type.{name}.yml`
+- Fields for heading, body, link/CTA
+- LB section with `layout_builder_styles` for section styling
+
+## 7. Accordion / FAQ Detection
+
+**Signals:**
+- `<details>` / `<summary>` elements in HTML
+- Slot with Q&A-structured items (question prop + answer prop)
+- Component type hints: accordion, faq, expandable
+
+**Drupal mapping:**
+- Custom block type with multi-value compound field (question + answer pairs)
+- SDC: Accordion organism (extend Radix accordion if available)
+
+**Config output:**
+- `block_content.type.{name}.yml`
+- Multi-value field group with question (string) + answer (text_long) sub-fields
+- OR: Paragraphs type if paragraphs module is enabled
+
+## 8. Statistics / Metrics
+
+**Signals:**
+- Short text values combined with numeric-looking props
+- Prop names like: stat-value, stat-label, metric, number, count
+- Typically 3-4 items in a row
+
+**Drupal mapping:**
+- Custom block type with multi-value stat field (value + label pairs)
+- SDC: Stats molecule for individual stat, Stats grid organism for the collection
+
+**Config output:**
+- `block_content.type.{name}.yml`
+- Multi-value field group: stat_value (string) + stat_label (string)
+
+---
+
+## Ambiguity Resolution
+
+Flag a component as `ambiguous: true` when the pattern classification is uncertain:
+
+- **Testimonials with 3-4 items** -- could be curated block or content type + view
+- **Team members with 4-6 items** -- borderline between curated and dynamic
+- **Content that might grow** but currently has a small item count
+- **Mixed grids** combining what looks like curated and dynamic content
+- **Items with 3 slots** where structure partially overlaps with existing content types
+
+When `ambiguous: true`, include both possible classifications in the output so the generator can prompt the user.
+
+## Quick-Mode Auto-Resolution Rules
+
+When running in quick mode (no user prompts for ambiguous cases), resolve automatically:
+
+| Condition | Resolution |
+|---|---|
+| 1-3 items in slot | `block_type` (curated content) |
+| 4+ items in slot | `content_type` + `view` (repeating content) |
+| Testimonials (any count) | `block_type` (usually curated, rarely grows fast) |
+| Team members 1-4 | `block_type` |
+| Team members 5+ | `content_type` + `view` |
+| Pricing tiers (any count) | `block_type` (always curated) |
+| Blog/article items | `content_type` + `view` (always dynamic) |
+
+## Classification Output Format
+
+Return each classification in this structure:
+
+```yaml
+classifications:
+  - component: hero
+    variant: centered
+    pattern: single_promotional
+    drupal_type: block_type
+    ambiguous: false
+    reasoning: "Single section with heading, subheadline, CTA -- promotional block"
+  - component: features
+    variant: grid
+    pattern: curated_content
+    drupal_type: block_type
+    ambiguous: false
+    reasoning: "3 feature items with icon, title, description -- curated block"
+  - component: blog
+    variant: cards
+    pattern: repeating_content
+    drupal_type: content_type_with_view
+    ambiguous: false
+    reasoning: "6 articles with identical structure, likely to grow -- content type + view"
+  - component: testimonials
+    variant: slider
+    pattern: curated_content
+    drupal_type: block_type
+    ambiguous: true
+    alt_pattern: repeating_content
+    alt_drupal_type: content_type_with_view
+    reasoning: "4 testimonials -- borderline count, flagged for user decision"
+```

--- a/brand-content-design/skills/radix-sdc-generator/SKILL.md
+++ b/brand-content-design/skills/radix-sdc-generator/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: radix-sdc-generator
+description: Use when generating a Drupal Radix sub-theme with SDC components from HTML analysis. Creates complete theme scaffolding, SDC components, SCSS with Bootstrap mapping, Layout Builder config, and icon pack.
+version: 2.2.0
+model: opus
+user-invocable: false
+---
+
+# Radix SDC Generator
+
+Generate a complete Drupal Radix 6.0.2 sub-theme from the analysis output produced by `html-to-radix-analyzer`. Receive the analysis YAML (design tokens, component inventory with props/slots/atomic levels, pattern classifications, backend reuse matches, and icon list). Produce a fully scaffolded theme with SDC components, Bootstrap-mapped SCSS, Layout Builder config, and an optional icon pack.
+
+## Inputs
+
+Receive from the analyzer or calling command:
+
+- **Analysis output** -- YAML with: `designTokens`, `components` (each with `name`, `variant`, `atomicLevel`, `props`, `slots`, `radixBase`, `classification`), `backendReuse` (existing config matches), `icons` (list of icon names found).
+- **THEME_NAME** -- machine name (lowercase, underscores).
+- **THEME_LABEL** -- human-readable label.
+- **DRUPAL_PATH** -- (optional) absolute path to the Drupal installation root.
+- **PROJECT_PATH** -- project directory for output when DRUPAL_PATH is not set.
+- **HTML_FILE** -- path to the source HTML file (needed for icon extraction).
+
+## Output Location
+
+- If `DRUPAL_PATH` is provided: write to `{DRUPAL_PATH}/themes/custom/{THEME_NAME}/`.
+- Otherwise: write to `{PROJECT_PATH}/converter/output/{THEME_NAME}/`.
+
+Set `THEME_DIR` to the chosen output path for use throughout all parts.
+
+---
+
+## Part 1: Theme Scaffolding
+
+Create the complete Radix sub-theme directory structure using `references/radix-theme-scaffold.md` as the template.
+
+1. Create all directories:
+   - `{THEME_DIR}/components/atoms/`
+   - `{THEME_DIR}/components/molecules/`
+   - `{THEME_DIR}/components/organisms/`
+   - `{THEME_DIR}/icons/`
+   - `{THEME_DIR}/src/scss/base/`
+   - `{THEME_DIR}/src/js/`
+   - `{THEME_DIR}/templates/layout/`
+   - `{THEME_DIR}/includes/`
+   - `{THEME_DIR}/build/`
+
+2. Write each scaffold file from the reference, replacing all `{THEME_NAME}` occurrences with the actual machine name and `{THEME_LABEL}` with the human-readable label:
+   - `{THEME_NAME}.info.yml`
+   - `{THEME_NAME}.libraries.yml`
+   - `webpack.mix.js`
+   - `package.json`
+   - `src/scss/main.style.scss`
+   - `src/scss/_init.scss`
+   - `src/scss/_bootstrap.scss`
+   - `src/scss/base/_variables.scss` (placeholder -- populated in Part 2)
+   - `src/scss/base/_elements.scss`
+   - `src/scss/base/_typography.scss` (placeholder -- populated in Part 2)
+   - `src/js/main.script.js`
+   - `includes/{THEME_NAME}.theme`
+   - `.gitignore`
+
+3. Write section template overrides from the scaffold reference:
+   - `templates/layout/layout--onecol.html.twig`
+   - `templates/layout/layout--twocol-section.html.twig`
+   - `templates/layout/layout--threecol-section.html.twig`
+
+Verify all files exist after writing.
+
+---
+
+## Part 2: Token to Bootstrap SCSS
+
+Apply the 6px threshold framework from `references/token-to-bootstrap-mapping.md` to convert design tokens into Bootstrap SCSS overrides.
+
+1. For each design token in `designTokens`, determine the mapping action:
+   - **Accommodate**: token value is within 6px (or delta E < 5 for colors) of Bootstrap's default. Do not write an override; add a comment noting the accommodation.
+   - **Extend**: token adds to an existing Bootstrap map (colors, spacers, container widths). Write the map extension.
+   - **Customize**: token overrides a Bootstrap variable. Write the variable override.
+   - **Create**: token has no Bootstrap equivalent. Write a CSS custom property in `:root`.
+
+2. Generate `src/scss/base/_variables.scss`:
+   - Write color overrides: `$primary`, `$secondary`, etc.
+   - Write `$custom-colors` map for brand-specific colors not in Bootstrap defaults.
+   - Write typography overrides: `$font-family-base`, `$font-family-heading`, `$font-size-base`, `$h1-font-size` through `$h6-font-size`.
+   - Write spacing overrides: `$spacer` base value, `$spacers` map extensions.
+   - Write layout overrides: `$border-radius`, `$container-max-widths`, `$box-shadow` variants.
+   - Add section header comments for each category.
+
+3. Generate `src/scss/base/_typography.scss`:
+   - Write `@import url(...)` for Google Fonts if font names are recognized Google Fonts.
+   - Otherwise write `@font-face` declarations with `font-display: swap`.
+   - Write heading font-family rule applying `$font-family-heading`.
+
+4. Update `src/scss/base/_elements.scss`:
+   - Populate `:root` block with CSS custom properties for interaction tokens (transition-duration, transition-easing, min-tap-target, focus-ring-width, focus-ring-color).
+
+5. Record every mapping decision in a `tokenMapping` array for the conversion report (see mapping output format in the reference).
+
+---
+
+## Part 3: SDC Component Generation
+
+For each component in the analysis output, generate a complete SDC directory. Follow patterns from `references/sdc-patterns.md`.
+
+1. Determine output directory from `atomicLevel`:
+   - atom: `{THEME_DIR}/components/atoms/{component-name}/`
+   - molecule: `{THEME_DIR}/components/molecules/{component-name}/`
+   - organism: `{THEME_DIR}/components/organisms/{component-name}/`
+
+2. Check the `radixBase` field from the analysis:
+   - If a Radix base component is identified (e.g., `card`, `accordion`, `button`), note this in the component.yml description and follow the same prop schema structure.
+   - If `radixBase` is null, create the component from scratch.
+
+3. Generate `{component-name}.component.yml`:
+   - Set `$schema` to the Drupal core metadata schema URL.
+   - Set `name` to the human-readable component name.
+   - Set `status` to `experimental`.
+   - Set `group` to `{THEME_NAME}`.
+   - Add `description` from the analysis.
+   - Add `props.properties.attributes` with type `Drupal\Core\Template\Attribute`.
+   - Add `props.properties.{component_name}_utility_classes` as array of strings with empty default.
+   - For each prop from the analysis, add a JSON Schema property with appropriate type, title, and description.
+   - For each slot from the analysis, add a slot entry with title and description.
+   - Set `required` array for props marked as required.
+
+4. Generate `{component-name}.twig`:
+   - Add file-level comment documenting all props and slots.
+   - Set `classes` array: base component class + utility classes merge.
+   - Render `attributes.addClass(classes)` on the outermost element.
+   - For each prop: render with appropriate HTML element and Bootstrap classes.
+   - For each slot: render as `{% block slot_name %}` with content check.
+   - Use Bootstrap utility classes for layout (grid, flexbox, spacing).
+   - Use BEM class names for component-specific styling.
+
+5. Generate `{component-name}.scss`:
+   - Import `_init.scss` at the top.
+   - Write BEM-structured styles using Bootstrap variables and mixins.
+   - Include responsive breakpoints where the component needs layout changes.
+   - Reference CSS custom properties for transitions and interactions.
+
+---
+
+## Part 4: Layout Builder Config
+
+Generate Layout Builder styles and section configuration from `references/layout-builder-config.md`.
+
+1. Generate `layout_builder_styles` group configs:
+   - `layout_builder_styles.group.background_color.yml`
+   - `layout_builder_styles.group.padding.yml`
+   - `layout_builder_styles.group.container_width.yml`
+
+2. Generate `layout_builder_styles` style configs:
+   - One background style per color in `$theme-colors` (primary, secondary, light, dark, white, plus any custom brand colors).
+   - Padding styles mapped from spacing tokens (small, medium, large, none).
+   - Container width styles (full, default, narrow).
+
+3. Create section template overrides if not already created in Part 1. Verify the nested container pattern is applied: outer full-width div, inner `.container`.
+
+4. Map the HTML page structure to Layout Builder sections:
+   - Read the page section order from the analysis.
+   - For each page section, determine: layout type (onecol, twocol, threecol), style selections (background, padding), and block placements.
+   - Navigation and footer components map to theme region block placements, not LB sections.
+   - Record the mapping in `pageLayout` format for the report.
+
+5. Write all config YAML files to:
+   - `{DRUPAL_PATH}/config/converter-exports/` if Drupal path is provided.
+   - `{PROJECT_PATH}/converter/config-exports/` otherwise.
+
+---
+
+## Part 5: Icon Pack
+
+If the analysis found icons (the `icons` list is non-empty), generate a Drupal Icon API icon pack.
+
+1. Run the extraction script:
+   ```
+   node "$BRAND_CONTENT_DESIGN_DIR/scripts/extract-icons.js" extract {HTML_FILE} {THEME_DIR}/icons/
+   ```
+
+2. Verify SVG files were created in `{THEME_DIR}/icons/`. List the directory and confirm each icon from the analysis has a corresponding `.svg` file.
+
+3. Generate `{THEME_NAME}.icons.yml` in the theme root:
+   ```yaml
+   {THEME_NAME}_icons:
+     label: '{THEME_LABEL} Icons'
+     description: 'Brand icons extracted from design system'
+     extractor: svg
+     enabled: true
+     template: '<svg xmlns="http://www.w3.org/2000/svg" width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">{{ content }}</svg>'
+     config:
+       sources:
+         - icons/
+       size: 24
+   ```
+
+4. If the extraction script reports missing icons, log warnings but continue. The icon pack works with whatever SVGs were successfully extracted.
+
+---
+
+## Part 6: Config Exports
+
+Generate Drupal config YAML for backend entities identified by the analyzer.
+
+### For components classified as block_type (curated content):
+
+1. Generate `block_content.type.{name}.yml` with id, label, and description.
+2. For each prop in the component:
+   - Generate `field.storage.block_content.field_{prop_name}.yml` with appropriate field type:
+     - string props: `type: string`, `max_length: 255`
+     - text props: `type: text_long`
+     - url props: `type: link`
+     - image props: `type: image`
+     - number props: `type: integer` or `type: decimal`
+   - Generate `field.field.block_content.{block_type}.field_{prop_name}.yml` with label and settings.
+   - For multi-value fields (from components with repeated items, 2-3 count): set `cardinality: -1` (unlimited).
+
+### For components classified as content_type_with_view (repeating content):
+
+1. Generate `node.type.{name}.yml` with type, label, description.
+2. Generate field storage and field instance configs as above, but with `entity_type: node`.
+3. Generate `views.view.{name}.yml` with:
+   - Default display: teaser view mode, pager, sort by created date descending.
+   - Block display: for embedding in Layout Builder sections.
+   - Filter by content type and published status.
+
+### For components classified as webform:
+
+1. Generate a basic `webform.webform.{name}.yml` with:
+   - Form elements derived from input fields in the analysis.
+   - Email handler configuration stub.
+
+### Backend Reuse
+
+For components where `backendReuse` matched an existing config:
+- Do NOT generate new config YAML.
+- Record the reuse in the report: "Reusing existing {config_id} for {component_name}."
+
+Write all config files to the config exports directory.
+
+---
+
+## Part 7: Conversion Report
+
+Generate `conversion-report.md` at the root of the output directory.
+
+### File Manifest
+
+List every generated file with its relative path from the theme root:
+
+```markdown
+## Generated Files
+
+| File | Description |
+|---|---|
+| {THEME_NAME}.info.yml | Theme info |
+| {THEME_NAME}.libraries.yml | Asset libraries |
+| src/scss/base/_variables.scss | Bootstrap overrides |
+| components/atoms/button/button.component.yml | Button SDC |
+| ... | ... |
+```
+
+### Module Requirements
+
+List Drupal modules required for the generated configuration:
+
+```markdown
+## Required Modules
+
+- layout_builder (core)
+- layout_builder_styles (contrib)
+- block_content (core)
+- views (core)
+- webform (contrib) -- only if webform config generated
+```
+
+### Manual Steps
+
+List actions the developer must perform after generation:
+
+```markdown
+## Manual Steps
+
+1. Run `composer install` in the Drupal root if missing contrib modules.
+2. Run `npm install && npm run build` in the theme directory.
+3. Enable the theme: `drush then {THEME_NAME}`.
+4. Set as default: `drush config:set system.theme default {THEME_NAME}`.
+5. Import config exports: `drush config:import --partial --source=config/converter-exports/`.
+6. Enable Layout Builder on the target content type.
+7. Review and adjust component styles in the browser.
+```
+
+### Token Mapping Table
+
+Display every mapping decision from Part 2:
+
+```markdown
+## Token Mapping
+
+| Token | Value | Bootstrap Variable | Action | Reasoning |
+|---|---|---|---|---|
+| --color-primary | #2563eb | $primary | customize | Delta E 12.4 |
+| --font-size-base | 16px | $font-size-base | accommodate | Exact match |
+| ... | ... | ... | ... | ... |
+```
+
+### Component Inventory
+
+```markdown
+## Components
+
+| Component | Atomic Level | SDC Path | Radix Base | Classification |
+|---|---|---|---|---|
+| hero | organism | components/organisms/hero/ | -- | single_promotional |
+| card | molecule | components/molecules/card/ | card (extend) | curated_content |
+| button | atom | components/atoms/button/ | button (extend) | -- |
+| ... | ... | ... | ... | ... |
+```
+
+### Backend Reuse Summary
+
+```markdown
+## Backend Reuse
+
+| Component | Action | Config |
+|---|---|---|
+| blog | reuse | node.type.article (existing) |
+| features | create_new | block_content.type.features |
+| ... | ... | ... |
+```
+
+### Warnings and Recommendations
+
+Include any issues encountered during generation:
+
+- Components where the Radix base extension may need manual adjustment.
+- Tokens that were accommodated but are borderline (5-6px difference).
+- Missing icons that could not be extracted.
+- Ambiguous pattern classifications that defaulted to quick-mode resolution.
+- Accessibility concerns (contrast ratios to verify, tap target sizes to check).
+
+---
+
+## Examples
+
+### Example 1: Landing Page Theme (Green-Field)
+
+**Input:** Analysis with 6 components (nav, hero, feature-grid, testimonials, CTA, footer), 15 design tokens, 4 icons. No existing Drupal backend.
+
+**Generation result:**
+- Theme scaffold at `converter/my_brand/`
+- `_variables.scss` with `$primary`, `$secondary`, `$font-family-base`, `$spacers` overrides
+- 6 SDC components: `organisms/navbar/`, `organisms/hero/`, `organisms/feature-grid/`, `molecules/testimonial-card/`, `organisms/cta/`, `organisms/footer/`
+- `layout_builder_styles` config: 3 background colors, 3 padding levels, 2 container widths
+- Icon pack: `my_brand.icons.yml` + 4 SVG files in `icons/`
+- Config exports: 3 block types, 1 view + content type (if testimonials = view)
+- Conversion report listing all generated files and next steps
+
+### Example 2: Blog Redesign (Existing Backend)
+
+**Input:** Analysis with 4 components, existing article content type + frontpage view matched. 2 components reuse existing backend.
+
+**Generation result:**
+- Theme scaffold with `_variables.scss` mapped from blog design tokens
+- 4 SDC components (card extends Radix card, navbar extends Radix navbar)
+- No icon pack (no icons in design)
+- Config exports: 1 new block type (hero), modified view display config
+- Report shows 50% backend reuse, 50% new config
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| extract-icons.js fails | Node.js not available or HTML file not found | Verify `node` is on PATH and HTML file path is correct |
+| SCSS import errors | Bootstrap not installed in theme | Run `npm install` in theme directory before compiling |
+| component.yml validation fails | Prop type not a valid JSON Schema type | Use `string`, `number`, `boolean`, `array`, `object`, or `Drupal\Core\Template\Attribute` |
+| Layout section template not rendering | Template override not registered | Clear Drupal cache: `drush cr` after copying theme |
+| Icon pack not discovered | `.icons.yml` file not at theme root | Ensure file is `{THEME_NAME}.icons.yml` at the same level as `.info.yml` |
+
+## References
+
+- `references/radix-theme-scaffold.md` -- Complete theme directory template and file contents.
+- `references/token-to-bootstrap-mapping.md` -- 6px threshold framework and mapping tables.
+- `references/sdc-patterns.md` -- component.yml, Twig, and SCSS templates with examples.
+- `references/layout-builder-config.md` -- Layout Builder styles and section configuration.
+- `scripts/extract-icons.js` -- CLI tool for extracting inline SVGs from HTML files.

--- a/brand-content-design/skills/radix-sdc-generator/references/layout-builder-config.md
+++ b/brand-content-design/skills/radix-sdc-generator/references/layout-builder-config.md
@@ -1,0 +1,444 @@
+# Layout Builder Configuration
+
+Configuration patterns for Layout Builder styles, section template overrides, and page composition. Use these patterns during Part 4 and Part 6 of the generator.
+
+## Contents
+
+- layout_builder_styles Module Configuration
+  - Style Group Configuration
+  - Background Color Styles
+  - Padding Styles
+  - Container Width Styles
+- Section Template Overrides
+  - Nested Container Pattern
+- Section-to-Page Mapping
+  - Mapping Rules
+  - Mapping Output Format
+- Config Export Format
+  - Block Type Config
+  - Field Storage Config
+  - Field Instance Config
+  - Views Config
+
+## layout_builder_styles Module Configuration
+
+The `layout_builder_styles` module adds CSS class selection to Layout Builder sections and blocks. Generate config entities that map design tokens to selectable style options.
+
+### Style Group Configuration
+
+```yaml
+# config/converter-exports/layout_builder_styles.group.background_color.yml
+langcode: en
+status: true
+id: background_color
+label: 'Background Color'
+weight: 0
+multiselect: single
+form_type: checkboxes
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.group.padding.yml
+langcode: en
+status: true
+id: padding
+label: 'Padding'
+weight: 1
+multiselect: single
+form_type: checkboxes
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.group.container_width.yml
+langcode: en
+status: true
+id: container_width
+label: 'Container Width'
+weight: 2
+multiselect: single
+form_type: checkboxes
+```
+
+### Background Color Styles
+
+Generate one style config per brand color token:
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.bg_primary.yml
+langcode: en
+status: true
+id: bg_primary
+label: 'Primary Background'
+classes: 'bg-primary text-white'
+group: background_color
+weight: 0
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.bg_secondary.yml
+langcode: en
+status: true
+id: bg_secondary
+label: 'Secondary Background'
+classes: 'bg-secondary text-white'
+group: background_color
+weight: 1
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.bg_light.yml
+langcode: en
+status: true
+id: bg_light
+label: 'Light Background'
+classes: 'bg-light'
+group: background_color
+weight: 2
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.bg_dark.yml
+langcode: en
+status: true
+id: bg_dark
+label: 'Dark Background'
+classes: 'bg-dark text-white'
+group: background_color
+weight: 3
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.bg_white.yml
+langcode: en
+status: true
+id: bg_white
+label: 'White Background'
+classes: 'bg-white'
+group: background_color
+weight: 4
+```
+
+For custom brand colors (e.g., `$accent`, `$bg-alt`), add matching styles:
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.bg_accent.yml
+langcode: en
+status: true
+id: bg_accent
+label: 'Accent Background'
+classes: 'bg-accent text-white'
+group: background_color
+weight: 5
+```
+
+### Padding Styles
+
+Map spacing tokens to padding classes:
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.py_sm.yml
+langcode: en
+status: true
+id: py_sm
+label: 'Small Padding'
+classes: 'py-3'
+group: padding
+weight: 0
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.py_md.yml
+langcode: en
+status: true
+id: py_md
+label: 'Medium Padding'
+classes: 'py-5'
+group: padding
+weight: 1
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.py_lg.yml
+langcode: en
+status: true
+id: py_lg
+label: 'Large Padding'
+classes: 'py-6'
+group: padding
+weight: 2
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.py_none.yml
+langcode: en
+status: true
+id: py_none
+label: 'No Padding'
+classes: 'py-0'
+group: padding
+weight: 3
+```
+
+### Container Width Styles
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.container_full.yml
+langcode: en
+status: true
+id: container_full
+label: 'Full Width'
+classes: 'container-fluid px-0'
+group: container_width
+weight: 0
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.container_default.yml
+langcode: en
+status: true
+id: container_default
+label: 'Default Width'
+classes: 'container'
+group: container_width
+weight: 1
+```
+
+```yaml
+# config/converter-exports/layout_builder_styles.style.container_narrow.yml
+langcode: en
+status: true
+id: container_narrow
+label: 'Narrow Width'
+classes: 'container' style='max-width: 800px'
+group: container_width
+weight: 2
+```
+
+## Section Template Overrides
+
+### Nested Container Pattern
+
+The core principle: outer div receives full viewport width for background colors and images. Inner `.container` constrains the content to the site max-width.
+
+**One column:**
+
+```twig
+{# templates/layout/layout--onecol.html.twig #}
+{% set container_classes = ['layout', 'layout--onecol'] %}
+
+<div{{ attributes.addClass(container_classes) }}>
+  <div class="container">
+    <div{{ content_attributes.addClass('layout__content') }}>
+      {{ content.content }}
+    </div>
+  </div>
+</div>
+```
+
+**Two column:**
+
+```twig
+{# templates/layout/layout--twocol-section.html.twig #}
+{% set container_classes = ['layout', 'layout--twocol-section'] %}
+
+<div{{ attributes.addClass(container_classes) }}>
+  <div class="container">
+    <div class="row">
+      <div{{ region_attributes.first.addClass('layout__region', 'layout__region--first', 'col-12', 'col-md-6') }}>
+        {{ content.first }}
+      </div>
+      <div{{ region_attributes.second.addClass('layout__region', 'layout__region--second', 'col-12', 'col-md-6') }}>
+        {{ content.second }}
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+**Three column:**
+
+```twig
+{# templates/layout/layout--threecol-section.html.twig #}
+{% set container_classes = ['layout', 'layout--threecol-section'] %}
+
+<div{{ attributes.addClass(container_classes) }}>
+  <div class="container">
+    <div class="row">
+      <div{{ region_attributes.first.addClass('layout__region', 'layout__region--first', 'col-12', 'col-md-4') }}>
+        {{ content.first }}
+      </div>
+      <div{{ region_attributes.second.addClass('layout__region', 'layout__region--second', 'col-12', 'col-md-4') }}>
+        {{ content.second }}
+      </div>
+      <div{{ region_attributes.third.addClass('layout__region', 'layout__region--third', 'col-12', 'col-md-4') }}>
+        {{ content.third }}
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Section-to-Page Mapping
+
+### Mapping Rules
+
+Apply these rules to convert the HTML page structure into Layout Builder sections:
+
+1. **Each component block maps to a Layout Builder section.** A `<!-- component: hero -->` becomes a one-column section containing the hero SDC block.
+
+2. **Adjacent related components may share a section.** If two components visually belong to the same page area (e.g., a section heading directly above a feature grid), they can be placed in the same LB section.
+
+3. **Full-bleed backgrounds become section styles.** When the HTML shows a section with a colored background spanning the full viewport width, apply a `layout_builder_styles` background class to the LB section's outer div.
+
+4. **Navigation and footer live outside Layout Builder.** These are placed in theme regions (`navbar_main`, `footer`) via block placement config, not in LB sections.
+
+5. **Section ordering follows HTML document order.** Top-to-bottom in the HTML becomes top-to-bottom in the LB layout.
+
+### Mapping Output Format
+
+Record section-to-LB mapping in the output config:
+
+```yaml
+pageLayout:
+  - section: 1
+    layout: layout_onecol
+    styles:
+      - bg_primary
+      - py_lg
+    blocks:
+      - component: hero
+        region: content
+        block_type: block_content:hero
+
+  - section: 2
+    layout: layout_onecol
+    styles:
+      - py_md
+    blocks:
+      - component: features
+        region: content
+        block_type: block_content:features
+
+  - section: 3
+    layout: layout_twocol_section
+    styles:
+      - bg_light
+      - py_md
+    blocks:
+      - component: about_image
+        region: first
+        block_type: block_content:about
+      - component: about_text
+        region: second
+        block_type: block_content:about
+
+  - section: 4
+    layout: layout_onecol
+    styles:
+      - py_lg
+    blocks:
+      - component: blog_listing
+        region: content
+        block_type: views_block:blog_listing
+```
+
+## Config Export Format
+
+### Block Type Config
+
+```yaml
+# config/converter-exports/block_content.type.{name}.yml
+langcode: en
+status: true
+id: {name}
+label: '{Label}'
+description: 'Generated from HTML component: {component_name}'
+revision: 1
+```
+
+### Field Storage Config
+
+```yaml
+# config/converter-exports/field.storage.block_content.field_{field_name}.yml
+langcode: en
+status: true
+id: block_content.field_{field_name}
+field_name: field_{field_name}
+entity_type: block_content
+type: string
+cardinality: 1
+settings:
+  max_length: 255
+```
+
+### Field Instance Config
+
+```yaml
+# config/converter-exports/field.field.block_content.{block_type}.field_{field_name}.yml
+langcode: en
+status: true
+id: block_content.{block_type}.field_{field_name}
+field_name: field_{field_name}
+entity_type: block_content
+bundle: {block_type}
+label: '{Field Label}'
+required: false
+settings: {}
+field_type: string
+```
+
+### Views Config
+
+```yaml
+# config/converter-exports/views.view.{name}.yml
+langcode: en
+status: true
+id: {name}
+label: '{Label}'
+module: views
+description: 'Generated listing for {content_type}'
+tag: ''
+base_table: node_field_data
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: '{Label}'
+      pager:
+        type: some
+        options:
+          items_per_page: 12
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          plugin_id: date
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            {content_type}: {content_type}
+          plugin_id: bundle
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          value: '1'
+          plugin_id: boolean
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+```

--- a/brand-content-design/skills/radix-sdc-generator/references/radix-theme-scaffold.md
+++ b/brand-content-design/skills/radix-sdc-generator/references/radix-theme-scaffold.md
@@ -1,0 +1,553 @@
+# Radix 6.0.2 Sub-Theme Scaffold
+
+Complete directory structure and file templates for a Radix sub-theme generated from a brand design system. Replace `{THEME_NAME}` with the machine name (lowercase, underscores) and `{THEME_LABEL}` with the human-readable label.
+
+## Contents
+
+- Theme Directory Structure
+- File Templates
+
+## Theme Directory Structure
+
+```
+{THEME_NAME}/
+├── {THEME_NAME}.info.yml
+├── {THEME_NAME}.libraries.yml
+├── {THEME_NAME}.icons.yml          # If icon pack generated
+├── webpack.mix.js
+├── package.json
+├── components/
+│   ├── atoms/
+│   ├── molecules/
+│   └── organisms/
+├── icons/                           # SVG icon files
+├── src/
+│   ├── scss/
+│   │   ├── main.style.scss          # Entry point
+│   │   ├── _init.scss               # Foundation (zero CSS output)
+│   │   ├── _bootstrap.scss          # Bootstrap module imports
+│   │   └── base/
+│   │       ├── _variables.scss      # Bootstrap variable overrides
+│   │       ├── _elements.scss       # Global element styles
+│   │       └── _typography.scss     # @font-face declarations
+│   └── js/
+│       └── main.script.js           # Theme JS entry
+├── templates/
+│   └── layout/                      # Layout Builder section overrides
+├── includes/
+│   └── {THEME_NAME}.theme           # Preprocess functions
+└── build/                           # Compiled output (gitignored)
+```
+
+## File Templates
+
+### {THEME_NAME}.info.yml
+
+```yaml
+name: '{THEME_LABEL}'
+type: theme
+description: 'Radix sub-theme generated from brand design system'
+core_version_requirement: ^10.3 || ^11
+base theme: radix
+starterkit: false
+
+regions:
+  navbar_top: 'Navbar Top'
+  navbar_main: 'Navbar Main'
+  header: 'Header'
+  highlighted: 'Highlighted'
+  help: 'Help'
+  content: 'Content'
+  sidebar_first: 'Sidebar First'
+  sidebar_second: 'Sidebar Second'
+  footer: 'Footer'
+  page_top: 'Page Top'
+  page_bottom: 'Page Bottom'
+
+libraries:
+  - {THEME_NAME}/global
+```
+
+### {THEME_NAME}.libraries.yml
+
+```yaml
+global:
+  css:
+    theme:
+      build/css/main.style.css: {}
+  js:
+    build/js/main.script.js: {}
+  dependencies:
+    - radix/bootstrap
+    - core/drupal
+```
+
+### {THEME_NAME}.icons.yml
+
+Generate only when the analysis found icons to extract.
+
+```yaml
+{THEME_NAME}_icons:
+  label: '{THEME_LABEL} Icons'
+  description: 'Brand icons extracted from design system'
+  extractor: svg
+  enabled: true
+  template: '<svg xmlns="http://www.w3.org/2000/svg" width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">{{ content }}</svg>'
+  config:
+    sources:
+      - icons/
+    size: 24
+```
+
+### webpack.mix.js
+
+```js
+const mix = require('laravel-mix');
+
+// Paths
+const proxy = 'https://SITE.ddev.site';
+const themePath = 'themes/custom/{THEME_NAME}';
+
+// SCSS compilation
+mix.sass(`${themePath}/src/scss/main.style.scss`, `${themePath}/build/css`)
+  .options({ processCssUrls: false });
+
+// JS compilation
+mix.js(`${themePath}/src/js/main.script.js`, `${themePath}/build/js`);
+
+// BrowserSync for live reload
+mix.browserSync({
+  proxy,
+  files: [
+    `${themePath}/**/*.twig`,
+    `${themePath}/build/**/*`,
+  ],
+});
+```
+
+### package.json
+
+```json
+{
+  "name": "{THEME_NAME}",
+  "version": "1.0.0",
+  "description": "Radix sub-theme generated from brand design system",
+  "private": true,
+  "scripts": {
+    "dev": "npx mix watch",
+    "build": "npx mix --production",
+    "watch": "npx mix watch"
+  },
+  "devDependencies": {
+    "bootstrap": "^5.3",
+    "laravel-mix": "^6.0",
+    "sass": "^1.77",
+    "sass-loader": "^14.0",
+    "resolve-url-loader": "^5.0"
+  }
+}
+```
+
+### src/scss/main.style.scss
+
+```scss
+// Foundation -- zero CSS output, provides vars + mixins
+@import 'init';
+
+// Bootstrap modules
+@import 'bootstrap';
+
+// Base
+@import 'base/elements';
+@import 'base/typography';
+```
+
+### src/scss/_init.scss
+
+```scss
+// 1. Bootstrap functions (needed for variable manipulation)
+@import '~bootstrap/scss/functions';
+
+// 2. Custom variables -- BEFORE Bootstrap defaults so ours take precedence
+@import 'base/variables';
+
+// 3. Bootstrap variables (use !default, so custom overrides win)
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/variables-dark';
+
+// 4. Bootstrap maps, mixins, utilities
+@import '~bootstrap/scss/maps';
+@import '~bootstrap/scss/mixins';
+@import '~bootstrap/scss/utilities';
+```
+
+### src/scss/_bootstrap.scss
+
+```scss
+// Bootstrap modules -- import only what the theme needs.
+// Comment out unused modules to reduce CSS output.
+
+@import '~bootstrap/scss/root';
+@import '~bootstrap/scss/reboot';
+@import '~bootstrap/scss/type';
+@import '~bootstrap/scss/images';
+@import '~bootstrap/scss/containers';
+@import '~bootstrap/scss/grid';
+@import '~bootstrap/scss/tables';
+@import '~bootstrap/scss/forms';
+@import '~bootstrap/scss/buttons';
+@import '~bootstrap/scss/transitions';
+@import '~bootstrap/scss/dropdown';
+@import '~bootstrap/scss/button-group';
+@import '~bootstrap/scss/nav';
+@import '~bootstrap/scss/navbar';
+@import '~bootstrap/scss/card';
+@import '~bootstrap/scss/accordion';
+@import '~bootstrap/scss/breadcrumb';
+@import '~bootstrap/scss/pagination';
+@import '~bootstrap/scss/badge';
+@import '~bootstrap/scss/alert';
+@import '~bootstrap/scss/progress';
+@import '~bootstrap/scss/list-group';
+@import '~bootstrap/scss/close';
+@import '~bootstrap/scss/toasts';
+@import '~bootstrap/scss/modal';
+@import '~bootstrap/scss/tooltip';
+@import '~bootstrap/scss/popover';
+@import '~bootstrap/scss/carousel';
+@import '~bootstrap/scss/spinners';
+@import '~bootstrap/scss/offcanvas';
+@import '~bootstrap/scss/placeholders';
+@import '~bootstrap/scss/helpers';
+@import '~bootstrap/scss/utilities/api';
+```
+
+### src/scss/base/_variables.scss
+
+```scss
+// ==========================================================================
+// Bootstrap Variable Overrides
+// Generated from brand design tokens via the converter.
+// Values placed here override Bootstrap defaults because _init.scss
+// imports this file BEFORE Bootstrap's own _variables.scss.
+// ==========================================================================
+
+// --------------------------------------------------------------------------
+// Colors
+// --------------------------------------------------------------------------
+// $primary:       #CONVERTER_VALUE;
+// $secondary:     #CONVERTER_VALUE;
+// $success:       #CONVERTER_VALUE;
+// $info:          #CONVERTER_VALUE;
+// $warning:       #CONVERTER_VALUE;
+// $danger:        #CONVERTER_VALUE;
+// $light:         #CONVERTER_VALUE;
+// $dark:          #CONVERTER_VALUE;
+// $body-bg:       #CONVERTER_VALUE;
+// $body-color:    #CONVERTER_VALUE;
+
+// Extend $theme-colors map with custom brand colors:
+// $custom-colors: (
+//   "accent":  $accent,
+//   "bg-alt":  $bg-alt,
+// );
+// $theme-colors: map-merge($theme-colors, $custom-colors);
+
+// --------------------------------------------------------------------------
+// Typography
+// --------------------------------------------------------------------------
+// $font-family-base:    'CONVERTER_BODY_FONT', sans-serif;
+// $font-family-heading: 'CONVERTER_HEADING_FONT', sans-serif;  // Radix convention
+// $font-size-base:      1rem;
+// $font-size-sm:        $font-size-base * 0.875;
+// $font-size-lg:        $font-size-base * 1.25;
+
+// $h1-font-size:        $font-size-base * 2.5;
+// $h2-font-size:        $font-size-base * 2;
+// $h3-font-size:        $font-size-base * 1.75;
+// $h4-font-size:        $font-size-base * 1.5;
+// $h5-font-size:        $font-size-base * 1.25;
+// $h6-font-size:        $font-size-base;
+
+// $line-height-base:    1.5;
+// $headings-font-weight: 700;
+// $headings-line-height: 1.2;
+
+// --------------------------------------------------------------------------
+// Spacing
+// --------------------------------------------------------------------------
+// $spacer: 1rem;
+// $spacers: map-merge($spacers, (
+//   6: $spacer * 4,
+//   7: $spacer * 5,
+//   8: $spacer * 6,
+// ));
+
+// --------------------------------------------------------------------------
+// Border Radius
+// --------------------------------------------------------------------------
+// $border-radius:    0.375rem;
+// $border-radius-sm: 0.25rem;
+// $border-radius-lg: 0.5rem;
+// $border-radius-xl: 1rem;
+
+// --------------------------------------------------------------------------
+// Container Widths
+// --------------------------------------------------------------------------
+// $container-max-widths: (
+//   sm:  540px,
+//   md:  720px,
+//   lg:  960px,
+//   xl:  1140px,
+//   xxl: 1320px,
+// );
+
+// --------------------------------------------------------------------------
+// Custom Properties (no Bootstrap equivalent)
+// --------------------------------------------------------------------------
+// Add brand tokens that don't map to any Bootstrap variable as
+// CSS custom properties via the :root rule in _elements.scss.
+```
+
+### src/scss/base/_elements.scss
+
+```scss
+// ==========================================================================
+// Global Element Styles
+// Base HTML element overrides beyond Bootstrap's Reboot.
+// ==========================================================================
+
+:root {
+  // Custom properties for tokens with no Bootstrap equivalent
+  // --transition-duration: CONVERTER_VALUE;
+  // --transition-easing: CONVERTER_VALUE;
+  // --min-tap-target: CONVERTER_VALUE;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  transition: color var(--transition-duration, 0.2s) var(--transition-easing, ease);
+
+  &:hover {
+    text-decoration-thickness: 2px;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $primary;
+    outline-offset: 2px;
+  }
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+button,
+.btn {
+  transition: all var(--transition-duration, 0.2s) var(--transition-easing, ease);
+}
+
+section {
+  padding-block: $spacer * 4;
+
+  @include media-breakpoint-up(lg) {
+    padding-block: $spacer * 6;
+  }
+}
+```
+
+### src/scss/base/_typography.scss
+
+```scss
+// ==========================================================================
+// Typography -- @font-face declarations and web font imports
+// ==========================================================================
+
+// Option A: Google Fonts via @import (simplest)
+// @import url('https://fonts.googleapis.com/css2?family=HEADING_FONT:wght@400;700&family=BODY_FONT:wght@400;500;700&display=swap');
+
+// Option B: Self-hosted @font-face (better performance, GDPR-friendly)
+// Download fonts and place in {THEME_NAME}/fonts/ directory.
+//
+// @font-face {
+//   font-family: 'HEADING_FONT';
+//   src: url('../fonts/heading-font-bold.woff2') format('woff2');
+//   font-weight: 700;
+//   font-style: normal;
+//   font-display: swap;
+// }
+//
+// @font-face {
+//   font-family: 'BODY_FONT';
+//   src: url('../fonts/body-font-regular.woff2') format('woff2');
+//   font-weight: 400;
+//   font-style: normal;
+//   font-display: swap;
+// }
+
+// Heading styles
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  font-family: $font-family-heading;
+}
+```
+
+### src/js/main.script.js
+
+```js
+/**
+ * @file
+ * Theme JS entry point.
+ */
+
+(function (Drupal) {
+  'use strict';
+
+  /**
+   * Scroll reveal observer -- fade in elements as they enter the viewport.
+   *
+   * Add the attribute `data-reveal` to any element that should animate in.
+   * The class `is-revealed` is added once the element is 15% visible.
+   */
+  Drupal.behaviors.scrollReveal = {
+    attach: function (context) {
+      const elements = context.querySelectorAll('[data-reveal]:not(.is-revealed)');
+      if (!elements.length || !('IntersectionObserver' in window)) {
+        return;
+      }
+
+      const observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('is-revealed');
+              observer.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.15 }
+      );
+
+      elements.forEach(function (el) {
+        observer.observe(el);
+      });
+    },
+  };
+
+})(Drupal);
+```
+
+### templates/layout/layout--onecol.html.twig
+
+```twig
+{#
+/**
+ * @file
+ * One-column Layout Builder section override.
+ *
+ * Nested container pattern:
+ *   - Outer div: full viewport width (receives background styles from
+ *     layout_builder_styles module).
+ *   - Inner .container: constrains content to max-width.
+ */
+#}
+{% set container_classes = ['layout', 'layout--onecol'] %}
+
+<div{{ attributes.addClass(container_classes) }}>
+  <div class="container">
+    <div{{ content_attributes.addClass('layout__content') }}>
+      {{ content.content }}
+    </div>
+  </div>
+</div>
+```
+
+### templates/layout/layout--twocol-section.html.twig
+
+```twig
+{#
+/**
+ * @file
+ * Two-column Layout Builder section override.
+ */
+#}
+{% set container_classes = ['layout', 'layout--twocol-section'] %}
+
+<div{{ attributes.addClass(container_classes) }}>
+  <div class="container">
+    <div class="row">
+      <div{{ region_attributes.first.addClass('layout__region', 'layout__region--first', 'col-12', 'col-md-6') }}>
+        {{ content.first }}
+      </div>
+      <div{{ region_attributes.second.addClass('layout__region', 'layout__region--second', 'col-12', 'col-md-6') }}>
+        {{ content.second }}
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### templates/layout/layout--threecol-section.html.twig
+
+```twig
+{#
+/**
+ * @file
+ * Three-column Layout Builder section override.
+ */
+#}
+{% set container_classes = ['layout', 'layout--threecol-section'] %}
+
+<div{{ attributes.addClass(container_classes) }}>
+  <div class="container">
+    <div class="row">
+      <div{{ region_attributes.first.addClass('layout__region', 'layout__region--first', 'col-12', 'col-md-4') }}>
+        {{ content.first }}
+      </div>
+      <div{{ region_attributes.second.addClass('layout__region', 'layout__region--second', 'col-12', 'col-md-4') }}>
+        {{ content.second }}
+      </div>
+      <div{{ region_attributes.third.addClass('layout__region', 'layout__region--third', 'col-12', 'col-md-4') }}>
+        {{ content.third }}
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### includes/{THEME_NAME}.theme
+
+```php
+<?php
+
+/**
+ * @file
+ * Theme preprocess functions for {THEME_LABEL}.
+ */
+
+/**
+ * Implements hook_preprocess_HOOK() for page templates.
+ */
+function {THEME_NAME}_preprocess_page(array &$variables): void {
+  // Add theme-specific variables to page template.
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for node templates.
+ */
+function {THEME_NAME}_preprocess_node(array &$variables): void {
+  // Add node-level preprocessing.
+}
+```
+
+### .gitignore
+
+```
+node_modules/
+build/
+```

--- a/brand-content-design/skills/radix-sdc-generator/references/sdc-patterns.md
+++ b/brand-content-design/skills/radix-sdc-generator/references/sdc-patterns.md
@@ -1,0 +1,573 @@
+# SDC Component Patterns
+
+Templates and conventions for generating Single Directory Components (SDC) in a Radix sub-theme. Use these patterns when creating `component.yml`, `.twig`, and `.scss` files from analysis output.
+
+## Contents
+
+- component.yml Template
+  - Required Props on Every Component
+  - Prop Type Reference
+- Example 1: Atom -- Button
+- Example 2: Molecule -- Card
+- Example 3: Organism -- Feature Grid
+- Twig Template Patterns
+  - Attribute Handling
+  - Utility Classes Merge
+  - Slot Rendering
+  - Dual-Mode Content (Prop and Slot)
+  - Conditional Wrapper
+- SCSS Patterns
+  - Import Convention
+  - BEM Methodology
+  - Use Bootstrap Variables and Mixins
+- Radix-Specific Conventions
+  - Bootstrap Classes in Twig
+  - Extending a Radix Base Component
+  - Component Library Discovery
+
+## component.yml Template
+
+Every SDC has a `component.yml` that declares its metadata, props (JSON Schema), and slots.
+
+```yaml
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Component Name
+status: experimental
+group: Theme Name
+description: 'Brief description of what this component renders.'
+props:
+  type: object
+  properties:
+    attributes:
+      type: Drupal\Core\Template\Attribute
+    {component_name}_utility_classes:
+      type: array
+      items:
+        type: string
+      default: []
+    # Additional props from analysis...
+slots:
+  # Slots from analysis...
+```
+
+### Required Props on Every Component
+
+1. **`attributes`** -- typed as `Drupal\Core\Template\Attribute`. Drupal passes HTML attributes (id, class, data-*) through this object. Always render it on the outermost element.
+
+2. **`{component_name}_utility_classes`** -- array of strings. Allows editors and parent templates to inject Bootstrap utility classes without modifying the component. Merge into the outermost element's class list.
+
+### Prop Type Reference
+
+| Analysis Type | JSON Schema Type | Notes |
+|---|---|---|
+| string | `type: string` | Plain text value |
+| text | `type: string` | Longer text, may contain HTML |
+| url | `type: string, format: uri` | Link href |
+| number | `type: number` | Numeric value |
+| boolean | `type: boolean` | Toggle |
+| image | `type: string, format: uri` | Image src URL |
+| enum | `type: string, enum: [...]` | Fixed set of values |
+| color | `type: string` | CSS color value |
+
+## Example 1: Atom -- Button
+
+### button.component.yml
+
+```yaml
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Button
+status: experimental
+group: theme_name
+description: 'Call-to-action button with brand styling and variant support.'
+props:
+  type: object
+  properties:
+    attributes:
+      type: Drupal\Core\Template\Attribute
+    button_utility_classes:
+      type: array
+      items:
+        type: string
+      default: []
+    label:
+      type: string
+      title: Label
+      description: 'Button text'
+    url:
+      type: string
+      format: uri
+      title: URL
+      description: 'Link destination'
+    variant:
+      type: string
+      title: Variant
+      enum:
+        - primary
+        - secondary
+        - outline
+      default: primary
+    size:
+      type: string
+      title: Size
+      enum:
+        - sm
+        - md
+        - lg
+      default: md
+  required:
+    - label
+```
+
+### button.twig
+
+```twig
+{#
+/**
+ * @file
+ * Button atom.
+ *
+ * Props:
+ *   - label: Button text.
+ *   - url: Link destination (renders <a> when provided, <button> otherwise).
+ *   - variant: primary | secondary | outline.
+ *   - size: sm | md | lg.
+ *   - button_utility_classes: Additional CSS classes.
+ *   - attributes: Drupal HTML attributes.
+ */
+#}
+
+{% set variant_class = 'btn-' ~ (variant ?? 'primary') %}
+{% if variant == 'outline' %}
+  {% set variant_class = 'btn-outline-primary' %}
+{% endif %}
+
+{% set size_class = (size and size != 'md') ? 'btn-' ~ size : '' %}
+
+{% set classes = [
+  'btn',
+  variant_class,
+  size_class,
+]|merge(button_utility_classes ?? [])
+|filter(c => c is not empty) %}
+
+{% if url %}
+  <a{{ attributes.addClass(classes) }} href="{{ url }}" role="button">
+    {{- label -}}
+  </a>
+{% else %}
+  <button{{ attributes.addClass(classes) }} type="button">
+    {{- label -}}
+  </button>
+{% endif %}
+```
+
+### button.scss
+
+```scss
+@import '../../../src/scss/init';
+
+.btn {
+  // Brand overrides applied via _variables.scss.
+  // Only add custom styles that go beyond Bootstrap's .btn here.
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: all var(--transition-duration, 0.2s) var(--transition-easing, ease);
+
+  &:focus-visible {
+    outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, rgba($primary, 0.5));
+    outline-offset: 2px;
+  }
+}
+```
+
+## Example 2: Molecule -- Card
+
+### card.component.yml
+
+```yaml
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Card
+status: experimental
+group: theme_name
+description: 'Content card with image, heading, body text, and optional CTA.'
+props:
+  type: object
+  properties:
+    attributes:
+      type: Drupal\Core\Template\Attribute
+    card_utility_classes:
+      type: array
+      items:
+        type: string
+      default: []
+    image:
+      type: string
+      format: uri
+      title: Image
+      description: 'Card image URL'
+    image_alt:
+      type: string
+      title: Image Alt
+      description: 'Image alt text for accessibility'
+    heading:
+      type: string
+      title: Heading
+    body:
+      type: string
+      title: Body
+      description: 'Card body text, may contain HTML'
+  required:
+    - heading
+slots:
+  card_footer:
+    title: Card Footer
+    description: 'Optional footer area, typically a CTA button or link'
+```
+
+### card.twig
+
+```twig
+{#
+/**
+ * @file
+ * Card molecule.
+ *
+ * Extends Bootstrap card pattern with brand styling.
+ *
+ * Props:
+ *   - image, image_alt: Card image.
+ *   - heading: Card title.
+ *   - body: Card text content.
+ *   - card_utility_classes: Additional CSS classes.
+ *   - attributes: Drupal HTML attributes.
+ *
+ * Slots:
+ *   - card_footer: Footer area for CTA.
+ */
+#}
+
+{% set classes = [
+  'card',
+  'card--brand',
+  'h-100',
+]|merge(card_utility_classes ?? []) %}
+
+<div{{ attributes.addClass(classes) }}>
+  {% if image %}
+    <img src="{{ image }}" alt="{{ image_alt ?? '' }}" class="card-img-top" loading="lazy">
+  {% endif %}
+
+  <div class="card-body">
+    {% if heading %}
+      <h3 class="card-title h5">{{ heading }}</h3>
+    {% endif %}
+
+    {% if body %}
+      <div class="card-text">{{ body }}</div>
+    {% endif %}
+  </div>
+
+  {% block card_footer %}
+    {% if card_footer is not empty %}
+      <div class="card-footer bg-transparent border-0">
+        {{ card_footer }}
+      </div>
+    {% endif %}
+  {% endblock %}
+</div>
+```
+
+### card.scss
+
+```scss
+@import '../../../src/scss/init';
+
+.card--brand {
+  border: 0;
+  border-radius: $border-radius-lg;
+  box-shadow: $box-shadow-sm;
+  overflow: hidden;
+  transition: transform var(--transition-duration, 0.2s) var(--transition-easing, ease),
+              box-shadow var(--transition-duration, 0.2s) var(--transition-easing, ease);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: $box-shadow;
+  }
+
+  &__img-top {
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+  }
+}
+```
+
+## Example 3: Organism -- Feature Grid
+
+### feature-grid.component.yml
+
+```yaml
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Feature Grid
+status: experimental
+group: theme_name
+description: 'Grid of feature cards with section heading. Used in Layout Builder sections.'
+props:
+  type: object
+  properties:
+    attributes:
+      type: Drupal\Core\Template\Attribute
+    feature_grid_utility_classes:
+      type: array
+      items:
+        type: string
+      default: []
+    heading:
+      type: string
+      title: Section Heading
+    subheading:
+      type: string
+      title: Section Subheading
+    columns:
+      type: integer
+      title: Columns
+      enum:
+        - 2
+        - 3
+        - 4
+      default: 3
+slots:
+  items:
+    title: Feature Items
+    description: 'Collection of card molecules or feature items'
+```
+
+### feature-grid.twig
+
+```twig
+{#
+/**
+ * @file
+ * Feature grid organism.
+ *
+ * Renders a responsive grid of feature items within a page section.
+ * Designed for placement in Layout Builder one-column sections.
+ *
+ * Props:
+ *   - heading, subheading: Section header text.
+ *   - columns: Grid column count (2, 3, or 4).
+ *   - feature_grid_utility_classes: Additional CSS classes.
+ *   - attributes: Drupal HTML attributes.
+ *
+ * Slots:
+ *   - items: Collection of feature cards.
+ */
+#}
+
+{% set col_class = 'col-md-' ~ (12 // (columns ?? 3)) %}
+
+{% set classes = [
+  'feature-grid',
+]|merge(feature_grid_utility_classes ?? []) %}
+
+<section{{ attributes.addClass(classes) }}>
+  {% if heading or subheading %}
+    <div class="feature-grid__header text-center mb-5">
+      {% if heading %}
+        <h2 class="feature-grid__heading">{{ heading }}</h2>
+      {% endif %}
+      {% if subheading %}
+        <p class="feature-grid__subheading lead text-muted">{{ subheading }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="row g-4">
+    {% block items %}
+      {% if items is not empty %}
+        {% for item in items %}
+          <div class="col-12 {{ col_class }}">
+            {{ item }}
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endblock %}
+  </div>
+</section>
+```
+
+### feature-grid.scss
+
+```scss
+@import '../../../src/scss/init';
+
+.feature-grid {
+  &__header {
+    max-width: 720px;
+    margin-inline: auto;
+  }
+
+  &__heading {
+    font-family: $font-family-heading;
+    margin-bottom: $spacer;
+  }
+
+  &__subheading {
+    font-size: $font-size-lg;
+  }
+}
+```
+
+## Twig Template Patterns
+
+### Attribute Handling
+
+Always render `attributes` on the outermost element:
+
+```twig
+{% set classes = ['component-name']|merge(component_name_utility_classes ?? []) %}
+<div{{ attributes.addClass(classes) }}>
+  {# content #}
+</div>
+```
+
+### Utility Classes Merge
+
+The `*_utility_classes` array prop allows injecting classes from the parent context. Merge it into the base class list:
+
+```twig
+{% set classes = [
+  'base-class',
+  'variant-' ~ (variant ?? 'default'),
+]|merge(my_component_utility_classes ?? [])
+|filter(c => c is not empty) %}
+```
+
+### Slot Rendering
+
+Slots are rendered as Twig blocks. This allows both direct content injection and template-level overrides:
+
+```twig
+{% block slot_name %}
+  {% if slot_name is not empty %}
+    {{ slot_name }}
+  {% endif %}
+{% endblock %}
+```
+
+### Dual-Mode Content (Prop and Slot)
+
+When a component accepts content as both a prop (simple string) and a slot (complex markup):
+
+```twig
+{% block content %}
+  {% if content is not empty %}
+    {{ content }}
+  {% else %}
+    {{ body_text }}
+  {% endif %}
+{% endblock %}
+```
+
+### Conditional Wrapper
+
+Wrap optional elements only when the prop has a value:
+
+```twig
+{% if url %}
+  <a href="{{ url }}" class="card-link">{{ label }}</a>
+{% else %}
+  <span class="card-label">{{ label }}</span>
+{% endif %}
+```
+
+## SCSS Patterns
+
+### Import Convention
+
+Every component SCSS file imports `_init.scss` relative to its location in the components directory:
+
+```scss
+// Atom (components/atoms/button/)
+@import '../../../src/scss/init';
+
+// Molecule (components/molecules/card/)
+@import '../../../src/scss/init';
+
+// Organism (components/organisms/feature-grid/)
+@import '../../../src/scss/init';
+```
+
+The import depth is the same for all levels because atoms, molecules, and organisms are all one directory deep under `components/`.
+
+### BEM Methodology
+
+Use Block-Element-Modifier naming:
+
+```scss
+.component-name {
+  // Block styles
+
+  &__element {
+    // Element styles
+  }
+
+  &__element--modifier {
+    // Modifier styles
+  }
+
+  &--variant {
+    // Block variant
+  }
+}
+```
+
+### Use Bootstrap Variables and Mixins
+
+Reference Bootstrap SCSS variables (which include brand overrides from `_variables.scss`) and mixins instead of hardcoding values:
+
+```scss
+.component-name {
+  padding: $spacer * 2;
+  border-radius: $border-radius-lg;
+  color: $body-color;
+  background-color: $gray-100;
+
+  @include media-breakpoint-up(md) {
+    padding: $spacer * 3;
+  }
+}
+```
+
+## Radix-Specific Conventions
+
+### Bootstrap Classes in Twig
+
+Use Bootstrap utility classes directly in Twig templates for layout and spacing. Reserve component SCSS for brand-specific styling only:
+
+```twig
+<div class="d-flex align-items-center gap-3 mb-4">
+  <div class="flex-shrink-0">{{ icon }}</div>
+  <div class="flex-grow-1">{{ content }}</div>
+</div>
+```
+
+### Extending a Radix Base Component
+
+When the analysis identifies a Radix base component to extend:
+
+1. The sub-theme component keeps the same `component.yml` prop schema.
+2. Override the `.twig` template to apply brand markup.
+3. Override the `.scss` to apply brand styles.
+4. Drupal's SDC discovery automatically uses the sub-theme version.
+
+When the analysis finds no Radix match, create a new component from scratch following the patterns above.
+
+### Component Library Discovery
+
+SDC components are discovered automatically by Drupal when placed in `components/`. No manual registration is required. The `component.yml` file is the discovery mechanism. Verify:
+
+- `component.yml` has a valid `$schema` reference.
+- Component directory name matches the component machine name.
+- `group` value matches the theme machine name.
+- `status` is set (`experimental`, `stable`, or `deprecated`).

--- a/brand-content-design/skills/radix-sdc-generator/references/token-to-bootstrap-mapping.md
+++ b/brand-content-design/skills/radix-sdc-generator/references/token-to-bootstrap-mapping.md
@@ -1,0 +1,232 @@
+# Token-to-Bootstrap Mapping
+
+6px threshold framework for mapping HTML design tokens (CSS custom properties) to Bootstrap SCSS variables. Apply this framework during Part 2 of the generator to produce `_variables.scss`.
+
+## Contents
+
+- The 6px Threshold Framework
+  - When to Accommodate
+  - When to Customize
+  - When to Extend
+  - When to Create
+- Color Token Mapping
+  - Adding Custom Colors to $theme-colors
+- Typography Token Mapping
+  - Custom Type Scale
+- Spacing Token Mapping
+  - Extending the $spacers Map
+- Layout Token Mapping
+  - Container Width Overrides
+- Interaction Token Mapping
+- Mapping Output Format
+
+## The 6px Threshold Framework
+
+For each design token extracted from the HTML, calculate the numeric difference from Bootstrap 5.3's default value. Classify the mapping action:
+
+| Category | Action | Criteria |
+|---|---|---|
+| **Accommodate** | Use Bootstrap default | Difference <= 6px or visually negligible (color delta E < 5) |
+| **Extend** | Add to existing map | Token extends Bootstrap (new breakpoint, new color, new spacer step) |
+| **Customize** | Override variable | Difference > 6px from default, or color delta E >= 5 |
+| **Create** | New custom variable | No Bootstrap equivalent exists |
+
+### When to Accommodate
+
+Do not override Bootstrap when the design token is close enough to the default. This reduces CSS output and keeps the theme aligned with Bootstrap's tested proportions.
+
+Examples:
+- Design specifies `font-size: 15px`, Bootstrap default is `16px` (1rem) -- difference is 1px, accommodate.
+- Design border-radius is `6px`, Bootstrap default is `0.375rem` (6px at 16px base) -- exact match, accommodate.
+- Design primary color is `#0d6efd` -- same as Bootstrap default, accommodate.
+
+### When to Customize
+
+Override the Bootstrap variable with the brand value.
+
+Examples:
+- Design specifies `font-size: 18px` for base, Bootstrap default is 16px -- difference is 2px but proportionally significant for base size, customize.
+- Design primary color is `#2563eb` -- different from Bootstrap `#0d6efd`, customize.
+- Design `$spacer` base is `1.25rem`, Bootstrap default is `1rem` -- customize.
+
+### When to Extend
+
+Add new entries to an existing Bootstrap Sass map without replacing existing ones.
+
+Examples:
+- Design has a spacing step `4rem` not in Bootstrap's `$spacers` map -- extend the map.
+- Design introduces `$accent` color not in `$theme-colors` -- extend the map.
+
+### When to Create
+
+Define a new SCSS variable or CSS custom property for tokens with no Bootstrap counterpart.
+
+Examples:
+- `--transition-duration` -- no Bootstrap variable, create as CSS custom property.
+- `--min-tap-target` -- accessibility token, create as CSS custom property.
+
+## Color Token Mapping
+
+| HTML Token | Bootstrap Variable | Notes |
+|---|---|---|
+| `--color-primary` | `$primary` | Direct override |
+| `--color-secondary` | `$secondary` | Direct override |
+| `--color-accent` | `$info` or custom `$accent` | If delta E < 5 from `$info`, use it; otherwise create `$accent` |
+| `--color-bg` | `$body-bg` | Direct override |
+| `--color-bg-alt` | `$gray-100` or custom `$bg-alt` | Check proximity to Bootstrap gray scale |
+| `--color-text` | `$body-color` | Direct override |
+| `--color-text-muted` | `$text-muted` | Direct override |
+| `--color-error` | `$danger` | Direct override |
+| `--color-success` | `$success` | Direct override |
+| `--color-warning` | `$warning` | Direct override |
+
+### Adding Custom Colors to $theme-colors
+
+When a brand color has no Bootstrap equivalent, add it to the theme colors map so Bootstrap utilities (`.bg-accent`, `.text-accent`, `.btn-accent`) are generated automatically:
+
+```scss
+// In _variables.scss, AFTER individual variable definitions:
+$accent: #8b5cf6;
+$bg-alt: #f8f9fb;
+
+$custom-colors: (
+  "accent": $accent,
+  "bg-alt": $bg-alt,
+);
+
+// This merge happens in _init.scss after Bootstrap's maps are loaded.
+// Place the $custom-colors definition here; the merge goes in a
+// separate partial or at the top of _bootstrap.scss:
+// $theme-colors: map-merge($theme-colors, $custom-colors);
+```
+
+## Typography Token Mapping
+
+| HTML Token | Bootstrap Variable | Notes |
+|---|---|---|
+| `--font-heading` | `$font-family-heading` | Radix convention (not core Bootstrap) |
+| `--font-body` | `$font-family-base` | Direct override |
+| `--font-mono` | `$font-family-monospace` | Direct override |
+| `--font-size-base` | `$font-size-base` | Direct override (in rem) |
+| `--font-size-sm` | `$font-size-sm` | Usually `$font-size-base * 0.875` |
+| `--font-size-lg` | `$font-size-lg` | Usually `$font-size-base * 1.25` |
+| `--font-size-h1` | `$h1-font-size` | Override with brand ratio |
+| `--font-size-h2` | `$h2-font-size` | Override with brand ratio |
+| `--font-size-h3` | `$h3-font-size` | Override with brand ratio |
+| `--font-size-h4` | `$h4-font-size` | Override with brand ratio |
+| `--font-size-h5` | `$h5-font-size` | Override with brand ratio |
+| `--font-size-h6` | `$h6-font-size` | Override with brand ratio |
+| `--line-height` | `$line-height-base` | Direct override |
+| `--heading-weight` | `$headings-font-weight` | Direct override |
+
+### Custom Type Scale
+
+When the brand uses a type scale that does not align with Bootstrap's default multipliers, define each heading size explicitly:
+
+```scss
+$h1-font-size: 3rem;      // Brand: 48px
+$h2-font-size: 2.25rem;   // Brand: 36px
+$h3-font-size: 1.75rem;   // Brand: 28px
+$h4-font-size: 1.375rem;  // Brand: 22px
+$h5-font-size: 1.125rem;  // Brand: 18px
+$h6-font-size: 1rem;      // Brand: 16px
+```
+
+## Spacing Token Mapping
+
+| HTML Token | Bootstrap Default | Bootstrap Variable |
+|---|---|---|
+| `--space-xs` | `$spacer * 0.25` (4px) | `$spacer` map key `1` |
+| `--space-sm` | `$spacer * 0.5` (8px) | `$spacer` map key `2` |
+| `--space-md` | `$spacer` (16px) | `$spacer` map key `3` |
+| `--space-lg` | `$spacer * 1.5` (24px) | `$spacer` map key `4` |
+| `--space-xl` | `$spacer * 3` (48px) | `$spacer` map key `5` |
+| `--space-2xl` | No default | Extend map |
+| `--space-3xl` | No default | Extend map |
+
+### Extending the $spacers Map
+
+```scss
+$spacer: 1rem;
+
+// Add large spacer steps for section padding
+$spacers: map-merge($spacers, (
+  6: $spacer * 4,    // 64px -- section padding small
+  7: $spacer * 5,    // 80px -- section padding medium
+  8: $spacer * 6,    // 96px -- section padding large
+));
+```
+
+## Layout Token Mapping
+
+| HTML Token | Bootstrap Variable | Notes |
+|---|---|---|
+| `--max-width` | `$container-max-widths` map | Override specific breakpoint values |
+| `--border-radius` | `$border-radius` | Apply threshold: <= 6px difference = accommodate |
+| `--border-radius-sm` | `$border-radius-sm` | Direct override |
+| `--border-radius-lg` | `$border-radius-lg` | Direct override |
+| `--border-radius-xl` | `$border-radius-xl` | Direct override if brand uses xl radius |
+| `--shadow-sm` | `$box-shadow-sm` | Direct override |
+| `--shadow-md` | `$box-shadow` | Direct override |
+| `--shadow-lg` | `$box-shadow-lg` | Direct override |
+
+### Container Width Overrides
+
+```scss
+$container-max-widths: (
+  sm:  540px,
+  md:  720px,
+  lg:  960px,
+  xl:  1140px,
+  xxl: 1320px,     // Override if brand uses wider/narrower max-width
+);
+```
+
+## Interaction Token Mapping
+
+Timing and easing tokens have no direct Bootstrap SCSS variable. Map them to CSS custom properties in `:root` via `_elements.scss`:
+
+| HTML Token | CSS Custom Property | Example Value |
+|---|---|---|
+| `--transition-duration` | `--transition-duration` | `0.2s` |
+| `--transition-easing` | `--transition-easing` | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `--min-tap-target` | `--min-tap-target` | `44px` |
+| `--focus-ring-width` | `--focus-ring-width` | `2px` |
+| `--focus-ring-color` | `--focus-ring-color` | `rgba(37, 99, 235, 0.5)` |
+
+These are declared in `_elements.scss` inside `:root {}` and referenced from component SCSS.
+
+## Mapping Output Format
+
+Record every mapping decision in the `radix-sdc.yml` output config so the conversion report can display the full table:
+
+```yaml
+tokenMapping:
+  - token: "--color-primary"
+    value: "#2563eb"
+    bootstrapVar: "$primary"
+    bootstrapDefault: "#0d6efd"
+    action: customize
+    reasoning: "Delta E 12.4, exceeds threshold"
+
+  - token: "--font-size-base"
+    value: "16px"
+    bootstrapVar: "$font-size-base"
+    bootstrapDefault: "1rem (16px)"
+    action: accommodate
+    reasoning: "Exact match"
+
+  - token: "--space-2xl"
+    value: "4rem"
+    bootstrapVar: "$spacers map"
+    bootstrapDefault: "N/A"
+    action: extend
+    reasoning: "Added as spacer key 6"
+
+  - token: "--transition-duration"
+    value: "0.2s"
+    bootstrapVar: "N/A"
+    bootstrapDefault: "N/A"
+    action: create
+    reasoning: "No Bootstrap SCSS equivalent, added as CSS custom property"
+```


### PR DESCRIPTION
## Summary

- Add metadata-driven converter pipeline that analyzes branded HTML pages (with embedded metadata comments) and generates complete Drupal Radix 6.0.2 sub-themes with SDC components, Bootstrap-mapped SCSS, Layout Builder config, and icon packs
- Architecture: shared analysis layer (`html-to-radix-analyzer`) produces target-agnostic output consumed by target-specific generators (`radix-sdc-generator` first, Canvas/Node.js future)
- Two command modes: `/convert-to-radix` (guided 7-phase wizard with 6 decision points) and `/convert-to-radix-quick` (3-question quick mode with auto-resolution)

### New files (13)
| Category | Files |
|----------|-------|
| Skills | `html-to-radix-analyzer/SKILL.md` (407 lines), `radix-sdc-generator/SKILL.md` (388 lines) |
| References | 8 files covering pattern/atomic classification, backend inventory, output schema, Radix scaffold, token-to-Bootstrap mapping, SDC patterns, Layout Builder config |
| Commands | `convert-to-radix.md` (guided), `convert-to-radix-quick.md` (quick) |
| Script | `extract-icons.js` — CLI to extract inline SVGs for Drupal Icon API |

### Modified files (3)
- `brand-content-design/SKILL.md` — added converter routing triggers
- `plugin.json` — version bump to 2.2.0
- `CHANGELOG.md` — full 2.2.0 entry

## Test plan

- [ ] Run `node brand-content-design/scripts/extract-icons.js list` on an HTML page with icon comments — should list icon names
- [ ] Run `node brand-content-design/scripts/extract-icons.js extract` on an HTML page — should create SVG files in output dir
- [ ] Invoke `/convert-to-radix-quick` on a brand project with HTML pages — should produce a complete Radix sub-theme directory
- [ ] Verify generated `component.yml` files pass YAML lint
- [ ] Verify generated `_variables.scss` is valid Bootstrap 5 SCSS
- [ ] Confirm router skill triggers on phrases like "convert to drupal", "generate theme"

🤖 Generated with [Claude Code](https://claude.com/claude-code)