### PR TITLE
fix: resolve plugin loading errors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,7 +73,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, design systems, HTML components, 114 infographic templates, visual components, 17 color palettes, and Presentation Zen principles",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,12 +1,11 @@
 {
   "name": "brand-content-design",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
-  "hooks": "./hooks/hooks.json",
   "keywords": [
     "brand",
     "presentations",

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-02-14
+
+### Fixed
+- Removed explicit `hooks` declaration from plugin.json — `hooks/hooks.json` is auto-loaded by Claude Code, duplicate declaration caused plugin load failure
+
 ## [2.3.0] - 2026-02-13
 
 ### Changed


### PR DESCRIPTION
## Summary
- **brand-content-design v2.3.1**: Removed explicit `"hooks": "./hooks/hooks.json"` from `plugin.json` — `hooks/hooks.json` is auto-loaded by Claude Code, so declaring it caused a duplicate hooks error preventing plugin load
- **code-quality-tools & code-paper-test**: Stale plugin cache contained `"commands": "commands"` (invalid string format). Source manifests are correct; cache cleared locally

## Changes
- `brand-content-design/.claude-plugin/plugin.json` — removed `hooks` field, version bump to 2.3.1
- `.claude-plugin/marketplace.json` — version sync to 2.3.1
- `brand-content-design/CHANGELOG.md` — added 2.3.1 entry

## Test plan
- [ ] Restart Claude Code and verify no plugin loading errors
- [ ] Verify brand-content-design hooks load correctly
- [ ] Verify code-quality-tools and code-paper-test commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)