### PR TITLE
feat: add dev-guides-navigator plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,6 +10,18 @@
   },
   "plugins": [
     {
+      "name": "dev-guides-navigator",
+      "source": "./dev-guides-navigator",
+      "description": "Smart guide discovery and routing for dev-guides. Uses manifest with KG metadata (concepts, disambiguation, relationships) and hash-based caching to route AI to the correct guide.",
+      "version": "0.1.0",
+      "author": {
+        "name": "camoa"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/camoa/claude-skills",
+      "keywords": ["guides", "dev-guides", "llms-txt", "knowledge-graph", "caching", "routing", "disambiguation", "drupal", "nextjs", "design-system"]
+    },
+    {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration",

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "dev-guides-navigator",
+  "version": "0.1.0",
+  "description": "Smart guide discovery and routing for dev-guides. Uses a manifest with Knowledge Graph metadata (concepts, disambiguation, relationships) and hash-based caching to route AI to the correct guide and enforce application of patterns.",
+  "author": {
+    "name": "camoa"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/camoa/claude-skills"
+}

--- a/dev-guides-navigator/README.md
+++ b/dev-guides-navigator/README.md
@@ -1,0 +1,39 @@
+# Dev Guides Navigator
+
+Brief description of what this plugin does.
+
+## Installation
+
+```bash
+/plugin marketplace add path/to/marketplace
+/plugin install dev-guides-navigator@marketplace-name
+```
+
+## Components
+
+- **Skill**: `dev-guides-navigator`
+
+## Usage
+
+[How to use this plugin]
+
+## Configuration
+
+[Any configuration options]
+
+## Output
+
+If hooks are enabled, outputs are written to `claude-outputs/`:
+
+```
+claude-outputs/
+├── logs/        # Session and operation logs
+├── artifacts/   # Generated files
+└── temp/        # Temporary files (cleaned on session end)
+```
+
+Add to `.gitignore`:
+```
+claude-outputs/
+.claude/settings.local.json
+```

--- a/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: dev-guides-navigator
+description: Smart guide discovery and routing for dev-guides site. Use when any development task might benefit from a guide — Drupal, Next.js, design systems, CSS, testing, security, SOLID, DRY, TDD. Caches llms.txt with hash-based freshness check. Reads topic index.md for KG metadata (concepts, disambiguation, relationships) to prevent wrong-guide selection. Keywords: guide, dev-guides, llms.txt, reference, pattern, best practice.
+model: haiku
+---
+
+# Dev-Guides Navigator
+
+Route to the correct online guide and enforce guide application.
+
+## When to Use
+
+- Any Drupal, Next.js, design system, or dev-practice task where a guide might help
+- When another skill or agent needs domain knowledge beyond its bundled references
+- When the user mentions a specific guide topic
+- NOT for: plugin methodology references (those are in drupal-dev-framework/references/)
+
+## Core Workflow
+
+### 1. Get llms.txt (with caching)
+
+Check for cache at `~/.claude/projects/{project-hash}/memory/dev-guides-cache.json`.
+
+**No cache (first time):**
+1. WebFetch `https://camoa.github.io/dev-guides/llms.hash` — save the hash
+2. WebFetch `https://camoa.github.io/dev-guides/llms.txt` — save the content
+3. Write both to cache file
+
+**Cache exists:**
+1. WebFetch `https://camoa.github.io/dev-guides/llms.hash` (tiny, fast)
+2. Compare with cached hash
+   - **Same** → use cached `llms.txt`, skip re-fetch
+   - **Different** → re-fetch `llms.txt`, update cache
+
+### 2. Match Task to Topic
+
+Scan `llms.txt` for the topic that matches the current task. Each line has a topic title, URL, guide count, and description.
+
+### 3. Fetch Topic Index
+
+WebFetch the matched topic's URL (e.g., `https://camoa.github.io/dev-guides/drupal/forms/`). This returns the topic's `index.md` containing:
+
+- **"I need to..." routing table** — maps user intent to specific guide
+- **`guide-meta:` frontmatter** — KG metadata for disambiguation and relationships
+
+### 4. Use KG Metadata (from index.md)
+
+The `guide-meta:` in the topic's frontmatter provides:
+
+- **`concepts`** — confirms this is the right topic
+- **`not`** — if the task matches a `not` term, this is the WRONG topic, go back to step 2
+- **`requires`** — load prerequisite topics first
+- **`complements`** — note related topics for the user
+
+| Example Task | Correct Topic | Wrong Topic | Why |
+|--------------|---------------|-------------|-----|
+| story.yml props | drupal/ui-patterns | drupal/storybook | "story.yml" in ui-patterns concepts, "storybook" in not |
+| stories.yml preview | drupal/storybook | drupal/ui-patterns | reverse |
+| inline blocks | drupal/layout-builder | drupal/blocks | "inline blocks" in blocks' not |
+
+### 5. Pick Specific Guide
+
+From the "I need to..." routing table, select the guide that matches the task. WebFetch that individual guide `.md`.
+
+### 6. Apply the Guide (Critical)
+
+**Do NOT just read and summarize.** Extract and apply:
+
+1. Identify the relevant section(s) for the current task
+2. Extract decision criteria, patterns, and code examples
+3. Apply them directly to the implementation
+4. Reference the guide in architecture docs if in design phase
+
+## Quick Reference
+
+| Step | Action |
+|------|--------|
+| Cache check | Compare `llms.hash` with cached hash |
+| Find topic | Match task keywords in `llms.txt` |
+| Get routing table | WebFetch topic `index.md` |
+| Disambiguate | Check `guide-meta:` concepts/not fields |
+| Get guide | WebFetch specific guide from routing table |
+| Apply | Extract patterns and implement, don't summarize |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Reading guide and only summarizing | Extract patterns and apply to current task |
+| Grabbing first keyword match | Check guide-meta `not` fields for disambiguation |
+| Fetching llms.txt every time | Check llms.hash first, use cache |
+| Ignoring `requires` | Load prerequisites first |
+
+## See Also
+
+- `references/cache-format.md` — cache file format
+- `references/manifest-schema.md` — build output (llms.txt + llms.hash)
+- `references/guide-index.md` — fallback keyword table (if llms.hash not yet deployed)

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/cache-format.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/cache-format.md
@@ -1,0 +1,35 @@
+# Cache Format
+
+## Location
+
+```
+~/.claude/projects/{project-hash}/memory/dev-guides-cache.json
+```
+
+## Structure
+
+```json
+{
+  "hash": "<contents of llms.hash>",
+  "llms_txt": "<contents of llms.txt>"
+}
+```
+
+## Flow
+
+**First time (no cache):**
+1. WebFetch `llms.txt` + `llms.hash`
+2. Save both to cache file
+
+**Subsequent times (cache exists):**
+1. WebFetch `llms.hash` (tiny file)
+2. Compare with cached hash
+   - Same → use cached `llms.txt`
+   - Different → re-fetch `llms.txt`, update cache
+
+**Finding a guide:**
+1. Match task keywords against cached `llms.txt` topics
+2. WebFetch the topic's `index.md` (routing table)
+3. Pick the specific guide from "I need to..." table
+4. WebFetch that individual guide `.md`
+5. Apply the guide content to the task

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/guide-index.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/guide-index.md
@@ -1,0 +1,99 @@
+# Guide Index (Fallback)
+
+Use this keyword-to-URL mapping when the `llms-manifest.json` is not yet available.
+Once the manifest is deployed, prefer it for routing (it includes disambiguation and relationships).
+
+## Discovery
+
+Index URL: `https://camoa.github.io/dev-guides/llms.txt`
+Base URL: `https://camoa.github.io/dev-guides/`
+
+## Drupal Guides
+
+| Keywords | Topic URL | Slug |
+|----------|-----------|------|
+| form, validation, form alter, FAPI | `drupal/forms/` | drupal-forms |
+| config form, settings form, ConfigFormBase | `drupal/config-forms/` | drupal-config-forms |
+| entity, field, content type, bundle | `drupal/entities/` | drupal-entities |
+| plugin, plugin type, annotation, attribute | `drupal/plugins/` | drupal-plugins |
+| route, access, permission, controller | `drupal/routing/` | drupal-routing |
+| service, dependency injection, container, autowire | `drupal/services/` | drupal-services |
+| cache, cache tag, cache context, max-age, BigPipe | `drupal/caching/` | drupal-caching |
+| config, config schema, Config Split, sync | `drupal/config-management/` | drupal-config-management |
+| render, render array, #theme, #type, attachments | `drupal/render-api/` | drupal-render-api |
+| security, XSS, CSRF, SQL injection, CSP | `drupal/security/` | drupal-security |
+| SDC, component, single directory, *.component.yml | `drupal/sdc/` | drupal-sdc |
+| JavaScript, behaviors, once, Drupal.ajax | `drupal/js-development/` | drupal-js-development |
+| views, display, filter, relationship, argument | `drupal/views/` | drupal-views |
+| block, block plugin, BlockBase, block_content | `drupal/blocks/` | drupal-blocks |
+| layout builder, section, inline block, LB Styles | `drupal/layout-builder/` | drupal-layout-builder |
+| migration, migrate, D7, source plugin, process | `drupal/migration/` | drupal-migration |
+| recipe, config action, DefaultContent | `drupal/recipes/` | drupal-recipes |
+| taxonomy, vocabulary, term, hierarchy | `drupal/taxonomy/` | drupal-taxonomy |
+| media, media type, oembed, media library | `drupal/media/` | drupal-media |
+| image style, responsive image, breakpoint | `drupal/image-styles/` | drupal-image-styles |
+| test, PHPUnit, kernel test, browser test | `drupal/testing/` | drupal-testing |
+| JSON:API, jsonapi, REST, decoupled | `drupal/jsonapi/` | drupal-jsonapi |
+| icon, icon pack, IconFinder | `drupal/icon-api/` | drupal-icon-api |
+| ECA, event condition action, workflow | `drupal/eca/` | drupal-eca |
+| GitHub Actions, CI/CD, deployment | `drupal/github-actions/` | drupal-github-actions |
+| AI, automator, assistant, chatbot | `drupal/ai-content/` | drupal-ai-content |
+| custom field, compound field, FieldType | `drupal/custom-field/` | drupal-custom-field |
+| Klaro, cookie consent, privacy | `drupal/klaro/` | drupal-klaro |
+| UI Patterns, story.yml, prop, slot, mapping | `drupal/ui-patterns/` | drupal-ui-patterns |
+| Storybook, stories.yml, component preview | `drupal/storybook/` | drupal-storybook |
+| Twig, template, preprocess, twig_tweak | `drupal/twig-theming/` | drupal-twig-theming |
+| multilingual, translation, i18n, TMGMT | `drupal/multilingual/` | drupal-multilingual |
+| breadcrumb, trail, navigation | `drupal/breadcrumbs/` | drupal-breadcrumbs |
+| Canvas, drawing, visual | `drupal/canvas/` | drupal-canvas |
+| Salesforce, CRM, sync | `drupal/salesforce/` | drupal-salesforce |
+| TDD, test-driven, Red-Green-Refactor (Drupal) | `drupal/tdd/` | drupal-tdd |
+| SOLID, SRP, OCP, DIP (Drupal) | `drupal/solid/` | drupal-solid |
+| DRY, duplication, reuse (Drupal) | `drupal/dry/` | drupal-dry |
+
+## Next.js Guides
+
+| Keywords | Topic URL | Slug |
+|----------|-----------|------|
+| Next.js, Next Drupal, decoupled, SSR | `nextjs/next-drupal/` | next-drupal |
+| Tiptap, ProseMirror, rich text editor | `nextjs/tiptap-editor/` | tiptap-editor |
+| DeepChat, chat component, streaming | `nextjs/deepchat-nextjs/` | deepchat-nextjs |
+
+## Design System Guides
+
+| Keywords | Topic URL | Slug |
+|----------|-----------|------|
+| design system recognition, element identification | `design-systems/recognition/` | design-system-recognition |
+| Bootstrap, SCSS, Sass, mapping | `design-systems/bootstrap/` | design-system-bootstrap |
+| Radix, sub-theme, SDC components | `design-systems/radix-sdc/` | design-system-radix-sdc |
+| Radix components, catalog | `design-systems/radix-components/` | design-system-radix-components |
+| Tailwind, tokens, DaisyUI, DTCG | `design-systems/tailwind-tokens/` | design-system-tailwind-tokens |
+| JSX to Twig, React to Drupal | `design-systems/jsx-to-twig/` | design-system-jsx-to-twig |
+| DaisyUI, UI Suite | `design-systems/daisyui/` | design-system-daisyui |
+
+## Development Practice Guides
+
+| Keywords | Topic URL | Slug |
+|----------|-----------|------|
+| SOLID, SRP, OCP, LSP, ISP, DIP (general) | `dev-practices/solid-principles/` | dev-solid-principles |
+| DRY, duplication, Rule of Three (general) | `dev-practices/dry-principles/` | dev-dry-principles |
+| TDD, spec-driven, test doubles (general) | `dev-practices/tdd-spec-driven/` | dev-tdd-spec-driven |
+| security, OWASP, auth, API security (general) | `dev-practices/security-practices/` | dev-security-practices |
+| CSS, modern CSS, container queries, @scope | `dev-practices/modern-css/` | modern-css |
+| CSS Craft, motion, micro-interactions | `dev-practices/css-craft/` | css-craft |
+
+## Disambiguation Quick Reference
+
+| Term | Correct Guide | NOT This Guide |
+|------|---------------|----------------|
+| story.yml | drupal-ui-patterns | drupal-storybook |
+| stories.yml | drupal-storybook | drupal-ui-patterns |
+| inline blocks | drupal-layout-builder | drupal-blocks |
+| block plugin, BlockBase | drupal-blocks | drupal-layout-builder |
+| *.component.yml | drupal-sdc | drupal-ui-patterns |
+| SOLID (Drupal context) | drupal-solid | dev-solid-principles |
+| SOLID (general) | dev-solid-principles | drupal-solid |
+| config entity | drupal-config-management | drupal-entities |
+| content entity | drupal-entities | drupal-config-management |
+| media library widget | drupal-media | drupal-image-styles |
+| responsive image | drupal-image-styles | drupal-media |

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/manifest-schema.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/manifest-schema.md
@@ -1,0 +1,56 @@
+# Build Output
+
+## Files Generated
+
+The build step (`generate_llms.py`) produces two files in `site/`:
+
+| File | Purpose | Size |
+|------|---------|------|
+| `llms.txt` | Topic index — maps topics to their URL | ~4KB |
+| `llms.hash` | SHA-256 of `llms.txt` content | 64 bytes |
+
+## llms.txt Format
+
+```
+# Dev Guides
+
+> AI-friendly atomic decision guides...
+
+## Drupal
+
+- [Drupal Form API](https://camoa.github.io/dev-guides/drupal/forms/): 26 guides — ...
+- [Drupal Blocks](https://camoa.github.io/dev-guides/drupal/blocks/): 23 guides — ...
+
+## Design Systems
+
+- [Bootstrap Mapping](https://camoa.github.io/dev-guides/design-systems/bootstrap/): 16 guides — ...
+```
+
+Each entry points to a topic's `index.md` page, which contains the "I need to..." routing table.
+
+## llms.hash Format
+
+Plain text file containing the SHA-256 hash of `llms.txt`:
+
+```
+a1b2c3d4e5f6...
+```
+
+## KG Metadata
+
+Lives in each topic's `index.md` frontmatter as `guide-meta:`. Not in the build output — read when the AI fetches the topic index.
+
+```yaml
+---
+description: Topic description
+guide-meta:
+  concepts: [terms this guide owns]
+  not: [terms that should NOT route here]
+  requires: [prerequisite topic keys]
+  complements: [related topic keys]
+  specializes: ""
+  category: drupal
+---
+```
+
+The AI reads this when it fetches the `index.md` to understand relationships and disambiguation.


### PR DESCRIPTION
## Summary

- Adds `dev-guides-navigator` plugin for AI guide discovery and routing
- Uses `llms.hash` for cache freshness — AI checks hash per session, reuses cached `llms.txt` if unchanged
- Guide-meta KG metadata (`concepts`/`not`/`requires`/`complements`) in topic `index.md` prevents wrong-guide selection (e.g., "story.yml" → UI Patterns, not Storybook)
- Two-hop routing: `llms.txt` → topic `index.md` → specific guide `.md`

## What's included

| File | Purpose |
|------|---------|
| `SKILL.md` | Cached two-hop routing workflow |
| `references/cache-format.md` | Simple `{ hash, llms_txt }` cache spec |
| `references/manifest-schema.md` | `llms.txt` + `llms.hash` build output docs |
| `references/guide-index.md` | Fallback keyword table for pre-hash deployment |
| `marketplace.json` | Plugin registered in marketplace |

## Dependencies

- `llms.hash` endpoint deployed at `https://camoa.github.io/dev-guides/llms.hash` ✅
- `guide-meta:` frontmatter added to all 66 topic `index.md` files ✅
- `generate_llms.py` updated to generate hash + topic index URLs ✅

## Test plan

- [ ] Install plugin: `/plugin marketplace add camoa-skills && /plugin install dev-guides-navigator`
- [ ] Test disambiguation: ask about "UI Patterns story.yml" — should route to `drupal/ui-patterns/`, not `drupal/storybook/`
- [ ] Test caching: second invocation should skip `llms.txt` re-fetch
- [ ] Test relationship awareness: loading a guide with `requires` should note prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)