### PR TITLE
drupal-htmx v1.4.0: modernize frontmatter, pushy descriptions, dev-guides delegation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -79,7 +79,7 @@
       "name": "drupal-htmx",
       "source": "./drupal-htmx",
       "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": {
         "name": "camoa"
       },
@@ -129,14 +129,27 @@
     {
       "name": "code-paper-test",
       "source": "./code-paper-test",
-      "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Includes 3-agent competing testers with isolated worktrees.",
+      "description": "Systematically test code, skills, commands, and configs through mental execution \u2014 trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Includes 3-agent competing testers with isolated worktrees.",
       "version": "0.4.0",
       "author": {
         "name": "camoa"
       },
       "license": "MIT",
       "repository": "https://github.com/camoa/claude-skills",
-      "keywords": ["testing", "debugging", "code-review", "paper-testing", "mental-execution", "bug-detection", "ai-code-auditing", "contract-verification", "dependency-verification", "skill-testing", "config-validation", "prompt-testing"]
+      "keywords": [
+        "testing",
+        "debugging",
+        "code-review",
+        "paper-testing",
+        "mental-execution",
+        "bug-detection",
+        "ai-code-auditing",
+        "contract-verification",
+        "dependency-verification",
+        "skill-testing",
+        "config-validation",
+        "prompt-testing"
+      ]
     },
     {
       "name": "brand-content-design",

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Features rubric-scored code review (/50 with quality gate), cross-audit correlat
 See [code-quality-tools/README.md](code-quality-tools/README.md) for full documentation.
 
 
-### drupal-htmx (v1.3.0)
+### drupal-htmx (v1.4.0)
 
 HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+.
 

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2026-03-14
+
+### Fixed
+- **Agent frontmatter**: All 3 agents changed from `tools`/`disallowedTools` to `allowed-tools` (current standard)
+- **Version alignment**: Skill version now matches plugin version (was 1.2.0 vs 1.3.0)
+- **Dev-guides reference**: Replaced direct llms.txt URL with dev-guides-navigator delegation
+
+### Changed
+- Pushy descriptions with trigger phrases on all 5 commands and main skill
+- Added `allowed-tools` and `user-invocable: true` to skill frontmatter
+- Enhanced dev-guides integration section with relevant Drupal topics for HTMX context
+
 ## [1.3.0] - 2026-02-16
 
 ### Changed

--- a/drupal-htmx/CLAUDE.md
+++ b/drupal-htmx/CLAUDE.md
@@ -17,9 +17,9 @@
 - Restrict `allowed-tools` to minimum needed
 
 ## Online Dev-Guides
-For Drupal domain context when analyzing or validating HTMX patterns, fetch the guide index:
-- **Index:** `https://camoa.github.io/dev-guides/llms.txt`
-- WebFetch the index to discover available topics, then fetch specific topic pages
+For Drupal domain context when analyzing or validating HTMX patterns, delegate to the dev-guides-navigator skill:
+- Invoke `/dev-guides-navigator` with relevant keywords (e.g., "forms", "routing", "js-development", "render-api")
+- Do NOT fetch llms.txt or dev-guides URLs directly — the navigator handles caching and disambiguation
 - Likely relevant topics: forms, routing, js-development, render-api
 
 ## General

--- a/drupal-htmx/agents/ajax-analyzer.md
+++ b/drupal-htmx/agents/ajax-analyzer.md
@@ -2,10 +2,9 @@
 name: ajax-analyzer
 description: Analyzes Drupal modules for AJAX patterns and identifies migration candidates. Use proactively when user wants to find AJAX code to migrate to HTMX.
 capabilities: ["AJAX pattern detection", "migration complexity assessment", "code scanning"]
-version: 1.0.0
+version: 1.4.0
 model: sonnet
-tools: Read, Grep, Glob
-disallowedTools: Edit, Write
+allowed-tools: Read, Grep, Glob
 ---
 
 # AJAX Analyzer

--- a/drupal-htmx/agents/htmx-recommender.md
+++ b/drupal-htmx/agents/htmx-recommender.md
@@ -2,10 +2,9 @@
 name: htmx-recommender
 description: Recommends HTMX patterns for Drupal development. Use when user needs guidance on implementing dynamic content, forms, or interactions with HTMX.
 capabilities: ["pattern recommendation", "Htmx class configuration", "best practice guidance"]
-version: 1.0.0
+version: 1.4.0
 model: sonnet
-tools: Read, Glob
-disallowedTools: Edit, Write, Bash
+allowed-tools: Read, Glob
 ---
 
 # HTMX Recommender

--- a/drupal-htmx/agents/htmx-validator.md
+++ b/drupal-htmx/agents/htmx-validator.md
@@ -2,10 +2,9 @@
 name: htmx-validator
 description: Validates HTMX implementations in Drupal modules against best practices. Use after implementing HTMX to check for issues, accessibility, and progressive enhancement.
 capabilities: ["code validation", "best practice checking", "accessibility audit"]
-version: 1.0.0
+version: 1.4.0
 model: sonnet
-tools: Read, Grep, Glob
-disallowedTools: Edit, Write
+allowed-tools: Read, Grep, Glob
 ---
 
 # HTMX Validator

--- a/drupal-htmx/commands/htmx-analyze.md
+++ b/drupal-htmx/commands/htmx-analyze.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze Drupal module for AJAX patterns and identify HTMX migration candidates
+description: Analyze Drupal module for AJAX patterns and identify HTMX migration candidates. Use when user says "analyze AJAX", "find AJAX patterns", "migration candidates", "what can I migrate", "scan for AJAX".
 allowed-tools: Read, Glob, Grep, Task
 argument-hint: <module-path>
 ---

--- a/drupal-htmx/commands/htmx-migrate.md
+++ b/drupal-htmx/commands/htmx-migrate.md
@@ -1,5 +1,5 @@
 ---
-description: Guide migration of a specific AJAX pattern to HTMX with step-by-step instructions
+description: Guided migration of specific AJAX pattern to HTMX with before/after code. Use when user says "migrate to HTMX", "convert AJAX", "replace AJAX callback", "HTMX migration", "migrate this form".
 allowed-tools: Read, Edit, Glob, Grep
 argument-hint: <file-path> [pattern-type]
 ---

--- a/drupal-htmx/commands/htmx-pattern.md
+++ b/drupal-htmx/commands/htmx-pattern.md
@@ -1,5 +1,5 @@
 ---
-description: Get HTMX pattern recommendation for a specific use case in Drupal
+description: Get HTMX pattern recommendation for specific use case with code examples. Use when user says "HTMX pattern for", "how to do X with HTMX", "best HTMX approach", "recommend HTMX pattern", "dependent dropdown HTMX".
 allowed-tools: Read, Glob, Task
 argument-hint: <use-case>
 ---

--- a/drupal-htmx/commands/htmx-validate.md
+++ b/drupal-htmx/commands/htmx-validate.md
@@ -1,5 +1,5 @@
 ---
-description: Validate HTMX implementation in Drupal module against best practices
+description: Validate HTMX implementation against best practices and accessibility requirements. Use when user says "validate HTMX", "check HTMX code", "HTMX best practices", "is my HTMX correct", "HTMX accessibility check".
 allowed-tools: Read, Glob, Grep, Task
 argument-hint: <module-path>
 ---

--- a/drupal-htmx/commands/htmx.md
+++ b/drupal-htmx/commands/htmx.md
@@ -1,5 +1,5 @@
 ---
-description: Show HTMX development status and suggest next actions for a Drupal module
+description: Show HTMX development status and suggest next actions. Use when user says "HTMX status", "what HTMX commands", "HTMX help", "show HTMX", "htmx overview".
 allowed-tools: Read, Glob, Grep
 argument-hint: [module-path]
 ---

--- a/drupal-htmx/skills/htmx-development/SKILL.md
+++ b/drupal-htmx/skills/htmx-development/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: htmx-development
-description: Use when developing HTMX features in Drupal 11.3+ or migrating AJAX to HTMX. Covers Htmx class usage, form patterns, migration strategies, and validation. Triggers on "htmx", "ajax to htmx", "dynamic form", "dependent dropdown".
-version: 1.2.0
+description: Use when implementing HTMX in Drupal, migrating from AJAX to HTMX, building dynamic forms, dependent dropdowns, infinite scroll, real-time validation, or multi-step wizards. Use when user says "HTMX", "migrate AJAX", "dependent dropdown", "dynamic form", "infinite scroll", "load more", "real-time validation", "multi-step wizard", "hx-get", "hx-post", "Htmx class". Use PROACTIVELY for any Drupal 11.3+ dynamic interaction that could use HTMX instead of AJAX. MUST check HTMX patterns before implementing AJAX callbacks.
+version: 1.4.0
 model: sonnet
+allowed-tools: Read, Glob, Grep
+user-invocable: true
 ---
 
 # HTMX Development
@@ -228,15 +230,13 @@ When reviewing HTMX implementations:
 - `references/migration-patterns.md` - 7 patterns with before/after code
 - `references/ajax-reference.md` - AJAX commands for understanding existing code
 
-### Online Dev-Guides (Drupal Domain)
+### Online Dev-Guides
 
-For Drupal domain context when analyzing, recommending, or validating HTMX patterns, fetch the guide index:
+For deeper Drupal context beyond bundled references, use the dev-guides-navigator plugin:
 
-**Index:** `https://camoa.github.io/dev-guides/llms.txt`
+Invoke `/dev-guides-navigator` with keywords like "Drupal forms", "routing", "JS development", or "render API". The navigator handles caching and disambiguation — never fetch dev-guides URLs directly.
 
-Likely relevant topics: forms, routing, js-development, render-api
-
-Usage: WebFetch the index to discover available topics, then fetch specific topic pages for Drupal patterns when the bundled HTMX references don't cover the underlying Drupal concept.
+Relevant topics: drupal/forms (FAPI with HTMX), drupal/routing (HTMX routes), drupal/js-development (behaviors + HTMX events), drupal/render-api (render arrays for HTMX responses).
 
 ## Key Files in Drupal Core
 


### PR DESCRIPTION
## Summary

- **Agent frontmatter modernized**: All 3 agents (`ajax-analyzer`, `htmx-recommender`, `htmx-validator`) changed from `tools`/`disallowedTools` to `allowed-tools`
- **Pushy descriptions**: All 5 commands + skill now have trigger phrases for reliable routing
- **Dev-guides delegation**: Replaced direct `llms.txt` URL references with `/dev-guides-navigator` invocation (SKILL.md + CLAUDE.md)
- **Skill infrastructure**: Added `allowed-tools`, `user-invocable: true`, version aligned to 1.4.0
- **HTMX-relevant topics**: Dev-guides section now lists drupal/forms, drupal/routing, drupal/js-development, drupal/render-api

## Changes (14 files)

| Category | Files |
|----------|-------|
| Agents (frontmatter) | ajax-analyzer, htmx-recommender, htmx-validator |
| Skill (frontmatter + dev-guides) | htmx-development/SKILL.md |
| Commands (descriptions) | All 5 command files |
| Metadata | plugin.json, marketplace.json, CHANGELOG.md, CLAUDE.md |
| Docs | Root README.md |

## Test plan

- [ ] Install plugin and verify `/htmx` triggers
- [ ] Verify "migrate AJAX" triggers `/htmx-analyze`
- [ ] Verify agents use `allowed-tools` (not `tools`/`disallowedTools`)
- [ ] Verify dev-guides section references navigator, not direct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)