### PR TITLE
Add Aaker personality depth to brand-content-design v3.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.10.0"
+    "version": "1.11.0"
   },
   "plugins": [
     {
@@ -154,8 +154,8 @@
     {
       "name": "brand-content-design",
       "source": "./brand-content-design",
-      "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with 21 visual styles, 114 infographic templates, 19 commands, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF/PPTX generation, HTML composition, and infographic rendering.",
-      "version": "2.8.0",
+      "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, 26 visual styles, 114 infographic templates, 19 commands, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF/PPTX generation, HTML composition, and infographic rendering.",
+      "version": "3.1.0",
       "author": {
         "name": "camoa"
       },
@@ -177,7 +177,10 @@
         "instagram",
         "design",
         "canvas",
-        "zen"
+        "zen",
+        "aaker",
+        "brand-personality",
+        "brand-depth"
       ]
     }
   ]

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brand-content-design",
-  "version": "3.0.0",
-  "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with style recommendation engine, visual components, 26 visual styles, design systems, and Presentation Zen principles",
+  "version": "3.1.0",
+  "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, visual components, 26 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"
   },
@@ -34,6 +34,9 @@
     "branding",
     "style-recommendation",
     "composition-rules",
-    "contemporary-professional"
+    "contemporary-professional",
+    "aaker",
+    "brand-personality",
+    "brand-depth"
   ]
 }

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-03-17
+
+### Added
+- **Brand Depth extraction**: `/brand-extract` now captures Aaker personality scores (0-5 with evidence), color profile (harmony/temperature/saturation), emotional profile, spatial & surface profile (spacing/radius/shadows/density), and brand maturity assessment
+- **Brand Depth template sections**: `brand-philosophy-template.md` has 5 new sections under `## Brand Depth` — purely additive, existing sections unchanged
+- **Pre-populated Aaker reading**: Style recommendation engine reads scores from `## Brand Depth` when available, skips voice-trait derivation (backward compatible fallback)
+- **Post-selection personality guidance** (`style-recommendation-engine.md` Section 7): Component selection weighting (7A), canvas philosophy tone modulation (7B), and color intensity weighting (7C) — all keyed by Aaker dimension
+- **Personality-informed template creation**: `template-presentation`, `template-carousel`, and `template-infographic` now load Aaker scores and use them for component suggestions, palette guidance, background presets, and canvas philosophy tone
+- **Infographic personality integration**: Category recommendations and background presets weighted by primary Aaker dimension
+- **Visual-content personality awareness**: Part 2b loads Aaker scores + spatial profile; Part 4 adds personality-informed color intensity; Part 7 Gate 2 factors personality into component decisions
+
+### Changed
+- **brand-analyst agent** (v3.1.0): 5 new analysis steps (Aaker scoring, color profile, emotional profile, spatial & surface profile, brand maturity) — output section updated to include Brand Depth
+- **brand-extract command**: Agent delegation prompt requests Brand Depth sections; review step highlights Aaker scores for user validation
+- **style-recommendation-engine**: Section 1 restructured — checks for pre-populated scores first (Step 1), voice-trait derivation is now Step 2 (fallback)
+- **template-presentation**: Steps 7, 8, 12 reference personality guidance from Section 7A/7B/7C
+- **template-carousel**: Steps 6, 7, 13 reference personality guidance; new step 4b loads personality
+- **template-infographic**: New Phase 1b loads personality; step 4 suggests categories by dimension; step 8 suggests backgrounds by dimension
+- **visual-content skill** (v3.1.0): New Part 2b, enhanced Part 4, personality-aware Gate 2
+
 ## [3.0.0] - 2026-03-16
 
 ### Added

--- a/brand-content-design/README.md
+++ b/brand-content-design/README.md
@@ -1,6 +1,6 @@
 # Brand Content Design Plugin
 
-> **Current version: v3.0.0**
+> **Current version: v3.1.0**
 
 Create branded presentations, LinkedIn carousels, infographics, and HTML pages with consistent visual identity.
 
@@ -97,7 +97,7 @@ Analyzes your brand from multiple sources:
 - **Verbal description** - describe your brand in chat
 - **Existing guidelines** - paste brand docs directly
 
-Generates `brand-philosophy.md` with your visual identity, voice, and core principles.
+Generates `brand-philosophy.md` with your visual identity, voice, core principles, and **Brand Depth** (Aaker personality scores, color profile, emotional profile, spatial profile, brand maturity).
 
 ### 3. Create Templates (Required before creating content)
 
@@ -454,6 +454,26 @@ Navigation, Hero, Feature Grid, Content Block, Testimonials, CTA, Stats Bar, Tea
 ### 10 Page Category Presets
 
 Landing Page, About/Company, Portfolio, Event, Pricing, Blog/Article, Documentation, Coming Soon, Contact, Custom.
+
+## Brand Depth (Aaker Personality)
+
+`/brand-extract` now captures deep brand data beyond visual identity:
+
+| Section | What It Captures | How It's Used |
+|---------|-----------------|---------------|
+| **Personality (Aaker)** | 5-dimension scores (0-5) with evidence | Style recommendation, component weighting, color intensity, canvas philosophy tone |
+| **Color Profile** | Harmony type, temperature, saturation | Design system token derivation |
+| **Emotional Profile** | Emotion words, visual mood | Canvas philosophy manifesto writing |
+| **Spatial & Surface** | Spacing rhythm, border radius, shadows, density | Design system element placement |
+| **Brand Maturity** | Growing / Established / Iconic | Brand signal preservation corridor |
+
+Personality flows through the entire creation pipeline:
+- **Style recommendation** reads pre-populated Aaker scores (skips voice-trait derivation)
+- **Template creators** weight component suggestions, color intensity, and background presets by personality
+- **Canvas philosophy** tone is modulated by primary dimension (Minimal + Competence = precision; Minimal + Sincerity = warmth)
+- **Visual-content skill** uses personality in component decision gates and color application
+
+All personality integration is backward-compatible: brand-philosophy.md files without Brand Depth still work (fallback to voice-trait derivation).
 
 ## Three-Layer Philosophy System
 

--- a/brand-content-design/agents/brand-analyst.md
+++ b/brand-content-design/agents/brand-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: brand-analyst
 description: Analyze brand assets (screenshots, documents, logos, websites) to extract brand elements including color palettes with color theory analysis. Use proactively when user provides assets for brand analysis.
-version: 2.9.0
+version: 3.1.0
 model: sonnet
 maxTurns: 25
 memory: project
@@ -76,6 +76,43 @@ Receive from caller:
    - Always patterns (consistent behaviors observed)
    - Never patterns (things consistently avoided)
 
+5. **Aaker Personality Scoring:**
+   Score the brand 0–5 on each dimension using evidence from visual assets + copy:
+   - **Sincerity** — warm colors, friendly copy, rounded shapes, casual imagery
+   - **Excitement** — bold/saturated colors, dynamic language, sharp angles, action imagery
+   - **Competence** — blues/grays, precise language, clean layout, professional imagery
+   - **Sophistication** — muted/dark palette, refined vocabulary, elegant typography, curated imagery
+   - **Ruggedness** — earthy colors, direct language, heavy weights, outdoor/textured imagery
+
+   Each score must cite evidence: "Competence: 4 — blue primary (#2563EB), precise technical copy, structured grid layout"
+
+   Identify primary dimension (highest score) and secondary (second highest, if ≥3).
+
+6. **Color Profile** (computed from extracted hex colors):
+   - Harmony type: monochromatic / analogous / complementary / split-complementary / triadic / tetradic
+   - Temperature: warm / cool / neutral (from primary hue position on color wheel)
+   - Saturation profile: vibrant / muted / mixed
+   - These are pure math on hex values — no subjective judgment needed
+
+7. **Emotional Profile** (derived from Aaker scores + color psychology + copy analysis):
+   - "We make people feel:" — 3-4 emotion words
+   - Visual mood: 2-sentence description
+   - Color temperature alignment: does palette temperature match personality?
+
+8. **Spatial & Surface Profile** (extracted from website CSS/HTML):
+   - Spacing rhythm: section padding, component gaps — detect tight / standard / generous
+   - Border radius patterns: sharp (0px) / subtle (4-8px) / rounded (12-20px) / pill
+   - Shadow usage: none / subtle / elevated / dramatic
+   - Layout density: content-dense / balanced / breathing
+
+   These feed directly into design-system token derivation downstream.
+
+9. **Brand Maturity Assessment** (inferred from asset consistency):
+   - **Growing** — inconsistent colors/fonts across pages, no clear system
+   - **Established** — consistent palette + typography, clear patterns
+   - **Iconic** — highly recognizable, distinctive visual language
+   - Output as corridor width: Growing = Wide, Established = Standard, Iconic = Narrow
+
 ## Quality Standards
 
 - **Hex codes required**: "#2563EB" not "blue"
@@ -91,5 +128,13 @@ Include in the Colors section:
 - Color table with Role, Name, Hex, Usage
 - Color harmony type identified
 - Temperature and saturation notes
+
+Include in the Brand Depth sections:
+- Aaker Personality table with scores (0-5) and evidence citations per dimension
+- Primary and secondary dimensions identified
+- Color Profile (harmony type, temperature, saturation profile)
+- Emotional Profile (emotion words, visual mood)
+- Spatial & Surface Profile (spacing, radius, shadows, density)
+- Brand Maturity (stage and corridor width)
 
 The caller will merge your analysis with any additional user input and generate the final brand-philosophy.md.

--- a/brand-content-design/commands/brand-extract.md
+++ b/brand-content-design/commands/brand-extract.md
@@ -81,7 +81,13 @@ Analyze brand from multiple sources (files, website, verbal description, pasted 
    Return analysis in brand-philosophy-template.md format with:
    - Visual Identity (colors with hex, typography, imagery style)
    - Verbal Identity (voice traits, tone, vocabulary)
-   - Core Principles (always/never patterns)"
+   - Core Principles (always/never patterns)
+   - Brand Depth sections:
+     - Aaker Personality scores (0-5) with evidence per dimension
+     - Color Profile (harmony type, temperature, saturation)
+     - Emotional Profile (emotion words, visual mood)
+     - Spatial & Surface Profile (spacing, radius, shadows, density)
+     - Brand Maturity (growing/established/iconic)"
    ```
 
 6. **Receive agent results**
@@ -114,6 +120,9 @@ Analyze brand from multiple sources (files, website, verbal description, pasted 
 
 9. **Present for review**
    Show generated brand philosophy.
+   Highlight the Aaker personality scores specifically — these are the most subjective part:
+   > "Here are the personality scores I derived from your brand assets. Do these feel right?"
+   Show the Aaker table and primary/secondary dimensions.
    Ask: "Does this capture your brand accurately? What would you like to adjust?"
 
 10. **Refine if needed**

--- a/brand-content-design/commands/template-carousel.md
+++ b/brand-content-design/commands/template-carousel.md
@@ -73,6 +73,12 @@ Create a new carousel template or edit an existing one.
 
    - Jump to appropriate step based on selection
 
+4b. **Load brand personality**
+   Check brand-philosophy.md for `## Brand Depth` > `### Personality (Aaker Framework)`:
+   - **If present and populated**: Read Aaker scores, note primary and secondary dimensions
+   - **If not present**: Read voice traits from `## Verbal Identity` > `### Voice Personality` and derive Aaker dimensions using the mapping from `style-recommendation-engine.md` Section 1
+   - Store personality context for use in component weighting (step 6), palette selection (step 7), and canvas philosophy (step 13)
+
 5. **Ask design aesthetic FIRST** (CREATE MODE, or if changing style in EDIT MODE)
 
    **Step 5a: Choose aesthetic family**
@@ -131,9 +137,11 @@ Create a new carousel template or edit an existing one.
 
    **Load style constraints** from plugin `references/style-constraints.md` for the selected style.
 
-6. **Visual Components (style-dependent)** (CREATE MODE, or if changing style in EDIT MODE)
+6. **Visual Components (style-dependent, personality-weighted)** (CREATE MODE, or if changing style in EDIT MODE)
 
-   After selecting a style, check `references/style-constraints.md` for which visual components the style supports:
+   After selecting a style, apply personality-informed component weighting from `style-recommendation-engine.md` Section 7A to suggest which components best match the brand personality. For example, suggest icons + gradients for Excitement brands, or minimal components for Sophistication brands.
+
+   Then check `references/style-constraints.md` for which visual components the style supports:
    - **Cards**: ✓ Full, ◐ Subtle only, ✗ None
    - **Icons**: ✓ Allowed, ✗ Not allowed
    - **Gradients**: ✓ Allowed, ✗ Not allowed
@@ -175,7 +183,9 @@ Create a new carousel template or edit an existing one.
 
    **Store component selections** for use in canvas-philosophy.md generation.
 
-7. **Ask color palette** (CREATE MODE, or if changing style in EDIT MODE)
+7. **Ask color palette (personality-informed)** (CREATE MODE, or if changing style in EDIT MODE)
+
+   Apply personality-informed color intensity guidance from `style-recommendation-engine.md` Section 7C when presenting palette options. For example, note that Excitement brands benefit from vibrant palettes, while Sophistication brands suit muted palettes.
 
    First, check brand-philosophy.md for `## Alternative Palettes` section.
    Count total palettes available (1 brand + N alternatives).
@@ -237,7 +247,7 @@ Create a new carousel template or edit an existing one.
     - Show proposed structure (5-10 cards)
     - Ask user to confirm or modify
 
-13. **Create/update canvas philosophy** (or skip if "Regenerate sample only")
+13. **Create/update canvas philosophy (personality-toned)** (or skip if "Regenerate sample only")
     Generate canvas-philosophy.md using:
     - canvas-philosophy-template.md from references
     - **Selected style constraints from style-constraints.md**
@@ -245,6 +255,7 @@ Create a new carousel template or edit an existing one.
     - **Text colors from palette** (`Text (light bg)` and `Text (dark bg)`)
     - **Visual component selections from step 6** (cards, icons, gradients)
     - Platform-specific considerations (mobile-first)
+    - **Personality tone modulation** from `style-recommendation-engine.md` Section 7B — use the brand's primary Aaker dimension to set the manifesto tone (e.g., Dramatic + Excitement = bold energy language, Dramatic + Sophistication = refined tension language)
 
     **Include the style's HARD LIMITS in the philosophy:**
     - Word count limits per card

--- a/brand-content-design/commands/template-infographic.md
+++ b/brand-content-design/commands/template-infographic.md
@@ -46,9 +46,26 @@ Create a new infographic template or edit an existing one.
    - If no templates exist: skip to CREATE MODE (step 4)
    - If templates exist: Ask "Create new or edit existing?" with options
 
+### Phase 1b: Personality Loading
+
+3b. **Load brand personality**
+   Check brand-philosophy.md for `## Brand Depth` > `### Personality (Aaker Framework)`:
+   - **If present and populated**: Read Aaker scores, note primary and secondary dimensions
+   - **If not present**: Read voice traits from `## Verbal Identity` > `### Voice Personality` and derive Aaker dimensions using the mapping from `style-recommendation-engine.md` Section 1
+   - Store personality context for use in category recommendation (step 4) and background selection (step 8)
+
 ### Phase 2: Type & Design Selection (Two-Step)
 
 4. **Step 1: Choose Category**
+
+   **Personality-informed suggestion**: Before showing the full table, suggest 2-3 categories based on primary Aaker dimension:
+   - **Competence** → Hierarchy, Chart, Compare (structured, data-clear)
+   - **Excitement** → Sequence, Process (energy, flow)
+   - **Sincerity** → List, Relation (approachable, connecting)
+   - **Sophistication** → List (minimal), Quadrant (curated)
+   - **Ruggedness** → Sequence, Compare (direct, bold)
+
+   Show: "Based on your brand personality ({primary dimension}), these categories work well: {suggestions}. But all categories are available:"
 
    Display this table:
    ```
@@ -383,7 +400,16 @@ Create a new infographic template or edit an existing one.
 
    **Store selected palette** including text colors for config generation.
 
-8. **Choose Background**
+8. **Choose Background (personality-informed)**
+
+   **Personality-informed default**: Suggest a background preset based on primary Aaker dimension:
+   - **Sophistication** → spotlight or diagonal-fade (refined, restrained)
+   - **Excitement** → tech-matrix or spotlight-grid (energetic, dynamic)
+   - **Competence** → spotlight-dots or tech-grid (structured, clean)
+   - **Sincerity** → subtle-dots or solid (warm, approachable)
+   - **Ruggedness** → diagonal-crosshatch or crosshatch (textured, grounded)
+
+   Show: "Suggested for your brand: {preset} ({reason}). All options:"
 
    Display options:
    ```
@@ -408,7 +434,7 @@ Create a new infographic template or edit an existing one.
    | 10| crosshatch    | Diagonal crosshatch       |
    | 11| solid         | Plain solid color         |
 
-   **Which background?** (enter number or name, default: 1)
+   **Which background?** (enter number or name, default: {personality-suggested})
    ```
 
 9. **Choose Shape Style** (optional)

--- a/brand-content-design/commands/template-presentation.md
+++ b/brand-content-design/commands/template-presentation.md
@@ -213,9 +213,11 @@ Create a new presentation template or edit an existing one.
 
    **Load style constraints** from plugin `references/style-constraints.md` for the selected style.
 
-7. **Visual Components (style-dependent)** (CREATE MODE, or if changing style in EDIT MODE)
+7. **Visual Components (style-dependent, personality-weighted)** (CREATE MODE, or if changing style in EDIT MODE)
 
-   After selecting a style, check `references/style-constraints.md` for which visual components the style supports:
+   After selecting a style, read Aaker personality scores from working context (set during style recommendation in step 6). Apply personality-informed component weighting from `style-recommendation-engine.md` Section 7A to suggest which components best match the brand personality. For example, suggest icons + gradients for Excitement brands, or minimal components for Sophistication brands.
+
+   Then check `references/style-constraints.md` for which visual components the style supports:
    - **Cards**: ✓ Full, ◐ Subtle only, ✗ None
    - **Icons**: ✓ Allowed, ✗ Not allowed
    - **Gradients**: ✓ Allowed, ✗ Not allowed
@@ -259,7 +261,9 @@ Create a new presentation template or edit an existing one.
 
    **Store component selections** for use in canvas-philosophy.md generation.
 
-8. **Ask color palette** (CREATE MODE, or if changing style in EDIT MODE)
+8. **Ask color palette (personality-informed)** (CREATE MODE, or if changing style in EDIT MODE)
+
+   Apply personality-informed color intensity guidance from `style-recommendation-engine.md` Section 7C when presenting palette options. For example, note that Excitement brands benefit from vibrant palettes, while Sophistication brands suit muted palettes.
 
    First, check brand-philosophy.md for `## Alternative Palettes` section.
    Count total palettes available (1 brand + N alternatives).
@@ -309,13 +313,14 @@ Create a new presentation template or edit an existing one.
     - Show proposed structure
     - Ask user to confirm or modify
 
-12. **Create/update canvas philosophy** (or skip if "Regenerate samples only")
+12. **Create/update canvas philosophy (personality-toned)** (or skip if "Regenerate samples only")
     Generate canvas-philosophy.md using:
     - canvas-philosophy-template.md from references
     - **Selected style constraints from style-constraints.md**
     - **Selected color palette** (brand colors or alternative palette from step 8)
     - **Text colors from palette** (`Text (light bg)` and `Text (dark bg)`)
     - **Visual component selections from step 7** (cards, icons, gradients)
+    - **Personality tone modulation** from `style-recommendation-engine.md` Section 7B — use the brand's primary Aaker dimension to set the manifesto tone (e.g., Minimal + Competence = precision language, Minimal + Sincerity = warmth language)
 
     **Include the style's HARD LIMITS in the philosophy:**
     - Word count limits per slide

--- a/brand-content-design/skills/brand-content-design/SKILL.md
+++ b/brand-content-design/skills/brand-content-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brand-content-design
 description: Use when user says "create presentation", "make slides", "make carousel", "LinkedIn carousel", "create HTML page", "make landing page", "build web page", "html design system", "design system", "setup brand", "brand init", "extract brand", "get outline", "color palette", "alternative colors", "infographic", "brand assets", "brand project". Use PROACTIVELY when user wants to create any visual content with consistent branding. MUST be invoked for branded content — routes to the correct command for presentations, carousels, infographics, and HTML pages.
-version: 3.0.0
+version: 3.1.0
 allowed-tools: Read, Glob, Grep, Write, Bash, AskUserQuestion, Skill
 user-invocable: true
 ---

--- a/brand-content-design/skills/brand-content-design/references/brand-philosophy-template.md
+++ b/brand-content-design/skills/brand-content-design/references/brand-philosophy-template.md
@@ -93,6 +93,48 @@ The brand voice is: **[Trait 1]**, **[Trait 2]**, **[Trait 3]**
 ## Brand Story (Optional)
 [Brief narrative about the brand's mission, origin, or purpose. 2-3 sentences.]
 
+## Brand Depth
+
+> These sections enrich AI design decisions. They are auto-populated by `/brand-extract`
+> and consumed by `/design-intelligence:design-html` for design system creation.
+> Presentation, carousel, and infographic commands do not use these sections.
+
+### Personality (Aaker Framework)
+
+| Dimension | Score (0-5) | Evidence |
+|-----------|-------------|----------|
+| Sincerity | | |
+| Excitement | | |
+| Competence | | |
+| Sophistication | | |
+| Ruggedness | | |
+
+**Primary dimension:** [highest scoring]
+**Secondary dimension:** [second highest, if ≥3]
+
+### Color Profile
+
+**Harmony type:** [Monochromatic / Analogous / Complementary / Split-Complementary / Triadic / Tetradic]
+**Temperature:** [Warm / Cool / Neutral]
+**Saturation profile:** [Vibrant / Muted / Mixed]
+
+### Emotional Profile
+
+**We make people feel:** [3-4 emotion words]
+**Visual mood:** [2-sentence description]
+
+### Spatial & Surface Profile
+
+**Spacing rhythm:** [Tight / Standard / Generous]
+**Border radius:** [Sharp (0px) / Subtle (4-8px) / Rounded (12-20px) / Pill]
+**Shadow style:** [None / Subtle / Elevated / Dramatic]
+**Layout density:** [Dense / Balanced / Breathing]
+
+### Brand Maturity
+
+**Stage:** [Growing / Established / Iconic]
+**Corridor width:** [Wide / Standard / Narrow]
+
 ---
 
 *Generated for [Brand Name] brand project*

--- a/brand-content-design/skills/brand-content-design/references/style-recommendation-engine.md
+++ b/brand-content-design/skills/brand-content-design/references/style-recommendation-engine.md
@@ -6,9 +6,21 @@ Intelligent style selection based on brand personality, presentation purpose, an
 
 ## Section 1: Brand Personality Extraction
 
-Extract brand personality from `brand-philosophy.md` voice traits, then map to Aaker's Brand Personality Dimensions.
+Extract brand personality from `brand-philosophy.md`, preferring pre-populated Aaker scores when available.
 
-### Voice Trait → Aaker Dimension Mapping
+### Step 1: Check for Pre-Populated Aaker Scores
+
+Look for `## Brand Depth` > `### Personality (Aaker Framework)` in brand-philosophy.md.
+
+**If present and populated** (scores filled in, not blank):
+- Read scores directly from the table
+- Read primary and secondary dimensions
+- Skip voice-trait derivation (Step 2) — go directly to Section 2
+- Store Aaker scores in working context for use in post-selection decisions (Section 7)
+
+**If not present or blank**: Fall back to voice-trait derivation (Step 2 below).
+
+### Step 2: Voice Trait → Aaker Dimension Mapping (Fallback)
 
 | Voice Adjectives | Aaker Dimension |
 |-----------------|-----------------|
@@ -142,6 +154,51 @@ The recommendation engine **recommends, never decides**. Users always have the f
 - User says "I want [specific style]" → go directly to that style
 - User is editing an existing template → keep current style unless they ask to change
 - Quick commands (`/presentation-quick`) → use template's existing style
+
+---
+
+## Section 7: Personality-Informed Post-Selection Guidance
+
+After a style is selected, carry the Aaker personality scores forward to inform design decisions. These modifiers apply on top of the selected style's constraints.
+
+### 7A. Component Selection Weighting
+
+When choosing visual components (Step 7 of template-presentation), weight recommendations by primary personality dimension:
+
+| Primary Dimension | Prioritize | De-prioritize |
+|-------------------|-----------|--------------|
+| **Excitement** | Cards + icons + gradients (visual energy) | Minimal text-only layouts |
+| **Competence** | Grid-aligned cards only (precision, restraint) | Decorative elements, gradients |
+| **Sincerity** | Soft cards + icons, fewer gradients (warmth) | Sharp edges, dramatic effects |
+| **Sophistication** | Minimal components, thin borders (refined) | Heavy cards, bold gradients |
+| **Ruggedness** | Textured fills, heavy borders (grounded) | Delicate, thin elements |
+
+### 7B. Canvas Philosophy Tone Modulation
+
+Same style, different personality → different tone in the manifesto paragraph of canvas-philosophy.md. Use these modifier words when writing the philosophy:
+
+| Dimension | Tone Modifier Words |
+|-----------|-------------------|
+| **Sincerity** | warmth, invitation, openness, comfort, trust, breathing |
+| **Excitement** | energy, momentum, boldness, dynamism, impact, surprise |
+| **Competence** | precision, clarity, system, structure, authority, evidence |
+| **Sophistication** | restraint, refinement, elegance, curation, quiet luxury |
+| **Ruggedness** | rawness, texture, weight, grounding, authenticity, craft |
+
+Example: Minimal + Competence = "Mathematical precision, calculated emptiness"
+Example: Minimal + Sincerity = "Inviting simplicity, space that breathes with warmth"
+
+### 7C. Color Intensity Weighting
+
+When choosing between palette variants or adjusting color application:
+
+| Dimension | Color Guidance |
+|-----------|---------------|
+| **Excitement** | Vibrant saturation, bold color blocks, high contrast accents |
+| **Sophistication** | Muted/desaturated, restrained use, subtle gradients |
+| **Sincerity** | Warm, accessible tones, medium saturation |
+| **Competence** | Clean, clear colors, systematic application |
+| **Ruggedness** | Earthy, natural tones, deep values |
 
 ---
 

--- a/brand-content-design/skills/visual-content/SKILL.md
+++ b/brand-content-design/skills/visual-content/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: visual-content
 description: Use when creating branded presentations or carousels. Generates museum-quality visual output from canvas philosophy, enforcing style constraints. Outputs PDF first, then converts to PPTX for editability.
-version: 3.0.0
+version: 3.1.0
 allowed-tools: Read, Write, Glob, Bash
 user-invocable: false
 ---
@@ -61,6 +61,23 @@ The topic becomes a **subtle, niche reference embedded within the design itself*
 Think like a jazz musician quoting another song—only those who know will catch it, but everyone appreciates the music.
 
 The canvas philosophy provides the aesthetic language. The content provides the soul—the quiet conceptual DNA woven invisibly into form, color, and composition.
+
+---
+
+## Part 2b: Brand Personality Loading
+
+Before creating visuals, check `brand-philosophy.md` for `## Brand Depth` > `### Personality (Aaker Framework)`:
+
+**If present and populated**: Read the Aaker scores and primary/secondary dimensions. Store in working context — these inform component decisions (Part 7), color intensity (Part 4), and spatial choices throughout.
+
+**If not present**: Read voice traits from `## Verbal Identity` > `### Voice Personality`. Map to Aaker dimensions using proximity:
+- precise, reliable, expert, professional → **Competence**
+- warm, friendly, approachable, genuine → **Sincerity**
+- bold, innovative, daring, creative → **Excitement**
+- elegant, refined, luxurious, polished → **Sophistication**
+- rugged, authentic, tough, adventurous → **Ruggedness**
+
+Also check for `### Spatial & Surface Profile` — if present, use its values (spacing rhythm, border radius, shadow style, layout density) to inform element placement and styling decisions.
 
 ---
 
@@ -162,6 +179,13 @@ Each piece must respect its style's **hard constraints**:
 - Accent: 10% for emphasis only—the punctuation
 - Never introduce off-brand colors—consistency builds trust
 ```
+
+**Personality-informed intensity** (from Part 2b):
+- **Excitement** → Push toward vibrant saturation, bolder color blocks, higher contrast accents
+- **Sophistication** → Pull toward muted/desaturated application, restrained accent use
+- **Sincerity** → Favor warm, accessible mid-saturation tones
+- **Competence** → Clean, systematic color application with clear hierarchy
+- **Ruggedness** → Deep earthy values, textured color application
 
 ### Spatial Communication
 
@@ -283,11 +307,11 @@ Does the selected style allow this component? (Check style-constraints.md or enf
 - If NO → skip component entirely
 - If YES → proceed to Gate 2
 
-**Gate 2: Content Justification**
-Does the slide's content warrant this component?
-- **Cards**: Does the slide have 2+ related points that benefit from grouping? If single message → no cards.
-- **Icons**: Is there a clear, unforced visual metaphor? If you have to think about it → no icon.
-- **Gradients**: Is this a hook, transition, or CTA slide? If content slide → no gradient.
+**Gate 2: Content + Personality Justification**
+Does the slide's content warrant this component? Also consider the brand's primary Aaker dimension (from Part 2b):
+- **Cards**: Does the slide have 2+ related points that benefit from grouping? If single message → no cards. *Personality modifier: Excitement brands → lower threshold (use cards more freely for visual energy); Sophistication brands → higher threshold (use cards sparingly, prefer negative space).*
+- **Icons**: Is there a clear, unforced visual metaphor? If you have to think about it → no icon. *Personality modifier: Sincerity/Excitement brands → icons add warmth/energy; Sophistication brands → icons risk feeling casual, prefer typographic emphasis.*
+- **Gradients**: Is this a hook, transition, or CTA slide? If content slide → no gradient. *Personality modifier: Excitement brands → gradients add dynamism; Competence brands → solid colors communicate precision.*
 - If NO justification → skip component
 - If YES → proceed to Gate 3
 


### PR DESCRIPTION
## Summary

- **Brand extraction** (`/brand-extract`) now captures deep brand data: Aaker personality scores (0-5 with evidence), color profile, emotional profile, spatial & surface profile, and brand maturity — all derivable from a website URL alone
- **Template creators** (presentation, carousel, infographic) load personality and use it for component weighting, color intensity guidance, background preset suggestions, and canvas philosophy tone modulation
- **Visual-content skill** reads personality for component decision gates and color application intensity
- **Style recommendation engine** reads pre-populated Aaker scores when available (skips voice-trait derivation), adds Section 7 with post-selection personality guidance
- Fully backward compatible — brand-philosophy.md files without Brand Depth sections still work via voice-trait fallback

## Files Changed (13 files, +295/-30 lines)

| File | Change |
|------|--------|
| `brand-philosophy-template.md` | +42 lines — Brand Depth sections (Aaker, color/emotional/spatial profile, maturity) |
| `brand-analyst.md` | +47 lines — 5 new analysis steps, updated output section |
| `brand-extract.md` | +11 lines — delegation prompt + review step for Aaker |
| `style-recommendation-engine.md` | +61 lines — pre-populated Aaker reading + Section 7 (7A/7B/7C) |
| `template-presentation.md` | +13 lines — personality-weighted steps 7, 8, 12 |
| `template-carousel.md` | +19 lines — personality loading (4b) + weighted steps 6, 7, 13 |
| `template-infographic.md` | +30 lines — Phase 1b + category/background suggestions |
| `visual-content/SKILL.md` | +36 lines — Part 2b + color intensity + Gate 2 personality |
| `plugin.json` | v3.1.0, updated description + keywords |
| `marketplace.json` | v3.1.0 plugin entry, v1.11.0 marketplace |
| `CHANGELOG.md` | Full [3.1.0] entry |
| `README.md` | v3.1.0 + Brand Depth documentation section |
| `brand-content-design/SKILL.md` | v3.1.0 |

## Test plan

- [ ] Extract brand from a SaaS website (URL only) — verify Brand Depth sections populated with Aaker scores, color profile, spatial profile
- [ ] Extract brand from website without Brand Depth — verify existing extraction unchanged (colors, fonts, voice, principles)
- [ ] Create presentation template — verify style recommendation reads pre-populated Aaker (skips derivation)
- [ ] Create carousel template — verify component/palette suggestions reflect personality
- [ ] Create infographic template — verify category suggestions and background presets weighted by personality
- [ ] Test with legacy brand-philosophy.md (no Brand Depth) — verify fallback to voice-trait derivation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)