### PR TITLE
feat(code-paper-test): v0.4.0 — methodology depth, skill/config testing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "plugins": [
     {
@@ -72,14 +72,14 @@
     {
       "name": "code-paper-test",
       "source": "./code-paper-test",
-      "description": "Systematically test code through mental execution - trace code line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, and contract violations before deployment",
-      "version": "0.3.0",
+      "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Includes 3-agent competing testers with isolated worktrees.",
+      "version": "0.4.0",
       "author": {
         "name": "camoa"
       },
       "license": "MIT",
       "repository": "https://github.com/camoa/claude-skills",
-      "keywords": ["testing", "debugging", "code-review", "paper-testing", "mental-execution", "bug-detection", "ai-code-auditing", "contract-verification", "dependency-verification"]
+      "keywords": ["testing", "debugging", "code-review", "paper-testing", "mental-execution", "bug-detection", "ai-code-auditing", "contract-verification", "dependency-verification", "skill-testing", "config-validation", "prompt-testing"]
     },
     {
       "name": "brand-content-design",

--- a/README.md
+++ b/README.md
@@ -148,15 +148,17 @@ HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+.
 
 See [drupal-htmx/README.md](drupal-htmx/README.md) for full documentation.
 
-### code-paper-test (v0.3.0)
+### code-paper-test (v0.4.0)
 
-Systematically test code through mental execution — trace code line-by-line with concrete values to find bugs, logic errors, edge cases, and contract violations before deployment.
+Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations before deployment.
 
 | Component | Contents |
 |-----------|----------|
-| Skills | 1 (`paper-test`) |
-| Commands | 1 (`/test-team` — competing agent team: Happy Path + Edge Case + Red Team) |
-| References | 7 (core method, dependency verification, contract patterns, AI code auditing, hybrid testing, common flaws, advanced techniques) |
+| Skills | 1 (`paper-test` — with data flow tracking, error propagation, config validation, severity scoring) |
+| Commands | 1 (`/test-team` — competing agent team with isolated worktrees: Happy Path + Edge Case + Red Team) |
+| References | 11 (core method, dependencies, contracts, AI auditing, hybrid testing, common flaws, advanced techniques + state machines, severity scoring, blind A/B comparison, rubric scoring, skill/config testing) |
+
+Tests code AND non-code artifacts: skills, commands, agents, YAML configs. Auto-detects skill files and switches to instruction tracing mode.
 
 See [code-paper-test/README.md](code-paper-test/README.md) for full documentation.
 

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "code-paper-test",
-  "description": "Systematic code testing through mental execution - trace code line-by-line with concrete values to find bugs, missing logic, and edge cases before running",
-  "version": "0.3.0",
+  "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
+  "version": "0.4.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["testing", "debugging", "code-review", "paper-testing", "mental-execution", "bug-detection", "ai-code-auditing", "contract-verification", "dependency-verification"]
+  "keywords": ["testing", "debugging", "code-review", "paper-testing", "mental-execution", "bug-detection", "ai-code-auditing", "contract-verification", "dependency-verification", "skill-testing", "config-validation", "prompt-testing"]
 }

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-13
+
+### Added
+
+**Track A — Methodology Depth**
+- **Data flow tracking** (Step 2b) — track type transformations across function boundaries
+- **Error propagation tracing** — follow exceptions up the call stack, check for partial state
+- **Untested path analysis** (Step 8) — identify code paths never exercised, assess risk
+- **N+1 and performance pattern detection** — flag N+1 queries, nested loops, missing cache
+- **Config validation** — verify YAML/JSON/services values match what code expects
+- **State machine validation** — verify all state transitions valid, reachable, guarded (in advanced-techniques.md)
+- **`references/severity-scoring.md`** — consistent severity rubric with 4-factor scoring (Reach, Impact, Reversibility, Exploitability)
+- **`references/blind-ab-comparison.md`** — compare two implementations with shared scenarios and blind protocol
+- **`references/rubric-scoring.md`** — structured grading system (Content + Structure, 50-point scale) with quality gate support
+
+**Track B — Plugin Infrastructure**
+- `maxTurns: 15` on all 3 test-team agents (cost control)
+- `isolation: worktree` on all 3 test-team agents (independent repo access)
+- `allowed-tools: Read, Glob, Grep, Bash` on paper-test skill
+- `user-invocable: true` on paper-test skill
+- Pushy descriptions with comprehensive trigger phrases on skill and command
+- Quality gate enforcement on test-team agents (must complete ALL assigned categories)
+- Model routing note: opus option for Red Team Attacker on complex security analysis
+
+**Track C — Skill/Config Testing**
+- **`references/skill-and-config-testing.md`** — extend paper testing to non-code artifacts
+  - Trigger analysis, instruction tracing, frontmatter verification, context budget, fidelity testing, agent team coordination, config file testing
+- Skill-mode auto-detection in test-team command (frontmatter → instruction tracing)
+- Updated "When to Use" to include skills, commands, agents, configs
+
+### Changed
+- Removed experimental agent teams flag — agent teams are now GA
+- SKILL.md version 0.2.0 → 0.4.0 (aligned with plugin)
+- plugin.json description and keywords updated for skill/config testing
+- CLAUDE.md expanded with "What This Plugin Tests" section
+- README.md rewritten for v0.4.0
+
+---
+
 ## [0.3.0] - 2026-02-11
 
 ### Added

--- a/code-paper-test/CLAUDE.md
+++ b/code-paper-test/CLAUDE.md
@@ -1,8 +1,17 @@
 # Code Paper Test - Plugin Conventions
 
+## What This Plugin Tests
+
+- **Code** — PHP, JavaScript, Python, etc. (trace execution with concrete values)
+- **Skills** — SKILL.md files (trace instructions through Claude)
+- **Commands** — Command .md files (verify orchestration logic)
+- **Agents** — Agent definitions (verify spawn configs, coordination)
+- **Configs** — YAML, JSON, services files (verify values match code expectations)
+
 ## Skills
-- Frontmatter must include: name, description, version, model
-- Description starts with "Use when..." and includes trigger phrases
+- Frontmatter must include: name, description, version, model, allowed-tools, user-invocable
+- Description starts with "Use when..." and includes multiple trigger phrases covering synonyms
+- Description must be pushy — include "Use proactively" and "MUST" enforcement where appropriate
 - Body uses imperative voice — instructions, not documentation
 - Under 500 lines per SKILL.md
 
@@ -10,8 +19,10 @@
 - Frontmatter must include: description, allowed-tools
 - Use `argument-hint:` when command accepts arguments
 - Agent team commands orchestrate AI debate workflows rather than wrapping scripts
+- Agent spawns should include `maxTurns` (cost control) and `isolation: worktree` (independence)
 
 ## General
 - Reference files instead of reproducing content
 - Current state only — no historical narratives
 - Language-agnostic examples preferred (PHP shown as primary)
+- Skill/config testing uses instruction tracing, not code tracing — see `references/skill-and-config-testing.md`

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -1,6 +1,6 @@
 # Paper Test
 
-Systematically test code through mental execution - trace code line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, and contract violations before deployment.
+Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, AI hallucinations, and contract violations before deployment.
 
 ## What is Paper Testing?
 
@@ -10,6 +10,17 @@ Paper testing is the practice of mentally executing code with concrete test case
 2. **Missing code** - Edge cases not handled, error paths missing
 3. **Contract violations** - Mismatched interfaces, missing abstract methods
 4. **Dependency issues** - Wrong method names, incorrect return types
+5. **AI hallucinations** - Invented methods, mixed API versions, wrong assumptions
+
+### Beyond Code: Testing Skills and Configs
+
+Paper testing extends naturally to non-code artifacts. When you "paper test" a skill, you trace **instructions through Claude** instead of code through a CPU:
+
+- **Skills/Commands** — Will Claude invoke this? Does it follow all steps? Do tool references exist?
+- **Agent configs** — Are spawn parameters correct? Do agents coordinate without conflicts?
+- **Config files** — Do YAML/JSON values match what code expects? Are required keys present?
+
+See `references/skill-and-config-testing.md` for the full methodology.
 
 ## Why Paper Testing Now? The AI-Enabled Renaissance
 
@@ -23,10 +34,10 @@ Paper testing is the practice of mentally executing code with concrete test case
 
 **AI changes everything** in 2025. What was impossible for humans is trivial for AI:
 
-✅ **Verify external dependencies instantly** - Check if methods exist, signatures match, return types correct
-✅ **Navigate OOP complexity** - Trace inheritance chains, verify interfaces, validate DI
-✅ **Detect AI-generated bugs** - Spot hallucinated methods, mixed API versions, wrong assumptions
-✅ **Mental execution at scale** - Follow state through complex object graphs and middleware chains
+- **Verify external dependencies instantly** - Check if methods exist, signatures match, return types correct
+- **Navigate OOP complexity** - Trace inheritance chains, verify interfaces, validate DI
+- **Detect AI-generated bugs** - Spot hallucinated methods, mixed API versions, wrong assumptions
+- **Mental execution at scale** - Follow state through complex object graphs and middleware chains
 
 ### The Problem: AI Code Generation
 
@@ -58,19 +69,18 @@ claude plugins add camoa-skills/code-paper-test
 
 The skill is automatically invoked when you ask questions like:
 
-- "Paper test this code"
-- "Trace this code"
-- "Test without running"
-- "Find bugs in this code"
-- "Check for edge cases"
-- "Validate this implementation"
+- "Paper test this code" / "Trace this code" / "Test without running"
+- "Find bugs in this code" / "Check for edge cases"
+- "Validate this implementation" / "Review this logic"
+- "Paper test this skill" / "Test this command" / "Validate this agent"
+- "Check this config" / "Verify this YAML"
 
 Or use it explicitly:
 
 - Before deploying changes
 - Debugging without a debugger
-- Reviewing unfamiliar code
-- Auditing AI-generated code
+- Reviewing unfamiliar or AI-generated code
+- Reviewing skills, commands, agents, or plugin configs
 - Validating complex logic (loops, conditionals, recursion)
 
 ### Competing Testers (Agent Team)
@@ -81,7 +91,15 @@ For complex or security-critical code, use the agent team command:
 /code-paper:test-team src/Service/PaymentService.php
 ```
 
-Spawns 3 competing testers — Happy Path Validator, Edge Case Hunter, and Red Team Attacker — who independently analyze the code and then debate findings. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+Spawns 3 competing testers — Happy Path Validator, Edge Case Hunter, and Red Team Attacker — who independently analyze the code in isolated worktrees and then debate findings. Each tester has a 15-turn limit for cost control.
+
+Also works with skills and configs:
+
+```
+/code-paper:test-team skills/paper-test/SKILL.md
+```
+
+Auto-detects skill files and switches to instruction tracing mode.
 
 ## How It Works
 
@@ -89,11 +107,15 @@ The skill guides you through a systematic workflow:
 
 ### 1. Define Test Scenarios
 
-Pick concrete input values - happy path, edge cases, error cases.
+Pick concrete input values — happy path, edge cases, error cases.
 
 ### 2. Trace Line by Line
 
 Follow each line, writing variable state after execution.
+
+### 2b. Track Data Flow
+
+At function boundaries, track type transformations and coercions.
 
 ### 3. Verify External Dependencies
 
@@ -102,6 +124,7 @@ For every external call, verify:
 - Parameters are correct
 - Return type matches usage
 - Error cases handled
+- Config values match expectations
 
 ### 4. Verify Code Contracts
 
@@ -113,7 +136,11 @@ For classes with relationships (extends, implements, uses, injects):
 
 ### 5. Document Flaws
 
-Report bugs found with line numbers and fixes.
+Report bugs found with line numbers, severity scores, and fixes.
+
+### 6. Analyze Untested Paths
+
+Identify code paths that were never exercised and assess risk.
 
 ## Features
 
@@ -121,13 +148,19 @@ Report bugs found with line numbers and fixes.
 
 The main SKILL.md provides the workflow. Detailed guides in `references/`:
 
-- **core-method.md** - Complete paper testing methodology
-- **dependency-verification.md** - How to verify external calls
-- **contract-patterns.md** - All code contract verification patterns (8 types)
-- **ai-code-auditing.md** - Specific checks for AI-generated code
-- **hybrid-testing.md** - Module-level testing strategy
-- **common-flaws.md** - Catalog of frequent bugs
-- **advanced-techniques.md** - Progressive injects, red team testing, attack surface analysis, scenario-based workflows, AAR format
+| Guide | Purpose |
+|-------|---------|
+| **core-method.md** | Complete paper testing methodology |
+| **dependency-verification.md** | How to verify external calls |
+| **contract-patterns.md** | All code contract verification patterns (8 types) |
+| **ai-code-auditing.md** | Specific checks for AI-generated code |
+| **hybrid-testing.md** | Module-level testing strategy |
+| **common-flaws.md** | Catalog of frequent bugs |
+| **advanced-techniques.md** | Progressive injects, red team, attack surface, scenario workflows, state machine validation, AAR format |
+| **severity-scoring.md** | Consistent severity rubric for flaw prioritization |
+| **blind-ab-comparison.md** | Comparing two implementations side by side |
+| **rubric-scoring.md** | Structured grading for code quality assessment |
+| **skill-and-config-testing.md** | Testing skills, commands, agents, and configs |
 
 ### Contract Pattern Coverage
 
@@ -149,6 +182,17 @@ For modules with multiple components:
 - **Flow-based testing** - Real user workflows end-to-end
 - **Component testing** - Each component with edge cases
 - **Coverage-driven** - Every component in at least one flow + edge cases
+
+### Skill/Config Testing
+
+For non-code artifacts:
+
+- **Trigger analysis** — Will Claude invoke this skill? Test multiple phrasings
+- **Instruction tracing** — Follow steps through Claude's execution
+- **Frontmatter verification** — All fields present and consistent?
+- **Context budget** — Does the skill fit in the context window?
+- **Instruction fidelity** — Will Claude follow all steps or drift?
+- **Agent team coordination** — Do spawned agents conflict?
 
 ## Example
 
@@ -184,6 +228,7 @@ Line 8: return $discount
 
 FLAW FOUND:
   Line 8: Returns undefined variable when no coupon matches
+  Severity: HIGH (Reach: 2, Impact: 2, Reversibility: 1, Exploitability: 2 = 7)
   FIX: Initialize $discount = 0 at start of function
 ```
 
@@ -201,14 +246,21 @@ Specific checks for AI-generated code:
 - **Find bugs before deployment** - Catch issues in development
 - **No test setup required** - Pure mental execution
 - **Works on any code** - Legacy, new, AI-generated
+- **Works on skills and configs** - Test Claude instructions, not just code
 - **Catches contract violations** - Verifies all relationships
+- **Consistent severity scoring** - Prioritize fixes objectively
 - **Fast** - Paper test in minutes vs hours of debugging
 
 ## Version
 
-**0.3.0** (Current) - Competing Testers agent team command
-- `/code-paper:test-team` — 3-agent team paper testing (Happy Path + Edge Case + Red Team)
-- Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+**0.4.0** (Current) - Methodology depth + skill/config testing + infrastructure
+- 6 new methodology steps: data flow tracking, error propagation, config validation, performance patterns, untested path analysis, state machine validation
+- 4 new reference guides: severity scoring, blind A/B comparison, rubric scoring, skill/config testing
+- Skill/config testing: trace instructions through Claude, not just code
+- Agent team: `maxTurns: 15`, `isolation: worktree`, removed experimental flag
+- Pushy descriptions with comprehensive trigger phrases
+
+**0.3.0** - Competing Testers agent team command
 
 **0.2.0** - Plugin conventions and model routing
 

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -1,5 +1,5 @@
 ---
-description: Paper test code with competing agent team (Happy Path + Edge Case + Red Team)
+description: Paper test code or skills with competing agent team (Happy Path + Edge Case + Red Team). Use when user says "test team", "3 perspectives", "competing testers", "thorough paper test", "security review", "deep code analysis", "test this skill with team". Best for complex code (50+ lines) or security-critical paths. Each tester runs in isolated worktree.
 allowed-tools: Read, Write, Glob, Grep, WebSearch
 argument-hint: <file-path> [file-path...]
 ---
@@ -44,14 +44,9 @@ Determine the **target directory** for output:
 
 ### Step 2 — Check Prerequisites
 
-Verify agent teams are available. If not:
+Verify agent teams are available by attempting to create a team. If creation fails:
 
-> Agent teams require the experimental flag:
-> ```json
-> // Add to ~/.claude/settings.json
-> { "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
-> ```
-> Or: `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+> Agent teams are not available in this environment.
 >
 > **Fallback:** Use the standard paper test skill instead — ask Claude to "paper test {file}".
 
@@ -67,6 +62,15 @@ If fewer than 50 lines total:
 
 Continue if user confirms or if 50+ lines.
 
+**Skill/Config Detection:**
+
+If target files have YAML frontmatter (`---` delimiters) and contain step-by-step instructions rather than code:
+> Target appears to be a skill/command/agent definition, not code.
+> Switching to instruction tracing mode — will trace Claude's execution of these instructions rather than code execution.
+> See `references/skill-and-config-testing.md` for methodology.
+
+Continue with skill-aware spawn prompts below.
+
 ### Step 4 — Create Shared Task List
 
 Create a team and these tasks:
@@ -78,6 +82,8 @@ Create a team and these tasks:
 | 3 | Attack with adversarial inputs — injection, malformed data, race conditions | Red Team Attacker | — |
 | 4 | Cross-challenge — debate flaw severity, dispute false findings, identify blind spots | All three | 1, 2, 3 |
 | 5 | Synthesize prioritized flaw report | Lead | 4 |
+
+**Quality Gate:** Each tester must complete ALL assigned categories before marking their task done. If a tester skips categories (e.g., Edge Case Hunter tests 3 of 6 categories), the lead should flag incomplete analysis in the final report and note which categories were untested.
 
 ### Step 5 — Spawn Teammates
 
@@ -102,6 +108,8 @@ When all teammates finish:
 ### Teammate 1: Happy Path Validator
 
 **Model:** sonnet
+**MaxTurns:** 15
+**Isolation:** worktree
 
 ```
 You are the Happy Path Validator for a paper testing team.
@@ -171,6 +179,15 @@ OUTPUT: {return value, side effects}
 - Contracts checked: {N}
 - Flaws found: {N}
 
+SKILL MODE:
+If target files are skills, commands, or agents (.md with frontmatter):
+- Instead of line-by-line code tracing, trace step-by-step INSTRUCTIONS
+- Design 2-3 scenarios with different user messages
+- Trace what Claude would do at each step
+- Verify all tool/file/skill references exist
+- Check frontmatter completeness and consistency
+- Test trigger phrases (will Claude invoke this?)
+
 WHEN DONE:
 Message the other teammates: "Happy path analysis complete. Review happy-path-analysis.md"
 Mark your task as completed.
@@ -179,6 +196,8 @@ Mark your task as completed.
 ### Teammate 2: Edge Case Hunter
 
 **Model:** sonnet
+**MaxTurns:** 15
+**Isolation:** worktree
 
 ```
 You are the Edge Case Hunter for a paper testing team.
@@ -241,6 +260,15 @@ Line [N]: [code]
 - Flaws found: {N}
 - Critical: {N}
 
+SKILL MODE:
+If target files are skills, commands, or agents (.md with frontmatter):
+- Test with ambiguous user messages that might or might not trigger the skill
+- Test with missing $ARGUMENTS, empty arguments, wrong argument types
+- Test with non-existent file paths referenced in instructions
+- Test what happens when a tool call returns empty results mid-workflow
+- Check context budget — will the skill fit when context is 80% full?
+- Check instruction fidelity — will Claude follow step 7 after a long step 3?
+
 WHEN DONE:
 Message the other teammates: "Edge case analysis complete. Review edge-case-analysis.md"
 Mark your task as completed.
@@ -249,6 +277,9 @@ Mark your task as completed.
 ### Teammate 3: Red Team Attacker
 
 **Model:** sonnet
+**MaxTurns:** 15
+**Isolation:** worktree
+**Note:** For complex security analysis, consider using `model: opus` for deeper reasoning.
 
 ```
 You are the Red Team Attacker for a paper testing team.
@@ -322,6 +353,15 @@ RESULT: EXPLOITABLE / BLOCKED at line {N} by {mechanism}
 - Blocked: {N}
 - Critical: {N}
 
+SKILL MODE:
+If target files are skills, commands, or agents (.md with frontmatter):
+- Test if skill can be tricked into running unintended tools
+- Test if instructions leak sensitive info in error messages
+- Test if agent team coordination can be disrupted (conflicting outputs, race conditions)
+- Test if allowed-tools are too permissive (does the skill need Write access?)
+- Test if description is so broad it steals triggers from other skills
+- Check for prompt injection vectors in user-provided arguments
+
 WHEN DONE:
 Message the other teammates: "Red team analysis complete. Review red-team-analysis.md"
 Mark your task as completed.
@@ -378,3 +418,4 @@ Source files: [happy-path-analysis.md] | [edge-case-analysis.md] | [red-team-ana
 ## Related Commands
 
 - Standard paper test: ask Claude to "paper test {file}" (single-agent, no debate)
+- Skill/config testing: ask Claude to "paper test {skill}" (traces instructions, not code)

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: paper-test
-description: Use when testing code through mental execution - trace code line-by-line with concrete input values to find bugs, logic errors, missing code, edge cases, and contract violations before deployment
-version: 0.2.0
+description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "validate this implementation", "review this logic", "check dependencies", "check this config". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
+version: 0.4.0
 model: sonnet
+allowed-tools: Read, Glob, Grep, Bash
+user-invocable: true
 ---
 
 # Paper Test
@@ -14,10 +16,13 @@ Systematically test code by mentally executing it line-by-line with concrete val
 - "Paper test this code" / "Trace this code" / "Test without running"
 - "Find bugs in this code" / "Check for edge cases"
 - "Validate this implementation" / "Review this logic"
+- "Paper test this skill" / "Test this command" / "Validate this agent"
+- "Check this config" / "Verify this YAML" / "Trace this prompt"
 - Before deploying changes
 - Debugging without a debugger
 - Reviewing unfamiliar or AI-generated code
 - Validating complex logic (loops, conditionals, recursion)
+- Reviewing skills, commands, agents, or plugin configs
 
 ## Method
 
@@ -95,6 +100,26 @@ DEPENDENCY CHECK: $externalApi->fetchData()
 
 Mark as risk - don't assume it works.
 
+### Verifying Configuration Dependencies
+
+When code reads config values (YAML, JSON, .env, services):
+
+1. **Find the config source** — Read the actual file
+2. **Verify key exists** — Does the key the code reads actually exist?
+3. **Verify value type** — Does the value match what code expects?
+4. **Verify defaults** — If config missing, is there a sensible fallback?
+
+```
+CONFIG CHECK: $this->config('my_module.settings')->get('api_timeout')
+  Source: config/install/my_module.settings.yml
+  Key exists?  YES / NO
+  Value:       30
+  Type match:  integer (code expects int) — MATCH / MISMATCH
+  Default:     NULL if missing — RISK: no fallback
+```
+
+Also check: services.yml (service IDs, arguments), routing.yml (route names), schema.yml (structure matches config).
+
 ---
 
 ## Quick Reference
@@ -133,6 +158,24 @@ Line [N]: [code statement]
          → [variable] = [new value]
          → [state change description]
 ```
+
+### Step 2b: Track Data Flow Across Boundaries
+
+At every function call, method return, or data handoff, track type transformations:
+
+```
+DATA FLOW: [source] → [destination]
+  Input type:  [what was passed]
+  Output type: [what was returned]
+  Coercion:    [any implicit type change]
+  Risk:        [what breaks if type is wrong]
+```
+
+Watch for:
+- **Implicit coercion** — string "30" used as int, null used as empty string
+- **Container types** — method returns array but code treats as single object
+- **Serialization boundaries** — object → JSON → object (properties may change case, nulls may disappear)
+- **Framework wrapping** — raw value wrapped in Response, FieldItemList, Result objects
 
 ### Step 3: Follow Every Branch
 
@@ -230,6 +273,20 @@ FLAWS FOUND:
     FIX: [how to resolve]
 ```
 
+### Step 8: Untested Path Analysis
+
+After all scenarios, review for paths NOT exercised:
+
+```
+UNTESTED PATHS:
+  - Line [N]-[M]: [else branch / catch block / default case] — never triggered
+    Risk: [what this path handles]
+    Scenario needed: [input that would trigger it]
+
+Coverage: [X of Y branches exercised]
+Recommendation: [add scenario for critical untested paths / accept risk]
+```
+
 ---
 
 ## What to Look For
@@ -260,6 +317,20 @@ FLAWS FOUND:
 - Unreachable code
 - Missing return statement
 - Early return skips cleanup
+
+### Error Propagation
+- Exception thrown but caught too high (wrong handler)
+- Exception swallowed silently (empty catch block)
+- Partial state left behind (DB row inserted, email not sent)
+- Wrong error code/status returned to caller
+- User retries after error — causes duplicates?
+
+### Performance Patterns
+- N+1 query — database call inside a loop
+- Nested loops on collections — O(n²) or worse
+- Same expensive call repeated — missing cache/variable
+- Unbounded collection growth — no size limit in loop
+- Missing pagination — loads entire table into memory
 
 ### AI Code Issues
 - Invented methods that don't exist
@@ -365,6 +436,10 @@ All detailed guides are in `references/` directory:
 - `references/hybrid-testing.md` - Module-level testing strategy
 - `references/common-flaws.md` - Catalog of frequent bugs
 - `references/advanced-techniques.md` - Progressive injects, red team testing, attack surface analysis, AAR format
+- `references/severity-scoring.md` - Consistent severity rubric for flaw prioritization
+- `references/blind-ab-comparison.md` - Comparing two implementations side by side
+- `references/rubric-scoring.md` - Structured grading for code quality assessment
+- `references/skill-and-config-testing.md` - Testing skills, commands, agents, and configs
 
 ---
 

--- a/code-paper-test/skills/paper-test/references/advanced-techniques.md
+++ b/code-paper-test/skills/paper-test/references/advanced-techniques.md
@@ -10,6 +10,7 @@ Decision-focused techniques adapted from security tabletop exercises for complex
 - [Attack Surface Analysis](#attack-surface-analysis)
 - [Scenario-Based Workflow Testing](#scenario-based-workflow-testing)
 - [After-Action Report Format](#after-action-report-format)
+- [State Machine Validation](#state-machine-validation)
 
 ---
 
@@ -925,6 +926,159 @@ FOLLOW-UP ACTIONS:
 
 ---
 
+---
+
+## State Machine Validation
+
+### Concept
+
+For code with defined states (entity status, workflow stages, order lifecycle), verify that all transitions are valid, reachable, and that invalid transitions are blocked.
+
+Adapted from formal verification of finite state machines.
+
+### When to Use
+
+- **Entity status fields** — published/unpublished/archived, order lifecycle
+- **Workflow systems** — content moderation, approval chains
+- **Multi-step processes** — wizards, onboarding, checkout flows
+- **Connection/session states** — connected/disconnected/reconnecting
+
+### Process
+
+```
+STATE MACHINE: [System name]
+
+STATES IDENTIFIED:
+  1. [state_1] — [description]
+  2. [state_2] — [description]
+  3. [state_3] — [description]
+  ...
+
+VALID TRANSITIONS:
+  [state_1] → [state_2]: [what triggers this]
+  [state_2] → [state_3]: [what triggers this]
+  [state_2] → [state_1]: [what triggers this — rollback?]
+  ...
+
+TRANSITION VERIFICATION:
+  For each valid transition, trace the code that performs it:
+
+  Transition: [from] → [to]
+    Code: [file:line]
+    Guard: [what condition must be true?]
+    Traced: [does the code check the guard?]
+    Side effects: [what else happens during transition?]
+
+INVALID TRANSITION CHECK:
+  Can the code reach these (it shouldn't):
+  - [state_3] → [state_1]: Should be impossible
+    Code check: Line [N] — $entity->setStatus($newStatus) ← NO validation!
+    FLAW: Any status transition allowed, no guard clause
+
+ORPHAN STATE CHECK:
+  - [state_X]: Can reach but no exit transitions defined
+    Risk: Entity stuck in this state forever
+
+MISSING STATE CHECK:
+  - Real-world scenario [description] has no corresponding state
+    Risk: System can't represent this valid situation
+```
+
+### Example: Order Lifecycle
+
+```
+STATE MACHINE: Order Status
+
+STATES:
+  1. draft       — order created, not submitted
+  2. pending     — submitted, awaiting payment
+  3. processing  — payment received, preparing shipment
+  4. shipped     — handed to carrier
+  5. delivered   — confirmed receipt
+  6. cancelled   — order cancelled
+  7. refunded    — payment returned
+
+VALID TRANSITIONS:
+  draft      → pending:    user submits order
+  draft      → cancelled:  user abandons
+  pending    → processing: payment confirmed
+  pending    → cancelled:  user cancels before payment
+  processing → shipped:    carrier picks up
+  processing → cancelled:  merchant cancels (with refund)
+  shipped    → delivered:  carrier confirms delivery
+  shipped    → refunded:   lost in transit
+  delivered  → refunded:   customer returns item
+  cancelled  → draft:      user reopens cancelled order (business decision)
+
+TRANSITION VERIFICATION:
+
+  Transition: pending → processing
+    Code: OrderService.php:45
+    Guard: $payment->isConfirmed() must be true
+    Traced:
+      Line 45: if ($payment->isConfirmed())
+      Line 46:   $order->setStatus('processing')
+    Result: Guard exists ✓
+
+  Transition: processing → cancelled
+    Code: OrderService.php:78
+    Guard: $order->canCancel() — checks shipment not dispatched
+    Traced:
+      Line 78: $order->setStatus('cancelled')
+      Line 79: $this->refundService->process($order)
+    Result: Guard exists, refund triggered ✓
+
+INVALID TRANSITION CHECK:
+
+  Can delivered → draft happen?
+    Code: OrderService.php:92
+      Line 92: public function setStatus($status) {
+      Line 93:   $this->status = $status;  // NO VALIDATION
+      Line 94: }
+    FLAW: setStatus() accepts ANY status string!
+      $deliveredOrder->setStatus('draft') would succeed
+      No guard, no validation, no transition check
+
+  FIX: Add transition guard:
+    private const VALID_TRANSITIONS = [
+      'draft' => ['pending', 'cancelled'],
+      'pending' => ['processing', 'cancelled'],
+      // ...
+    ];
+
+    public function setStatus($newStatus) {
+      if (!in_array($newStatus, self::VALID_TRANSITIONS[$this->status])) {
+        throw new InvalidTransitionException();
+      }
+      $this->status = $newStatus;
+    }
+
+ORPHAN STATE CHECK:
+  None found — all states have at least one exit
+
+MISSING STATE CHECK:
+  Scenario: "Payment pending but expired" — order left in 'pending' indefinitely
+  Risk: No timeout mechanism, no auto-cancellation
+  Missing state: 'expired' (or missing cron job to cancel stale pending orders)
+
+RESULT:
+  FLAW 1: setStatus() has no transition validation (CRITICAL)
+  FLAW 2: No timeout for pending orders (MEDIUM)
+```
+
+### Summary of State Machine Checks
+
+| Check | Question |
+|-------|----------|
+| Valid transitions | Does code enforce transition rules? |
+| Invalid transitions | Can code reach states it shouldn't? |
+| Guard clauses | Are preconditions checked before transition? |
+| Orphan states | Can entity get stuck with no way out? |
+| Missing states | Does the model cover all real-world scenarios? |
+| Side effects | Are the right actions triggered on each transition? |
+
+---
+
 ## Summary
 
 These advanced techniques complement standard paper testing for complex scenarios:
@@ -934,5 +1088,6 @@ These advanced techniques complement standard paper testing for complex scenario
 **Attack Surface**: Prioritize testing effort on highest-risk entry points
 **Scenario Workflows**: Test end-to-end integration, not isolated components
 **AAR Format**: Structure findings for team review and improvement tracking
+**State Machine Validation**: Verify all state transitions are valid, reachable, and that invalid transitions are blocked
 
 Use when code complexity, security criticality, or multi-component integration demands more rigorous analysis than standard paper testing provides.

--- a/code-paper-test/skills/paper-test/references/blind-ab-comparison.md
+++ b/code-paper-test/skills/paper-test/references/blind-ab-comparison.md
@@ -1,0 +1,123 @@
+# Blind A/B Comparison
+
+Compare two implementations of the same functionality to determine which is better.
+
+## When to Use
+
+- Comparing AI-generated code vs human-written code
+- Evaluating a refactored version against the original
+- Choosing between two competing approaches
+- Reviewing vendor code against internal implementation
+
+---
+
+## Method
+
+### Step 1: Define the comparison scope
+
+```
+A/B COMPARISON: [what's being compared]
+
+Implementation A: [source — file path or description]
+Implementation B: [source — file path or description]
+
+Same interface? YES/NO
+Same inputs?     YES/NO
+Same expected output? YES/NO
+```
+
+### Step 2: Design shared test scenarios
+
+Use the SAME scenarios for both implementations:
+
+```
+SHARED SCENARIOS:
+  1. Happy path:  [concrete inputs]
+  2. Edge case 1: [empty/null/zero]
+  3. Edge case 2: [boundary values]
+  4. Error case:  [invalid input]
+  5. Stress case: [large/concurrent]
+```
+
+### Step 3: Trace each implementation independently
+
+Paper test A with all scenarios first. Then paper test B with the same scenarios. Do NOT compare during tracing — complete each independently.
+
+### Step 4: Score each implementation
+
+Use the rubric scoring template for each:
+
+```
+SCORECARD: Implementation [A/B]
+
+| Category | Score (1-5) | Notes |
+|----------|-------------|-------|
+| Correctness | | All scenarios produce correct output? |
+| Edge case handling | | How many edge cases handled gracefully? |
+| Error handling | | Errors caught, reported, recovered? |
+| Security | | Input validation, injection prevention? |
+| Performance | | N+1 queries, unnecessary loops, caching? |
+| Readability | | Clear naming, structure, comments? |
+| Maintainability | | Easy to extend, modify, debug? |
+| **Total** | **/35** | |
+```
+
+### Step 5: Compare and recommend
+
+```
+A/B COMPARISON RESULT:
+
+Implementation A: [total]/35
+Implementation B: [total]/35
+
+Winner: [A/B]
+
+Key differences:
+  - A handles [X] better because [reason]
+  - B handles [Y] better because [reason]
+
+Recommendation: [Use A/B, or hybrid — take X from A and Y from B]
+```
+
+---
+
+## Blind Protocol
+
+For unbiased comparison:
+1. Label implementations "A" and "B" without indicating which is "expected to be better"
+2. Complete all tracing before comparing scores
+3. If tracing both yourself, do A fully first, then B — don't interleave
+4. With agent teams: assign A to one agent, B to another, synthesize only after both complete
+
+---
+
+## Example: AI-Generated vs Human Code
+
+```
+A/B COMPARISON: User authentication service
+
+Implementation A: src/auth/AuthService.php (human-written, 6 months old)
+Implementation B: src/auth/AuthServiceV2.php (AI-generated refactor)
+
+SHARED SCENARIOS:
+  1. Valid login (correct username + password)
+  2. Wrong password
+  3. Non-existent user
+  4. Empty username
+  5. SQL injection attempt: username = "admin' OR 1=1--"
+  6. Concurrent login from 2 devices
+
+RESULTS:
+  Implementation A: 28/35
+    - Handles SQL injection (parameterized queries) ✓
+    - Missing: concurrent session handling
+    - Missing: rate limiting on failed attempts
+
+  Implementation B: 24/35
+    - Better error messages to user ✓
+    - FLAW: Uses string concatenation in query (SQL injection risk!)
+    - FLAW: Calls $user->getFullName() which doesn't exist (AI hallucination)
+    - Missing: concurrent session handling (same as A)
+
+RECOMMENDATION: Keep A, adopt B's error messages, fix both for concurrent sessions
+```

--- a/code-paper-test/skills/paper-test/references/rubric-scoring.md
+++ b/code-paper-test/skills/paper-test/references/rubric-scoring.md
@@ -1,0 +1,117 @@
+# Rubric-Based Scoring
+
+Structured grading system for overall code quality assessment during paper testing.
+
+## When to Use
+
+- Code reviews and PR assessments
+- Vendor code evaluation
+- Before/after refactoring comparison
+- Quality gate decisions (pass/fail for deployment)
+- Training — calibrate team on what "good" looks like
+
+---
+
+## Content Rubric (Does it work?)
+
+| Category | 1 (Poor) | 3 (Adequate) | 5 (Excellent) |
+|----------|----------|--------------|---------------|
+| **Correctness** | Fails on happy path | Works for happy path, fails edge cases | Handles all scenarios correctly |
+| **Completeness** | Missing major functionality | Core functionality present, gaps in edge cases | All requirements met, edge cases handled |
+| **Edge cases** | No edge case handling | Some edge cases handled (null, empty) | Comprehensive (null, empty, zero, large, concurrent) |
+| **Error handling** | No error handling, crashes | Basic try/catch, generic messages | Specific errors, recovery paths, user-friendly messages |
+| **Security** | Obvious vulnerabilities (SQLi, XSS) | Basic sanitization, some gaps | Defense in depth, validated at all boundaries |
+
+## Structure Rubric (Is it maintainable?)
+
+| Category | 1 (Poor) | 3 (Adequate) | 5 (Excellent) |
+|----------|----------|--------------|---------------|
+| **Readability** | Cryptic names, no structure | Reasonable names, some structure | Self-documenting, clear intent |
+| **Separation of concerns** | Business logic in controllers/forms | Some separation, some mixing | Clean layers, single responsibility |
+| **DRY** | Copy-pasted blocks, duplicated logic | Minor duplication | No unnecessary duplication, good abstractions |
+| **Testability** | Untestable (hardcoded deps, global state) | Partially testable | Fully injectable, pure functions where possible |
+| **Extensibility** | Changes require rewriting | Can extend with moderate effort | Open for extension, closed for modification |
+
+---
+
+## Scoring Template
+
+```
+RUBRIC SCORE: [file/module name]
+
+CONTENT (Does it work?):
+  Correctness:      [1-5] — [notes]
+  Completeness:     [1-5] — [notes]
+  Edge cases:       [1-5] — [notes]
+  Error handling:   [1-5] — [notes]
+  Security:         [1-5] — [notes]
+  Content subtotal: [sum]/25
+
+STRUCTURE (Is it maintainable?):
+  Readability:      [1-5] — [notes]
+  Separation:       [1-5] — [notes]
+  DRY:              [1-5] — [notes]
+  Testability:      [1-5] — [notes]
+  Extensibility:    [1-5] — [notes]
+  Structure subtotal: [sum]/25
+
+TOTAL: [sum]/50
+
+GRADE:
+  45-50: Excellent — production ready
+  35-44: Good — minor improvements needed
+  25-34: Adequate — several improvements needed before production
+  15-24: Below standard — significant rework required
+  <15:   Poor — fundamental issues, consider rewriting
+```
+
+---
+
+## Quality Gate Usage
+
+For deployment decisions:
+
+```
+QUALITY GATE: [module/feature name]
+
+Minimum for deployment: 35/50 (Good)
+Minimum per category:   2/5 (no category below Adequate)
+
+Score: [X]/50
+Below-minimum categories: [list any category scoring 1]
+
+GATE: PASS / FAIL
+Reason: [why]
+```
+
+---
+
+## Example
+
+```
+RUBRIC SCORE: src/Service/PaymentProcessor.php
+
+CONTENT:
+  Correctness:      4 — Happy path works, one edge case wrong (negative amounts)
+  Completeness:     3 — Missing refund flow, partial cancellation
+  Edge cases:       2 — Handles null, misses empty cart and zero amount
+  Error handling:   2 — Generic catch, user sees "Something went wrong"
+  Security:         3 — Parameterized queries, missing rate limiting
+  Content subtotal: 14/25
+
+STRUCTURE:
+  Readability:      4 — Clear names, good method length
+  Separation:       3 — Some validation mixed into processing
+  DRY:              4 — Minimal duplication
+  Testability:      4 — Injectable dependencies, one static call
+  Extensibility:    3 — New payment methods require modifying switch statement
+  Structure subtotal: 18/25
+
+TOTAL: 32/50
+
+GRADE: Adequate — several improvements needed before production
+
+QUALITY GATE: FAIL
+  Below-minimum: Edge cases (2), Error handling (2)
+  Action: Fix edge case handling and error messages before deployment
+```

--- a/code-paper-test/skills/paper-test/references/severity-scoring.md
+++ b/code-paper-test/skills/paper-test/references/severity-scoring.md
@@ -1,0 +1,107 @@
+# Severity Scoring Rubric
+
+Consistent criteria for rating flaw severity during paper testing.
+
+## Severity Levels
+
+| Severity | Criteria | Action |
+|----------|----------|--------|
+| **CRITICAL** | Data loss, security breach, financial impact, crash on main path | Fix immediately — blocks deployment |
+| **HIGH** | Feature broken for common use case, data corruption possible, auth bypass | Fix before release |
+| **MEDIUM** | Edge case failure, degraded UX, workaround exists | Fix in current sprint |
+| **LOW** | Code quality issue, minor UX issue, theoretical risk | Fix when convenient |
+| **INFO** | Observation, not a bug — code smell, future concern | Document only |
+
+---
+
+## Scoring Factors
+
+Rate each factor 1-3, then use the matrix:
+
+### 1. Reach — How many users/requests hit this path?
+
+| Score | Description |
+|-------|-------------|
+| 3 | Every request / main flow |
+| 2 | Common but not universal (10-50% of requests) |
+| 1 | Rare edge case (<10% of requests) |
+
+### 2. Impact — What happens when triggered?
+
+| Score | Description |
+|-------|-------------|
+| 3 | Crash, data loss, security breach, financial loss |
+| 2 | Feature broken, wrong data returned, silent failure |
+| 1 | Wrong message, cosmetic issue, minor inconvenience |
+
+### 3. Reversibility — Can the damage be undone?
+
+| Score | Description |
+|-------|-------------|
+| 3 | Irreversible (data deleted, money sent, security exposed) |
+| 2 | Recoverable with effort (restore backup, manual fix) |
+| 1 | Self-correcting or trivially fixable |
+
+### 4. Exploitability — Can an attacker trigger this intentionally?
+
+| Score | Description |
+|-------|-------------|
+| 3 | Public input, no auth required |
+| 2 | Authenticated user can trigger |
+| 1 | Requires system access or unlikely conditions |
+
+### Severity Matrix
+
+| Total Score (4-12) | Severity |
+|-------------------|----------|
+| 10-12 | CRITICAL |
+| 7-9 | HIGH |
+| 4-6 | MEDIUM |
+| 2-3 | LOW |
+
+---
+
+## Template
+
+```
+FLAW: [description]
+  Line: [N]
+  Reach:         [1-3] — [reason]
+  Impact:        [1-3] — [reason]
+  Reversibility: [1-3] — [reason]
+  Exploitability:[1-3] — [reason]
+  Total:         [sum] → SEVERITY: [level]
+```
+
+---
+
+## Example
+
+```
+FLAW: No input validation on payment amount — negative values process as refunds
+  Line: 15
+  Reach:         3 — every payment request hits this
+  Impact:        3 — financial loss, attacker receives money
+  Reversibility: 3 — money transferred, hard to recover
+  Exploitability:3 — public API, no auth needed beyond login
+  Total:         12 → SEVERITY: CRITICAL
+
+FLAW: Error message reveals stack trace to user
+  Line: 88
+  Reach:         1 — only on unhandled exceptions
+  Impact:        2 — information disclosure, no direct exploit
+  Reversibility: 1 — no lasting damage
+  Exploitability:2 — authenticated user can trigger with bad input
+  Total:         6 → SEVERITY: MEDIUM
+```
+
+---
+
+## When to Use
+
+- **Always** for security-related flaws
+- **Team reports** from test-team command (consistent cross-tester scoring)
+- **Prioritization** when multiple flaws found (fix highest severity first)
+- **Communication** with stakeholders (objective severity, not opinion)
+
+For quick paper tests of simple code, informal CRITICAL/HIGH/MEDIUM/LOW labels without scoring are acceptable.

--- a/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
+++ b/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
@@ -1,0 +1,365 @@
+# Testing Skills, Commands, Agents, and Configs
+
+Extend paper testing to non-code artifacts by tracing instructions through Claude instead of code through a CPU.
+
+## The Mapping
+
+| Code Concept | Skill/Config Equivalent |
+|-------------|------------------------|
+| Input values | User message / `$ARGUMENTS` |
+| Line-by-line trace | Step-by-step instruction following |
+| Branch (if/else) | Conditional steps ("If no arguments...") |
+| Method call | Tool call (Read, Grep, Write, Agent) |
+| Return type | Output format (markdown, file, message) |
+| Dependency verification | Does referenced tool/skill/file exist? |
+| Contract verification | Does frontmatter match body? All required fields present? |
+| Null access | Missing `$ARGUMENTS`, empty input |
+| N+1 performance | Context budget — how much window does it consume? |
+| Edge case | Ambiguous user message, tool call fails, no matches found |
+| Error propagation | Step 3 fails — does step 4 handle it or crash? |
+| Race condition | Parallel agent output conflicts |
+
+---
+
+## When to Use
+
+- Reviewing a skill or command before publishing
+- Validating a plugin before release
+- Debugging why a skill doesn't trigger or produces wrong output
+- Comparing two versions of a skill
+- Auditing agent team coordination
+- Verifying config files match what code expects
+
+---
+
+## 1. Trigger Analysis
+
+Will Claude actually invoke this skill? Test with multiple phrasings.
+
+```
+TRIGGER TEST: [skill name]
+Description: "[the skill's description field]"
+
+Test phrases (would Claude match this skill?):
+  "paper test this code"         → MATCH? [YES/NO/MAYBE]
+  "find bugs in my service"      → MATCH? [YES/NO/MAYBE]
+  "review this for issues"       → MATCH? [YES/NO/MAYBE]
+  "audit the payment module"     → MATCH? [YES/NO/MAYBE]
+  "trace the login flow"         → MATCH? [YES/NO/MAYBE]
+
+Undertrigger risk:
+  Phrases that SHOULD invoke but probably won't:
+  - "[phrase]" — missing trigger word in description
+
+Overtrigger risk:
+  Phrases that would match but shouldn't:
+  - "[phrase]" — description too broad, steals from other skills
+
+Competing skills:
+  - [other skill name] — could Claude choose this instead?
+  - Resolution: [which should win and why]
+```
+
+### What Makes a Good Trigger
+
+**Pushy descriptions include:**
+- Multiple trigger phrases covering synonyms
+- "Use when user says..." with concrete examples
+- "Use proactively when..." for automatic activation
+- "MUST" / "ALWAYS" for enforcement
+
+**Red flags for undertriggering:**
+- Description is a definition, not a trigger ("A tool that..." vs "Use when...")
+- Only one trigger phrase
+- No synonyms or alternate phrasings
+- No proactive activation guidance
+
+---
+
+## 2. Instruction Tracing
+
+Follow the skill's steps with a concrete scenario. Instead of tracing code with variable values, trace instructions with Claude's likely behavior.
+
+```
+SKILL TRACE: [skill name]
+SCENARIO: User says "[concrete message]"
+CONTEXT: [what's in the conversation, what files exist]
+
+Step 1: [instruction text from skill]
+  Claude would: [what Claude actually does]
+  Tool calls:   [Read X, Grep Y, Write Z]
+  Output:       [what's produced — text, file, message]
+  Risk:         [what could go wrong]
+    - Tool returns empty results → [does step handle this?]
+    - File doesn't exist → [does step handle this?]
+
+Step 2: [instruction text]
+  Depends on: Step 1 output
+  Claude would: [...]
+  Risk: What if Step 1 produced empty/unexpected results?
+    - Step 1 found no files → Step 2 tries to read non-existent file → ERROR
+
+Step 3: [instruction text with conditional]
+  Condition: "[if X then Y]"
+  Evaluation: [X is true/false because...]
+  TAKES: [which branch]
+  Risk: Is the condition clear enough for Claude to evaluate?
+
+FINAL OUTPUT:
+  What user sees: [the actual response]
+  Files created:  [list]
+  Side effects:   [tool calls, writes, etc.]
+
+FLAWS FOUND:
+  - Step [N]: [issue — e.g., "no handling for empty grep results"]
+    FIX: [add conditional: "If no matches found, tell user and suggest alternatives"]
+  - Step [N]-[M]: [issue — e.g., "20-line instruction block, Claude will drift"]
+    FIX: [break into smaller numbered steps]
+```
+
+---
+
+## 3. Frontmatter Verification
+
+Check that all frontmatter fields are present, correct, and consistent.
+
+```
+FRONTMATTER CHECK: [skill/command/agent name]
+
+Required fields:
+  - name:           [present?] [matches filename convention?]
+  - description:    [present?] [includes trigger phrases?] [pushy enough?]
+  - model:          [present?] [appropriate — sonnet for simple, opus for complex?]
+  - allowed-tools:  [present?] [includes ALL tools the body references?]
+  - user-invocable: [present if skill should be user-accessible?]
+  - version:        [present?] [matches plugin.json version?]
+
+Agent-specific:
+  - maxTurns:       [present?] [reasonable limit?]
+  - isolation:      [worktree if read-only or needs independence?]
+
+Command-specific:
+  - argument-hint:  [present if command takes arguments?]
+  - context:        [fork if produces large output?]
+
+BODY-FRONTMATTER CONSISTENCY:
+  Tools used in body:     [list every tool name mentioned in instructions]
+  Tools in allowed-tools: [list from frontmatter]
+  Gap:                    [tools used but NOT in allowed-tools — FLAW]
+  Extra:                  [tools in allowed-tools but never used — unnecessary]
+
+  Skills/commands referenced in body: [list]
+  Do they exist in the plugin?        [verify each — YES/NO]
+
+  Files/paths referenced in body:     [list]
+  Do they exist?                      [verify each — YES/NO]
+```
+
+---
+
+## 4. Context Budget Analysis
+
+Skills consume context window when loaded. Too much content = Claude forgets earlier conversation.
+
+```
+CONTEXT BUDGET: [skill name]
+
+SKILL.md size:         [N] lines
+Referenced guides:
+  - [guide name]:      [N] lines
+  - [guide name]:      [N] lines
+Total if all loaded:   [N] lines (~[estimate]K tokens)
+
+Budget guideline: Skills should be under 500 lines; reference guides extend via progressive disclosure.
+
+Risk assessment:
+  - If context is 20% full:  [fits comfortably / tight / won't fit]
+  - If context is 50% full:  [fits / tight / won't fit]
+  - If context is 80% full:  [fits / tight / won't fit — Claude may truncate]
+
+Optimization:
+  - Can any sections be moved to reference guides? [list candidates]
+  - Are any reference guides loaded unnecessarily? [list]
+  - Could the skill use `${CLAUDE_SKILL_DIR}` to load guides on demand?
+```
+
+---
+
+## 5. Instruction Fidelity Testing
+
+Will Claude follow ALL steps faithfully, or drift/skip/summarize?
+
+```
+FIDELITY CHECK: [skill name]
+
+Total steps: [N]
+Total instruction lines: [N]
+
+Risk factors:
+  Long steps (>20 lines):
+    - Step [N]: [title] — [N] lines
+      Risk: Claude may summarize rather than follow each sub-instruction
+      Fix: Break into smaller numbered sub-steps
+
+  Conditional steps:
+    - Step [N]: "If [condition]..."
+      Risk: Claude may skip evaluation and always take one branch
+      Fix: Make condition explicit with examples of both outcomes
+
+  Enforcement language:
+    - Steps with MUST/NEVER/ALWAYS: [list]
+      Assessment: [enforceable? or will Claude soften?]
+
+  Late steps:
+    - Steps [N]-[M] come after complex earlier steps
+      Risk: By this point, Claude may have used significant context on earlier steps
+      Fix: [add bold reminder, or front-load critical instructions]
+
+  Repetition instructions ("for EACH item"):
+    - Step [N]: "For each [X], do [Y]"
+      Risk: Claude may do 2-3 of 10 items and summarize the rest
+      Fix: Add "Do ALL items — do not skip or summarize any"
+```
+
+---
+
+## 6. Agent/Team Command Testing
+
+For commands that spawn agent teams.
+
+```
+AGENT TEAM TEST: [command name]
+
+SPAWN CONFIGURATION:
+  Agent 1: [name]
+    Model:     [sonnet/opus]
+    MaxTurns:  [N] — [reasonable?]
+    Isolation: [worktree? — should they be independent?]
+    Tools:     [scoped appropriately?]
+
+  Agent 2: [name]
+    [same fields]
+
+COORDINATION CHECK:
+  - Do agents write to same file?     → [YES = CONFLICT RISK / NO]
+  - Task dependencies correct?        → [verify DAG: no cycles, all deps exist]
+  - Quality gate:                      → [do agents validate completeness before done?]
+  - What if an agent fails/times out?  → [handled? fallback?]
+
+OUTPUT SYNTHESIS:
+  - Lead reads files from: [list paths]
+  - Agents write files to: [list paths]
+  - Paths match?          [YES/NO — mismatch = lead can't find agent output]
+  - Output format captures all findings? [YES/NO — anything lost in synthesis?]
+
+SCENARIO TRACES:
+  Trace 1: All agents complete successfully
+    → Lead reads all files → synthesizes → report produced ✓
+
+  Trace 2: Agent 2 times out (maxTurns exceeded)
+    → Lead reads available files → [what happens? partial report? error?]
+
+  Trace 3: Target is a skill file, not code
+    → Agents recognize non-code target? → [switch to instruction tracing?]
+```
+
+---
+
+## 7. Config File Testing
+
+For YAML, JSON, services.yml, routing.yml, and other config files.
+
+```
+CONFIG TEST: [config file path]
+
+TYPE: [YAML / JSON / .env / services.yml / routing.yml / schema.yml]
+
+STRUCTURE CHECK:
+  - Valid syntax?       [parse without errors]
+  - Required keys present? [list required keys and check each]
+  - Types correct?      [string where string expected, int where int expected]
+  - No unused keys?     [keys present but never read by code — dead config]
+
+CODE REFERENCE CHECK:
+  For each key in the config:
+    Key: [key name]
+    Read by: [file:line where code reads this key]
+    Used as: [type — string, int, bool, array]
+    Matches? [config value type matches usage]
+
+  For each config read in code:
+    Code reads: [key name]
+    Exists in config? [YES/NO]
+    Default if missing: [value / none — RISK if none]
+
+SERVICE DEFINITION CHECK (services.yml):
+  Service: [service.id]
+    Class: [fully qualified class name] → EXISTS? [YES/NO]
+    Arguments:
+      - [argument] → [type matches constructor parameter?]
+    Tags: [tag names] → [collector exists for this tag?]
+
+ROUTING CHECK (routing.yml):
+  Route: [route.name]
+    Path: [/path/{param}]
+    Controller: [class::method] → EXISTS? [YES/NO]
+    Requirements: [param constraints] → [validated in controller?]
+```
+
+---
+
+## Quick Reference: Code vs Skill Testing
+
+| What You're Testing | Trace Method | Key Checks |
+|---------------------|-------------|------------|
+| PHP/JS/Python function | Line-by-line with values | Dependencies, contracts, edge cases |
+| SKILL.md | Step-by-step instructions | Triggers, fidelity, tools, context budget |
+| Command .md | Step-by-step + agent spawns | Arguments, prerequisites, spawn configs |
+| Agent .md | Frontmatter + body | maxTurns, isolation, description, enforcement |
+| services.yml | Key-by-key | Class exists, arguments match constructor |
+| routing.yml | Route-by-route | Controller exists, params validated |
+| plugin.json | Field-by-field | Version consistency, keywords relevant |
+| hooks.json | Event-by-event | Script exists, exit codes handled |
+
+---
+
+## Example: Paper Testing a Skill
+
+```
+SKILL TRACE: guide-integrator
+SCENARIO: User starts Phase 2 design work, skill should activate proactively
+
+Step 1: "Check current phase from task file"
+  Claude would: Read the current task file to determine phase
+  Tool calls: Glob for task files, Read the active task
+  Output: Phase 2 detected
+  Risk: No active task file → step fails silently
+
+Step 2: "Load relevant guides for this phase"
+  Claude would: Based on Phase 2, load architecture decision guides
+  Tool calls: Read guide files from dev-guides path
+  Output: SOLID, Library-First, DRY guides loaded
+  Risk: Guide path doesn't exist → Read fails → no guides loaded
+    Does step handle this? NO — needs fallback message
+
+Step 3: "Skip if already loaded in this session"
+  Condition: "guides already loaded earlier"
+  Evaluation: How does Claude know? No session state tracking.
+  Risk: Claude may reload guides every time (wastes context)
+    OR Claude may skip when it shouldn't (false positive)
+  Fix: Add explicit check: "Search conversation for 'Loaded guides:' message"
+
+FRONTMATTER CHECK:
+  allowed-tools: [not set] — FLAW: should be Read, Glob, Grep
+  model: [not set] — acceptable (inherits from parent)
+
+FIDELITY CHECK:
+  "PROACTIVE: Activate at the START of every phase activity"
+  — Enforceable? MAYBE — depends on Claude remembering across turns
+  — Fix: Add to agent body prompt as bold reminder
+
+FLAWS FOUND:
+  1. No error handling if guide path doesn't exist
+  2. No reliable way to detect "already loaded" state
+  3. Missing allowed-tools in frontmatter
+```


### PR DESCRIPTION
## Summary

- **Track A — Methodology Depth (9 items):** Data flow tracking, error propagation tracing, untested path analysis, N+1/performance detection, config validation, state machine validation. 3 new reference guides: severity scoring rubric, blind A/B comparison, rubric-based scoring.
- **Track B — Infrastructure (8 items):** `maxTurns: 15` + `isolation: worktree` on all test-team agents, removed experimental flag (GA), pushy descriptions, `allowed-tools`/`user-invocable` on skill, quality gate enforcement, opus option for Red Team.
- **Track C — Skill/Config Testing (4 items):** New reference guide extending paper testing to skills, commands, agents, and configs. Auto-detects skill files in test-team and switches to instruction tracing mode. All 3 tester spawn prompts include skill-mode sections.

**13 files changed** (9 modified + 4 new), **1,137 additions**.

## Test plan

- [ ] Load plugin with `--plugin-dir` and invoke `/code-paper:test-team` on a code file — verify maxTurns and isolation in spawn
- [ ] Invoke `paper test this skill` on a SKILL.md — verify trigger matches and instruction tracing mode
- [ ] Verify SKILL.md stays under 500 lines (currently 496)
- [ ] Check marketplace.json version consistency (plugin 0.4.0, marketplace 1.7.0)
- [ ] Verify no experimental flag references remain in commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)