### PR TITLE
fix: resolve plugin loading errors

### DIFF
--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "camoa"
   },
   "license": "MIT",
-  "hooks": "./hooks/hooks.json",
   "keywords": [
     "brand",
     "presentations",


### PR DESCRIPTION
## Summary
- **brand-content-design**: Removed explicit `"hooks": "./hooks/hooks.json"` from `plugin.json` — `hooks/hooks.json` is auto-loaded by Claude Code, so declaring it caused a duplicate hooks error
- **code-quality-tools & code-paper-test**: Stale plugin cache contained `"commands": "commands"` (invalid string format). Source manifests are correct; cache was cleared locally

## Test plan
- [ ] Restart Claude Code and verify no plugin loading errors
- [ ] Verify brand-content-design hooks load correctly
- [ ] Verify code-quality-tools and code-paper-test commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)