### PR TITLE
fix: sync brand-content-design marketplace version to 2.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,7 +73,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, design systems, HTML components, 114 infographic templates, visual components, 17 color palettes, and Presentation Zen principles",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "author": {
         "name": "camoa"
       },


### PR DESCRIPTION
## Summary
- brand-content-design plugin.json was bumped to 2.4.0 in PR #67 but marketplace.json was left at 2.3.1
- Syncs marketplace.json to match

## Test plan
- [ ] Verify `marketplace.json` brand-content-design version matches `plugin.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)