### PR TITLE
feat(code-paper-test): v0.3.0 - Competing Testers agent team command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -65,7 +65,7 @@
       "name": "code-paper-test",
       "source": "./code-paper-test",
       "description": "Systematically test code through mental execution - trace code line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, and contract violations before deployment",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "camoa"
       },

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,10 +1,11 @@
 {
   "name": "code-paper-test",
   "description": "Systematic code testing through mental execution - trace code line-by-line with concrete values to find bugs, missing logic, and edge cases before running",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
-  "repository": "https://github.com/camoa/claude-skills"
+  "repository": "https://github.com/camoa/claude-skills",
+  "commands": "commands"
 }

--- a/code-paper-test/.claude/rules/command-conventions.md
+++ b/code-paper-test/.claude/rules/command-conventions.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "commands/**"
+---
+
+# Command Conventions
+
+## Required Frontmatter
+- `description` — clear, concise action description
+- `allowed-tools` — minimum needed tools
+
+## Optional Frontmatter
+- `argument-hint` — when command accepts arguments
+
+## Body
+- Step-by-step workflow with numbered steps
+- Include error handling for missing prerequisites
+- Agent team commands contain team orchestration logic

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-11
+
+### Added
+- **NEW: `/test-team` command** — paper test code with competing agent team (3 perspectives)
+  - **Happy Path Validator** (sonnet) — traces correct flow with ideal inputs, verifies dependencies and contracts
+  - **Edge Case Hunter** (sonnet) — probes boundaries: nulls, empty, zero, large values, type mismatches
+  - **Red Team Attacker** (sonnet) — adversarial inputs: injection, path traversal, race conditions, resource exhaustion
+  - Cross-challenge debate resolves flaw severity and disputes false findings
+  - Lead synthesizes prioritized flaw report next to target code
+  - Scope gate: suggests standard paper test for <50 lines
+  - Falls back to standard paper test skill when agent teams not available
+  - Requires experimental flag: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+- `commands/` directory — first command in this plugin
+- `.claude/rules/command-conventions.md` for path-scoped command standards
+- Command conventions section in `CLAUDE.md`
+
+---
+
 ## [0.2.0] - 2026-02-09
 
 ### Added

--- a/code-paper-test/CLAUDE.md
+++ b/code-paper-test/CLAUDE.md
@@ -6,6 +6,11 @@
 - Body uses imperative voice — instructions, not documentation
 - Under 500 lines per SKILL.md
 
+## Commands
+- Frontmatter must include: description, allowed-tools
+- Use `argument-hint:` when command accepts arguments
+- Agent team commands orchestrate AI debate workflows rather than wrapping scripts
+
 ## General
 - Reference files instead of reproducing content
 - Current state only — no historical narratives

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -73,6 +73,16 @@ Or use it explicitly:
 - Auditing AI-generated code
 - Validating complex logic (loops, conditionals, recursion)
 
+### Competing Testers (Agent Team)
+
+For complex or security-critical code, use the agent team command:
+
+```
+/code-paper:test-team src/Service/PaymentService.php
+```
+
+Spawns 3 competing testers — Happy Path Validator, Edge Case Hunter, and Red Team Attacker — who independently analyze the code and then debate findings. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+
 ## How It Works
 
 The skill guides you through a systematic workflow:
@@ -196,7 +206,11 @@ Specific checks for AI-generated code:
 
 ## Version
 
-0.2.0
+**0.3.0** (Current) - Competing Testers agent team command
+- `/code-paper:test-team` — 3-agent team paper testing (Happy Path + Edge Case + Red Team)
+- Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+
+**0.2.0** - Plugin conventions and model routing
 
 ## License
 

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -1,0 +1,380 @@
+---
+description: Paper test code with competing agent team (Happy Path + Edge Case + Red Team)
+allowed-tools: Read, Write, Glob, Grep, WebSearch
+argument-hint: <file-path> [file-path...]
+---
+
+# Test Team
+
+Paper test code from 3 competing perspectives using an agent team. A Happy Path Validator traces correct flow, an Edge Case Hunter probes boundaries, and a Red Team Attacker tries adversarial inputs. They debate findings and produce a prioritized flaw report.
+
+## Usage
+
+```
+/code-paper:test-team <file-path> [file-path...]
+```
+
+## What This Does
+
+Spawns a 3-teammate agent team that paper-tests the specified code files from competing perspectives. Each teammate traces the code with different input strategies, then they cross-challenge findings. The lead synthesizes a prioritized flaw report next to the target code.
+
+## Instructions
+
+When this command is invoked with `$ARGUMENTS`:
+
+### Step 1 — Check Target Exists
+
+Parse `$ARGUMENTS` as one or more file paths. Verify each file exists using the Read tool.
+
+If no arguments provided:
+> What code should the team test? Provide one or more file paths:
+> ```
+> /code-paper:test-team src/Service/PaymentService.php
+> ```
+
+If a file doesn't exist:
+> File not found: `{path}`. Check the path and try again.
+
+Stop here if no valid targets.
+
+Determine the **target directory** for output:
+- Single file → same directory as the file
+- Multiple files in same directory → that directory
+- Multiple files across directories → their common parent directory
+
+### Step 2 — Check Prerequisites
+
+Verify agent teams are available. If not:
+
+> Agent teams require the experimental flag:
+> ```json
+> // Add to ~/.claude/settings.json
+> { "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
+> ```
+> Or: `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+>
+> **Fallback:** Use the standard paper test skill instead — ask Claude to "paper test {file}".
+
+Stop here if not available.
+
+### Step 3 — Assess Scope
+
+Read target files and count total lines.
+
+If fewer than 50 lines total:
+> Target is {N} lines. For small code, standard paper testing may be sufficient.
+> Continue with the 3-agent team? (The team adds most value with complex code.)
+
+Continue if user confirms or if 50+ lines.
+
+### Step 4 — Create Shared Task List
+
+Create a team and these tasks:
+
+| # | Task | Assign to | Depends on |
+|---|------|-----------|------------|
+| 1 | Trace happy path — verify correct flow with ideal inputs | Happy Path Validator | — |
+| 2 | Probe edge cases — boundary values, nulls, empty, large inputs | Edge Case Hunter | — |
+| 3 | Attack with adversarial inputs — injection, malformed data, race conditions | Red Team Attacker | — |
+| 4 | Cross-challenge — debate flaw severity, dispute false findings, identify blind spots | All three | 1, 2, 3 |
+| 5 | Synthesize prioritized flaw report | Lead | 4 |
+
+### Step 5 — Spawn Teammates
+
+Spawn 3 teammates using the prompt templates below. After spawning:
+
+1. Tell the user: "Team spawned. Teammates are working — I'll synthesize when they finish."
+2. If running inside tmux, teammates appear in split panes (visible output). Otherwise they run in-process (background).
+3. Do NOT perform testing yourself — wait for all teammates to complete before proceeding.
+
+### Step 6 — Synthesize
+
+When all teammates finish:
+
+- Read `{target_dir}/happy-path-analysis.md`, `{target_dir}/edge-case-analysis.md`, `{target_dir}/red-team-analysis.md`
+- Write `{target_dir}/paper-test-team-report.md` using the Output Format below
+- Tell the user: "Paper test team complete. Report saved to `{target_dir}/paper-test-team-report.md`"
+
+---
+
+## Spawn Prompts
+
+### Teammate 1: Happy Path Validator
+
+**Model:** sonnet
+
+```
+You are the Happy Path Validator for a paper testing team.
+
+TARGET FILES:
+{list each file path}
+
+YOUR MISSION:
+Trace the code with ideal inputs and document expected behavior. Your lens: "Does this code work correctly when everything goes right?"
+
+1. Design 2-3 happy path scenarios with concrete input values
+2. Trace each line recording variable state after execution:
+   ```
+   Line [N]: [code statement]
+            → [variable] = [new value]
+   ```
+3. At each conditional, note which branch is taken and why
+4. For loops, trace EACH iteration with index and values
+5. For EVERY external call (methods, services, APIs):
+   - Use Read tool to verify method exists and check signature
+   - DO NOT assume — read actual source or mark as UNVERIFIED RISK
+6. For code contracts (extends, implements, uses, injects):
+   - Read parent/base classes and interfaces
+   - Verify all abstract methods implemented, signatures match
+7. Document expected outputs and side effects
+
+WRITE your analysis to:
+  {target_dir}/happy-path-analysis.md
+
+Use this format:
+
+# Happy Path Analysis
+
+## Target
+{File paths, total lines}
+
+## Scenarios Tested
+| # | Scenario | Inputs | Expected Output |
+|---|----------|--------|-----------------|
+
+## Trace: Scenario {N}
+```
+SCENARIO: {description}
+INPUT: {concrete values}
+
+Line [N]: [code]
+         → [variable] = [value]
+
+OUTPUT: {return value, side effects}
+```
+
+## Dependency Verification
+| # | External Call | File | Method Exists? | Signature Correct? | Issue |
+|---|-------------|------|----------------|-------------------|-------|
+
+## Contract Verification
+| # | Relationship | Base/Interface | Verified? | Issue |
+|---|-------------|---------------|-----------|-------|
+
+## Flaws Found
+| # | Line | Flaw | Severity | Fix |
+|---|------|------|----------|-----|
+
+## Summary
+- Scenarios traced: {N}
+- Dependencies verified: {N}
+- Contracts checked: {N}
+- Flaws found: {N}
+
+WHEN DONE:
+Message the other teammates: "Happy path analysis complete. Review happy-path-analysis.md"
+Mark your task as completed.
+```
+
+### Teammate 2: Edge Case Hunter
+
+**Model:** sonnet
+
+```
+You are the Edge Case Hunter for a paper testing team.
+
+TARGET FILES:
+{list each file path}
+
+YOUR MISSION:
+Probe boundaries and find where the code breaks. Your lens: "What inputs make this code fail?"
+
+Design test scenarios for EACH of these categories:
+1. **Null/undefined** — null, undefined, missing parameters
+2. **Empty** — empty string "", empty array [], zero-length
+3. **Zero and negative** — 0, -1, negative amounts, negative indices
+4. **Boundary values** — MAX_INT, very long strings, Unicode, special characters
+5. **Type mismatches** — string where int expected, array where object expected
+6. **Missing keys** — array key that doesn't exist, missing config values
+
+For each scenario:
+1. Trace the code line-by-line with the adversarial input
+2. At each operation, ask: "What happens with THIS value?"
+3. Check for: uninitialized variables, off-by-one errors, missing default/else branches, unchecked return values, division by zero
+4. Note the exact line where the failure occurs and what happens
+
+WRITE your analysis to:
+  {target_dir}/edge-case-analysis.md
+
+Use this format:
+
+# Edge Case Analysis
+
+## Target
+{File paths, total lines}
+
+## Scenarios Tested
+| # | Category | Input | Line | Result | Severity |
+|---|----------|-------|------|--------|----------|
+
+## Trace: {Category} — {Scenario}
+```
+SCENARIO: {description}
+INPUT: {adversarial values}
+
+Line [N]: [code]
+         → [variable] = [value]
+         → PROBLEM: {what goes wrong}
+```
+
+## Flaws Found
+| # | Line | Flaw | Trigger Input | Consequence | Severity | Fix |
+|---|------|------|--------------|-------------|----------|-----|
+
+## Missing Defensive Code
+| # | Location | What's Missing | Risk |
+|---|----------|---------------|------|
+
+## Summary
+- Categories tested: {N}/6
+- Scenarios traced: {N}
+- Flaws found: {N}
+- Critical: {N}
+
+WHEN DONE:
+Message the other teammates: "Edge case analysis complete. Review edge-case-analysis.md"
+Mark your task as completed.
+```
+
+### Teammate 3: Red Team Attacker
+
+**Model:** sonnet
+
+```
+You are the Red Team Attacker for a paper testing team.
+
+TARGET FILES:
+{list each file path}
+
+YOUR MISSION:
+Try adversarial inputs and find security/reliability holes. Your lens: "How would an attacker exploit this code?"
+
+Design attack scenarios for EACH relevant category:
+1. **SQL injection** — `' OR 1=1 --`, union-based, blind SQLi
+2. **XSS** — `<script>alert(1)</script>`, event handlers, encoded payloads
+3. **Path traversal** — `../../etc/passwd`, null bytes
+4. **Command injection** — `; rm -rf /`, backticks, $() substitution
+5. **Malformed data** — invalid JSON/XML, oversized payloads, binary in text fields
+6. **Race conditions** — concurrent access, TOCTOU, double-submit
+7. **Resource exhaustion** — huge loops, recursive bombs, memory allocation
+
+For each attack:
+1. Trace the malicious input through the code from entry point to dangerous operation
+2. Check if framework protections (Drupal sanitization, React escaping, parameterized queries) actually apply to THIS code path
+3. If the attack is blocked, note WHERE and HOW
+4. If the attack reaches a dangerous operation, document the full chain
+5. Search for known CVEs if the code uses identifiable libraries/patterns (WebSearch)
+
+WRITE your analysis to:
+  {target_dir}/red-team-analysis.md
+
+Use this format:
+
+# Red Team Analysis
+
+## Target
+{File paths, total lines}
+
+## Attack Scenarios
+| # | Category | Payload | Entry Point | Reaches Danger? | Blocked By |
+|---|----------|---------|-------------|-----------------|------------|
+
+## Attack Trace: {Category} — {Scenario}
+```
+ATTACK: {description}
+PAYLOAD: {malicious input}
+
+Line [N]: [code] — input enters here
+         → [variable] = [malicious value]
+
+Line [N]: [code] — DANGER: {dangerous operation}
+         → {what happens with the malicious input}
+
+RESULT: EXPLOITABLE / BLOCKED at line {N} by {mechanism}
+```
+
+## Exploitable Vulnerabilities
+| # | Line | Vulnerability | Attack | Impact | Severity |
+|---|------|--------------|--------|--------|----------|
+
+## Blocked Attacks (Framework Protected)
+| # | Attack | Blocked By | Confidence |
+|---|--------|-----------|------------|
+
+## Missing Protections
+| # | Location | What's Missing | Attack It Enables |
+|---|----------|---------------|-------------------|
+
+## Summary
+- Attack categories tested: {N}/7
+- Scenarios traced: {N}
+- Exploitable: {N}
+- Blocked: {N}
+- Critical: {N}
+
+WHEN DONE:
+Message the other teammates: "Red team analysis complete. Review red-team-analysis.md"
+Mark your task as completed.
+```
+
+---
+
+## Output Format
+
+The lead synthesizes into `{target_dir}/paper-test-team-report.md`:
+
+```markdown
+# Paper Test Team Report
+
+## Target
+{File paths tested, line counts, language}
+
+## Test Method
+Agent team with 3 competing perspectives.
+Source files: [happy-path-analysis.md] | [edge-case-analysis.md] | [red-team-analysis.md]
+
+## Summary
+| Perspective | Scenarios Run | Flaws Found | Critical |
+|-------------|---------------|-------------|----------|
+| Happy Path | {N} | {N} | {N} |
+| Edge Case | {N} | {N} | {N} |
+| Red Team | {N} | {N} | {N} |
+
+## Prioritized Flaws
+| # | Line | Flaw | Found By | Severity | Confirmed By Others? | Fix |
+|---|------|------|----------|----------|---------------------|-----|
+
+## Disputed Findings
+| # | Flaw | Claimed By | Disputed By | Resolution |
+|---|------|-----------|-------------|------------|
+
+## Dependency Verification
+| # | External Call | Verified? | Issue |
+|---|-------------|-----------|-------|
+
+## Contract Verification
+| # | Relationship | Verified? | Issue |
+|---|-------------|-----------|-------|
+
+## Blind Spots (Unanimous Agreements)
+{Areas where all 3 agreed the code is fine — flag for human review}
+
+## Recommended Test Cases
+{Concrete test cases to write based on flaws found}
+| # | Test | Input | Expected | Covers Flaw |
+|---|------|-------|----------|-------------|
+```
+
+## Related Commands
+
+- Standard paper test: ask Claude to "paper test {file}" (single-agent, no debate)


### PR DESCRIPTION
## Summary

- **New command** `/code-paper:test-team` — spawns a 3-agent team (Happy Path Validator + Edge Case Hunter + Red Team Attacker) to paper test code from competing perspectives
- Happy Path traces correct flow with ideal inputs, verifies all dependencies and contracts
- Edge Case Hunter probes boundaries: nulls, empty, zero, negative, large values, type mismatches
- Red Team tries adversarial inputs: SQL injection, XSS, path traversal, command injection, race conditions
- Cross-challenge debate resolves flaw severity and disputes false findings
- Lead synthesizes prioritized flaw report next to the target code
- Scope gate: suggests standard paper test for <50 lines of code
- Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; falls back to standard paper test skill when unavailable
- First command in this plugin — creates `commands/` directory and registers it in plugin.json
- New `.claude/rules/command-conventions.md` and updated `CLAUDE.md` with command conventions
- Version bump: code-paper-test 0.2.0 → 0.3.0 (plugin.json, marketplace.json, README, CHANGELOG)

## Test plan

- [ ] Run `/code-paper:test-team src/path/to/file.php` with agent teams enabled — verify 3 teammates spawn
- [ ] Verify each teammate writes their analysis file (happy-path, edge-case, red-team) in the target directory
- [ ] Verify lead synthesizes `paper-test-team-report.md` after debate
- [ ] Run without agent teams flag — verify fallback message
- [ ] Run without arguments — verify it prompts for file path
- [ ] Run on small file (<50 lines) — verify scope gate suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)