### PR TITLE
dev-guides-navigator v0.2.0: fix WebFetch contradictions, enforce curl-only

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
     {
       "name": "dev-guides-navigator",
       "source": "./dev-guides-navigator",
-      "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) in topic index pages to route AI to the correct guide.",
-      "version": "0.1.0",
+      "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
+      "version": "0.2.0",
       "author": {
         "name": "camoa"
       },

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-guides-navigator",
-  "version": "0.1.0",
-  "description": "Smart guide discovery and routing for dev-guides. Uses a manifest with Knowledge Graph metadata (concepts, disambiguation, relationships) and hash-based caching to route AI to the correct guide and enforce application of patterns.",
+  "version": "0.2.0",
+  "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"
   },

--- a/dev-guides-navigator/CHANGELOG.md
+++ b/dev-guides-navigator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.2.0 (2026-03-13)
+
+### Fixed
+- **WebFetch contradiction**: cache-format.md and CHANGELOG said "WebFetch for topic/guide pages" while SKILL.md said "NEVER use WebFetch" — all files now consistently use `curl -s` with raw GitHub URLs
+- Added `allowed-tools: Read, Bash, Glob, Grep, Write` to SKILL.md — explicitly excludes WebFetch so Claude cannot default to it
+
+### Changed
+- Model upgraded from `haiku` to `sonnet` for more reliable enforcement of curl-only fetching
+- Pushy description with comprehensive trigger phrases and proactive enforcement
+- Added `version` and `user-invocable: true` to SKILL.md frontmatter
+- Updated README with fetching rules, troubleshooting, and current usage
+
 ## 0.1.0 (2026-03-09)
 
 - Initial release
@@ -7,4 +19,4 @@
 - KG metadata disambiguation via `guide-meta:` in topic `index.md`
 - Two-hop routing: `llms.txt` -> topic `index.md` -> specific guide
 - Fallback keyword table in `references/guide-index.md`
-- Uses `curl` for raw llms.txt/hash fetches, WebFetch for topic/guide pages
+- All fetches use `curl -s` via Bash (raw content, no AI summarization)

--- a/dev-guides-navigator/README.md
+++ b/dev-guides-navigator/README.md
@@ -5,22 +5,59 @@ Smart guide discovery and routing for the [dev-guides](https://camoa.github.io/d
 ## Installation
 
 ```bash
-/plugin marketplace add camoa-skills
-/plugin install dev-guides-navigator
+/plugin install dev-guides-navigator@camoa-skills
 ```
 
 ## How It Works
 
-1. **Cache check** — fetches `llms.hash` (64 bytes), compares with cached hash
+1. **Cache check** — `curl -s` fetches `llms.hash` (64 bytes), compares with cached hash
 2. **Topic match** — scans cached `llms.txt` for matching topic
-3. **Fetch index** — reads topic's `index.md` with routing table and guide-meta
+3. **Fetch index** — `curl -s` reads topic's raw `index.md` with routing table and guide-meta
 4. **Disambiguate** — uses `concepts`/`not` fields to prevent wrong-guide selection
-5. **Fetch guide** — loads the specific guide from the routing table
+5. **Fetch guide** — `curl -s` loads the specific guide from raw GitHub URL
 6. **Apply** — extracts patterns and applies them to the current task
 
-## Components
+## Usage
 
-- **Skill**: `dev-guides-navigator` — triggered by any task that might benefit from a guide (Drupal, Next.js, design systems, CSS, testing, security, SOLID, DRY, TDD)
+The skill triggers automatically when any development task might benefit from a guide. You can also invoke it directly:
+
+```
+/dev-guides-navigator forms
+/dev-guides-navigator SOLID drupal
+/dev-guides-navigator design system bootstrap
+```
+
+### What It Covers
+
+| Category | Topics |
+|----------|--------|
+| Drupal | Forms, entities, plugins, services, routing, caching, config, security, SDC, views, blocks, layout builder, migration, recipes, testing, and more |
+| Design Systems | Bootstrap mapping, Radix/SDC, Tailwind tokens, DaisyUI, JSX-to-Twig, component recognition |
+| Dev Practices | SOLID, DRY, TDD, security, modern CSS, CSS Craft |
+| Next.js | next-drupal, Tiptap editor, DeepChat |
+
+## Fetching Rule: curl Only
+
+**All fetches use `curl -s` via Bash — never WebFetch.**
+
+Why:
+- **WebFetch summarizes content through AI**, destroying the structured markdown formats needed for routing and pattern matching
+- **MkDocs GitHub Pages URLs** return 400KB+ HTML navigation shells, not guide content
+- **Guides are atomic** and small enough for `curl` — no summarization needed
+
+```bash
+# Hash check (64 bytes)
+curl -s https://camoa.github.io/dev-guides/llms.hash
+
+# Topic index (llms.txt)
+curl -s https://camoa.github.io/dev-guides/llms.txt
+
+# Topic routing table (raw GitHub, not GitHub Pages)
+curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/drupal/forms/index.md
+
+# Specific guide (raw GitHub)
+curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/drupal/forms/form-validation.md
+```
 
 ## Configuration
 
@@ -30,7 +67,38 @@ No configuration required. The skill automatically caches `llms.txt` per project
 ~/.claude/projects/{project-hash}/memory/dev-guides-cache.json
 ```
 
+## Disambiguation
+
+KG metadata in each topic's `index.md` prevents routing to the wrong guide:
+
+| Term | Correct Guide | NOT This Guide |
+|------|---------------|----------------|
+| story.yml | drupal/ui-patterns | drupal/storybook |
+| stories.yml | drupal/storybook | drupal/ui-patterns |
+| inline blocks | drupal/layout-builder | drupal/blocks |
+| block plugin | drupal/blocks | drupal/layout-builder |
+| SOLID (Drupal) | drupal/solid | dev-practices/solid-principles |
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| AI uses WebFetch instead of curl | The `allowed-tools` field excludes WebFetch — if it still happens, check that the plugin is installed |
+| curl fails (network error) | Falls back to built-in `references/guide-index.md` keyword table |
+| No topic matches | Broaden keywords or check category sections in llms.txt |
+| Guide too large for context | Request only the specific section from the routing table |
+
 ## Dependencies
 
 - `llms.hash` and `llms.txt` published at `https://camoa.github.io/dev-guides/`
 - `guide-meta:` frontmatter in each topic's `index.md`
+
+## Version
+
+**v0.2.0** (Current) — Fixed WebFetch contradictions, upgraded to sonnet, pushy descriptions, allowed-tools enforcement
+
+**v0.1.0** — Initial release with hash-based caching and KG metadata disambiguation
+
+## License
+
+MIT

--- a/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: dev-guides-navigator
-description: Smart guide discovery and routing for dev-guides site. Use when any development task might benefit from a guide — Drupal, Next.js, design systems, CSS, testing, security, SOLID, DRY, TDD. Caches llms.txt with hash-based freshness check. Reads topic index.md for KG metadata (concepts, disambiguation, relationships) to prevent wrong-guide selection. Keywords: guide, dev-guides, llms.txt, reference, pattern, best practice.
-model: haiku
+description: Use when ANY development task might benefit from a guide. Use when user says "how do I", "best practice", "pattern for", "guide for", "Drupal form", "entity type", "plugin type", "routing", "caching", "config management", "SDC component", "design system", "Bootstrap mapping", "Radix theme", "JSX to Twig", "Tailwind tokens", "SOLID", "DRY", "TDD", "security", "CSS", "Next.js". Use PROACTIVELY before any design, architecture, or implementation work. MUST be invoked before writing code that touches Drupal APIs, theming, design systems, or security. NEVER skip guide check — patterns prevent bugs.
+version: 0.2.0
+model: sonnet
+allowed-tools: Read, Bash, Glob, Grep, Write
+user-invocable: true
 ---
 
 # Dev-Guides Navigator

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/cache-format.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/cache-format.md
@@ -29,7 +29,9 @@
 
 **Finding a guide:**
 1. Match task keywords against cached `llms.txt` topics
-2. WebFetch the topic's `index.md` (routing table)
+2. `curl -s` the topic's raw GitHub `index.md` (routing table)
 3. Pick the specific guide from "I need to..." table
-4. WebFetch that individual guide `.md`
+4. `curl -s` the raw GitHub URL for that guide `.md`
 5. Apply the guide content to the task
+
+**NEVER use WebFetch** — it summarizes content through AI, destroying the structured formats needed for matching and routing.


### PR DESCRIPTION
## Summary

- **Fixed WebFetch contradiction**: `cache-format.md` and CHANGELOG said "WebFetch for topic/guide pages" while SKILL.md said "NEVER use WebFetch" — all files now consistently use `curl -s` with raw GitHub URLs
- **Added `allowed-tools`**: `Read, Bash, Glob, Grep, Write` — explicitly excludes WebFetch so Claude cannot default to it
- **Upgraded model**: `haiku` → `sonnet` for more reliable enforcement of curl-only fetching
- **Pushy description**: comprehensive trigger phrases with proactive enforcement language

## Root Cause

Claude kept using WebFetch instead of curl because:
1. The reference files contradicted the SKILL.md instructions
2. `allowed-tools` was missing, so WebFetch was available as a tool
3. Haiku model didn't follow enforcement as strictly

## Test plan

- [ ] Install plugin and invoke `/dev-guides-navigator forms`
- [ ] Verify all fetches use `curl -s` via Bash (no WebFetch calls)
- [ ] Verify `llms.hash` cache check works
- [ ] Verify raw GitHub URLs used for index.md and guide fetches
- [ ] Verify disambiguation works (e.g., "story.yml" routes to ui-patterns, not storybook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)