### PR TITLE
Remove model pinning from skills to fix rate limit errors

### DIFF
--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -2,7 +2,6 @@
 name: brand-content-design
 description: Use when user says "create presentation", "make slides", "make carousel", "LinkedIn carousel", "create HTML page", "make landing page", "build web page", "html design system", "design system", "setup brand", "brand init", "extract brand", "get outline", "color palette", "alternative colors", "infographic", "brand assets", "brand project". Use PROACTIVELY when user wants to create any visual content with consistent branding. MUST be invoked for branded content — routes to the correct command for presentations, carousels, infographics, and HTML pages.
 version: 2.8.0
-model: sonnet
 allowed-tools: Read, Glob, Grep, Write, Bash, AskUserQuestion, Skill
 user-invocable: true
 ---

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -2,7 +2,6 @@
 name: html-generator
 description: Use when generating branded HTML pages and components from a design system. Creates standalone HTML components and composes them into full pages with embedded CSS, responsive design, and brand integration.
 version: 2.8.0
-model: opus
 allowed-tools: Read, Write, Glob, Grep, Bash
 user-invocable: false
 ---

--- a/brand-content-design/skills/infographic-generator/SKILL.md
+++ b/brand-content-design/skills/infographic-generator/SKILL.md
@@ -2,7 +2,6 @@
 name: generating-infographics
 description: Use when creating infographics, data visualizations, process diagrams, timelines, or comparisons - generates branded infographics using @antv/infographic with 114 templates across 7 categories. Triggers on "create infographic", "make infographic", "visualize data", "timeline", "process diagram".
 version: 2.8.0
-model: sonnet
 allowed-tools: Read, Write, Glob, Bash
 user-invocable: false
 ---

--- a/brand-content-design/skills/visual-content/SKILL.md
+++ b/brand-content-design/skills/visual-content/SKILL.md
@@ -2,7 +2,6 @@
 name: visual-content
 description: Use when creating branded presentations or carousels. Generates museum-quality visual output from canvas philosophy, enforcing style constraints. Outputs PDF first, then converts to PPTX for editability.
 version: 2.8.0
-model: opus
 allowed-tools: Read, Write, Glob, Bash
 user-invocable: false
 ---

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -2,7 +2,6 @@
 name: paper-test
 description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "validate this implementation", "review this logic", "check dependencies", "check this config". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
 version: 0.4.0
-model: sonnet
 allowed-tools: Read, Glob, Grep, Bash
 user-invocable: true
 ---

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -2,7 +2,6 @@
 name: code-quality-audit
 description: Use when checking code quality, running security audits, testing coverage, finding SOLID/DRY violations, or setting up quality tools. Use when user says "audit this code", "check security", "run PHPStan", "code quality", "find violations", "SOLID check", "DRY check", "test coverage", "lint this", "security review", "is this production ready", "check for vulnerabilities", "code review", "grade this code". Supports Drupal (PHPStan, PHPMD, Psalm, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Use proactively before deployment or after significant code changes.
 version: 2.7.0
-model: sonnet
 allowed-tools: Read, Bash, Grep, Glob
 user-invocable: true
 ---

--- a/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
@@ -2,7 +2,6 @@
 name: dev-guides-navigator
 description: Use when ANY development task might benefit from a guide. Use when user says "how do I", "best practice", "pattern for", "guide for", "Drupal form", "entity type", "plugin type", "routing", "caching", "config management", "SDC component", "design system", "Bootstrap mapping", "Radix theme", "JSX to Twig", "Tailwind tokens", "SOLID", "DRY", "TDD", "security", "CSS", "Next.js". Use PROACTIVELY before any design, architecture, or implementation work. MUST be invoked before writing code that touches Drupal APIs, theming, design systems, or security. NEVER skip guide check — patterns prevent bugs.
 version: 0.2.0
-model: sonnet
 allowed-tools: Read, Bash, Glob, Grep, Write
 user-invocable: true
 ---

--- a/drupal-dev-framework/skills/component-designer/SKILL.md
+++ b/drupal-dev-framework/skills/component-designer/SKILL.md
@@ -2,7 +2,6 @@
 name: component-designer
 description: Use when designing a specific module component - creates architecture/component_name.md with purpose, interface, dependencies, and pattern references
 version: 1.1.0
-model: opus
 ---
 
 # Component Designer

--- a/drupal-dev-framework/skills/core-pattern-finder/SKILL.md
+++ b/drupal-dev-framework/skills/core-pattern-finder/SKILL.md
@@ -2,7 +2,6 @@
 name: core-pattern-finder
 description: Use when needing Drupal core implementation examples - searches core modules for specific patterns and returns file path references
 version: 1.1.0
-model: haiku
 user-invocable: false
 ---
 

--- a/drupal-dev-framework/skills/diagram-generator/SKILL.md
+++ b/drupal-dev-framework/skills/diagram-generator/SKILL.md
@@ -2,7 +2,6 @@
 name: diagram-generator
 description: "Use when visualizing architecture - generates Mermaid diagrams for data flow, service relationships, or entity structures. Trigger: 'draw diagram', 'visualize', 'show relationships', 'mermaid chart'."
 version: 1.1.0
-model: sonnet
 ---
 
 # Diagram Generator

--- a/drupal-dev-framework/skills/guide-loader/SKILL.md
+++ b/drupal-dev-framework/skills/guide-loader/SKILL.md
@@ -2,7 +2,6 @@
 name: guide-loader
 description: Use when needing specialized guide content - delegates to dev-guides-navigator plugin for online guide discovery with caching and disambiguation
 version: 3.0.0
-model: haiku
 user-invocable: false
 ---
 

--- a/drupal-dev-framework/skills/phase-detector/SKILL.md
+++ b/drupal-dev-framework/skills/phase-detector/SKILL.md
@@ -2,7 +2,6 @@
 name: phase-detector
 description: Use when determining task phase - analyzes task file to identify Phase 1, 2, or 3 for a specific task
 version: 3.0.0
-model: haiku
 user-invocable: false
 allowed-tools: Read, Glob
 ---

--- a/drupal-htmx/skills/htmx-development/SKILL.md
+++ b/drupal-htmx/skills/htmx-development/SKILL.md
@@ -2,7 +2,6 @@
 name: htmx-development
 description: Use when implementing HTMX in Drupal, migrating from AJAX to HTMX, building dynamic forms, dependent dropdowns, infinite scroll, real-time validation, or multi-step wizards. Use when user says "HTMX", "migrate AJAX", "dependent dropdown", "dynamic form", "infinite scroll", "load more", "real-time validation", "multi-step wizard", "hx-get", "hx-post", "Htmx class". Use PROACTIVELY for any Drupal 11.3+ dynamic interaction that could use HTMX instead of AJAX. MUST check HTMX patterns before implementing AJAX callbacks.
 version: 1.4.0
-model: sonnet
 allowed-tools: Read, Glob, Grep
 user-invocable: true
 ---


### PR DESCRIPTION
## Summary
- Skills with `model: sonnet/opus/haiku` cause "API Error: Rate limit reached" when the session runs on a different model (e.g., Opus on Max Pro)
- Removed `model:` from all 13 skills across 7 plugins — skills now inherit the session's active model
- Agents are untouched — they spawn as subagents where model pinning works correctly

## Test plan
- [ ] Run `/code-paper-test:paper-test` on Opus session — should no longer hit rate limit
- [ ] Run `/code-quality-tools:audit` — still works
- [ ] Run `/brand-content-design:brand` — still works
- [ ] Verify agents still spawn with their pinned models

🤖 Generated with [Claude Code](https://claude.com/claude-code)