### PR TITLE
feat(brand-content-design): v2.5.0 — online dev-guides integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,7 +73,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, design systems, HTML components, 114 infographic templates, visual components, 17 color palettes, and Presentation Zen principles",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-02-15
+
+### Added
+- Online dev-guides integration for design system fundamentals
+  - html-generator SKILL.md: 11-entry keyword→URL mapping table for design tokens, component classification, Bootstrap patterns, SCSS, accessibility, progressive enhancement
+  - brand-content-design SKILL.md: 6-entry keyword→URL mapping table for design system recognition, analysis methodology, screenshot/Figma analysis
+- "See also" pointers in html-components.md, html-technical.md, html-design-guide.md, color-palettes.md linking to online design system guides
+
+---
+
 ## [2.4.0] - 2026-02-15
 
 ### Fixed

--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -116,6 +116,7 @@ The `visual-content` skill is bundled with this plugin. For HTML-to-Drupal conve
 
 ## References
 
+### Bundled (Plugin-Specific)
 - `references/brand-philosophy-template.md` - Template for brand philosophy
 - `references/template-structure.md` - Template for template.md files
 - `references/canvas-philosophy-template.md` - Template for canvas philosophy
@@ -124,3 +125,18 @@ The `visual-content` skill is bundled with this plugin. For HTML-to-Drupal conve
 - `references/style-constraints.md` - 13 visual styles with enforcement blocks
 - `references/color-palettes.md` - Color theory and palette types
 - `references/output-specs.md` - Dimensions, formats, file sizes
+
+### Online Dev-Guides (Design Systems)
+
+For design system recognition and analysis methodology, WebFetch from https://camoa.github.io/dev-guides/.
+
+| Topic | URL | Use when |
+|-------|-----|----------|
+| Design system recognition | `design-systems/recognition/` | Analyzing existing brand assets systematically |
+| Design tokens | `design-systems/recognition/design-tokens/` | Extracting color, typography, spacing tokens |
+| Screenshot analysis | `design-systems/recognition/screenshot-analysis/` | Identifying patterns from visual samples |
+| Figma analysis | `design-systems/recognition/figma-analysis/` | Extracting from Figma design files |
+| Validation checklist | `design-systems/recognition/validation-checklist/` | Ensuring analysis completeness |
+| Reference design systems | `design-systems/recognition/reference-design-systems/` | Comparing against industry standards |
+
+**How to use:** Prefix URLs with `https://camoa.github.io/dev-guides/` and WebFetch when extracting brand elements or analyzing design systems.

--- a/brand-content-design/skills/brand-content-design/references/color-palettes.md
+++ b/brand-content-design/skills/brand-content-design/references/color-palettes.md
@@ -2,6 +2,8 @@
 
 Reference for generating alternative color palettes from brand colors.
 
+> **Online Dev-Guides:** For design token extraction methodology including color tokens, contrast validation, and accessibility standards, see https://camoa.github.io/dev-guides/design-systems/recognition/design-tokens/.
+
 ---
 
 ## Palette Categories

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: html-generator
 description: Use when generating branded HTML pages and components from a design system. Creates standalone HTML components and composes them into full pages with embedded CSS, responsive design, and brand integration.
-version: 2.1.0
+version: 2.5.0
 model: opus
 user-invocable: false
 ---
@@ -552,9 +552,31 @@ Design components for future conversion to Drupal SDC, React, Canvas, and other 
 
 ## References
 
+### Bundled (Plugin-Specific)
+
 Load these reference files when generating:
 
 - `references/html-design-guide.md` — Design system philosophy and content type guide
 - `references/web-style-constraints.md` — 21 style enforcement blocks for web
 - `references/html-components.md` — 15 component types with HTML/CSS patterns
 - `references/html-technical.md` — Technical specs, boilerplate, file format
+
+### Online Dev-Guides (Design Systems)
+
+For design system fundamentals beyond this plugin's visual styles, WebFetch from https://camoa.github.io/dev-guides/.
+
+| Topic | URL | Use when |
+|-------|-----|----------|
+| Design tokens | `design-systems/recognition/design-tokens/` | Mapping brand tokens to CSS custom properties |
+| Component classification | `design-systems/recognition/component-classification-framework/` | Atomic design methodology for components |
+| HTML/CSS analysis | `design-systems/recognition/html-css-analysis/` | Analyzing existing HTML for design patterns |
+| Bootstrap component mapping | `design-systems/bootstrap/` | Bootstrap-based layout and component patterns |
+| Atoms → components | `design-systems/bootstrap/atoms-bootstrap-components/` | Button, input, badge patterns |
+| Molecules → combinations | `design-systems/bootstrap/molecules-component-combinations/` | Input groups, card content patterns |
+| Organisms → layouts | `design-systems/bootstrap/organisms-layout-components/` | Navbar, card, form layout patterns |
+| SCSS best practices | `design-systems/bootstrap/scss-best-practices/` | SCSS variable overrides, mixins |
+| Progressive enhancement | `design-systems/bootstrap/progressive-enhancement-guidelines/` | Modern CSS, responsive patterns |
+| Accessibility (WCAG) | `design-systems/radix-components/accessibility-best-practices/` | WCAG 2.2 AA compliance patterns |
+| SDC CSS patterns | `drupal/sdc/scss-css-in-sdcs/` | BEM scoping, CSS custom properties |
+
+**How to use:** Prefix URLs with `https://camoa.github.io/dev-guides/` and WebFetch when needing design system fundamentals that complement the bundled 21-style system.

--- a/brand-content-design/skills/html-generator/references/html-components.md
+++ b/brand-content-design/skills/html-generator/references/html-components.md
@@ -2,6 +2,8 @@
 
 15 reusable component types for HTML page composition. Each component is standalone, responsive, and uses design tokens via CSS custom properties.
 
+> **Online Dev-Guides:** For component classification methodology (atomic design) and Bootstrap component mapping patterns, see https://camoa.github.io/dev-guides/design-systems/recognition/component-classification-framework/ and https://camoa.github.io/dev-guides/design-systems/bootstrap/.
+
 ---
 
 ## Component Conventions

--- a/brand-content-design/skills/html-generator/references/html-design-guide.md
+++ b/brand-content-design/skills/html-generator/references/html-design-guide.md
@@ -2,6 +2,8 @@
 
 Design system philosophy for branded HTML pages. This is the content type guide for the HTML generation system.
 
+> **Online Dev-Guides:** For design system analysis best practices and reference design systems to compare against, see https://camoa.github.io/dev-guides/design-systems/recognition/design-system-analysis-best-practices/ and https://camoa.github.io/dev-guides/design-systems/recognition/reference-design-systems/.
+
 ---
 
 ## Why Design System (Not Template)

--- a/brand-content-design/skills/html-generator/references/html-technical.md
+++ b/brand-content-design/skills/html-generator/references/html-technical.md
@@ -2,6 +2,8 @@
 
 Technical reference for HTML page generation: boilerplate, file format, responsive breakpoints, font loading, image handling, JS patterns, accessibility, and convertibility metadata.
 
+> **Online Dev-Guides:** For WCAG 2.2 AA accessibility patterns and progressive enhancement techniques, see https://camoa.github.io/dev-guides/design-systems/radix-components/accessibility-best-practices/ and https://camoa.github.io/dev-guides/design-systems/bootstrap/progressive-enhancement-guidelines/.
+
 ## Contents
 - HTML Boilerplate
 - Responsive Breakpoints


### PR DESCRIPTION
## Summary
- Added online dev-guides mapping tables to html-generator (11 entries) and brand-content-design (6 entries) SKILL.md files
- Added "See also" pointers to 4 bundled reference files (html-components.md, html-technical.md, html-design-guide.md, color-palettes.md) linking to relevant online design system guides
- Version bump 2.4.0 → 2.5.0 across plugin.json, marketplace.json, CHANGELOG.md

## Online Guide Coverage
- **Design tokens** — extraction methodology, CSS custom properties
- **Component classification** — atomic design, Bootstrap mapping (atoms/molecules/organisms)
- **SCSS best practices** — variable overrides, mixins
- **Accessibility** — WCAG 2.2 AA compliance
- **Progressive enhancement** — modern CSS, responsive patterns
- **Design system recognition** — screenshot analysis, Figma analysis, validation checklist

## Test plan
- [ ] Verify html-generator skill loads mapping table correctly
- [ ] Verify brand-content-design skill loads mapping table correctly
- [ ] Verify "See also" links resolve to correct online guide URLs
- [ ] Verify plugin.json and marketplace.json versions are in sync at 2.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)