### PR TITLE
fix: html-page output path and metadata instruction (v2.7.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,7 +73,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, design systems, HTML components, 114 infographic templates, visual components, 17 color palettes, and Presentation Zen principles",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-02-17
+
+### Fixed
+- **html-page command**: Output path changed from `html-pages/{date}-{page-name}/` to `html-pages/{design-system-name}/{page-name}/` — prevents cross-design-system mixing and duplicate directories on regeneration
+- **html-page command**: Added explicit convertibility metadata instruction — generator now mandated to include `<!-- prop: -->` and `<!-- slot: -->` annotations, not just component boundaries
+- **html-technical.md**: Updated Output Pages structure to match new design-system-namespaced path, added images directory documentation
+
 ## [2.7.0] - 2026-02-17
 
 ### Changed

--- a/brand-content-design/commands/html-page.md
+++ b/brand-content-design/commands/html-page.md
@@ -142,8 +142,13 @@ Invoke the `html-generator` skill via Skill tool with:
 - The 4 reference files read above (pass their content to the skill)
 
 The html-generator skill will:
-1. Generate any NEW components as standalone HTML with metadata annotations
-2. Compose all components into a single page preserving all `<!-- component: -->`, `<!-- prop: -->`, `<!-- slot: -->` metadata
+1. Generate any NEW components as standalone HTML with full convertibility metadata
+2. Compose all components into a single page with all metadata comments
+
+**Convertibility metadata is MANDATORY for every component:**
+- `<!-- component: type variant: variant -->` / `<!-- /component: type -->` — component boundaries
+- `<!-- prop: name type: type -->` — before EVERY dynamic content element (headlines, text, images, links, labels, dates)
+- `<!-- slot: name -->` / `<!-- /slot: name -->` — around repeatable/swappable content areas (nav links, list items, grid entries, footer columns)
 
 ### Step 10: Save Components
 
@@ -153,15 +158,18 @@ For each newly generated component:
 
 ### Step 11: Save Page
 
-Create output directory and save the composed page:
+Create output directory namespaced by design system name and save the composed page:
+```bash
+mkdir -p {PROJECT_PATH}/html-pages/{DESIGN_SYSTEM_NAME}/{page-name}
 ```
-{PROJECT_PATH}/html-pages/{YYYY-MM-DD}-{page-name}/{page-name}.html
-```
+Save to: `{PROJECT_PATH}/html-pages/{DESIGN_SYSTEM_NAME}/{page-name}/{page-name}.html`
+
+On first page for this design system, copy images from `templates/html/{name}/images/` to `html-pages/{DESIGN_SYSTEM_NAME}/images/` so pages use clean relative paths (`../images/`).
 
 ### Step 12: Confirm
 
 Tell user:
-- Page saved to: `html-pages/{date}-{page-name}/{page-name}.html`
+- Page saved to: `html-pages/{DESIGN_SYSTEM_NAME}/{page-name}/{page-name}.html`
 - New components generated: list any new components saved to the library
 - Total components in library: count
 - Open the HTML file in a browser to preview
@@ -174,6 +182,6 @@ Suggest:
 
 ## Output
 
-- Created: `html-pages/{YYYY-MM-DD}-{page-name}/{page-name}.html`
+- Created: `html-pages/{DESIGN_SYSTEM_NAME}/{page-name}/{page-name}.html`
 - Created (if new): `templates/html/{name}/components/{type}-{variant}.html` for each new component
 - Updated: `templates/html/{name}/design-system.md` (Generated Components section)

--- a/brand-content-design/skills/html-generator/references/html-technical.md
+++ b/brand-content-design/skills/html-generator/references/html-technical.md
@@ -490,9 +490,15 @@ templates/html/{design-system-name}/
 ### Output Pages
 ```
 html-pages/
-└── {YYYY-MM-DD}-{page-name}/
-    └── {page-name}.html
+└── {design-system-name}/
+    ├── images/              ← copied from templates on first page
+    ├── {page-name}/
+    │   └── {page-name}.html
+    └── {another-page}/
+        └── {another-page}.html
 ```
+
+Pages are namespaced by design system name (not date) so multiple design systems stay separate and pages can be regenerated without creating duplicates.
 
 ### Naming Rules
 - All lowercase
@@ -500,4 +506,3 @@ html-pages/
 - Design system names: descriptive (e.g., `acme-corp`, `product-launch`, `developer-portal`)
 - Page names: descriptive (e.g., `landing-page`, `about-us`, `pricing`)
 - Component files: `{type}-{variant}.html` (e.g., `hero-centered.html`, `nav-simple.html`)
-- Date format: ISO 8601 (`YYYY-MM-DD`)


### PR DESCRIPTION
## Summary
- **BUG-1**: Output path changed from `html-pages/{date}-{page-name}/` to `html-pages/{design-system-name}/{page-name}/` — prevents cross-design-system mixing and avoids duplicate directories when regenerating pages
- **BUG-2**: Added explicit convertibility metadata instruction requiring `<!-- prop: -->` and `<!-- slot: -->` annotations in generated HTML, not just component boundaries
- Updated `html-technical.md` output structure documentation to match

## Test plan
- [ ] Run `/html-page` and verify output goes to `html-pages/{design-system-name}/{page}/`
- [ ] Verify generated HTML includes prop and slot metadata comments
- [ ] Verify images are copied to `html-pages/{design-system-name}/images/` on first page

🤖 Generated with [Claude Code](https://claude.com/claude-code)