### PR TITLE
feat: dev-guides integration v2 — llms.txt discovery + topic hints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "author": {
         "name": "camoa"
       },
@@ -37,7 +37,7 @@
       "name": "drupal-htmx",
       "source": "./drupal-htmx",
       "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "camoa"
       },
@@ -49,7 +49,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks, Roave via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks, Socket CLI) projects - TDD, SOLID, DRY, OWASP security",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "camoa"
       },
@@ -73,7 +73,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, design systems, HTML components, 114 infographic templates, visual components, 17 color palettes, and Presentation Zen principles",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-02-16
+
+### Changed
+- **Dev-guides integration v2**: Replaced keyword→URL mapping tables (11-entry in html-generator, 6-entry in brand-content-design) with lightweight `llms.txt` discovery + topic hints
+- **CLAUDE.md**: Added Online Dev-Guides section with `llms.txt` index URL and topic hints for session-wide awareness
+
 ## [2.5.0] - 2026-02-15
 
 ### Added

--- a/brand-content-design/CLAUDE.md
+++ b/brand-content-design/CLAUDE.md
@@ -19,6 +19,12 @@
 - Restrict `allowed-tools` to minimum needed
 - Interactive commands use AskUserQuestion for user input
 
+## Online Dev-Guides
+For design system fundamentals beyond bundled references, fetch the guide index:
+- **Index:** `https://camoa.github.io/dev-guides/llms.txt`
+- WebFetch the index to discover available topics, then fetch specific topic pages
+- Likely relevant topics: design-systems/recognition, design-systems/bootstrap, design-systems/radix-sdc, design-systems/radix-components, drupal/sdc
+
 ## General
 - Accessibility (WCAG AA) is mandatory — never skip contrast validation
 - Three-layer philosophy: brand → content type → template

--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -128,15 +128,10 @@ The `visual-content` skill is bundled with this plugin. For HTML-to-Drupal conve
 
 ### Online Dev-Guides (Design Systems)
 
-For design system recognition and analysis methodology, WebFetch from https://camoa.github.io/dev-guides/.
+For design system recognition and analysis methodology, fetch the guide index:
 
-| Topic | URL | Use when |
-|-------|-----|----------|
-| Design system recognition | `design-systems/recognition/` | Analyzing existing brand assets systematically |
-| Design tokens | `design-systems/recognition/design-tokens/` | Extracting color, typography, spacing tokens |
-| Screenshot analysis | `design-systems/recognition/screenshot-analysis/` | Identifying patterns from visual samples |
-| Figma analysis | `design-systems/recognition/figma-analysis/` | Extracting from Figma design files |
-| Validation checklist | `design-systems/recognition/validation-checklist/` | Ensuring analysis completeness |
-| Reference design systems | `design-systems/recognition/reference-design-systems/` | Comparing against industry standards |
+**Index:** `https://camoa.github.io/dev-guides/llms.txt`
 
-**How to use:** Prefix URLs with `https://camoa.github.io/dev-guides/` and WebFetch when extracting brand elements or analyzing design systems.
+Likely relevant topics: design-systems/recognition
+
+Usage: WebFetch the index to discover available topics, then fetch specific topic pages when extracting brand elements or analyzing design systems.

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -563,20 +563,10 @@ Load these reference files when generating:
 
 ### Online Dev-Guides (Design Systems)
 
-For design system fundamentals beyond this plugin's visual styles, WebFetch from https://camoa.github.io/dev-guides/.
+For design system fundamentals beyond this plugin's visual styles, fetch the guide index:
 
-| Topic | URL | Use when |
-|-------|-----|----------|
-| Design tokens | `design-systems/recognition/design-tokens/` | Mapping brand tokens to CSS custom properties |
-| Component classification | `design-systems/recognition/component-classification-framework/` | Atomic design methodology for components |
-| HTML/CSS analysis | `design-systems/recognition/html-css-analysis/` | Analyzing existing HTML for design patterns |
-| Bootstrap component mapping | `design-systems/bootstrap/` | Bootstrap-based layout and component patterns |
-| Atoms → components | `design-systems/bootstrap/atoms-bootstrap-components/` | Button, input, badge patterns |
-| Molecules → combinations | `design-systems/bootstrap/molecules-component-combinations/` | Input groups, card content patterns |
-| Organisms → layouts | `design-systems/bootstrap/organisms-layout-components/` | Navbar, card, form layout patterns |
-| SCSS best practices | `design-systems/bootstrap/scss-best-practices/` | SCSS variable overrides, mixins |
-| Progressive enhancement | `design-systems/bootstrap/progressive-enhancement-guidelines/` | Modern CSS, responsive patterns |
-| Accessibility (WCAG) | `design-systems/radix-components/accessibility-best-practices/` | WCAG 2.2 AA compliance patterns |
-| SDC CSS patterns | `drupal/sdc/scss-css-in-sdcs/` | BEM scoping, CSS custom properties |
+**Index:** `https://camoa.github.io/dev-guides/llms.txt`
 
-**How to use:** Prefix URLs with `https://camoa.github.io/dev-guides/` and WebFetch when needing design system fundamentals that complement the bundled 21-style system.
+Likely relevant topics: design-systems/recognition, design-systems/bootstrap, design-systems/radix-sdc, design-systems/radix-components, drupal/sdc
+
+Usage: WebFetch the index to discover available topics, then fetch specific topic pages for design system fundamentals that complement the bundled 21-style system.

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks, Roave via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks, Socket CLI) projects - TDD, SOLID, DRY, OWASP security",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-02-16
+
+### Changed
+- **Dev-guides integration v2**: Replaced 45-entry keyword→URL mapping table in SKILL.md with lightweight `llms.txt` discovery + topic hints
+- **CLAUDE.md**: Added Online Dev-Guides section with `llms.txt` index URL and topic hints for session-wide awareness
+
 ## [2.5.0] - 2026-02-15
 
 ### Added

--- a/code-quality-tools/CLAUDE.md
+++ b/code-quality-tools/CLAUDE.md
@@ -13,6 +13,12 @@
 - Commands wrap existing scripts — no logic duplication
 - Agent team commands orchestrate debate workflows — these are a new category alongside script wrappers
 
+## Online Dev-Guides
+For Drupal-specific patterns when explaining violations or suggesting fixes, fetch the guide index:
+- **Index:** `https://camoa.github.io/dev-guides/llms.txt`
+- WebFetch the index to discover available topics, then fetch specific topic pages
+- Likely relevant topics: solid-principles, dry-principles, security, testing, tdd, js-development, github-actions
+
 ## General
 - Reference files instead of reproducing content
 - Current state only — no historical narratives

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -223,57 +223,13 @@ All reports must follow `schemas/audit-report.schema.json`:
 
 ### Online Dev-Guides (Drupal Domain)
 
-For deeper Drupal-specific patterns beyond tool commands, WebFetch from https://camoa.github.io/dev-guides/. Use when explaining violations, suggesting fixes, or providing architectural context.
+For deeper Drupal-specific patterns beyond tool commands, fetch the guide index:
 
-| Topic | URL | Use when |
-|-------|-----|----------|
-| SOLID principles | `drupal/solid-principles/` | Explaining SOLID violations with Drupal patterns |
-| SRP — controllers & forms | `drupal/solid-principles/controllers-srp/` | SRP violations in controllers or forms |
-| OCP — config overrides | `drupal/solid-principles/config-overrides-ocp/` | OCP violations in configuration |
-| LSP — entity hierarchy | `drupal/solid-principles/entity-hierarchy-lsp/` | LSP violations in entity types |
-| ISP — entity interfaces | `drupal/solid-principles/entity-interfaces-isp/` | ISP violations in interfaces |
-| DIP — dependency injection | `drupal/solid-principles/dependency-injection-patterns-dip/` | DIP violations, static calls |
-| DIP — anti-patterns | `drupal/solid-principles/anti-patterns-dip/` | Common DI anti-patterns |
-| SOLID common mistakes | `drupal/solid-principles/common-mistakes/` | Recurring SOLID violation patterns |
-| SOLID best practices | `drupal/solid-principles/best-practices-checklist/` | Checklist for SOLID compliance |
-| DRY principles | `drupal/dry-principles/` | Explaining DRY violations with Drupal patterns |
-| Services for shared logic | `drupal/dry-principles/services-shared-logic/` | Extracting duplicated logic to services |
-| Traits for cross-cutting | `drupal/dry-principles/traits-cross-cutting/` | Using traits to reduce duplication |
-| Base classes | `drupal/dry-principles/base-classes-inheritance/` | Extracting common base classes |
-| Plugin reuse | `drupal/dry-principles/plugin-reuse/` | DRY patterns in plugin system |
-| Over-DRY anti-patterns | `drupal/dry-principles/over-dry-anti-patterns/` | When NOT to DRY (wrong abstraction) |
-| DRY decision framework | `drupal/dry-principles/best-practices-decision-framework/` | When to extract vs duplicate |
-| Security overview | `drupal/security/` | Drupal security patterns and practices |
-| OWASP Top 10 in Drupal | `drupal/security/owasp-top-10-in-drupal/` | OWASP mapping to Drupal context |
-| XSS prevention | `drupal/security/xss-prevention/` | XSS findings context |
-| SQL injection prevention | `drupal/security/sql-injection-prevention/` | SQLi findings context |
-| CSRF protection | `drupal/security/csrf-protection/` | CSRF findings context |
-| Input validation | `drupal/security/input-validation-and-sanitization/` | Input validation findings |
-| Access control | `drupal/security/entity-access-control/` | Access control findings |
-| Route access checks | `drupal/security/route-access-checks/` | Route security findings |
-| Twig autoescape | `drupal/security/twig-autoescape-and-safe-markup/` | Template security findings |
-| Testing overview | `drupal/testing/` | Test frameworks, setup, progressive strategy |
-| Test type selection | `drupal/testing/framework-selection-decision-matrix/` | Unit vs Kernel vs Functional decision |
-| Unit tests | `drupal/testing/phpunit-unit-tests/` | PHPUnit unit test patterns |
-| Kernel tests | `drupal/testing/phpunit-kernel-tests/` | Kernel test patterns with services/DB |
-| Functional tests | `drupal/testing/phpunit-functional-tests/` | Browser test patterns |
-| Progressive testing | `drupal/testing/progressive-testing-strategy/` | Test coverage planning for new modules |
-| Testing best practices | `drupal/testing/best-practices-anti-patterns/` | Testing anti-patterns and standards |
-| TDD overview | `drupal/tdd/` | RED-GREEN-REFACTOR, spec-driven development |
-| TDD workflow | `drupal/tdd/tdd-workflow-red-green-refactor/` | RED-GREEN-REFACTOR cycle details |
-| Coverage metrics | `drupal/tdd/coverage-metrics-strategy/` | Coverage targets, metrics interpretation |
-| Quality gates | `drupal/tdd/quality-gates-audit-checklist/` | Pre-commit/push/merge gate definitions |
-| Test type decision | `drupal/tdd/test-type-decision-matrix/` | When to use which test type |
-| Spec-driven dev | `drupal/tdd/spec-driven-drupal-development/` | Writing specs before code |
-| Testing services | `drupal/tdd/testing-services/` | Service testing patterns |
-| Testing forms | `drupal/tdd/testing-forms/` | Form testing patterns |
-| Testing entities | `drupal/tdd/testing-entities/` | Entity testing patterns |
-| Testing plugins | `drupal/tdd/testing-plugins/` | Plugin testing patterns |
-| Testing (GitHub Actions) | `drupal/github-actions/` | CI/CD quality pipeline context |
-| JS security | `drupal/js-development/security/` | JavaScript security findings |
-| JS testing | `drupal/js-development/testing-javascript/` | JavaScript testing context |
+**Index:** `https://camoa.github.io/dev-guides/llms.txt`
 
-**How to use:** When analyzing violations or providing remediation guidance for Drupal projects, WebFetch the relevant topic URL (prefix with `https://camoa.github.io/dev-guides/`) to get comprehensive Drupal-specific patterns and examples.
+Likely relevant topics: solid-principles, dry-principles, security, testing, tdd, js-development, github-actions
+
+Usage: WebFetch the index to discover available topics, then fetch specific topic pages when explaining violations, suggesting fixes, or providing architectural context.
 
 ## Decision Guides
 

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-02-16
+
+### Changed
+- **Dev-guides integration v2**: Replaced keyword→URL mapping table in guide-integrator with lightweight `llms.txt` discovery + topic hints
+- **guide-integrator workflow**: Now fetches `llms.txt` index to discover topics instead of matching against a static table
+- **CLAUDE.md**: Added Online Dev-Guides section with `llms.txt` index URL and topic hints for session-wide awareness
+
 ## [3.4.0] - 2026-02-14
 
 ### Added

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -18,6 +18,12 @@
 - Use `argument-hint:` for discoverability
 - Restrict `allowed-tools` to minimum needed
 
+## Online Dev-Guides
+For Drupal domain knowledge beyond bundled references, fetch the guide index:
+- **Index:** `https://camoa.github.io/dev-guides/llms.txt`
+- WebFetch the index to discover available topics, then fetch specific topic pages for decision guides, patterns, and best practices
+- Likely relevant topics: forms, config-forms, entities, plugins, routing, services, caching, config-management, render-api, security, sdc, js-development, views, blocks, layout-builder, media, migration, recipes, taxonomy, jsonapi, image-styles, icon-api, eca, github-actions, ai-content, custom-field, klaro, testing, tdd, solid-principles, dry-principles
+
 ## General
 - Current state only — no historical narratives
 - Replace outdated content, don't keep alongside new

--- a/drupal-dev-framework/skills/guide-integrator/SKILL.md
+++ b/drupal-dev-framework/skills/guide-integrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guide-integrator
 description: Use when designing features - loads plugin methodology refs, fetches online dev-guides for Drupal domain knowledge, and optionally loads user's custom guides
-version: 3.0.0
+version: 3.1.0
 user-invocable: false
 ---
 
@@ -20,39 +20,15 @@ Load development references and integrate into architecture documents. Three sou
 | Quality Gates | `references/quality-gates.md` |
 | Purposeful Code | `references/purposeful-code.md` |
 
-## Online Dev-Guides (Drupal Domain)
+## Online Dev-Guides
 
-Decision guides at `https://camoa.github.io/dev-guides/`. WebFetch the topic index, then fetch the specific atomic guide needed.
+For Drupal domain knowledge beyond bundled references, fetch the guide index:
 
-| Keywords Detected | Topic URL |
-|-------------------|-----------|
-| "form", "validation", "form alter" | `drupal/forms/` |
-| "config form", "settings form", "ConfigFormBase" | `drupal/config-forms/` |
-| "entity", "field", "content type", "bundle" | `drupal/entities/` |
-| "plugin", "plugin type", "annotation", "attribute" | `drupal/plugins/` |
-| "route", "access check", "permission", "controller" | `drupal/routing/` |
-| "service", "dependency injection", "container" | `drupal/services/` |
-| "cache", "cache tag", "cache context", "max-age" | `drupal/caching/` |
-| "config", "config schema", "config entity" | `drupal/config-management/` |
-| "render", "render array", "#theme", "lazy builder" | `drupal/render-api/` |
-| "security", "XSS", "SQL injection", "CSRF" | `drupal/security/` |
-| "SDC", "component", "single directory" | `drupal/sdc/` |
-| "JavaScript", "behaviors", "once", "library" | `drupal/js-development/` |
-| "view", "views", "display", "filter" | `drupal/views/` |
-| "block", "block plugin", "block type" | `drupal/blocks/` |
-| "layout builder", "section", "inline block" | `drupal/layout-builder/` |
-| "migration", "migrate", "D7 to D11" | `drupal/migration/` |
-| "recipe", "config action" | `drupal/recipes/` |
-| "taxonomy", "vocabulary", "term" | `drupal/taxonomy/` |
-| "media", "media type", "oembed" | `drupal/media/` |
-| "image style", "responsive image" | `drupal/image-styles/` |
-| "test", "PHPUnit", "kernel test" | `drupal/testing/` |
-| "JSON:API", "jsonapi", "REST" | `drupal/jsonapi/` |
-| "icon", "icon pack", "icon API" | `drupal/icon-api/` |
-| "ECA", "event condition action" | `drupal/eca/` |
-| "GitHub Actions", "CI/CD" | `drupal/github-actions/` |
-| "CSS", "SCSS", "BEM", "Bootstrap" | `design-systems/bootstrap/` |
-| "Radix", "sub-theme" | `design-systems/radix-sdc/` |
+**Index:** `https://camoa.github.io/dev-guides/llms.txt`
+
+Likely relevant topics: forms, config-forms, entities, plugins, routing, services, caching, config-management, render-api, security, sdc, js-development, views, blocks, layout-builder, media, migration, recipes, taxonomy, jsonapi, image-styles, icon-api, eca, github-actions, ai-content, custom-field, klaro, testing, tdd, solid-principles, dry-principles
+
+Usage: WebFetch the index to discover available topics, then fetch specific topic pages for decision guides, patterns, and best practices.
 
 ## Activation
 
@@ -89,13 +65,13 @@ Based on detected keywords in the task:
 2. Read each applicable reference file
 3. Extract patterns relevant to current task
 
-### 2. Fetch Online Dev-Guides (Drupal Domain)
+### 2. Fetch Online Dev-Guides
 
 For Drupal-specific architecture decisions:
-1. Match task keywords to the Online Dev-Guides table
-2. WebFetch `https://camoa.github.io/dev-guides/{topic_url}` for the topic index
-3. Identify the specific atomic guide from the index
-4. WebFetch that atomic guide for the decision pattern
+1. WebFetch `https://camoa.github.io/dev-guides/llms.txt` to discover available topics
+2. Match task keywords against the topic list and the likely relevant topics hint
+3. WebFetch the relevant topic page for the decision guide index
+4. WebFetch specific atomic guides for patterns and best practices
 
 Only fetch topics relevant to the current task — not all topics.
 

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2026-02-16
+
+### Changed
+- **Dev-guides integration v2**: Replaced 12-entry keyword→URL mapping table in SKILL.md with lightweight `llms.txt` discovery + topic hints
+- **CLAUDE.md**: Added Online Dev-Guides section with `llms.txt` index URL and topic hints for session-wide awareness
+
 ## [1.2.0] - 2026-02-15
 
 ### Added

--- a/drupal-htmx/CLAUDE.md
+++ b/drupal-htmx/CLAUDE.md
@@ -16,6 +16,12 @@
 - Use `argument-hint:` when command accepts arguments
 - Restrict `allowed-tools` to minimum needed
 
+## Online Dev-Guides
+For Drupal domain context when analyzing or validating HTMX patterns, fetch the guide index:
+- **Index:** `https://camoa.github.io/dev-guides/llms.txt`
+- WebFetch the index to discover available topics, then fetch specific topic pages
+- Likely relevant topics: forms, routing, js-development, render-api
+
 ## General
 - Drupal 11.3+ HTMX patterns only — no legacy AJAX guidance
 - Reference files instead of reproducing content

--- a/drupal-htmx/skills/htmx-development/SKILL.md
+++ b/drupal-htmx/skills/htmx-development/SKILL.md
@@ -230,24 +230,13 @@ When reviewing HTMX implementations:
 
 ### Online Dev-Guides (Drupal Domain)
 
-For Drupal domain context when analyzing, recommending, or validating HTMX patterns, WebFetch from https://camoa.github.io/dev-guides/.
+For Drupal domain context when analyzing, recommending, or validating HTMX patterns, fetch the guide index:
 
-| Topic | URL | Use when |
-|-------|-----|----------|
-| AJAX form architecture | `drupal/forms/ajax-architecture/` | Understanding existing AJAX before migration |
-| AJAX security | `drupal/forms/ajax-security/` | Security review of AJAX patterns |
-| JS AJAX integration | `drupal/js-development/ajax-integration/` | JS-level AJAX patterns to migrate |
-| Drupal.behaviors | `drupal/js-development/drupal-behaviors-pattern/` | HTMX JS event integration context |
-| Multi-step forms | `drupal/forms/multi-step-forms/` | Wizard pattern migration context |
-| Form #states | `drupal/forms/form-states-system/` | When #states is better than HTMX |
-| Form alter system | `drupal/forms/form-alter-system/` | Altering forms with HTMX elements |
-| Routing | `drupal/routing/` | HTMX route configuration context |
-| Render API | `drupal/render-api/` | Render arrays for HTMX responses |
-| Render array patterns | `drupal/render-api/render-array-patterns/` | Progressive enhancement patterns |
-| Security best practices | `drupal/forms/security-best-practices/` | Form security for HTMX endpoints |
-| JS testing | `drupal/js-development/testing-javascript/` | Testing HTMX JS interactions |
+**Index:** `https://camoa.github.io/dev-guides/llms.txt`
 
-**How to use:** Prefix URLs with `https://camoa.github.io/dev-guides/` and WebFetch for Drupal-specific patterns when the bundled HTMX references don't cover the underlying Drupal concept.
+Likely relevant topics: forms, routing, js-development, render-api
+
+Usage: WebFetch the index to discover available topics, then fetch specific topic pages for Drupal patterns when the bundled HTMX references don't cover the underlying Drupal concept.
 
 ## Key Files in Drupal Core
 


### PR DESCRIPTION
## Summary

- Replaced keyword→URL mapping tables in all 4 plugins with lightweight `llms.txt` discovery + curated topic hints
- Added `## Online Dev-Guides` section to each plugin's `CLAUDE.md` for session-wide awareness (loaded at plugin activation)
- "See also" pointers in bundled reference files preserved (stable, low maintenance)
- Security debate command in code-quality-tools preserved (uses specific URLs for operational purposes)

### Before (v1)
Each plugin had a mapping table with specific keyword→URL pairs (45, 12, 11, 6 entries). These go stale when topics are added/reorganized.

### After (v2)
Each plugin points to `llms.txt` index + a curated list of likely-relevant topic names. The AI discovers topics at runtime.

### Version bumps
| Plugin | Old | New |
|--------|-----|-----|
| drupal-dev-framework | 3.4.0 | 3.5.0 |
| code-quality-tools | 2.5.0 | 2.6.0 |
| drupal-htmx | 1.2.0 | 1.3.0 |
| brand-content-design | 2.5.0 | 2.6.0 |

### Files changed (18)
- 5 SKILL.md files (mapping tables → generic discovery)
- 4 CLAUDE.md files (added Online Dev-Guides section)
- 4 plugin.json files (version bumps)
- 4 CHANGELOG.md files (new entries)
- 1 marketplace.json (4 version bumps)

## Test plan
- [ ] Verify `llms.txt` URL is accessible: `curl https://camoa.github.io/dev-guides/llms.txt`
- [ ] Verify "See also" pointers still work in bundled refs
- [ ] Verify security-debate command preserved
- [ ] Verify all version numbers in sync across plugin.json, marketplace.json, CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)