### PR TITLE
fix(code-paper-test): remove invalid commands field from plugin.json

### DIFF
--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
     "name": "camoa"
   },
   "license": "MIT",
-  "repository": "https://github.com/camoa/claude-skills",
-  "commands": "commands"
+  "repository": "https://github.com/camoa/claude-skills"
 }


### PR DESCRIPTION
## Summary

- Same root cause as PR #63: `"commands": "commands"` is an invalid plugin.json field (paths must start with `./`)
- This was introduced in PR #62 (v0.3.0) when adding the `/test-team` command
- Auto-discovery handles the `commands/` directory automatically, no explicit field needed

## Test plan

- [ ] `/plugin install code-paper-test@camoa-skills` succeeds
- [ ] `/code-paper-test:paper-test` and `/code-paper-test:test-team` appear in slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)