### PR TITLE
fix: session context survives compaction (v3.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/.claude/rules/command-conventions.md
+++ b/drupal-dev-framework/.claude/rules/command-conventions.md
@@ -16,3 +16,25 @@ paths:
 - Clear instructions for what Claude should do when command is invoked
 - Support `$ARGUMENTS` for user-provided arguments
 - Reference skills/agents for complex workflows rather than inlining logic
+
+## Session Context Tracking
+
+When a command resolves which project and/or task the user is working on, **write the session context file** so it survives context compaction:
+
+```bash
+mkdir -p ~/.claude/drupal-dev-framework
+cat > ~/.claude/drupal-dev-framework/session_context.json << EOF
+{
+  "project": "{project_name}",
+  "projectPath": "{project_path}",
+  "task": "{task_name_or_null}",
+  "taskPath": "{task_path_or_null}",
+  "updatedAt": "$(date -I)"
+}
+EOF
+```
+
+- Write after the user selects/confirms a project and task (not before)
+- Set `task` and `taskPath` to `null` if only the project is known
+- On `/complete`, clear `task` and `taskPath` (set to `null`) since the task moved to completed
+- The pre-compact hook reads this file to inject accurate context into the compacted prompt

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1] - 2026-02-18
+
+### Fixed
+- **Session context survives compaction**: Commands now write `session_context.json` with active project/task so pre-compact hook can inject accurate context instead of guessing from `lastAccessed`
+- **pre-compact.sh**: Reads session context first, outputs task.md content for active task; falls back to registry-based guess only when no session context exists
+- **next.md, status.md**: Added `Write` and `Bash` to allowed-tools so they can write session context
+- **command-conventions.md**: Added session context tracking convention — all commands that resolve a project/task must write the context file
+
 ## [3.5.0] - 2026-02-16
 
 ### Changed

--- a/drupal-dev-framework/commands/next.md
+++ b/drupal-dev-framework/commands/next.md
@@ -1,6 +1,6 @@
 ---
 description: Suggest next action based on project state
-allowed-tools: Read, Glob, Task
+allowed-tools: Read, Write, Glob, Bash, Task
 argument-hint: [project-name]
 ---
 

--- a/drupal-dev-framework/commands/status.md
+++ b/drupal-dev-framework/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: Show current project state and task progress
-allowed-tools: Read, Glob
+allowed-tools: Read, Write, Glob, Bash
 argument-hint: [project-name]
 ---
 

--- a/drupal-dev-framework/hooks/pre-compact.sh
+++ b/drupal-dev-framework/hooks/pre-compact.sh
@@ -1,14 +1,58 @@
 #!/usr/bin/env bash
-# Pre-compact hook: Save project state summary before context compaction
-# This ensures critical project context survives compaction
+# Pre-compact hook: Preserve active project/task context before compaction
+# Reads session_context.json (set by commands) for accurate tracking
 
+SESSION_CONTEXT="$HOME/.claude/drupal-dev-framework/session_context.json"
 REGISTRY="$HOME/.claude/drupal-dev-framework/active_projects.json"
 
+# Try session context first (most accurate — written during this session)
+if [ -f "$SESSION_CONTEXT" ]; then
+  PROJECT_NAME=$(jq -r '.project // empty' "$SESSION_CONTEXT" 2>/dev/null)
+  PROJECT_PATH=$(jq -r '.projectPath // empty' "$SESSION_CONTEXT" 2>/dev/null)
+  TASK_NAME=$(jq -r '.task // empty' "$SESSION_CONTEXT" 2>/dev/null)
+  TASK_PATH=$(jq -r '.taskPath // empty' "$SESSION_CONTEXT" 2>/dev/null)
+
+  if [ -n "$PROJECT_NAME" ] && [ -d "$PROJECT_PATH" ]; then
+    echo "## Active Session Context"
+    echo ""
+    echo "**Project:** $PROJECT_NAME"
+    echo "**Path:** $PROJECT_PATH"
+
+    if [ -n "$TASK_NAME" ] && [ -d "$TASK_PATH" ]; then
+      echo "**Task:** $TASK_NAME"
+      echo ""
+
+      # Output task.md for full context
+      TASK_FILE="$TASK_PATH/task.md"
+      if [ -f "$TASK_FILE" ]; then
+        echo "### Active Task Details"
+        head -50 "$TASK_FILE"
+        echo ""
+      fi
+    fi
+
+    # List other in-progress tasks
+    OTHER_TASKS=""
+    while IFS= read -r dir; do
+      name=$(basename "$dir")
+      if [ "$name" != "$TASK_NAME" ]; then
+        OTHER_TASKS="${OTHER_TASKS}- ${name}\n"
+      fi
+    done < <(find "$PROJECT_PATH/implementation_process/in_progress/" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+
+    if [ -n "$OTHER_TASKS" ]; then
+      echo "### Other In-Progress Tasks"
+      printf "%b" "$OTHER_TASKS"
+    fi
+    exit 0
+  fi
+fi
+
+# Fallback: guess from registry (less accurate — no task info)
 if [ ! -f "$REGISTRY" ]; then
   exit 0
 fi
 
-# Find the most recently accessed project
 LATEST_PROJECT=$(jq -r '.projects | sort_by(.lastAccessed) | last | .path // empty' "$REGISTRY" 2>/dev/null)
 
 if [ -z "$LATEST_PROJECT" ] || [ ! -d "$LATEST_PROJECT" ]; then
@@ -23,7 +67,6 @@ if [ -f "$STATE_FILE" ]; then
   echo "### Active Project"
   echo "Path: $LATEST_PROJECT"
   echo ""
-  # Output first 30 lines of project state as context preservation
   head -30 "$STATE_FILE"
   echo ""
   echo "### Active Tasks"


### PR DESCRIPTION
## Summary
- Commands now write `~/.claude/drupal-dev-framework/session_context.json` when user selects a project/task
- Pre-compact hook reads this file to inject the active task's `task.md` content (up to 50 lines) instead of guessing from `lastAccessed`
- Added `Write` and `Bash` to `next.md` and `status.md` allowed-tools so they can write session context

## Test plan
- [ ] Run `/drupal-dev-framework:next`, select a project and task, verify `session_context.json` is written
- [ ] Trigger compaction (or run `pre-compact.sh` manually) and verify task details appear in output
- [ ] Remove `session_context.json` and verify fallback to registry-based guess still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)