### PR TITLE
Close documentation gaps in plugin-creation-tools v2.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,8 +35,8 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Complete guide for creating Claude Code plugins \u2014 skills, commands, agents, hooks, MCP servers, and configuration. Covers 18 hook events, 4 hook types, agent isolation and cost control, marketplace distribution, and pushy description optimization.",
-      "version": "2.3.1",
+      "description": "Complete guide for creating Claude Code plugins \u2014 skills, commands, agents, hooks, MCP servers, and configuration. Covers 18 hook events, 4 hook types, statusMessage/once fields, 5 permission modes, agent isolation and cost control, outputStyles, marketplace distribution, and pushy description optimization.",
+      "version": "2.4.0",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-03-17
+
+### Added
+- **`statusMessage` return field** in hook-events.md PreToolUse — custom status text displayed in Claude Code status line during tool execution, with JSON return format example
+- **`once` field** in hook-events.md — fire a hook only once per session; documented with use cases and example
+- **Hook execution order** clarification — hooks within a matcher group run in parallel, not sequentially
+- **Hook timeout behavior** — what happens when hooks time out (process killed, treated as exit 0)
+- **3 new hook patterns** in hook-patterns.md: Status Message Pattern, One-Time Hook Pattern, Three-Way Decision Pattern (`approve`/`deny`/`ask`)
+- **`dontAsk` permission mode** in agent-tools.md — auto-deny all permission prompts for non-interactive agents
+- **`outputStyles` field** in plugin-json.md and output-config.md — custom output style paths in plugin.json
+- **`skills` and `settings` fields** in plugin-json.md Component Path Fields table
+- **`strictKnownMarketplaces`** in settings.md — enterprise managed setting to restrict marketplace additions with host/path pattern matching
+- **Reserved marketplace names** in marketplace-json.md — 7 names reserved by Anthropic that cannot be used
+
+### Fixed
+- **agent-tools.md**: Replaced invalid `ignore` permission mode with correct `dontAsk` mode (5 modes: default, acceptEdits, dontAsk, bypassPermissions, plan)
+- **hook-events.md**: Expanded `ask` decision value from 1-line mention to full explanation of user escalation UX
+
 ## [2.3.1] - 2026-03-15
 
 ### Added
@@ -18,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `agents/plugin-structure-auditor.md` — deep structural audit covering architecture, consistency, distribution readiness, security, and performance
 - **4 new hook events** documented: `InstructionsLoaded`, `ConfigChange`, `WorktreeCreate`, `WorktreeRemove` (total now 18 events)
 - **HTTP hook type** documentation (`type: "http"`) — POST event JSON to a URL with header env var interpolation
-- **Hook fields**: `statusMessage` (TUI display), `once` (fire once per session), `"ask"` decision value for PreToolUse
+- **Hook fields**: `"ask"` decision value for PreToolUse (note: `statusMessage` and `once` were identified but not added to reference files until v2.4.0)
 - **Agent frontmatter fields**: `isolation: worktree`, `background: true`, `maxTurns`, `mcpServers`, `Agent(type)` tool syntax
 - **Full model IDs** in agent docs: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
 - **Skill frontmatter fields**: `hooks` (skill-scoped lifecycle), `argument-hint` (autocomplete hints)

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
@@ -142,9 +142,9 @@ permissionMode: default
 |------|----------|----------|
 | default | Normal prompting | Most agents |
 | acceptEdits | Auto-accept edits | Trusted formatters |
+| dontAsk | Auto-deny all permission prompts | Non-interactive agents |
 | bypassPermissions | Skip all prompts | Automation scripts |
 | plan | Read-only mode | Planning agents |
-| ignore | Ignore permission system | Testing |
 
 ### Default Mode
 
@@ -161,6 +161,14 @@ permissionMode: acceptEdits
 ```
 
 Automatically accepts edit operations. Use for trusted refactoring agents.
+
+### Don't Ask Mode
+
+```yaml
+permissionMode: dontAsk
+```
+
+Auto-deny all permission prompts. The agent can only use tools in its `allowed-tools` list without prompting. Useful for non-interactive background agents that should never block waiting for user input.
 
 ### Bypass Permissions
 

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
@@ -147,7 +147,27 @@ All hook events receive JSON input with the following common fields:
 - Exit non-zero: Block execution
 - Stdout `approve`: Bypass permission check
 - Stdout `deny`: Block with denial message
-- Stdout `ask`: Escalate the decision to the user
+- Stdout `ask`: Escalate the decision to the user — shows the normal permission prompt to the user, letting them decide instead of the hook. Useful when a hook can't determine safety on its own.
+
+**Return Fields** (JSON stdout, optional):
+- `statusMessage`: Custom status text displayed in the Claude Code status line while the tool runs. Useful for showing progress like "Running linter..." or "Validating schema...".
+
+**Example with statusMessage**:
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "echo '{\"decision\": \"approve\", \"statusMessage\": \"Running validated bash...\"}'"
+        }
+      ]
+    }
+  ]
+}
+```
 
 ### PermissionRequest
 
@@ -624,6 +644,42 @@ All hook events receive JSON input with the following common fields:
   ]
 }
 ```
+
+## Hook Configuration Fields
+
+### The `once` Field
+
+Set `once: true` on a hook to fire it only once per session, regardless of how many times the event triggers. After the first execution, the hook is skipped for subsequent events.
+
+```json
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/first-write-notification.sh",
+          "once": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Use cases**: One-time initialization that shouldn't repeat (e.g., "first file written" notification), license check on first tool use, session-start-like logic triggered by first tool use rather than session start.
+
+### Hook Execution Order
+
+When multiple hooks match the same event, they run **in parallel** (not sequentially). If you need ordered execution, combine logic into a single script. Within a matcher group, all hooks fire simultaneously.
+
+### Hook Timeout Behavior
+
+Hooks have configurable timeouts (via `timeout` field, in seconds). When a hook times out:
+- **Command hooks**: Process is killed, treated as exit 0 (non-blocking)
+- **SessionEnd hooks**: Fixed 1.5-second timeout (cannot be overridden)
+- Best practice: keep hooks fast; use `timeout` field for safety
 
 ## Multiple Hooks per Event
 

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
@@ -346,6 +346,114 @@ Multiple hooks for the same event:
 
 Both hooks run (in parallel) for matching operations.
 
+## Status Message Pattern
+
+Show custom status text during tool execution:
+
+### hooks.json
+
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/status-message.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/status-message.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Set status message based on command type
+if echo "$COMMAND" | grep -q "npm test"; then
+  echo '{"decision": "approve", "statusMessage": "Running tests..."}'
+elif echo "$COMMAND" | grep -q "npm run build"; then
+  echo '{"decision": "approve", "statusMessage": "Building project..."}'
+else
+  echo "approve"
+fi
+
+exit 0
+```
+
+## One-Time Hook Pattern
+
+Fire a hook only once per session using `once: true`:
+
+```json
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/first-modification-alert.sh",
+          "once": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+The hook fires on the first matching event, then is skipped for the rest of the session.
+
+## Three-Way Decision Pattern
+
+Use `ask` to escalate uncertain decisions to the user:
+
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/risk-assessment.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/risk-assessment.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Known safe commands — auto-approve
+if echo "$COMMAND" | grep -qE '^(ls|cat|echo|git status|git log)'; then
+  echo "approve"
+  exit 0
+fi
+
+# Known dangerous — auto-deny
+if echo "$COMMAND" | grep -qE '(rm -rf /|DROP TABLE|format)'; then
+  echo "deny"
+  exit 2
+fi
+
+# Uncertain — let the user decide
+echo "ask"
+exit 0
+```
+
 ## Best Practices
 
 1. **Fast hooks**: Keep execution time minimal

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/marketplace-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/marketplace-json.md
@@ -334,6 +334,20 @@ For team-wide availability, add to project settings:
 
 Team members are prompted to install when they trust the folder.
 
+## Reserved Marketplace Names
+
+The following names are reserved by Anthropic and cannot be used for custom marketplaces:
+
+- `claude-code-marketplace`
+- `claude-code-plugins`
+- `claude-plugins-official`
+- `anthropic-marketplace`
+- `anthropic-plugins`
+- `agent-skills`
+- `life-sciences`
+
+Using a reserved name will cause marketplace registration to fail.
+
 ## See Also
 
 - `plugin-json.md` - plugin manifest

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/output-config.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/output-config.md
@@ -2,6 +2,26 @@
 
 Plugins often need to write logs, artifacts, and reports. This guide covers best practices for output management.
 
+## Output Styles
+
+Plugins can provide custom output styles via the `outputStyles` field in `plugin.json`. Output styles customize how Claude Code renders output (e.g., custom formatting, themes). Configure as a path or array of paths:
+
+```json
+{
+  "outputStyles": "./styles/"
+}
+```
+
+Or multiple paths:
+
+```json
+{
+  "outputStyles": ["./styles/dark.css", "./styles/compact.css"]
+}
+```
+
+Paths are relative to plugin root and follow the same rules as other component paths.
+
 ## Standard Environment Variables
 
 | Variable | Purpose | Availability |

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -87,9 +87,12 @@ Or simple string:
 |-------|------|-------------|
 | commands | string/array | Custom command file paths |
 | agents | string/array | Custom agent file paths |
+| skills | string/array | Custom skill directory paths |
 | hooks | string/object | Hook config path or inline config |
 | mcpServers | string/object | MCP config path or inline config |
 | lspServers | string/object | LSP config path or inline config |
+| outputStyles | string/array | Custom output style paths |
+| settings | string | Path to settings.json (only `agent` key supported) |
 
 ### Path Patterns
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
@@ -288,6 +288,36 @@ Control tool permissions:
 - Secrets and credentials
 - Development-only configs
 
+## Enterprise: Restricting Marketplaces
+
+Managed settings can restrict which marketplaces users can add using `strictKnownMarketplaces`:
+
+```json
+{
+  "strictKnownMarketplaces": []
+}
+```
+
+**Empty array**: Locks down all marketplace additions — users cannot add any new marketplaces.
+
+**With entries**: Only the listed marketplaces are allowed:
+
+```json
+{
+  "strictKnownMarketplaces": [
+    "https://github.com/org/approved-marketplace.git",
+    {
+      "hostPattern": "^github\\.com$",
+      "pathPattern": "^our-org/"
+    }
+  ]
+}
+```
+
+Pattern objects support `hostPattern` and `pathPattern` regex for flexible matching (e.g., allow any repo under your GitHub org).
+
+This setting is typically configured in managed policies (enterprise level) and cannot be overridden by user or project settings.
+
 ## See Also
 
 - `plugin-json.md` - plugin manifest


### PR DESCRIPTION
## Summary

Audit of plugin-creation-tools reference docs against latest Claude Code documentation revealed 12 gaps where features were documented in our guides but missing from the reference files users actually read when creating plugins.

- **hook-events.md**: Added `statusMessage` return field (JSON format + example), `once` field (fire-once-per-session), expanded `ask` decision value explanation, hook execution order (parallel within matcher groups), hook timeout behavior
- **hook-patterns.md**: 3 new patterns — Status Message, One-Time Hook, Three-Way Decision (`approve`/`deny`/`ask`)
- **agent-tools.md**: Added `dontAsk` permission mode, removed invalid `ignore` mode (now 5 correct modes)
- **plugin-json.md**: Added `outputStyles`, `skills`, `settings` to Component Path Fields table
- **output-config.md**: Added Output Styles section with configuration examples
- **settings.md**: Added `strictKnownMarketplaces` enterprise lockdown section with host/path pattern matching
- **marketplace-json.md**: Added 7 reserved marketplace names

## Files Changed (10 files, +263/-6 lines)

| File | Change |
|------|--------|
| `06-hooks/hook-events.md` | +58 — statusMessage, once, execution order, timeout |
| `06-hooks/hook-patterns.md` | +108 — 3 new patterns with full script examples |
| `05-agents/agent-tools.md` | +10 — dontAsk mode, fixed permission table |
| `08-configuration/plugin-json.md` | +3 — outputStyles, skills, settings fields |
| `08-configuration/output-config.md` | +20 — Output Styles section |
| `08-configuration/settings.md` | +30 — strictKnownMarketplaces section |
| `08-configuration/marketplace-json.md` | +14 — reserved names |
| `plugin.json` | v2.4.0 |
| `marketplace.json` | v2.4.0 + updated description |
| `CHANGELOG.md` | Full [2.4.0] entry, corrected 2.3.0 statusMessage/once claim |

## Test plan

- [ ] Read hook-events.md — verify statusMessage JSON format is clear and once field has complete example
- [ ] Read hook-patterns.md — verify 3 new patterns have working bash scripts
- [ ] Read agent-tools.md — verify 5 permission modes listed correctly (no `ignore`)
- [ ] Read plugin-json.md — verify outputStyles in Component Path Fields table
- [ ] Read settings.md — verify strictKnownMarketplaces with both empty array and pattern examples
- [ ] Read marketplace-json.md — verify 7 reserved names listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)