### PR TITLE
Bump versions for model-removal update

### DIFF
--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks, Roave via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks, Socket CLI) projects - TDD, SOLID, DRY, OWASP security",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "author": {
     "name": "camoa"
   },

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guides-navigator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "camoa"
   },


### PR DESCRIPTION
## Summary
Version bumps for all 6 plugins affected by PR #93 (model removal). Without these, the plugin cache won't pick up the changes.

## Changes
| Plugin | Old | New |
|--------|-----|-----|
| code-paper-test | 0.4.1 | 0.4.2 |
| code-quality-tools | 2.7.1 | 2.7.2 |
| brand-content-design | 2.8.0 | 2.8.1 |
| dev-guides-navigator | 0.2.1 | 0.2.2 |
| drupal-dev-framework | 3.6.1 | 3.6.2 |
| drupal-htmx | 1.4.1 | 1.4.2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)