### PR TITLE
Update 6 plugins from doc refresh findings

### DIFF
--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, visual components, 26 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-03-20
+
+### Changed
+- CLAUDE.md reviewed against 200-line size guidance — at 33 lines, no changes needed
+- Agent frontmatter reviewed for `hooks`/`mcpServers`/`permissionMode` — none present in brand-analyst agent
+
 ## [3.1.0] - 2026-03-17
 
 ### Added

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-03-20
+
+### Changed
+- **`commands/test-team.md`**: Added `effort: high` to Edge Case Hunter and Red Team Attacker spawn specs — these agents perform exhaustive boundary and adversarial analysis and benefit from extended reasoning
+- **`commands/test-team.md`**: Added dual-control completion pattern to all three teammate "WHEN DONE" blocks — agents can exit with code 2 (feedback loop) or output `{"continue": false}` (hard stop) to signal task completion to the lead
+- **`hooks/pre-compact.sh`**: Fixed filename mismatch — hook was looking for `paper-test-synthesis.md` but the command writes `paper-test-team-report.md`; now correctly preserves the synthesis report on compaction
+
+### Notes
+- Frontmatter fields `hooks`, `mcpServers`, and `permissionMode` are silently ignored for plugin-packaged agents; spawn specs in this plugin use prose format only — no such fields are present
+
+---
+
 ## [0.4.1] - 2026-03-15
 
 ### Added

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -191,6 +191,10 @@ If target files are skills, commands, or agents (.md with frontmatter):
 WHEN DONE:
 Message the other teammates: "Happy path analysis complete. Review happy-path-analysis.md"
 Mark your task as completed.
+
+To signal completion to the lead, either:
+- Exit with code 2 to trigger a feedback loop (the lead reviews and may ask for more)
+- Or output JSON: {"continue": false} to hard-stop your turn immediately
 ```
 
 ### Teammate 2: Edge Case Hunter
@@ -198,6 +202,7 @@ Mark your task as completed.
 **Model:** sonnet
 **MaxTurns:** 15
 **Isolation:** worktree
+**Effort:** high
 
 ```
 You are the Edge Case Hunter for a paper testing team.
@@ -272,6 +277,10 @@ If target files are skills, commands, or agents (.md with frontmatter):
 WHEN DONE:
 Message the other teammates: "Edge case analysis complete. Review edge-case-analysis.md"
 Mark your task as completed.
+
+To signal completion to the lead, either:
+- Exit with code 2 to trigger a feedback loop (the lead reviews and may ask for more)
+- Or output JSON: {"continue": false} to hard-stop your turn immediately
 ```
 
 ### Teammate 3: Red Team Attacker
@@ -279,6 +288,7 @@ Mark your task as completed.
 **Model:** sonnet
 **MaxTurns:** 15
 **Isolation:** worktree
+**Effort:** high
 **Note:** For complex security analysis, consider using `model: opus` for deeper reasoning.
 
 ```
@@ -365,6 +375,10 @@ If target files are skills, commands, or agents (.md with frontmatter):
 WHEN DONE:
 Message the other teammates: "Red team analysis complete. Review red-team-analysis.md"
 Mark your task as completed.
+
+To signal completion to the lead, either:
+- Exit with code 2 to trigger a feedback loop (the lead reviews and may ask for more)
+- Or output JSON: {"continue": false} to hard-stop your turn immediately
 ```
 
 ---

--- a/code-paper-test/hooks/pre-compact.sh
+++ b/code-paper-test/hooks/pre-compact.sh
@@ -15,7 +15,7 @@ fi
 if [ -n "$REPORTS_DIR" ] && [ -d "$REPORTS_DIR" ]; then
   FOUND_REPORTS=false
 
-  for report in happy-path-analysis.md edge-case-analysis.md red-team-analysis.md paper-test-synthesis.md; do
+  for report in happy-path-analysis.md edge-case-analysis.md red-team-analysis.md paper-test-team-report.md; do
     if [ -f "$REPORTS_DIR/$report" ]; then
       if [ "$FOUND_REPORTS" = false ]; then
         echo "### Test Team Reports in $REPORTS_DIR"

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks, Roave via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks, Socket CLI) projects - TDD, SOLID, DRY, OWASP security",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-03-20
+
+### Added
+- **`/simplify` distinction note** in SKILL.md: Documents how Claude Code's built-in `/simplify` differs from `/code-quality:review` (rubric scoring, quality gate, persisted report vs quick ad-hoc feedback)
+- **`effort: high` on all debate agents**: All 6 agent spawn prompts in `security-debate.md` and `architecture-debate.md` now declare `effort: high` for deeper analysis
+- **`StopFailure` hook guidance** in CLAUDE.md: Documents how users can configure the `StopFailure` event in their project's `.claude/hooks.json` for CI failure alerting (e.g., Slack webhook on audit failure)
+- **`REVIEW.md` convention** in `commands/review.md`: Documents that a `REVIEW.md` file at project root customizes Claude's review behavior, consistent with Claude Code's Code Review feature
+- **Sandbox path whitelisting note** in SKILL.md: Guidance for users with sandbox mode enabled — linter binaries (PHPStan, ESLint, Semgrep, Trivy, Gitleaks) must be whitelisted; DDEV-proxied commands are unaffected
+- **Agent frontmatter limitations note** in CLAUDE.md: Clarifies that `hooks`, `mcpServers`, and `permissionMode` are not valid in agent spawn prompt blocks and will be silently ignored
+
 ## [2.7.1] - 2026-03-15
 
 ### Added

--- a/code-quality-tools/CLAUDE.md
+++ b/code-quality-tools/CLAUDE.md
@@ -23,6 +23,35 @@
 - Agent team commands include `maxTurns` (cost control) and `isolation: worktree` (independence)
 - Agent team commands orchestrate debate workflows with quality gate enforcement
 
+## Agent Frontmatter Limitations
+Agent spawn prompts in this plugin document `effort`, `model`, `maxTurns`, and `isolation` as intent markers inside Markdown. These are NOT evaluated as YAML frontmatter — they are instructions to Claude on how to configure the spawned agent. The actual agent launch mechanism (TeamCreate/TaskCreate) is what enforces model routing and isolation. Do not add `hooks`, `mcpServers`, or `permissionMode` to agent spawn prompt blocks — those fields are not processed in the agent spawning context and will be silently ignored.
+
+## Hooks
+The plugin registers one hook in `hooks/hooks.json`:
+- **PreCompact** — `hooks/pre-compact.sh` — Preserves audit context before conversation compaction
+
+### StopFailure Hook (CI pipelines)
+For users running audits in CI, the `StopFailure` hook event fires when a Claude Code session exits with a non-zero status. This is useful for error alerting. Example pattern to document for CI-integrated projects:
+
+```json
+{
+  "hooks": {
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST $SLACK_WEBHOOK -d '{\"text\":\"Code quality audit failed in CI\"}'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Users can add this to their project's `.claude/hooks.json` (not this plugin's hooks.json) to receive failure alerts when `/code-quality:audit` or `/code-quality:security` exits with errors in CI.
+
 ## Online Dev-Guides
 For Drupal-specific patterns when explaining violations or suggesting fixes, fetch the guide index:
 - **Index:** `https://camoa.github.io/dev-guides/llms.txt`

--- a/code-quality-tools/commands/architecture-debate.md
+++ b/code-quality-tools/commands/architecture-debate.md
@@ -94,6 +94,7 @@ When all teammates finish:
 **Model:** sonnet
 **MaxTurns:** 10
 **Isolation:** worktree
+**Effort:** high
 
 ```
 You are the Pragmatist for an architecture debate team.
@@ -155,6 +156,7 @@ Mark your task as completed.
 **Model:** sonnet
 **MaxTurns:** 10
 **Isolation:** worktree
+**Effort:** high
 
 ```
 You are the Purist for an architecture debate team.
@@ -235,6 +237,7 @@ Mark your task as completed.
 **Model:** sonnet
 **MaxTurns:** 10
 **Isolation:** worktree
+**Effort:** high
 
 ```
 You are the Maintainer for an architecture debate team.

--- a/code-quality-tools/commands/review.md
+++ b/code-quality-tools/commands/review.md
@@ -153,6 +153,10 @@ Write to `.reports/code-review-{filename-or-dirname}.md`:
 > Report saved to `.reports/code-review-{name}.md`
 > {if FAIL: "Quality gate FAILED. See action items for required fixes."}
 
+## REVIEW.md Convention
+
+Claude Code's Code Review feature supports a `REVIEW.md` file at the project root to customize review behavior. If `REVIEW.md` exists in the project, Claude will read it before scoring to apply project-specific standards (e.g., required patterns, team conventions, framework-specific rules). Create a `REVIEW.md` to tailor the rubric to your project's needs.
+
 ## Related Commands
 
 - `/code-quality:audit` — Full automated audit (tools only, no rubric)

--- a/code-quality-tools/commands/security-debate.md
+++ b/code-quality-tools/commands/security-debate.md
@@ -105,6 +105,7 @@ When all teammates finish:
 **MaxTurns:** 10
 **Isolation:** worktree
 **Tools:** Read, Glob, Grep
+**Effort:** high
 
 ```
 You are the Defender for a security audit debate team.
@@ -164,6 +165,7 @@ Mark your task as completed.
 **MaxTurns:** 10
 **Isolation:** worktree
 **Tools:** Read, Glob, Grep, WebSearch
+**Effort:** high
 
 ```
 You are the Red Team Attacker for a security audit debate team.
@@ -227,6 +229,7 @@ Mark your task as completed.
 **MaxTurns:** 10
 **Isolation:** worktree
 **Tools:** Read, Glob, Grep, WebFetch
+**Effort:** high
 
 ```
 You are the Compliance Checker for a security audit debate team.

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -26,6 +26,8 @@ Run quality and security audits for **Drupal** and **Next.js** projects with con
 
 **For conversational workflows, continue reading...**
 
+> **Note — Claude Code's built-in `/simplify`:** Claude Code ships a built-in `/simplify` skill for quick single-pass code review. `/code-quality:review` is different: it runs automated tools (PHPStan/ESLint), scores across 10 rubric categories with a /50 scale, enforces a quality gate (PASS 35+/FAIL), and writes a persisted report. Use `/simplify` for fast ad-hoc feedback; use `/code-quality:review` when you need a structured, scored, and documented assessment.
+
 ## When to Use
 
 **Drupal projects:**
@@ -86,6 +88,8 @@ Run quality and security audits for **Drupal** and **Next.js** projects with con
 **Next.js:**
 1. Verify npm: `npm --version`
 2. Create reports directory: `mkdir -p .reports && echo ".reports/" >> .gitignore`
+
+> **Sandbox users:** If Claude Code sandbox mode is enabled, bash scripts that invoke linters (PHPStan, ESLint, Semgrep, Trivy, Gitleaks) require their binary paths to be whitelisted. Add the tool binaries to your `allowedPaths` in `claude_code_config.json` (e.g., `vendor/bin/phpstan`, `/usr/local/bin/semgrep`). DDEV-proxied commands run inside the container and are unaffected.
 
 ## When to Run What
 

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guides-navigator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"

--- a/dev-guides-navigator/CHANGELOG.md
+++ b/dev-guides-navigator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.3 (2026-03-20)
+
+### Changed
+- Maintenance: confirmed CLAUDE.md under 200-line limit (38 lines), no content to move
+- Confirmed `user-invocable: true` is correct — no internal routing sub-skills requiring `false`
+
 ## 0.2.1 (2026-03-15)
 
 ### Added

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/.claude/rules/agent-conventions.md
+++ b/drupal-dev-framework/.claude/rules/agent-conventions.md
@@ -18,6 +18,10 @@ paths:
 - `skills` — preload skills into agent context
 - `hooks` — scoped hooks that run only when this agent is active
 
+## Agent Frontmatter Limitations
+- `hooks`, `mcpServers`, and `permissionMode` in agent frontmatter are **not supported** when agents are invoked as sub-agents via the Agent SDK or spawned programmatically. These fields only take effect when the agent runs as the top-level session.
+- `architecture-validator` currently uses `hooks: PreToolUse` in frontmatter — this works for interactive sessions but will be silently ignored if the agent is ever invoked as a sub-agent. The `disallowedTools: Edit, Write` field remains the reliable write-block mechanism.
+
 ## Body Structure
 1. Purpose section — what the agent does
 2. When to Invoke — trigger conditions

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.3] - 2026-03-20
+
+### Added
+- **PostCompact hook** (`hooks/post-compact.sh`): Re-injects active project/task context after compaction — reads `session_context.json` and outputs project state + task details so Claude can continue without manual re-orientation
+- **StopFailure hook** (`hooks/stop-failure.sh`): Logs task failures caused by API errors to `~/.claude/drupal-dev-framework/logs/failures.log`, with project/task name from session context, so the next session can detect unclean exits
+- **`hooks.json`**: Added `PostCompact` and `StopFailure` event registrations for the two new hook scripts
+
+### Changed
+- **agent-conventions.md**: Added "Agent Frontmatter Limitations" section — documents that `hooks`, `mcpServers`, and `permissionMode` in agent frontmatter are ignored when agents run as sub-agents via the Agent SDK. Notes that `architecture-validator`'s PreToolUse hook frontmatter is interactive-only; `disallowedTools` remains the reliable write-block
+
 ## [3.6.1] - 2026-03-15
 
 ### Fixed

--- a/drupal-dev-framework/hooks/hooks.json
+++ b/drupal-dev-framework/hooks/hooks.json
@@ -21,6 +21,28 @@
           }
         ]
       }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-compact.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-failure.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/drupal-dev-framework/hooks/post-compact.sh
+++ b/drupal-dev-framework/hooks/post-compact.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Post-compact hook: Re-inject active project/task context after compaction
+# Reads session_context.json to restore task state Claude needs to continue
+
+SESSION_CONTEXT="$HOME/.claude/drupal-dev-framework/session_context.json"
+
+if [ ! -f "$SESSION_CONTEXT" ]; then
+  exit 0
+fi
+
+PROJECT_NAME=$(jq -r '.project // empty' "$SESSION_CONTEXT" 2>/dev/null)
+PROJECT_PATH=$(jq -r '.projectPath // empty' "$SESSION_CONTEXT" 2>/dev/null)
+TASK_NAME=$(jq -r '.task // empty' "$SESSION_CONTEXT" 2>/dev/null)
+TASK_PATH=$(jq -r '.taskPath // empty' "$SESSION_CONTEXT" 2>/dev/null)
+
+if [ -z "$PROJECT_NAME" ] || [ ! -d "$PROJECT_PATH" ]; then
+  exit 0
+fi
+
+echo "## Session Restored After Compaction"
+echo ""
+echo "**Project:** $PROJECT_NAME"
+echo "**Path:** $PROJECT_PATH"
+
+# Re-inject project_state.md if present
+STATE_FILE="$PROJECT_PATH/project_state.md"
+if [ -f "$STATE_FILE" ]; then
+  echo ""
+  echo "### Project State"
+  head -40 "$STATE_FILE"
+fi
+
+# Re-inject active task context
+if [ -n "$TASK_NAME" ] && [ -d "$TASK_PATH" ]; then
+  echo ""
+  echo "**Active Task:** $TASK_NAME"
+
+  TASK_FILE="$TASK_PATH/task.md"
+  if [ -f "$TASK_FILE" ]; then
+    echo ""
+    echo "### Task Details"
+    head -30 "$TASK_FILE"
+  fi
+fi
+
+echo ""
+echo "_Context restored by PostCompact hook. Continue from where you left off._"

--- a/drupal-dev-framework/hooks/stop-failure.sh
+++ b/drupal-dev-framework/hooks/stop-failure.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# StopFailure hook: Log task failures caused by API errors
+# Writes a failure record so the next session can detect and recover
+
+SESSION_CONTEXT="$HOME/.claude/drupal-dev-framework/session_context.json"
+LOG_DIR="$HOME/.claude/drupal-dev-framework/logs"
+LOG_FILE="$LOG_DIR/failures.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date -Iseconds)
+PROJECT_NAME=""
+TASK_NAME=""
+
+if [ -f "$SESSION_CONTEXT" ]; then
+  PROJECT_NAME=$(jq -r '.project // empty' "$SESSION_CONTEXT" 2>/dev/null)
+  TASK_NAME=$(jq -r '.task // empty' "$SESSION_CONTEXT" 2>/dev/null)
+fi
+
+# Log the failure
+{
+  echo "---"
+  echo "timestamp: $TIMESTAMP"
+  echo "project: ${PROJECT_NAME:-unknown}"
+  echo "task: ${TASK_NAME:-unknown}"
+  echo "event: StopFailure (API error caused session to end)"
+} >> "$LOG_FILE"
+
+echo "## Session Ended Due to API Failure"
+echo ""
+if [ -n "$PROJECT_NAME" ]; then
+  echo "**Project:** $PROJECT_NAME"
+fi
+if [ -n "$TASK_NAME" ]; then
+  echo "**Task:** $TASK_NAME"
+fi
+echo ""
+echo "Failure logged to: $LOG_FILE"
+echo ""
+echo "To resume: run \`/drupal-dev-framework:next\` in your next session."

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.3] - 2026-03-20
+
+### Changed
+- Maintenance audit: verified CLAUDE.md (28 lines, within limit), agent frontmatter clean (no ignored fields)
+- Version bump: 1.4.2 → 1.4.3
+
 ## [1.4.1] - 2026-03-15
 
 ### Added


### PR DESCRIPTION
## Summary
- Updates 6 camoa-skills plugins based on full Claude Code docs re-fetch (2026-03-20)
- 85 guides analyzed, 8 significantly rewritten, findings applied per-plugin

## Changes by plugin

### code-quality-tools (v2.7.2 → v2.8.0)
- `/simplify` built-in skill distinction documented
- `effort: high` on 6 debate agents
- REVIEW.md convention for code review customization
- StopFailure hook pattern for CI failure alerting
- Sandbox compatibility notes for linter scripts
- Agent frontmatter limitations documented in CLAUDE.md

### drupal-dev-framework (v3.6.2 → v3.6.3)
- PostCompact hook + script: re-injects project state after compaction
- StopFailure hook + script: logs API failures with recovery guidance
- Agent frontmatter limitations documented in rules

### code-paper-test (v0.4.2 → v0.4.3)
- `effort: high` on Edge Case + Red Team agents
- Dual-control completion pattern (exit code 2 vs JSON stop)
- Pre-compact hook filename fix (was scanning wrong filename)

### brand-content-design (v3.1.0 → v3.1.1)
### dev-guides-navigator (v0.2.2 → v0.2.3)
### drupal-htmx (v1.4.2 → v1.4.3)
- Maintenance audit: CLAUDE.md size, agent frontmatter — all clean

## Test plan
- [ ] Verify drupal-dev-framework PostCompact/StopFailure hooks execute correctly
- [ ] Run `/code-quality:review` to confirm REVIEW.md section renders
- [ ] Run `/code-paper:test-team` to confirm effort and dual-control changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)