### PR TITLE
Add brand anchors, font auto-download, palette primary rule

### DIFF
--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2026-03-16
+
+### Changed
+- Remove brand bias from runtime JS fallbacks — Palcera colors (#0D2B5C, #194582, #00f3ff) replaced with neutral grays
+- Replace hardcoded hex values in reference docs (theming.md, backgrounds.md) with {brand-*} placeholders
+- Remove warm/earth color temperature prescriptions from Organic, Wabi-Sabi, Hygge, Feng Shui styles — styles now define color relationships, not temperature
+- Replace Helvetica defaults in technical-implementation.md with brand_fonts.get() pattern
+- Fix accent color search bug that caused invisible overlays on light-background brands
+- Fix draw_feature_card crash from None font defaults
+
+### Added
+- Brand Anchors section in canvas-philosophy-template.md (logo placement, primary color requirement, font mandate)
+- bias-prevention.md shared reference with Value Derivation Hierarchy
+- No-brand safeguard on infographic, visual-content, and html-generator skills
+- Pre-output validation checklists on all generation skills
+- Auto-download Google Fonts in brand-extract command
+- Brand anchor rule: derived/alternative palettes must include primary brand color
+
+### Fixed
+- brand-extract.md font examples used hardcoded "Inter" — now uses {detected heading font}
+- template-infographic.md palette display showed Palcera hex — now uses {from brand-philosophy.md}
+- style-constraints.md Swiss typography referenced "Helvetica" by name
+- web-style-constraints.md Organic/Wabi-Sabi/Hygge enforcement blocks prescribed warm-only colors
+- visual-components.md card style table referenced "warm tones"
+
 ## [2.8.0] - 2026-03-14
 
 ### Fixed

--- a/brand-content-design/README.md
+++ b/brand-content-design/README.md
@@ -1,6 +1,6 @@
 # Brand Content Design Plugin
 
-> **Current version: v2.8.0**
+> **Current version: v2.9.0**
 
 Create branded presentations, LinkedIn carousels, infographics, and HTML pages with consistent visual identity.
 

--- a/brand-content-design/agents/brand-analyst.md
+++ b/brand-content-design/agents/brand-analyst.md
@@ -1,8 +1,9 @@
 ---
 name: brand-analyst
 description: Analyze brand assets (screenshots, documents, logos, websites) to extract brand elements including color palettes with color theory analysis. Use proactively when user provides assets for brand analysis.
-version: 2.8.0
+version: 2.9.0
 model: sonnet
+maxTurns: 25
 memory: project
 allowed-tools: Read, Glob, WebFetch
 ---

--- a/brand-content-design/commands/brand-extract.md
+++ b/brand-content-design/commands/brand-extract.md
@@ -156,19 +156,38 @@ When analyzing a website, the brand-analyst agent should:
    - Body font(s)
    - Any accent/special fonts
 
-3. **Recommend font upload** - If custom/web fonts detected:
-   > "I detected these fonts on your website:
-   > - **Heading**: {detected heading font} (Google Fonts)
-   > - **Body**: {detected body font} (Google Fonts)
-   >
-   > For best results, download these fonts and add them to `input/fonts/`:
-   > - [Download Inter](https://fonts.google.com/specimen/Inter)
-   > - [Download Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro)
-   >
-   > This ensures your presentations and carousels match your website typography."
+3. **Auto-download Google Fonts** - If Google Fonts detected:
+   - Download TTF files directly using the Google Fonts API:
+     ```bash
+     # Download font family (all weights)
+     mkdir -p "{PROJECT_PATH}/assets/fonts"
+     curl -L "https://fonts.google.com/download?family={Font+Name}" -o /tmp/{font-name}.zip
+     unzip -o /tmp/{font-name}.zip -d /tmp/{font-name}/
+     cp /tmp/{font-name}/*.ttf "{PROJECT_PATH}/assets/fonts/" 2>/dev/null
+     cp /tmp/{font-name}/static/*.ttf "{PROJECT_PATH}/assets/fonts/" 2>/dev/null
+     ```
+   - Report what was downloaded:
+     > "Downloaded brand fonts to `assets/fonts/`:
+     > - **Heading**: {font name} ({N} weights)
+     > - **Body**: {font name} ({N} weights)
+     >
+     > These will be used automatically in presentations, carousels, and infographics."
 
-4. **Fallback recommendation** - If fonts cannot be identified or are proprietary:
-   > "I couldn't identify the exact fonts. Please add your brand fonts to `input/fonts/` or specify them manually."
+4. **Non-Google fonts** - If Adobe Fonts, custom @font-face, or proprietary:
+   > "I detected these fonts but cannot auto-download them:
+   > - **Heading**: {font name} ({source})
+   > - **Body**: {font name} ({source})
+   >
+   > Please add the TTF/OTF files to `input/fonts/` manually.
+   > Without brand fonts, generated content will fall back to system fonts."
+
+5. **Verify fonts were loaded** - After extraction, check:
+   ```bash
+   ls "{PROJECT_PATH}/assets/fonts/"/*.ttf "{PROJECT_PATH}/assets/fonts/"/*.otf 2>/dev/null
+   ```
+   - If no font files found: warn prominently
+     > "⚠️ No brand fonts in assets/fonts/. Generated content will use system font fallbacks.
+     > Run `/brand-assets` to add fonts, or download from Google Fonts."
 
 ## Notes
 

--- a/brand-content-design/commands/brand-palette.md
+++ b/brand-content-design/commands/brand-palette.md
@@ -118,6 +118,8 @@ If user selected "Derived":
     - Label results: "Complementary (from Primary)", "Complementary (from Secondary)"
     - Remove duplicates if colors are very similar (< 5% difference)
 
+    **Brand anchor rule:** Every derived palette MUST include the brand's primary color as one entry. This ensures brand recognition across all palette variations. If the harmony calculation doesn't naturally include it, add it as the first or last entry.
+
     → Continue to step 10
 
 ---
@@ -173,6 +175,8 @@ If user selected "Alternative":
        - Keep relative contrast between colors
        - Preserve warm/cool balance
        - Maintain hierarchy (primary still dominant, accent still pop)
+
+    **Brand anchor rule:** Every alternative palette MUST include the brand's primary color (original or mood-transformed version). This ensures brand recognition across all palette variations.
 
     → Continue to step 10
 

--- a/brand-content-design/commands/template-carousel.md
+++ b/brand-content-design/commands/template-carousel.md
@@ -298,7 +298,12 @@ Create a new carousel template or edit an existing one.
     - **Load brand assets**:
       - Read logo file from brand-philosophy.md Brand Assets section
       - If logo is SVG, convert to PNG first (visual-content handles this)
-      - Load fonts from `{PROJECT_PATH}/assets/fonts/` if present
+      - Load fonts from `{PROJECT_PATH}/assets/fonts/`
+      - **If no font files found**: STOP and warn — do not silently fall back to system fonts
+    - **Apply Brand Anchors** (from canvas-philosophy-template.md):
+      - Logo on first card (top-left) and last/CTA card (bottom-center)
+      - Primary brand color as accent on every card
+      - Brand heading font (mandatory — no fallback)
     - **Apply visual components** (if enabled in step 6):
       - Use `scripts/icons.py` for icon rendering
       - Apply card patterns from `technical-implementation.md`

--- a/brand-content-design/commands/template-presentation.md
+++ b/brand-content-design/commands/template-presentation.md
@@ -291,7 +291,12 @@ Create a new presentation template or edit an existing one.
     - **Load brand assets**:
       - Read logo file from brand-philosophy.md Brand Assets section
       - If logo is SVG, convert to PNG first (visual-content handles this)
-      - Load fonts from `{PROJECT_PATH}/assets/fonts/` if present
+      - Load fonts from `{PROJECT_PATH}/assets/fonts/`
+      - **If no font files found**: STOP and warn — do not silently fall back to system fonts
+    - **Apply Brand Anchors** (from canvas-philosophy-template.md):
+      - Logo on every slide (bottom-right, subtle, max 150px)
+      - Primary brand color as accent on every slide
+      - Brand heading font (mandatory — no fallback)
     - **Apply visual components** (if enabled in step 6):
       - Use `scripts/icons.py` for icon rendering
       - Apply card patterns from `technical-implementation.md`

--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brand-content-design
 description: Use when user says "create presentation", "make slides", "make carousel", "LinkedIn carousel", "create HTML page", "make landing page", "build web page", "html design system", "design system", "setup brand", "brand init", "extract brand", "get outline", "color palette", "alternative colors", "infographic", "brand assets", "brand project". Use PROACTIVELY when user wants to create any visual content with consistent branding. MUST be invoked for branded content — routes to the correct command for presentations, carousels, infographics, and HTML pages.
-version: 2.8.0
+version: 2.9.0
 allowed-tools: Read, Glob, Grep, Write, Bash, AskUserQuestion, Skill
 user-invocable: true
 ---
@@ -126,6 +126,7 @@ The `visual-content` skill is bundled with this plugin. For HTML-to-Drupal conve
 - `references/style-constraints.md` - 13 visual styles with enforcement blocks
 - `references/color-palettes.md` - Color theory and palette types
 - `references/output-specs.md` - Dimensions, formats, file sizes
+- `references/bias-prevention.md` - Brand bias prevention checks
 
 ### Online Dev-Guides (Design Systems)
 

--- a/brand-content-design/skills/brand-content-design/references/canvas-philosophy-template.md
+++ b/brand-content-design/skills/brand-content-design/references/canvas-philosophy-template.md
@@ -156,6 +156,17 @@ Example: Feature Highlights with Icon Cards
 - Icons: lightbulb, zap, shield (from 'misc' and 'security' categories)
 ```
 
+## Brand Anchors (Always Present)
+
+Regardless of style, these brand elements appear on every slide/card:
+
+- **Logo**: Placed in a consistent position across all slides/cards
+  - Presentations: bottom-right of every slide (subtle, small — max 150px wide)
+  - Carousels: top-left of first card, bottom-center of last card (CTA)
+  - Infographics: not applicable (too small)
+- **Primary brand color**: Appears at least once per slide/card — as an accent line, icon color, card border, or text highlight. Even when using derived/special palettes, the primary brand color anchors brand recognition.
+- **Brand font**: Heading font from brand-philosophy.md is mandatory. If font files are not in `assets/fonts/`, STOP and instruct user to run `/brand-extract` again or add fonts manually. Never silently fall back to system fonts.
+
 ## Quality Standards
 
 - This work must appear as if created by a master craftsman

--- a/brand-content-design/skills/html-generator/SKILL.md
+++ b/brand-content-design/skills/html-generator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: html-generator
 description: Use when generating branded HTML pages and components from a design system. Creates standalone HTML components and composes them into full pages with embedded CSS, responsive design, and brand integration.
-version: 2.8.0
+version: 2.9.0
 allowed-tools: Read, Write, Glob, Grep, Bash
 user-invocable: false
 ---

--- a/brand-content-design/skills/visual-content/SKILL.md
+++ b/brand-content-design/skills/visual-content/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: visual-content
 description: Use when creating branded presentations or carousels. Generates museum-quality visual output from canvas philosophy, enforcing style constraints. Outputs PDF first, then converts to PPTX for editability.
-version: 2.8.0
+version: 2.9.0
 allowed-tools: Read, Write, Glob, Bash
 user-invocable: false
 ---


### PR DESCRIPTION
## Summary

- Add Brand Anchors section to canvas-philosophy-template.md — logo, primary color, and brand font must appear on every slide/card
- Auto-download Google Fonts in `/brand-extract` instead of just recommending manual download
- Derived/alternative palettes must always include the primary brand color for recognition
- Template generation commands now enforce font availability and brand anchor application
- Plugin audit fixes: version alignment to 2.9.0, CHANGELOG entry, maxTurns on agent

## Context

After bias hardening (PR #95), OSP test brand showed correct color uniqueness but weak brand coherence — fonts silently fell back to Helvetica, infographic lost brand identity with monochromatic-only palette, no logo on any output. These are production quality fixes within the POC scope.

## Test plan

- [ ] Run `/brand-extract` on a brand with Google Fonts — fonts auto-download to assets/fonts/
- [ ] Run `/brand-palette` — all derived palettes include the primary brand color
- [ ] Run `/template-presentation` — sample PDF has logo on every slide
- [ ] Run `/template-carousel` — sample PDF has logo on first and last card
- [ ] Generate with missing fonts — should STOP with warning, not silently use Helvetica
- [ ] Verify all SKILL.md versions show 2.9.0
- [ ] Verify CHANGELOG has [2.9.0] entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)