### PR TITLE
feat: enhance html-generator with aesthetic principles v2.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development (HTMX, AJAX migration), brand content creation (presentations, carousels, infographics), code quality auditing, paper testing (mental code execution), and plugin development",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {
@@ -73,7 +73,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, design systems, HTML components, 114 infographic templates, visual components, 17 color palettes, and Presentation Zen principles",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-02-17
+
+### Changed
+- **html-generator skill**: Enhanced with 6 aesthetic principles inspired by Anthropic's frontend-design skill
+  - **"The one memorable thing"** — differentiation test now requires naming the ONE distinctive element per page
+  - **Intentionality over intensity** — calibrate design complexity to match the style (restraint for minimal, elaborate for maximalist)
+  - **Color dominance** — dominant primary with sharp accent outperforms evenly-distributed palettes
+  - **Motion hierarchy** — focus animation budget on one high-impact page load moment, keep the rest subtle
+  - **Anti-convergence** — never reuse the same font choices across different page generations
+  - **Match complexity to aesthetic** — Swiss precision ≠ Memphis energy; each style demands its own execution approach
+
 ## [2.6.0] - 2026-02-16
 
 ### Changed

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: html-generator
 description: Use when generating branded HTML pages and components from a design system. Creates standalone HTML components and composes them into full pages with embedded CSS, responsive design, and brand integration.
-version: 2.5.0
+version: 2.6.0
 model: opus
 user-invocable: false
 ---
@@ -67,12 +67,18 @@ Before writing any HTML, internalize the design system:
 
 ### The Differentiation Test
 
-Before generating, ask: "Could this page belong to any brand?" If yes, push harder. Incorporate:
+Before generating, ask: "Could this page belong to any brand?" If yes, push harder. Then ask: **"What is the ONE thing someone will remember about this page?"** — a dramatic type scale, a surprising color moment, an unexpected layout break. If you cannot name it, the design is not distinctive enough.
+
+Incorporate:
 - The canvas philosophy's unique movement name and spirit
 - Unexpected layout choices (asymmetry, overlap, grid-breaking)
 - Typography as art (size contrasts, weight mixing, letter-spacing play)
 - Atmosphere (gradient meshes, noise textures, patterns, shadows with depth)
 - The brand's personality expressed through micro-interactions (hover states, transitions)
+
+### Intentionality Over Intensity
+
+**Match implementation complexity to the aesthetic vision.** Maximalist designs need elaborate code with extensive animations and layered effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. The key is intentionality, not intensity — a Swiss design executed with mathematical precision is as powerful as a Memphis design executed with wild energy. Never apply "bold" uniformly; calibrate to the style.
 
 ---
 
@@ -90,6 +96,10 @@ Read the project's `design-system.md` and map ALL token sections to `:root` cust
 - **Forms** (if page has forms) — `--color-error`, `--color-success`, field/label/error styling
 
 The design-system.md is the single source of truth for all token values. Do not hardcode values — read them from the file.
+
+### Color Dominance Principle
+
+Dominant colors with sharp accents outperform timid, evenly-distributed palettes. Use `--color-primary` as the dominant voice (headings, CTAs, navigation active states), `--color-accent` as the sharp punctuation (links, hover states, highlights), and let `--color-bg` and `--color-text` do the quiet structural work. If the palette feels "even" — one color is not leading — push the primary harder or pull the secondary back.
 
 ### Font Loading
 
@@ -298,6 +308,10 @@ Mobile-first approach with 3 breakpoints:
 
 Prefer CSS solutions. Use JS only when CSS cannot achieve the effect.
 
+### Motion Hierarchy
+
+Focus the motion budget on **one high-impact moment** per page. One well-orchestrated page load with staggered reveals (`animation-delay`) creates more delight than scattered micro-interactions on every element. Decide: is it the hero entrance, the stats counting up, or the card grid cascading in? Pick one, make it great, and keep the rest subtle.
+
 ### CSS-Only Patterns
 
 - **Hover effects**: `transform`, `box-shadow`, `opacity` transitions
@@ -346,10 +360,14 @@ Typography is the primary design tool for HTML pages. Make bold choices:
 
 ### Never Use
 
-- Inter, Roboto, Arial, Helvetica (unless the brand specifically uses them)
+- Inter, Roboto, Arial, Helvetica (unless the brand specifically uses them or the style's Visual DNA specifies them)
 - System font stack alone (always include a distinctive Google Font)
 - Single weight throughout (exploit the full weight range)
 - Uniform sizing (create dramatic scale contrast)
+
+### Anti-Convergence
+
+NEVER converge on the same font choices across different page generations. If you generated a page with Space Grotesk last time, pick a different font this time. Each design system and page should feel independently designed. Vary display fonts, body fonts, weight distributions, and size scales between projects. The goal: if someone lined up 10 generated pages, they should look like they came from 10 different designers.
 
 ---
 


### PR DESCRIPTION
## Summary
- Enriches `html-generator` skill with 6 design principles from Anthropic's `frontend-design` skill
- Adds "the one memorable thing" test, intentionality-over-intensity calibration, color dominance, motion hierarchy, anti-convergence across generations, and complexity-matching to aesthetic vision
- Version bumps: brand-content-design 2.6.0 → 2.7.0, marketplace 1.3.0 → 1.4.0, html-generator skill 2.5.0 → 2.6.0

## Test plan
- [ ] Run `/brand-content-design:html-page` with an existing design system
- [ ] Verify generated page demonstrates the new principles (one memorable element, motion focused on one moment, color dominance)
- [ ] Check that minimal/Swiss styles get restrained execution while bold styles get elaborate execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)