### PR TITLE
fix: inline metadata format in html-generator skill

### DIFF
--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-02-15
+
+### Fixed
+- **html-generator metadata**: Inlined full metadata format (component/prop/slot) in SKILL.md Parts 3, 10, 12 — previously only referenced an unreachable external file, causing generated HTML pages to lack converter-compatible annotations
+- **html-page command**: Step 9 now explicitly loads all 4 reference files before invoking html-generator skill
+- **html-page-quick command**: Step 5 now explicitly loads all 4 reference files before invoking html-generator skill
+
+### Added
+- Framework mapping table in Part 12 showing how HTML metadata maps to Drupal SDC, React, and Twig
+- Complete composed page example in Part 10 with all metadata markers
+- Explicit anti-pattern: "Do NOT replace metadata with section divider comments"
+
 ## [2.3.1] - 2026-02-14
 
 ### Fixed

--- a/brand-content-design/commands/html-page-quick.md
+++ b/brand-content-design/commands/html-page-quick.md
@@ -57,13 +57,25 @@ Parse the pasted content and automatically:
 
 ### Step 5: Generate
 
+**Before invoking the skill, read these reference files** from the html-generator skill directory (`$BRAND_CONTENT_DESIGN_DIR/skills/html-generator/references/`):
+
+1. `references/html-technical.md` — Boilerplate, metadata format, file structure
+2. `references/html-components.md` — 15 component types with HTML/CSS patterns
+3. `references/html-design-guide.md` — Design philosophy and content type guide
+4. `references/web-style-constraints.md` — Style enforcement blocks
+
+If `$BRAND_CONTENT_DESIGN_DIR` is not set, find it:
+```bash
+find ~/.claude -path "*/brand-content-design/skills/html-generator/references" -type d 2>/dev/null | head -1
+```
+
 Invoke the `html-generator` skill with:
 - Design system files
 - Brand philosophy
 - Auto-selected components + variants
 - Existing reusable components from library
 - Mapped content
-- Style constraints
+- The 4 reference files read above (pass their content to the skill)
 
 ### Step 6: Save and Confirm
 

--- a/brand-content-design/commands/html-page.md
+++ b/brand-content-design/commands/html-page.md
@@ -121,17 +121,29 @@ If **section by section**: for each selected component, ask for the specific con
 
 ### Step 9: Generate
 
+**Before invoking the skill, read these reference files** from the html-generator skill directory (`$BRAND_CONTENT_DESIGN_DIR/skills/html-generator/references/`):
+
+1. `references/html-technical.md` — Boilerplate, metadata format, file structure
+2. `references/html-components.md` — 15 component types with HTML/CSS patterns
+3. `references/html-design-guide.md` — Design philosophy and content type guide
+4. `references/web-style-constraints.md` — Style enforcement blocks
+
+If `$BRAND_CONTENT_DESIGN_DIR` is not set, find it:
+```bash
+find ~/.claude -path "*/brand-content-design/skills/html-generator/references" -type d 2>/dev/null | head -1
+```
+
 Invoke the `html-generator` skill via Skill tool with:
 - Design system files (canvas-philosophy.md + design-system.md)
 - Brand philosophy (or sub-identity)
 - Selected components (type + variant for each)
 - Existing components to reuse (read their HTML from components/)
 - Content mapped to each component
-- Style constraints from `references/web-style-constraints.md`
+- The 4 reference files read above (pass their content to the skill)
 
 The html-generator skill will:
-1. Generate any NEW components as standalone HTML
-2. Compose all components into a single page
+1. Generate any NEW components as standalone HTML with metadata annotations
+2. Compose all components into a single page preserving all `<!-- component: -->`, `<!-- prop: -->`, `<!-- slot: -->` metadata
 
 ### Step 10: Save Components
 

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -117,9 +117,50 @@ Choose DISTINCTIVE fonts — never default to Inter, Roboto, or Arial. Every des
 7. **Interactive states** — every clickable/tappable element must define hover, focus, and active styles using the interaction tokens from design-system.md
 8. **Touch-ready** — interactive elements meet `--min-tap-target` size with adequate spacing
 
-### Metadata Comments Format
+### Metadata Comments Format (MANDATORY)
 
-Every component includes conversion-ready metadata comments (`<!-- component: -->`, `<!-- prop: -->`, `<!-- slot: -->`). See Part 10 for the full format and preservation rules. These comments MUST appear in both standalone components AND composed pages.
+Every component MUST include conversion-ready metadata comments. These enable automated conversion to Drupal SDC, React, and other frameworks. Without them, the design-system-converter cannot identify components, props, or slots.
+
+**Component boundaries** — wrap the entire component:
+```html
+<!-- component: hero variant: centered -->
+<section class="hero">
+  ...
+</section>
+<!-- /component: hero -->
+```
+
+**Props** — place immediately BEFORE the element they annotate:
+```html
+<!-- prop: headline type: string -->
+<h1 class="hero__title">Your Headline</h1>
+
+<!-- prop: show-badge type: boolean -->
+```
+
+**Slots** — wrap repeating or insertable content areas:
+```html
+<!-- slot: features -->
+<div class="feature-grid__list">
+  <div class="feature-grid__item">
+    <!-- prop: feature-title type: string -->
+    <h3>Feature Title</h3>
+    <!-- prop: feature-description type: string -->
+    <p>Description</p>
+  </div>
+</div>
+<!-- /slot: features -->
+```
+
+**Icons** — place before SVG elements:
+```html
+<!-- icon: rocket -->
+<svg>...</svg>
+```
+
+**Supported prop types:** `string`, `boolean`
+
+These comments MUST appear in both standalone components AND composed pages. See Part 10 for preservation rules during page composition.
 
 ### Component CSS Pattern
 
@@ -357,13 +398,78 @@ When using Neumorphism style, DOUBLE-CHECK contrast ratios. Soft shadows on simi
 
 ## Part 10: Page Composition
 
-When assembling components into a full page:
+When assembling components into a full page, every component section MUST retain its metadata comments. This is the **most critical requirement** for framework convertibility.
 
-See `references/html-technical.md` → "HTML Boilerplate" for the full page template and "Page Composition Format" for assembly rules.
+### Metadata Preservation (CRITICAL — ENFORCE STRICTLY)
 
-### Metadata Preservation (CRITICAL)
+**Rules:**
+- Place `<!-- component: type variant: variant -->` BEFORE the component's outermost HTML element
+- Place `<!-- /component: type -->` AFTER the component's closing tag
+- Place `<!-- prop: name type: type -->` immediately BEFORE the element it annotates
+- Place `<!-- slot: name -->` / `<!-- /slot: name -->` around slot content areas
+- Do NOT strip, summarize, or simplify metadata during page assembly
+- Do NOT replace metadata with section divider comments like `<!-- Navigation -->` or `<!-- ====== HERO ====== -->`
 
-Preserve all `<!-- component: -->`, `<!-- prop: -->`, and `<!-- slot: -->` metadata comments when composing pages. Copy them verbatim from standalone components into the assembled page. See `references/html-technical.md` → "Metadata Preservation" for the full format and rules.
+**Complete composed page structure:**
+
+```html
+<body>
+  <a href="#main" class="skip-link">Skip to main content</a>
+
+  <!-- component: nav variant: sticky -->
+  <header class="nav" role="banner">
+    <!-- prop: site-name type: string -->
+    <span class="nav__name">Site Name</span>
+    <!-- slot: menu -->
+    <nav role="navigation" aria-label="Main navigation">
+      <a href="#">Home</a>
+    </nav>
+    <!-- /slot: menu -->
+  </header>
+  <!-- /component: nav -->
+
+  <main id="main">
+    <!-- component: hero variant: centered -->
+    <section class="hero">
+      <!-- prop: headline type: string -->
+      <h1 class="hero__title">Page Title</h1>
+      <!-- prop: subheadline type: string -->
+      <p class="hero__subtitle">Subtitle text</p>
+    </section>
+    <!-- /component: hero -->
+
+    <!-- component: article-card-grid variant: 3-col -->
+    <section class="card-grid">
+      <!-- prop: section-title type: string -->
+      <h2>Latest Articles</h2>
+      <!-- slot: cards -->
+      <div class="card-grid__list">
+        <article class="card">
+          <!-- prop: card-image type: string -->
+          <img src="image.jpg" alt="Article">
+          <!-- prop: card-title type: string -->
+          <h3>Card Title</h3>
+          <!-- prop: card-excerpt type: string -->
+          <p>Excerpt text</p>
+        </article>
+      </div>
+      <!-- /slot: cards -->
+    </section>
+    <!-- /component: article-card-grid -->
+  </main>
+
+  <!-- component: footer variant: simple -->
+  <footer class="footer" role="contentinfo">
+    <!-- prop: copyright type: string -->
+    <p>&copy; 2026 Brand Name</p>
+  </footer>
+  <!-- /component: footer -->
+</body>
+```
+
+**Every component in the page must have opening and closing component markers.** No exceptions.
+
+Also see `references/html-technical.md` for the full HTML boilerplate and additional technical specs.
 
 ### CSS Organization in Composed Page
 
@@ -409,7 +515,18 @@ Since Claude cannot generate actual images, use smart placeholders:
 
 ## Part 12: Convertibility Structure
 
-Design components for future conversion to Drupal SDC, React, Canvas, and other frameworks. Apply the metadata format from Part 10 to both standalone components AND composed pages.
+Design components for future conversion to Drupal SDC, React, Canvas, and other frameworks. The metadata comments from Part 3 and Part 10 are what make conversion possible.
+
+### How Metadata Maps to Frameworks
+
+| HTML Metadata | Drupal SDC | React | Twig |
+|---|---|---|---|
+| `<!-- component: hero -->` | Component directory name | Component file name | Template name |
+| `<!-- prop: headline type: string -->` | `props.headline` in schema | `props.headline` | `{{ headline }}` |
+| `<!-- prop: featured type: boolean -->` | Boolean prop | Conditional render | `{% if featured %}` |
+| `<!-- slot: content -->` | `{% block content %}` | `children` | `{% block content %}` |
+| `<!-- /component: hero -->` | Template boundary | Component boundary | Template boundary |
+| CSS custom properties | SCSS variables | Theme tokens | Twig with attach_library |
 
 ### Naming Conventions
 


### PR DESCRIPTION
## Summary

- **Inlined full metadata format** (component boundaries, props, slots, icons) directly in SKILL.md Part 3 so the LLM always has the spec available at generation time
- **Added composed page example** with all metadata markers in SKILL.md Part 10 (nav + hero + card-grid + footer)
- **Added framework mapping table** in SKILL.md Part 12 showing how HTML metadata maps to Drupal SDC, React, and Twig
- **Wired reference file loading** in both `html-page.md` and `html-page-quick.md` commands — they now read all 4 reference files and pass them to the skill

## Problem

Generated HTML pages lacked converter-compatible metadata annotations (`<!-- component: -->`, `<!-- prop: -->`, `<!-- slot: -->`). The design-system-converter's analyzer is metadata-driven and couldn't parse pages without these markers.

Root cause: 3 breaks in the reference chain:
1. Commands didn't pass reference files to the skill
2. Skill used unresolvable relative paths for metadata examples
3. Metadata format with concrete examples only existed in an external file the LLM couldn't access

## Test plan

- [ ] Run `/html-page` or `/html-page-quick` on an existing brand project
- [ ] Verify generated HTML contains `<!-- component: -->`, `<!-- prop: -->`, `<!-- slot: -->` markers
- [ ] Verify standalone component files are saved to `components/` directory
- [ ] Verify `design-system.md` Generated Components section is updated
- [ ] Run `/convert-to-radix` on a generated page and confirm the analyzer detects all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)