### PR TITLE
feat(drupal-htmx): v1.2.0 — online dev-guides integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
       "name": "drupal-htmx",
       "source": "./drupal-htmx",
       "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2026-02-15
+
+### Added
+- Online dev-guides integration for Drupal domain context
+  - SKILL.md: 12-entry keyword→URL mapping table for WebFetch from https://camoa.github.io/dev-guides/
+  - Topics: AJAX architecture, JS behaviors, forms (#states, multi-step, alter, security), routing, render API
+- "See also" pointer in ajax-reference.md linking to online AJAX architecture and JS integration guides
+
+---
+
 ## [1.1.0] - 2026-02-09
 
 ### Added

--- a/drupal-htmx/README.md
+++ b/drupal-htmx/README.md
@@ -81,6 +81,8 @@ The plugin includes condensed reference guides from comprehensive source documen
 - `migration-patterns.md` - 7 detailed migration patterns
 - `ajax-reference.md` - AJAX commands reference for understanding existing code
 
+Online dev-guides from https://camoa.github.io/dev-guides/ provide supplementary Drupal domain context (AJAX architecture, forms, routing, render API, JS behaviors).
+
 ## Requirements
 
 - Drupal 11.3+ (native HTMX support)

--- a/drupal-htmx/skills/htmx-development/SKILL.md
+++ b/drupal-htmx/skills/htmx-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: htmx-development
 description: Use when developing HTMX features in Drupal 11.3+ or migrating AJAX to HTMX. Covers Htmx class usage, form patterns, migration strategies, and validation. Triggers on "htmx", "ajax to htmx", "dynamic form", "dependent dropdown".
-version: 1.0.0
+version: 1.2.0
 model: sonnet
 ---
 
@@ -222,10 +222,32 @@ When reviewing HTMX implementations:
 
 ## References
 
+### Bundled (HTMX-Specific)
 - `references/quick-reference.md` - Command equivalents, method tables
 - `references/htmx-implementation.md` - Full Htmx class API, detection, JS
 - `references/migration-patterns.md` - 7 patterns with before/after code
 - `references/ajax-reference.md` - AJAX commands for understanding existing code
+
+### Online Dev-Guides (Drupal Domain)
+
+For Drupal domain context when analyzing, recommending, or validating HTMX patterns, WebFetch from https://camoa.github.io/dev-guides/.
+
+| Topic | URL | Use when |
+|-------|-----|----------|
+| AJAX form architecture | `drupal/forms/ajax-architecture/` | Understanding existing AJAX before migration |
+| AJAX security | `drupal/forms/ajax-security/` | Security review of AJAX patterns |
+| JS AJAX integration | `drupal/js-development/ajax-integration/` | JS-level AJAX patterns to migrate |
+| Drupal.behaviors | `drupal/js-development/drupal-behaviors-pattern/` | HTMX JS event integration context |
+| Multi-step forms | `drupal/forms/multi-step-forms/` | Wizard pattern migration context |
+| Form #states | `drupal/forms/form-states-system/` | When #states is better than HTMX |
+| Form alter system | `drupal/forms/form-alter-system/` | Altering forms with HTMX elements |
+| Routing | `drupal/routing/` | HTMX route configuration context |
+| Render API | `drupal/render-api/` | Render arrays for HTMX responses |
+| Render array patterns | `drupal/render-api/render-array-patterns/` | Progressive enhancement patterns |
+| Security best practices | `drupal/forms/security-best-practices/` | Form security for HTMX endpoints |
+| JS testing | `drupal/js-development/testing-javascript/` | Testing HTMX JS interactions |
+
+**How to use:** Prefix URLs with `https://camoa.github.io/dev-guides/` and WebFetch for Drupal-specific patterns when the bundled HTMX references don't cover the underlying Drupal concept.
 
 ## Key Files in Drupal Core
 

--- a/drupal-htmx/skills/htmx-development/references/ajax-reference.md
+++ b/drupal-htmx/skills/htmx-development/references/ajax-reference.md
@@ -2,6 +2,8 @@
 
 Drupal AJAX system reference for understanding existing patterns before migration.
 
+> **Online Dev-Guides:** For comprehensive Drupal AJAX architecture, security patterns, and JS integration beyond this migration-focused reference, see https://camoa.github.io/dev-guides/drupal/forms/ajax-architecture/ and https://camoa.github.io/dev-guides/drupal/js-development/ajax-integration/.
+
 ## AJAX Configuration
 
 ### Form Element AJAX Settings


### PR DESCRIPTION
## Summary
- Integrates online dev-guides (https://camoa.github.io/dev-guides/) into drupal-htmx for Drupal domain context
- 12-entry keyword→URL mapping in SKILL.md: AJAX architecture, JS behaviors, forms, routing, render API
- "See also" pointer in ajax-reference.md to online AJAX guides
- HTMX-specific bundled references unchanged — online guides supplement underlying Drupal concepts only

## Test plan
- [ ] Verify SKILL.md online dev-guides URLs resolve correctly
- [ ] Verify version sync: plugin.json, marketplace.json, CHANGELOG.md all at 1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)