### PR TITLE
Remove brand bias from brand-content-design plugin

### DIFF
--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with visual components, 21 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/commands/brand-extract.md
+++ b/brand-content-design/commands/brand-extract.md
@@ -158,8 +158,8 @@ When analyzing a website, the brand-analyst agent should:
 
 3. **Recommend font upload** - If custom/web fonts detected:
    > "I detected these fonts on your website:
-   > - **Heading**: Inter (Google Fonts)
-   > - **Body**: Source Sans Pro (Google Fonts)
+   > - **Heading**: {detected heading font} (Google Fonts)
+   > - **Body**: {detected body font} (Google Fonts)
    >
    > For best results, download these fonts and add them to `input/fonts/`:
    > - [Download Inter](https://fonts.google.com/specimen/Inter)

--- a/brand-content-design/commands/template-infographic.md
+++ b/brand-content-design/commands/template-infographic.md
@@ -372,11 +372,11 @@ Create a new infographic template or edit an existing one.
 
    | # | Palette         | Colors                                    | Text Colors |
    |---|-----------------|-------------------------------------------|-------------|
-   | 1 | Brand (default) | Primary: #194582, Accent: #00f3ff         | ✓           |
-   | 2 | Monochromatic   | #0C2341, #194582, #3773B4, #78A5D7        | ✓           |
-   | 3 | Complementary   | #194582, #825A19, #B47D23, #D7A041        | ✓           |
-   | 4 | Pastel          | #E0E7FF, #FCE7F3, #D1FAE5                 | ⚠️ derived  |
-   | ... (list all from brand-philosophy.md)
+   | 1 | Brand (default) | Primary: {from brand-philosophy.md}       | ✓           |
+   | 2 | Monochromatic   | {derived from brand primary}              | ✓           |
+   | 3 | Complementary   | {derived from brand palette}              | ✓           |
+   | 4 | Pastel          | {lightened from brand colors}             | ⚠️ derived  |
+   | ... (list all palettes found in brand-philosophy.md)
 
    **Which palette?** (enter number or name, default: 1)
    ```

--- a/brand-content-design/references/visual-components.md
+++ b/brand-content-design/references/visual-components.md
@@ -43,8 +43,8 @@ Rounded rectangle containers that group related content.
 |--------------|----------------|
 | **Minimal** | Thin border only, no fill |
 | **Dramatic** | Bold fill, high contrast |
-| **Organic** | Soft fill, warm tones |
-| **Hygge** | Warm fill, large radius |
+| **Organic** | Soft fill, muted brand tones |
+| **Hygge** | Softened brand fill, large radius |
 | **Swiss** | Precise borders, grid-aligned |
 | **Memphis** | Colorful fills, geometric |
 

--- a/brand-content-design/skills/brand-content-design/references/bias-prevention.md
+++ b/brand-content-design/skills/brand-content-design/references/bias-prevention.md
@@ -1,0 +1,101 @@
+# Bias Prevention Guidelines
+
+Rules for preventing brand-specific values from leaking into generated output.
+Adapted from design-intelligence's bias-prevention-guidelines.md for brand-content-design output types.
+
+## Core Principle
+
+**Reference files are DECISION FRAMEWORKS, not LOOKUP TABLES.**
+
+Every generated output must derive its visual values from the project's brand-philosophy.md,
+not from defaults, examples, or fallback values in reference files or code.
+
+## Value Derivation Hierarchy
+
+When generating any branded output, derive ALL visual values from these sources in priority order:
+
+1. **Brand philosophy** — colors, fonts, and personality from `brand-philosophy.md`
+2. **Design system tokens** — if a `design-system.md` exists, use its CSS custom properties
+3. **Canvas philosophy** — aesthetic direction from `canvas-philosophy.md`
+4. **WCAG constraint floors** — contrast ≥ 4.5:1, text sizes ≥ 14px
+5. **Deliberately bland neutrals** — only if no brand is available (#1a1a1a, #666, #f5f5f5)
+
+### Per Output Type
+
+| Output Type | Color Source | Font Source | Spacing Source |
+|-------------|-------------|-------------|----------------|
+| **Infographic (JSON)** | Derived hex from brand palette | Brand heading/body fonts | Template defaults |
+| **HTML page** | CSS custom properties from design-system.md | Google Fonts `<link>` from brand | Design tokens |
+| **Presentation (PDF)** | `parse_brand_colors()` from brand-philosophy.md | `load_brand_fonts()` from assets | Style constraints |
+| **Carousel (PDF)** | `parse_brand_colors()` from brand-philosophy.md | `load_brand_fonts()` from assets | Style constraints |
+| **PPTX** | Converted from PDF brand colors | Embedded from assets/fonts | From PDF layout |
+
+## Known Biased Defaults
+
+These values are former hardcoded defaults that should NEVER appear in generated output:
+
+### Colors
+| Hex | Origin | Neutral Replacement |
+|-----|--------|-------------------|
+| `#0D2B5C` | Former Palcera navy | `#333333` |
+| `#194582` | Former Palcera blue | `#444444` |
+| `#00f3ff` | Former Palcera cyan | `#888888` |
+| `#061120` | Former Palcera dark | `#1a1a1a` |
+| `#60A5FA` | Former example blue | `#666666` |
+
+### Fonts
+| Font | Context | Replacement |
+|------|---------|-------------|
+| `Inter` | Former default heading/body | Brand's heading/body font |
+| `Helvetica-Bold` | PDF code example default | `brand_fonts.get('heading', 'Helvetica-Bold')` |
+| `Helvetica` | PDF code example default | `brand_fonts.get('body', 'Helvetica')` |
+
+## Pre-Output Validation Checklist
+
+Run before finalizing ANY generated content:
+
+```
+□ colorBg / background derived from brand-philosophy.md, not a default
+□ colorPrimary / accent derived from brand-philosophy.md, not a default
+□ Colors traced to brand-philosophy.md (not copied from reference docs or runtime fallbacks)
+□ font-family from brand, not "Inter" or "Helvetica" (unless brand actually uses these)
+□ Text colors WCAG-validated against actual background
+□ Palette colors used for shapes/fills only, not text
+□ If dark background: text is white/near-white
+□ If light background: text is near-black/dark gray
+```
+
+## Marking Illustrative Values
+
+When reference files must show example values for educational purposes:
+
+- Prefix with comment: `/* Illustrative — derive from brand-philosophy.md */`
+- Use `{brand-*}` placeholder syntax: `{brand-primary}`, `{brand-bg}`, `{brand-heading-font}`
+- Add note: "The values shown are placeholders. Actual values come from your project's brand-philosophy.md."
+
+## No-Brand Safeguard
+
+If `brand-philosophy.md` is not found in the project:
+
+1. **STOP generation** — inform user: "No brand-philosophy.md found. Run `/brand-extract` first to analyze your brand."
+2. **If user insists on proceeding without brand**: Use deliberately bland neutrals that cannot be mistaken for any specific brand:
+   - Background: `#f5f5f5` (light) or `#1a1a1a` (dark)
+   - Text: `#333333` (on light) or `#e5e5e5` (on dark)
+   - Accent: `#666666`
+   - Fonts: System font stack (`-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`)
+3. **Never** fall back to Palcera, example, or any recognizable brand colors.
+
+## What Counts as Bias
+
+### BIASED (must fix)
+- Specific hex colors from any particular brand
+- Specific font names as defaults (unless they're system fonts)
+- Fixed pixel values when a token or range exists
+- Example values that get copied verbatim into output
+
+### NOT BIASED (keep)
+- `#FFFFFF` / `#000000` (universal black/white)
+- WCAG contrast calculation logic
+- `rgba(255,255,255,0.85)` for text opacity on dark backgrounds (universal pattern)
+- Safe zone margins and spacing constants
+- Template structure and layout dimensions

--- a/brand-content-design/skills/brand-content-design/references/style-constraints.md
+++ b/brand-content-design/skills/brand-content-design/references/style-constraints.md
@@ -43,12 +43,12 @@ Components available per style. See `references/visual-components.md` for full d
 |-------|:-----:|:-----:|:---------:|-------|
 | Minimal | ◐ | ✗ | ✗ | Cards: thin border only, no fill |
 | Dramatic | ✓ | ✓ | ✓ | Bold fills, high contrast |
-| Organic | ✓ | ✓ | ✓ | Warm, soft, natural |
+| Organic | ✓ | ✓ | ✓ | Soft, natural, brand colors muted |
 | Wabi-Sabi | ◐ | ✗ | ✗ | Cards: textured, imperfect edges |
 | Shibui | ◐ | ✗ | ✗ | Cards: hairline borders only |
 | Iki | ✓ | ✓ | ✗ | B&W cards + pop color |
 | Ma | ✗ | ✗ | ✗ | No components - emptiness only |
-| Hygge | ✓ | ✓ | ✓ | Warm, cozy, soft corners |
+| Hygge | ✓ | ✓ | ✓ | Cozy, soft corners, brand colors softened |
 | Lagom | ✓ | ✓ | ✗ | Functional, balanced |
 | Swiss | ✓ | ✓ | ✗ | Grid-aligned, precise |
 | Memphis | ✓ | ✓ | ✓ | Colorful, playful, geometric |
@@ -183,7 +183,7 @@ STYLE: Dramatic (Japanese Zen)
 
 ## Organic
 
-Based on **Shizen** (naturalness) and **Yugen** (hidden depth). Warmth and humanity over precision.
+Based on **Shizen** (naturalness) and **Yugen** (hidden depth). Humanity and approachability over precision.
 
 **Learn more**: [Yugen](https://en.wikipedia.org/wiki/Y%C5%ABgen) | [Shizen](https://en.wikipedia.org/wiki/Japanese_aesthetics#Shizen)
 
@@ -196,7 +196,7 @@ Based on **Shizen** (naturalness) and **Yugen** (hidden depth). Warmth and human
 | Whitespace | 50-60% | HARD LIMIT |
 | Max words/slide | 10 | HARD LIMIT |
 | Max elements | 4 | HARD LIMIT |
-| Colors | 5-6 warm tones | Warm spectrum only |
+| Colors | 5-6 from brand, muted/softened | Soften brand palette — reduce saturation, not change hue |
 
 ### Layout Rules
 - Natural groupings, organic flow
@@ -211,23 +211,21 @@ Based on **Shizen** (naturalness) and **Yugen** (hidden depth). Warmth and human
 
 ### Texture
 - Subtle paper/linen background at 3-5% opacity
-- Warm filters on images
 - Soft, organic borders
 
 ### Anti-Patterns (NEVER)
 - Stark black/white contrast
 - Rigid grid alignment
-- Cold colors
 - Sharp geometric shapes
 - Pure white backgrounds
 
 ### Example
-> Warm cream slide with subtle paper texture. Headline in warm charcoal, naturally off-center. Documentary image integrates with text. Everything feels connected, human.
+> Soft-toned slide with subtle paper texture. Headline in muted brand primary, naturally off-center. Documentary image integrates with text. Everything feels connected, human. Colors drawn from brand palette, softened to feel natural.
 
 ### Visual Components
-- **Cards**: Full support - soft fills in warm tones, large radius (16-24px), no sharp corners
-- **Icons**: Allowed - warm colors, organic feel
-- **Gradients**: Allowed - warm, subtle transitions (earth tones)
+- **Cards**: Full support - soft fills from brand palette (muted), large radius (16-24px), no sharp corners
+- **Icons**: Allowed - brand colors, organic feel
+- **Gradients**: Allowed - subtle transitions between brand palette tones
 
 ### Enforcement Block
 ```
@@ -237,11 +235,13 @@ STYLE: Organic (Japanese Zen)
 - HARD LIMIT: Max 4 elements.
 - Layout: Natural groupings, organic flow.
 - Typography: Medium weights (400-600), headlines 48-60pt.
-- Color: Warm palette only. No stark black or white.
+- Color: Brand palette softened (reduce saturation 20-30%). No stark black or pure white.
 - Texture: Subtle background texture (3-5% opacity).
-- Components: Soft cards (warm fills, large radius), warm icons, subtle gradients.
-- NEVER: Stark contrast, rigid grids, cold colors, sharp-cornered cards.
+- Components: Soft cards (muted brand fills, large radius), brand-colored icons, subtle gradients.
+- NEVER: Stark contrast, rigid grids, sharp-cornered cards.
 ```
+
+---
 
 ---
 
@@ -260,7 +260,7 @@ Beauty in imperfection, impermanence, and incompleteness. Embraces texture, age,
 | Whitespace | 45-55% | HARD LIMIT |
 | Max words/slide | 10 | HARD LIMIT |
 | Max elements | 4 | HARD LIMIT |
-| Colors | 4-5 earth tones | Muted, natural only |
+| Colors | 4-5 from brand, heavily muted | Desaturate brand palette 30-40% for aged feel |
 
 ### Layout Rules
 - Intentionally imperfect alignment
@@ -283,15 +283,15 @@ Beauty in imperfection, impermanence, and incompleteness. Embraces texture, age,
 ### Anti-Patterns (NEVER)
 - Perfect geometry
 - Pristine, polished surfaces
-- Synthetic colors
+- Neon or saturated colors (desaturate first)
 - Machine-precision alignment
 - Glossy finishes
 
 ### Example
-> Textured paper background with visible grain. Headline slightly off-axis in humanist typeface. Muted earth colors. Image with natural grain, edges soft and imperfect. Beauty in the imperfect.
+> Textured paper background with visible grain. Headline slightly off-axis in humanist typeface. Brand colors heavily muted to feel aged and natural. Image with natural grain, edges soft and imperfect. Beauty in the imperfect.
 
 ### Visual Components
-- **Cards**: Limited - textured/rough edges, imperfect corners, muted earth fills
+- **Cards**: Limited - textured/rough edges, imperfect corners, muted brand palette fills
 - **Icons**: Not allowed (too precise/synthetic)
 - **Gradients**: Not allowed (too smooth/perfect)
 
@@ -303,10 +303,10 @@ STYLE: Wabi-Sabi (Japanese Zen)
 - HARD LIMIT: Max 4 elements.
 - Layout: Intentionally imperfect. Visible texture.
 - Typography: Medium (400-500), humanist fonts, 44-54pt headlines.
-- Color: Earth tones only. Muted, natural.
+- Color: Brand palette desaturated 30-40%. Muted, low-chroma versions of brand colors.
 - Texture: Paper/cloth texture 5-10% opacity.
 - Components: Textured cards only (rough edges), no icons, no gradients.
-- NEVER: Perfect geometry, synthetic colors, glossy finishes, precise icons.
+- NEVER: Perfect geometry, neon/saturated colors, glossy finishes, precise icons.
 ```
 
 ---
@@ -516,7 +516,7 @@ Two styles based on Nordic design philosophy emphasizing warmth, balance, and in
 
 ## Hygge
 
-Danish concept of cozy togetherness and contentment. Warm, inviting, comfortable.
+Danish concept of cozy togetherness and contentment. Inviting, comfortable, approachable.
 
 **Learn more**: [Hygge (Wikipedia)](https://en.wikipedia.org/wiki/Hygge)
 
@@ -529,7 +529,7 @@ Danish concept of cozy togetherness and contentment. Warm, inviting, comfortable
 | Whitespace | 40-50% | HARD LIMIT |
 | Max words/slide | 12 | HARD LIMIT |
 | Max elements | 5 | HARD LIMIT |
-| Colors | 5-6 warm | Cozy palette |
+| Colors | 5-6 from brand, softened | Reduce saturation 15-25%, lighten for cozy feel |
 
 ### Layout Rules
 - Comfortable, inviting arrangement
@@ -540,35 +540,35 @@ Danish concept of cozy togetherness and contentment. Warm, inviting, comfortable
 ### Typography
 - Weight: Medium (400-500)
 - Headlines: 44-56pt
-- Style: Friendly, rounded sans or warm serif
+- Style: Friendly, rounded sans or brand serif
 - Comfortable reading
 
 ### Color
-- Warm candlelight palette
-- Soft oranges, warm browns, cream
-- Muted reds, gentle yellows
-- Nothing cold or harsh
+- Brand palette softened and lightened for cozy feel
+- Add slight warmth shift if brand allows (shift hue 5-10° toward amber)
+- Background: lightest brand color or tinted off-white from brand primary
+- Nothing harsh or high-saturation
 
 ### Texture
 - Soft textures (wool, knit, wood grain)
-- Warm gradients allowed
+- Soft gradients between brand tones allowed
 - Inviting surfaces
 - Tactile feel
 
 ### Anti-Patterns (NEVER)
-- Cold colors (blue, gray, white)
 - Sharp edges
 - Clinical layouts
 - Distant, corporate feel
 - High contrast
+- Neon or fully saturated colors
 
 ### Example
-> Soft cream background with subtle warmth. Friendly headline in warm brown. Image of cozy scene with soft focus. Warm orange accent. Everything invites you in like a warm blanket.
+> Soft background tinted with lightest brand color. Friendly headline in muted brand primary. Image of welcoming scene with soft focus. Brand accent softened. Everything invites you in — cozy, approachable.
 
 ### Visual Components
-- **Cards**: Full support - warm fills, large radius (20-24px), soft shadows allowed
-- **Icons**: Allowed - warm colors, friendly/rounded icons
-- **Gradients**: Allowed - warm tones only (cream → amber, peach → coral)
+- **Cards**: Full support - soft brand fills, large radius (20-24px), soft shadows allowed
+- **Icons**: Allowed - brand colors (softened), friendly/rounded icons
+- **Gradients**: Allowed - subtle transitions between softened brand colors
 
 ### Enforcement Block
 ```
@@ -578,10 +578,10 @@ STYLE: Hygge (Scandinavian)
 - HARD LIMIT: Max 5 elements.
 - Layout: Comfortable, intimate arrangement.
 - Typography: Medium (400-500), friendly fonts, 44-56pt headlines.
-- Color: Warm candlelight palette. No cold colors.
+- Color: Brand palette softened (reduce saturation 15-25%, lighten). Slight warmth shift OK if brand allows.
 - Texture: Soft, tactile (wool, wood grain).
-- Components: Warm cards (large radius, soft shadows), friendly icons, warm gradients.
-- NEVER: Cold colors, sharp edges, clinical feel, sharp-cornered cards.
+- Components: Soft cards (large radius, soft shadows), friendly icons, subtle gradients.
+- NEVER: Sharp edges, clinical feel, neon colors, sharp-cornered cards.
 ```
 
 ---
@@ -683,7 +683,7 @@ International Typographic Style. Mathematical precision, objective clarity, grid
 ### Typography
 - Weight: Medium (400-500)
 - Headlines: 48-60pt
-- Style: Helvetica, Univers, or similar grotesque
+- Style: Grotesque sans-serif (brand's heading font if grotesque, or Helvetica-family)
 - Flush left, ragged right
 
 ### Color
@@ -881,7 +881,7 @@ Chinese Yin-Yang balance. Harmonious energy flow through balanced opposing force
 | Whitespace | 50-60% | HARD LIMIT |
 | Max words/slide | 10 | HARD LIMIT |
 | Max elements | 4 | HARD LIMIT |
-| Colors | 5 (Five Elements) | Earth, Fire, Water, Wood, Metal |
+| Colors | 5 from brand palette | Map brand colors to Five Element roles |
 
 ### Layout Rules
 - Balance curved and angular
@@ -895,12 +895,14 @@ Chinese Yin-Yang balance. Harmonious energy flow through balanced opposing force
 - Mix of curved and angular letterforms
 - Balanced sizing
 
-### Color (Five Elements)
-- Earth: Yellow, brown, beige
-- Fire: Red, orange, pink
-- Water: Blue, black
-- Wood: Green, teal
-- Metal: White, gray, metallic
+### Color (Five Elements — mapped from brand)
+- Map brand palette to Element roles by hue proximity:
+  - Earth role: warm brand colors (yellows, browns, oranges)
+  - Fire role: energetic brand colors (reds, oranges)
+  - Water role: cool brand colors (blues, blacks)
+  - Wood role: growth brand colors (greens, teals)
+  - Metal role: neutral brand colors (whites, grays, silvers)
+- Not all Elements required — use 3-5 from brand palette as available
 
 ### Anti-Patterns (NEVER)
 - All angular or all curved
@@ -910,11 +912,11 @@ Chinese Yin-Yang balance. Harmonious energy flow through balanced opposing force
 - Sharp, aggressive shapes
 
 ### Example
-> Soft earth-tone background. Headline balances curved and angular forms. Circular image element balanced by rectangular text block. Colors from complementary elements. Energy flows naturally through the composition.
+> Soft background in lightest brand color. Headline balances curved and angular forms. Circular image element balanced by rectangular text block. Brand colors mapped to complementary Element roles. Energy flows naturally through the composition.
 
 ### Visual Components
 - **Cards**: Full support - mix curved and angular shapes, balanced fills
-- **Icons**: Allowed - balanced placement, Five Elements colors
+- **Icons**: Allowed - balanced placement, brand colors
 - **Gradients**: Allowed - harmonious transitions, balanced Yin-Yang
 
 ### Enforcement Block
@@ -925,7 +927,7 @@ STYLE: Feng Shui (East Asian)
 - HARD LIMIT: Max 4 elements.
 - Layout: Balance Yin (curved/soft) and Yang (angular/strong).
 - Typography: Medium (400-500), 46-56pt headlines.
-- Color: Five Elements palette (earth, fire, water, wood, metal).
+- Color: Brand palette mapped to Five Element roles by hue proximity.
 - Energy: Natural eye flow. No blocked corners.
 - Components: Balanced cards (curved + angular), icons, harmonious gradients.
 - NEVER: All angular or curved, imbalanced, cluttered, one-sided designs.

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -59,6 +59,7 @@ Assemble components into a single `.html` file:
 
 Before writing any HTML, internalize the design system:
 
+0. **Verify brand exists** — if no `design-system.md` in the project, STOP and suggest `/design-html` first. If no `brand-philosophy.md`, suggest `/brand-extract` first. Never proceed with default/example values.
 1. **Read the canvas philosophy** — absorb its aesthetic movement, not just rules
 2. **Load design tokens** — colors, fonts, spacing become CSS custom properties
 3. **Understand the style** — read enforcement blocks from `references/web-style-constraints.md`
@@ -96,6 +97,21 @@ Read the project's `design-system.md` and map ALL token sections to `:root` cust
 - **Forms** (if page has forms) — `--color-error`, `--color-success`, field/label/error styling
 
 The design-system.md is the single source of truth for all token values. Do not hardcode values — read them from the file.
+
+### Brand Bias Prevention
+
+Before generating any HTML, verify:
+
+```
+□ All colors use CSS custom properties from design-system.md (--color-primary, etc.)
+□ No hardcoded hex values except #FFFFFF/#000000 for universal black/white
+□ font-family from design-system.md, never "Inter", "Roboto", or "Arial" as defaults
+□ If no design-system.md exists: STOP, suggest /design-html first
+□ Background colors, accent colors, text colors all traced to design tokens
+```
+
+**Never copy hex codes or font names from reference file examples into generated HTML.**
+All visual values must flow from: design-system.md → CSS custom properties → component styles.
 
 ### Color Dominance Principle
 

--- a/brand-content-design/skills/html-generator/references/web-style-constraints.md
+++ b/brand-content-design/skills/html-generator/references/web-style-constraints.md
@@ -165,13 +165,13 @@ Based on **Shizen** (naturalness) and **Yugen** (hidden depth).
 | Section padding | 60-80px vertical | HARD LIMIT |
 | Max words/section body | 50 | HARD LIMIT |
 | Max content blocks/section | 4 | HARD LIMIT |
-| Colors | 5-6 warm tones | Warm spectrum only |
+| Colors | 5-6 from brand, softened | Reduce saturation 20-30% for natural feel |
 
 ### CSS Patterns
 - Rounded elements: `border-radius: 16px` to `24px`
 - Soft shadows: `box-shadow: 0 4px 20px rgba(0,0,0,0.08)`
 - Flowing layouts: asymmetric flex/grid, not rigid
-- Warm gradient backgrounds: subtle warm-tone gradients
+- Subtle gradient backgrounds between softened brand tones
 
 ### Typography
 - Weight: 400-600 (Medium)
@@ -184,11 +184,11 @@ Based on **Shizen** (naturalness) and **Yugen** (hidden depth).
 STYLE: Organic (Japanese Zen) — Web
 - HARD LIMIT: Max 50 words per section body.
 - HARD LIMIT: Max 4 content blocks per section.
-- HARD LIMIT: Warm colors only (no cold blues, pure grays).
+- HARD LIMIT: Brand palette softened (reduce saturation 20-30%). No stark black or pure white.
 - Layout: Flowing, rounded, soft. No sharp angles.
 - Typography: Medium weights, serif or rounded sans-serif.
-- CSS: border-radius 16-24px, soft shadows, warm gradients.
-- NEVER: Sharp corners, cold palette, rigid grid, industrial feel.
+- CSS: border-radius 16-24px, soft shadows, subtle brand-tone gradients.
+- NEVER: Sharp corners, rigid grid, industrial feel, neon/fully saturated colors.
 - JS: Not needed.
 ```
 
@@ -207,7 +207,7 @@ Beauty in imperfection, transience, and incompleteness.
 | Section padding | 60-80px vertical | HARD LIMIT |
 | Max words/section body | 50 | HARD LIMIT |
 | Max content blocks/section | 4 | HARD LIMIT |
-| Colors | 4-5 muted/earthy | Natural palette only |
+| Colors | 4-5 from brand, heavily muted | Desaturate brand palette 30-40% for aged feel |
 
 ### CSS Patterns
 - Textured backgrounds: subtle noise overlays, grain effects
@@ -226,7 +226,7 @@ Beauty in imperfection, transience, and incompleteness.
 STYLE: Wabi-Sabi (Japanese Zen) — Web
 - HARD LIMIT: Max 50 words per section body.
 - HARD LIMIT: Max 4 content blocks per section.
-- HARD LIMIT: Natural/earthy palette only.
+- HARD LIMIT: Brand palette desaturated 30-40%. Muted, low-chroma versions of brand colors.
 - Layout: Slightly imperfect, humanistic. Avoid mathematical precision.
 - Typography: Serif or humanist sans. Medium weight.
 - CSS: Texture overlays, irregular border-radius, muted shadows.
@@ -384,13 +384,13 @@ Cozy, warm, inviting — like a warm drink by a fire.
 | Section padding | 60-80px vertical | HARD LIMIT |
 | Max words/section body | 60 | HARD LIMIT |
 | Max content blocks/section | 5 | HARD LIMIT |
-| Colors | 5-6 warm | No cold tones |
+| Colors | 5-6 from brand, softened | Reduce saturation 15-25%, lighten for cozy feel |
 
 ### CSS Patterns
-- Warm backgrounds: soft cream, warm gray, blush
+- Soft backgrounds: lightest brand color or tinted off-white from brand primary
 - Rounded cards: `border-radius: 16px` with subtle shadow
 - Cozy grid: `gap: var(--space-md)` with comfortable spacing
-- Soft gradients: warm-tone linear gradients
+- Soft gradients: subtle transitions between softened brand tones
 
 ### Typography
 - Weight: 400-500 (Medium)
@@ -403,11 +403,11 @@ Cozy, warm, inviting — like a warm drink by a fire.
 STYLE: Hygge (Scandinavian Nordic) — Web
 - HARD LIMIT: Max 60 words per section body.
 - HARD LIMIT: Max 5 content blocks per section.
-- HARD LIMIT: Warm palette only (no cold blues, stark blacks).
+- HARD LIMIT: Brand palette softened (reduce saturation 15-25%, lighten). Slight warmth shift OK if brand allows.
 - Layout: Cozy grid with comfortable spacing. Rounded elements.
 - Typography: Rounded/friendly fonts, medium weight, generous line-height.
-- CSS: border-radius 16px, warm backgrounds, soft shadows.
-- NEVER: Cold colors, sharp corners, industrial feel, stark contrast.
+- CSS: border-radius 16px, soft brand-tinted backgrounds, soft shadows.
+- NEVER: Sharp corners, industrial feel, neon colors, stark contrast.
 - JS: Not needed.
 ```
 

--- a/brand-content-design/skills/infographic-generator/SKILL.md
+++ b/brand-content-design/skills/infographic-generator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: generating-infographics
 description: Use when creating infographics, data visualizations, process diagrams, timelines, or comparisons - generates branded infographics using @antv/infographic with 114 templates across 7 categories. Triggers on "create infographic", "make infographic", "visualize data", "timeline", "process diagram".
-version: 2.8.0
+version: 2.9.0
 allowed-tools: Read, Write, Glob, Bash
 user-invocable: false
 ---
@@ -15,6 +15,13 @@ Generate branded infographics with custom themes and backgrounds using @antv/inf
 1. Run `/brand-init` to create project structure
 2. Run `/brand-extract` to generate brand-philosophy.md
 3. Run `/template-infographic` to create an infographic template
+
+### No-Brand Safeguard
+
+If `brand-philosophy.md` is not found OR contains no `## Color Palette` section:
+- **STOP generation** — inform user: "No brand colors found. Run `/brand-extract` first to analyze your brand."
+- If user insists on proceeding: use deliberately bland neutrals (#1a1a1a, #666, #f5f5f5, system fonts)
+- Never fall back to any recognizable brand colors
 
 ## When to Use
 
@@ -134,8 +141,8 @@ Select template → paste content → name → get PNG
 
 | Background Type | Title Fill | Description Fill | Label Fill |
 |-----------------|------------|------------------|------------|
-| **Dark** (spotlight-dots, tech-matrix) | `#FFFFFF` | `rgba(255,255,255,0.85)` | `#FFFFFF` |
-| **Light** (solid, subtle-dots) | `#1A202C` | `#4A5568` | `#1A202C` |
+| **Dark** (spotlight-dots, tech-matrix) | White or near-white (WCAG >= 4.5:1) | White at ~85% opacity | White or near-white |
+| **Light** (solid, subtle-dots) | Near-black (WCAG >= 4.5:1) | Dark gray | Near-black |
 
 **Never use palette colors for text** - they're for decorative shapes only.
 
@@ -157,6 +164,11 @@ Select template → paste content → name → get PNG
 □ Content fits template capacity (check item limits)
 □ Dark bg → white text, Light bg → dark text
 □ No text touching edges
+□ colorBg derived from brand-philosophy.md, not from skill defaults
+□ colorPrimary derived from brand-philosophy.md, not from skill defaults
+□ Colors traced to brand-philosophy.md (not copied from reference docs or runtime fallbacks)
+□ font-family from brand-philosophy.md, not a generic default
+□ Text colors WCAG-validated against actual background
 ```
 
 **If ANY check fails, DO NOT generate. Fix the content or config first.**
@@ -166,8 +178,8 @@ Select template → paste content → name → get PNG
 **Dark Backgrounds (spotlight-dots, tech-matrix, etc.)**
 ```json
 {
-  "colorBg": "#0D2B5C",
-  "colorPrimary": "#60A5FA",
+  "colorBg": "{brand-bg-dark}",
+  "colorPrimary": "{brand-primary}",
   "title": { "fill": "#FFFFFF" },
   "desc": { "fill": "rgba(255,255,255,0.85)" },
   "item": {
@@ -181,7 +193,7 @@ Select template → paste content → name → get PNG
 ```json
 {
   "colorBg": "#FFFFFF",
-  "colorPrimary": "#3B82F6",
+  "colorPrimary": "{brand-primary}",
   "title": { "fill": "#1A202C" },
   "desc": { "fill": "#4A5568" },
   "item": {
@@ -194,6 +206,9 @@ Select template → paste content → name → get PNG
 **Common mistake:** Using pastel palette colors for text on light backgrounds. Pastels are for decorative shapes only.
 
 See template-infographic.md for complete config examples.
+
+> **Note:** The `/template-infographic` command generates correct configs from your brand-philosophy.md.
+> Never copy hex values from the examples above — they are illustrative placeholders only.
 
 ## Data Structure by Type
 

--- a/brand-content-design/skills/infographic-generator/generate.js
+++ b/brand-content-design/skills/infographic-generator/generate.js
@@ -317,17 +317,19 @@ async function main() {
       const brandColors = {};
       if (config.themeConfig) {
         // Use colorBg as primary background color (for dark backgrounds, this is the dark base)
-        const bgColor = config.themeConfig.colorBg || '#0D2B5C';
+        const bgColor = config.themeConfig.colorBg || '#333333';
         brandColors.primary = bgColor;
         // Derive darker shades from the background color
         brandColors.dark = darkenColor(bgColor, 0.3);
         brandColors.darker = darkenColor(bgColor, 0.6);
         // Accent comes from colorPrimary (for patterns) or palette
-        brandColors.accent = config.themeConfig.colorPrimary || '#00f3ff';
+        brandColors.accent = config.themeConfig.colorPrimary || '#888888';
         if (config.themeConfig.palette && config.themeConfig.palette.length > 1) {
           // If palette has accent color, use it (typically second light color for dark themes)
+          // Exclude white and the background color itself to avoid invisible overlays
           const potentialAccent = config.themeConfig.palette.find(c =>
             isLightColor(c) && c !== '#FFFFFF' && c !== '#ffffff'
+            && c.toUpperCase() !== bgColor.toUpperCase()
           );
           if (potentialAccent) brandColors.accent = potentialAccent;
         }

--- a/brand-content-design/skills/infographic-generator/lib/backgrounds.js
+++ b/brand-content-design/skills/infographic-generator/lib/backgrounds.js
@@ -130,11 +130,11 @@ function applyPattern(svg, defs, bg, getOrCreateBgRect, document) {
   const patternBg = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
   patternBg.setAttribute('width', bg.size || 20);
   patternBg.setAttribute('height', bg.size || 20);
-  patternBg.setAttribute('fill', bg.backgroundColor || '#0D2B5C');
+  patternBg.setAttribute('fill', bg.backgroundColor || '#333333');
   pattern.appendChild(patternBg);
 
   const size = bg.size || 20;
-  const fgColor = bg.foregroundColor || '#194582';
+  const fgColor = bg.foregroundColor || '#666666';
 
   switch (bg.pattern) {
     case 'dots':
@@ -218,10 +218,10 @@ function applyPattern(svg, defs, bg, getOrCreateBgRect, document) {
  * @returns {Object} Background configuration
  */
 function createBackgroundPreset(preset, brandColors = {}) {
-  const primary = brandColors.primary || '#194582';
-  const dark = brandColors.dark || '#0D2B5C';
-  const darker = brandColors.darker || '#061120';
-  const accent = brandColors.accent || '#00f3ff';
+  const primary = brandColors.primary || '#444444';
+  const dark = brandColors.dark || '#333333';
+  const darker = brandColors.darker || '#1a1a1a';
+  const accent = brandColors.accent || '#888888';
 
   const presets = {
     'spotlight': {
@@ -480,10 +480,10 @@ function applyLayeredBackground(svg, layeredConfig, dom) {
  * @returns {Object} Layered background configuration
  */
 function createLayeredPreset(preset, brandColors = {}) {
-  const primary = brandColors.primary || '#194582';
-  const dark = brandColors.dark || '#0D2B5C';
-  const darker = brandColors.darker || '#061120';
-  const accent = brandColors.accent || '#00f3ff';
+  const primary = brandColors.primary || '#444444';
+  const dark = brandColors.dark || '#333333';
+  const darker = brandColors.darker || '#1a1a1a';
+  const accent = brandColors.accent || '#888888';
 
   const presets = {
     'spotlight-dots': {

--- a/brand-content-design/skills/infographic-generator/references/backgrounds.md
+++ b/brand-content-design/skills/infographic-generator/references/backgrounds.md
@@ -1,5 +1,9 @@
 # Custom Background Reference
 
+> **⚠️ BIAS WARNING:** All color values below are **illustrative**. Never copy hex codes into generated output.
+> Derive colors from `brand-philosophy.md` using the palette derivation pattern:
+> `darkenColor(brandColors.primary, 0.3)` for dark shades, `darkenColor(brandColors.primary, 0.6)` for darker shades.
+
 ## Contents
 - Background Limitations
 - Simple Backgrounds
@@ -44,9 +48,9 @@ const svgBuffer = renderer.extractSVGBuffer(dom, { customBackground: bg });
   cy: '40%',    // Center Y
   r: '80%',     // Radius
   stops: [
-    { offset: '0%', color: '#194582' },
-    { offset: '50%', color: '#0D2B5C' },
-    { offset: '100%', color: '#020810' }
+    { offset: '0%', color: brandColors.primary },
+    { offset: '50%', color: brandColors.dark },
+    { offset: '100%', color: brandColors.darker }
   ]
 }
 ```
@@ -59,8 +63,8 @@ const svgBuffer = renderer.extractSVGBuffer(dom, { customBackground: bg });
   x1: '0%', y1: '0%',     // Start point
   x2: '100%', y2: '100%', // End point
   stops: [
-    { offset: '0%', color: '#194582' },
-    { offset: '100%', color: '#020810' }
+    { offset: '0%', color: brandColors.primary },
+    { offset: '100%', color: brandColors.darker }
   ]
 }
 ```
@@ -74,7 +78,7 @@ const svgBuffer = renderer.extractSVGBuffer(dom, { customBackground: bg });
   pattern: 'dots',
   size: 20,           // Grid size
   dotSize: 1,         // Dot radius
-  foregroundColor: '#00f3ff',
+  foregroundColor: brandColors.accent,
   backgroundColor: 'transparent',
   opacity: 0.08
 }
@@ -87,7 +91,7 @@ const svgBuffer = renderer.extractSVGBuffer(dom, { customBackground: bg });
   pattern: 'grid',
   size: 30,
   strokeWidth: 0.5,
-  foregroundColor: '#00f3ff',
+  foregroundColor: brandColors.accent,
   opacity: 0.06
 }
 ```
@@ -99,7 +103,7 @@ const svgBuffer = renderer.extractSVGBuffer(dom, { customBackground: bg });
   pattern: 'diagonal',
   size: 15,
   strokeWidth: 1,
-  foregroundColor: '#00f3ff',
+  foregroundColor: brandColors.accent,
   opacity: 0.08
 }
 ```
@@ -111,7 +115,7 @@ const svgBuffer = renderer.extractSVGBuffer(dom, { customBackground: bg });
   pattern: 'crosshatch',
   size: 15,
   strokeWidth: 0.5,
-  foregroundColor: '#00f3ff',
+  foregroundColor: brandColors.accent,
   opacity: 0.06
 }
 ```
@@ -122,10 +126,10 @@ Combine gradient base + pattern overlay:
 
 ```javascript
 const layered = renderer.createLayeredPreset('spotlight-dots', {
-  primary: '#194582',
-  dark: '#0D2B5C',
-  darker: '#061120',
-  accent: '#00f3ff'
+  primary: brandColors.primary,
+  dark: brandColors.dark,
+  darker: brandColors.darker,
+  accent: brandColors.accent
 });
 
 const svgBuffer = renderer.extractSVGBuffer(dom, {
@@ -148,10 +152,10 @@ const svgBuffer = renderer.extractSVGBuffer(dom, {
 
 ```javascript
 const brandColors = {
-  primary: '#194582',   // Main brand blue
-  dark: '#0D2B5C',      // Dark blue
-  darker: '#061120',    // Darkest (near black)
-  accent: '#00f3ff'     // Cyan accent
+  primary: brandPalette.primary,         // From brand-philosophy.md
+  dark: darkenColor(brandPalette.primary, 0.3),    // Derived darker shade
+  darker: darkenColor(brandPalette.primary, 0.6),  // Derived darkest shade
+  accent: brandPalette.accent            // From brand-philosophy.md
 };
 ```
 
@@ -179,16 +183,16 @@ const custom = {
     cy: '30%',
     r: '90%',
     stops: [
-      { offset: '0%', color: '#194582' },
-      { offset: '40%', color: '#0D2B5C' },
-      { offset: '100%', color: '#020810' }
+      { offset: '0%', color: brandColors.primary },
+      { offset: '40%', color: brandColors.dark },
+      { offset: '100%', color: brandColors.darker }
     ]
   },
   pattern: {
     pattern: 'dots',
     size: 16,
     dotSize: 1.2,
-    foregroundColor: '#00f3ff',
+    foregroundColor: brandColors.accent,
     opacity: 0.12
   }
 };
@@ -214,8 +218,8 @@ const patternOnly = {
   pattern: 'dots',
   size: 20,
   dotSize: 1,
-  foregroundColor: '#00f3ff',
-  backgroundColor: '#0D2B5C',  // Solid base
+  foregroundColor: brandColors.accent,
+  backgroundColor: brandColors.dark,  // Solid base
   opacity: 0.1
 };
 

--- a/brand-content-design/skills/infographic-generator/references/theming.md
+++ b/brand-content-design/skills/infographic-generator/references/theming.md
@@ -1,5 +1,8 @@
 # Theme Configuration Reference
 
+> **⚠️ BIAS WARNING:** All color and font values in this file are **illustrative placeholders**.
+> Derive actual values from the project's `brand-philosophy.md`. Never copy hex codes or font names from these examples.
+
 ## Contents
 - Theme Basics
 - Color Configuration
@@ -26,8 +29,8 @@ await createInfographic({
 
 ```javascript
 themeConfig: {
-  colorPrimary: '#00f3ff',  // Main accent color (titles, highlights)
-  colorBg: '#0D2B5C',       // Background color (solid only)
+  colorPrimary: '{brand-primary}',  // Main accent color (titles, highlights) — Illustrative — derive from brand-philosophy.md
+  colorBg: '{brand-bg}',            // Background color (solid only) — Illustrative — derive from brand-philosophy.md
 }
 ```
 
@@ -37,8 +40,8 @@ The `palette` array cycles through colors for items:
 
 ```javascript
 themeConfig: {
-  palette: ['#00f3ff', '#78A5D7', '#3773B4', '#B9D2F0'],
-  // Item 1: #00f3ff, Item 2: #78A5D7, etc.
+  palette: ['{brand-primary}', '{brand-palette-2}', '{brand-palette-3}', '{brand-palette-4}'],
+  // Illustrative — derive from brand-philosophy.md. Items cycle through palette colors.
 }
 ```
 
@@ -50,7 +53,7 @@ themeConfig: {
 themeConfig: {
   base: {
     text: {
-      'font-family': 'Inter, sans-serif',
+      'font-family': '{brand-heading-font}, sans-serif',  // Illustrative — derive from brand-philosophy.md
       'fill': '#FFFFFF',
       'font-size': 14
     }
@@ -63,15 +66,15 @@ themeConfig: {
 ```javascript
 themeConfig: {
   title: {
-    'fill': '#00f3ff',
+    'fill': '{brand-primary}',  // Illustrative — derive from brand-philosophy.md
     'font-weight': 'bold',
     'font-size': 28,
-    'font-family': 'Inter, sans-serif'
+    'font-family': '{brand-heading-font}, sans-serif'  // Illustrative — derive from brand-philosophy.md
   },
   desc: {
-    'fill': '#B9D2F0',
+    'fill': '{brand-palette-4}',  // Illustrative — derive from brand-philosophy.md
     'font-size': 16,
-    'font-family': 'Inter, sans-serif'
+    'font-family': '{brand-heading-font}, sans-serif'  // Illustrative — derive from brand-philosophy.md
   }
 }
 ```
@@ -82,12 +85,12 @@ themeConfig: {
 themeConfig: {
   item: {
     label: {
-      'fill': '#00f3ff',
+      'fill': '{brand-primary}',  // Illustrative — derive from brand-philosophy.md
       'font-weight': 'bold',
       'font-size': 18
     },
     desc: {
-      'fill': '#B9D2F0',
+      'fill': '{brand-palette-4}',  // Illustrative — derive from brand-philosophy.md
       'font-size': 14
     }
   }
@@ -102,7 +105,7 @@ themeConfig: {
 themeConfig: {
   base: {
     shape: {
-      'stroke': '#00f3ff',
+      'stroke': '{brand-primary}',  // Illustrative — derive from brand-philosophy.md
       'stroke-width': 2,
       'fill': 'transparent'
     }
@@ -139,47 +142,47 @@ themeConfig: {
 themeConfig: {
   stylize: {
     type: 'linear-gradient',
-    colors: ['#00f3ff', '#194582']
+    colors: ['{brand-primary}', '{brand-dark}']  // Illustrative — derive from brand-philosophy.md
   }
 }
 ```
 
 ## Complete Example
 
-Palcera brand theme:
+Brand theme (all values illustrative — derive from brand-philosophy.md):
 
 ```javascript
-const palceraTheme = {
-  colorPrimary: '#00f3ff',
-  colorBg: '#0D2B5C',
-  palette: ['#00f3ff', '#78A5D7', '#3773B4', '#B9D2F0'],
+const brandTheme = {
+  colorPrimary: '{brand-primary}',
+  colorBg: '{brand-bg}',
+  palette: ['{brand-primary}', '{brand-palette-2}', '{brand-palette-3}', '{brand-palette-4}'],
   base: {
     text: {
-      'font-family': 'Inter, sans-serif',
+      'font-family': '{brand-heading-font}, sans-serif',
       'fill': '#FFFFFF'
     },
     shape: {
-      'stroke': '#00f3ff',
+      'stroke': '{brand-primary}',
       'stroke-width': 1
     }
   },
   title: {
-    'fill': '#00f3ff',
+    'fill': '{brand-primary}',
     'font-weight': 'bold',
     'font-size': 28
   },
   desc: {
-    'fill': '#B9D2F0',
+    'fill': '{brand-palette-4}',
     'font-size': 16
   },
   item: {
     label: {
-      'fill': '#00f3ff',
+      'fill': '{brand-primary}',
       'font-weight': 'bold',
       'font-size': 18
     },
     desc: {
-      'fill': '#B9D2F0',
+      'fill': '{brand-palette-4}',
       'font-size': 14
     }
   }

--- a/brand-content-design/skills/visual-content/SKILL.md
+++ b/brand-content-design/skills/visual-content/SKILL.md
@@ -381,6 +381,24 @@ When invoking this skill, provide:
 6. **Dimensions** (based on content type)
 7. **Visual components config** (optional - from canvas-philosophy.md Visual Components section)
 
+### No-Brand Safeguard
+
+If `brand-philosophy.md` is not found OR contains no `## Color Palette` section:
+- **STOP generation** — inform user: "No brand colors found. Run `/brand-extract` first to analyze your brand."
+- If user insists on proceeding: use deliberately bland neutrals (#1a1a1a, #666, #f5f5f5, system fonts)
+- Never fall back to any recognizable brand colors
+
+### Pre-Output Brand Bias Check
+
+Before finalizing any presentation or carousel:
+```
+□ All colors derived from brand-philosophy.md color table
+□ All fonts loaded from project assets/fonts/ or brand-philosophy.md
+□ Colors traced to brand-philosophy.md (not copied from reference docs or runtime fallbacks)
+□ No generic font defaults (unless brand actually uses them)
+□ Text colors WCAG-validated against actual background
+```
+
 ---
 
 ## Part 11: The Ultimate Test

--- a/brand-content-design/skills/visual-content/references/technical-implementation.md
+++ b/brand-content-design/skills/visual-content/references/technical-implementation.md
@@ -1,5 +1,8 @@
 # Technical Implementation
 
+> **⚠️ BIAS WARNING:** Font names and hex colors in code examples below are **illustrative**.
+> Always derive fonts from `brand_fonts` and colors from `brand_colors` parsed from brand-philosophy.md.
+
 Code patterns for PDF generation with reportlab.
 
 ## Contents
@@ -113,7 +116,7 @@ def create_presentation_pdf(output_path, slides_content, brand_colors, logo_path
 
         # Headline (positioned in top third)
         c.setFillColor(text_color)
-        c.setFont("Helvetica-Bold", 72)
+        c.setFont(brand_fonts.get('heading', 'Helvetica-Bold'), 72)
         c.drawString(safe_left, safe_top - 100, slide['headline'])
 
         # Logo (bottom right, respecting safe zone)
@@ -155,10 +158,10 @@ def create_carousel_pdf(output_path, cards_content, brand_colors, logo_path):
 
         # Headline (large, bold, thumb-stopping)
         c.setFillColor(text_color)
-        c.setFont("Helvetica-Bold", 64)
+        c.setFont(brand_fonts.get('heading', 'Helvetica-Bold'), 64)
 
         # Center text horizontally
-        text_width = c.stringWidth(card['headline'], "Helvetica-Bold", 64)
+        text_width = c.stringWidth(card['headline'], brand_fonts.get('heading', 'Helvetica-Bold'), 64)
         x = (CARD_WIDTH - text_width) / 2
         c.drawString(x, CARD_HEIGHT * 0.6, card['headline'])
 
@@ -314,8 +317,10 @@ def draw_icon_card(canvas, x, y, size, icon_path,
 def draw_feature_card(canvas, x, y, width, height,
                       icon_path, title, description,
                       fill_color, text_color,
-                      title_font="Helvetica-Bold", title_size=24,
-                      desc_font="Helvetica", desc_size=16,
+                      title_font=None,  # Pass brand_fonts.get('heading', 'Helvetica-Bold')
+                      title_size=24,
+                      desc_font=None,  # Pass brand_fonts.get('body', 'Helvetica')
+                      desc_size=16,
                       icon_size=48, radius=16, padding=24):
     """
     Draw a feature card with icon, title, and description.
@@ -328,6 +333,10 @@ def draw_feature_card(canvas, x, y, width, height,
     +------------------------+
     """
     canvas.saveState()
+
+    # Resolve font defaults from brand (None means caller didn't specify)
+    title_font = title_font or brand_fonts.get('heading', 'Helvetica-Bold')
+    desc_font = desc_font or brand_fonts.get('body', 'Helvetica')
 
     # Draw card background
     if fill_color:
@@ -494,7 +503,7 @@ else:
 **Note:** The code tries multiple fallback paths if the environment variable isn't set. Ensure `cairosvg` is installed (`pip install cairosvg`).
 
 ```python
-def draw_icon(canvas, name, x, y, color='#000000', size=48):
+def draw_icon(canvas, name, x, y, color=None, size=48):
     """
     Draw a Lucide icon on canvas.
 
@@ -502,12 +511,14 @@ def draw_icon(canvas, name, x, y, color='#000000', size=48):
         canvas: reportlab canvas
         name: Icon name (e.g., 'lightbulb', 'rocket', 'check-circle')
         x, y: Position (bottom-left of icon)
-        color: Icon stroke color (hex)
+        color: Icon stroke color (hex) — defaults to brand_colors['text']
         size: Icon dimensions in pixels
 
     Returns:
         True if icon was drawn, False if not found
     """
+    if color is None:
+        color = brand_colors.get('text', '#000000')
     icon_path = get_icon_png(name, color=color, size=size)
 
     if icon_path:
@@ -519,7 +530,7 @@ def draw_icon(canvas, name, x, y, color='#000000', size=48):
 # Usage examples:
 
 # Draw single icon
-draw_icon(canvas, 'rocket', x=100, y=500, color='#3B82F6', size=64)
+draw_icon(canvas, 'rocket', x=100, y=500, color=brand_colors['primary'], size=64)
 
 # Search for icons
 chart_icons = search_icons('chart')  # ['chart-bar', 'chart-line', 'chart-pie', ...]
@@ -529,7 +540,7 @@ business_icons = ICON_CATEGORIES['business']  # ['briefcase', 'building', ...]
 
 # Draw row of category icons
 for i, icon_name in enumerate(ICON_CATEGORIES['growth'][:4]):
-    draw_icon(canvas, icon_name, x=100 + i*80, y=400, color='#10B981', size=48)
+    draw_icon(canvas, icon_name, x=100 + i*80, y=400, color=brand_colors['accent'], size=48)
 ```
 
 ### Combined Example: Feature Card with Gradient
@@ -556,8 +567,8 @@ def draw_feature_slide(canvas, title, features, brand_colors):
     )
 
     # Title at top
-    canvas.setFillColor(HexColor('#FFFFFF'))
-    canvas.setFont("Helvetica-Bold", 48)
+    canvas.setFillColor(HexColor(brand_colors.get('text_on_dark', '#FFFFFF')))
+    canvas.setFont(brand_fonts.get('heading', 'Helvetica-Bold'), 48)
     canvas.drawCentredString(width/2, height - 120, title)
 
     # Feature cards
@@ -578,7 +589,7 @@ def draw_feature_slide(canvas, title, features, brand_colors):
             icon_path=icon_path,
             title=feature['title'],
             description=feature['description'],
-            fill_color='#FFFFFF',
+            fill_color=brand_colors.get('card_bg', '#FFFFFF'),
             text_color=brand_colors['text'],
             radius=16
         )
@@ -813,6 +824,30 @@ def pre_render_checks(slide_content, canvas_width, canvas_height, margin, bg_col
 
     can_render = len(issues) == 0
     return can_render, issues
+
+
+def validate_no_default_bias(brand_colors, brand_fonts):
+    """
+    Verify no Palcera/default brand values leaked into output.
+    Run before finalizing any visual content.
+
+    Returns: (is_clean, issues_list)
+    """
+    issues = []
+
+    # Known biased defaults that should never appear in output
+    BIASED_COLORS = {'#0D2B5C', '#194582', '#00f3ff', '#061120', '#60A5FA'}
+    BIASED_FONTS = {'Inter', 'Inter, sans-serif'}
+
+    for key, value in brand_colors.items():
+        if isinstance(value, str) and value.upper() in {c.upper() for c in BIASED_COLORS}:
+            issues.append(f"Biased color detected: {key}={value}. Derive from brand-philosophy.md")
+
+    for key, value in brand_fonts.items():
+        if isinstance(value, str) and value in BIASED_FONTS:
+            issues.append(f"Default font detected: {key}={value}. Use brand's actual font")
+
+    return len(issues) == 0, issues
 ```
 
 ### 5. Gradient Text Safety


### PR DESCRIPTION
## Summary

- Replace Palcera-specific hex fallbacks (#0D2B5C, #194582, #00f3ff) in runtime JS with neutral grays
- Replace 23+ hardcoded hex values in reference docs with `{brand-*}` placeholders and `brandColors.*` derivation patterns
- Remove warm/earth color temperature prescriptions from Organic, Wabi-Sabi, and Hygge styles — styles now define color *relationships* (muted, softened, desaturated) not *temperature* (warm, earth, candlelight)
- Fix accent color search bug that caused invisible overlays on light-background brands
- Fix `draw_feature_card` crash from None font defaults and `draw_icon` mutable default argument
- Add no-brand safeguards, bias-prevention reference, and pre-output validation checklists

## What changed

| Layer | Files | Change |
|-------|-------|--------|
| Runtime JS | backgrounds.js, generate.js | Neutral gray fallbacks, bgColor exclusion in accent search |
| Reference docs | theming.md, backgrounds.md, technical-implementation.md | `{brand-*}` placeholders, `brandColors.*` derivation |
| SKILL.md files | infographic, visual-content, html-generator | No-brand safeguards, validation checklists, version 2.9.0 |
| Style system | style-constraints.md, web-style-constraints.md, visual-components.md | Remove warm/earth prescriptions from 4 styles |
| New file | bias-prevention.md | Shared reference with derivation hierarchy |
| Commands | brand-extract.md, template-infographic.md | Remove hardcoded Inter/Palcera examples |

## Verification

Paper tested with two contrasting brands (warm bakery vs dark cybersecurity SaaS):
- Both produce fundamentally different outputs
- Zero cross-brand contamination
- Organic/Hygge styles correctly soften brand palette without forcing warm tones
- No-brand safeguard blocks generation when brand-philosophy.md is missing/empty

## Test plan

- [ ] `grep -rn '#0D2B5C\|#194582\|#00f3ff' skills/` returns only checklist/validation references
- [ ] `grep -rn 'Warm palette\|earth tones only\|warm tones only\|no cold' skills/` returns zero hits
- [ ] Generate infographic for a cool-toned brand — should NOT get warm/brown output
- [ ] Generate with no brand-philosophy.md — should STOP with safeguard message
- [ ] Generate with light-background brand — accent overlay should be visible (not same color as bg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)