### PR TITLE
Add phase checkpoints MVP to drupal-dev-framework (v3.9.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging. Requires: dev-guides-navigator.",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/.claude/rules/command-conventions.md
+++ b/drupal-dev-framework/.claude/rules/command-conventions.md
@@ -26,3 +26,26 @@ When a command resolves which project and/or task the user is working on, **invo
 - On `/complete`, invoke with task set to `null` since the task moved to completed
 - Session context is per-workspace (keyed by `$PWD` hash) — multiple Claude windows don't conflict
 - The pre/post-compact hooks read the workspace-specific session file to point Claude at the right `project_state.md`
+
+## Checkpoint Frontmatter (v3.9.0+)
+
+New tasks use a `checkpoints` key in task.md frontmatter to track phase progress. Canonical IDs and entry conditions live in `references/checkpoint-catalog.md`.
+
+```yaml
+---
+task: <task_name>
+phase: 1
+checkpoints:
+  phase_1:
+    - {id: "1.1", status: done, evidence: "research.md#constraints"}
+    - {id: "1.2", status: in_progress}
+    - {id: "1.5", status: skipped, justification: "meta-task, no Drupal core applies"}
+  phase_2: []
+  phase_3: []
+---
+```
+
+- Status values: `pending`, `in_progress`, `done`, `skipped` (skipped requires `justification`)
+- `/design` and `/implement` invoke the `checkpoint-gate` skill at start to enforce phase entry
+- `/step` command reads this schema to show current state and next action
+- Tasks without `checkpoints` key fall through to legacy Phase Status checklist (backward compatible)

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2026-04-19
+
+### Added
+- **Phase checkpoints MVP** — expanded Research/Architecture/Implementation into 7/6/8 named checkpoints with explicit entry conditions. Catalog at `references/checkpoint-catalog.md`.
+- **`checkpoint-gate` skill** (`skills/checkpoint-gate/`) — internal skill invoked by `/design` and `/implement` at start. Enforces phase entry via checkpoint status (or legacy Phase Status checklist in grandfather mode). Blocks with actionable guidance when prior-phase checkpoints incomplete.
+- **`/step` command** — show current checkpoint state, mark-done, skip (with required justification), or reset. Human-first readable output; all mutations use `Edit` for concurrent-safety.
+- **Checkpoint frontmatter schema** in task.md — YAML `checkpoints` key tracks per-checkpoint status (`pending`/`in_progress`/`done`/`skipped`). `skipped` requires non-empty `justification` to count.
+- **Case-insensitive status comparison** + explicit conflict rule (checkpoint frontmatter wins over legacy `## Phase Status` checklist).
+
+### Changed
+- **`/design` and `/implement`** — now invoke `checkpoint-gate` as step 0 before any other work. Updates task.md both legacy checklist and checkpoint frontmatter when present.
+- **`phase-detector` skill** — reads checkpoint frontmatter when present, falls back to Phase Status checklist + phase-file existence heuristic for grandfather tasks.
+- **`.claude/rules/command-conventions.md`** — documents the checkpoint frontmatter schema.
+
+### Backward compatible
+Tasks without `checkpoints` key in frontmatter continue to work unchanged via grandfather mode. Existing completed tasks are not affected.
+
 ## [3.8.0] - 2026-04-08
 
 ### Fixed

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -14,17 +14,18 @@ Design architecture for a specific task (Phase 2 of a task).
 /drupal-dev-framework:design <task-name>
 ```
 
-## What This Does (v3.0.0)
+## What This Does (v3.9.0)
 
+0. **Invokes `checkpoint-gate` skill** with `target_phase=2` — blocks if Phase 1 checkpoints (or legacy Phase Status) are not complete. If gate returns `block`, stop and show the gate's guidance to the user. Do not proceed.
 1. Loads task from `implementation_process/in_progress/{task_name}/`
 2. Reviews research findings in `research.md`
 3. **Loads dev-guides** for architecture decisions via `guide-integrator` (unless already loaded this session)
 4. Invokes `architecture-drafter` agent
 5. Invokes `guide-integrator` for methodology refs
-5. Creates/updates `architecture.md` with design
-6. Updates `task.md` to mark Phase 2 as in progress
-7. Optionally creates component file in `architecture/{component}.md`
-8. **Invokes `session-context-writer` skill with the resolved project and task**
+6. Creates/updates `architecture.md` with design
+7. Updates `task.md` to mark Phase 2 as in progress (both legacy checklist AND checkpoint frontmatter when present)
+8. Optionally creates component file in `architecture/{component}.md`
+9. **Invokes `session-context-writer` skill with the resolved project and task**
 
 ## Task-Based Workflow
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -14,8 +14,9 @@ Start implementing a specific task with full context loaded (Phase 3 of a task).
 /drupal-dev-framework:implement <task-name>
 ```
 
-## What This Does (v3.0.0)
+## What This Does (v3.9.0)
 
+0. **Invokes `checkpoint-gate` skill** with `target_phase=3` — blocks if Phase 1 OR Phase 2 checkpoints (or legacy Phase Status) are not complete. If gate returns `block`, stop and show the gate's guidance to the user. Do not proceed.
 1. Loads task from `implementation_process/in_progress/{task_name}/`
 2. Loads architecture from `architecture.md`
 3. Loads research context from `research.md`
@@ -23,7 +24,7 @@ Start implementing a specific task with full context loaded (Phase 3 of a task).
 5. **Loads dev-guides** for security, SDC, JS patterns via `guide-integrator` (unless already loaded this session)
 6. Loads methodology refs (via `guide-integrator`)
 7. Creates/updates `implementation.md` for progress tracking
-8. Updates `task.md` to mark Phase 3 as in progress
+8. Updates `task.md` to mark Phase 3 as in progress (both legacy checklist AND checkpoint frontmatter when present)
 9. Activates `tdd-companion` for TDD discipline
 10. Prepares for interactive development
 11. **Invokes `session-context-writer` skill with the resolved project and task**

--- a/drupal-dev-framework/commands/step.md
+++ b/drupal-dev-framework/commands/step.md
@@ -1,0 +1,138 @@
+---
+description: "Show current checkpoint state for the active task and recommend next action. Also mark-done, skip, or reset individual checkpoints. Trigger: 'where am I', 'what's next checkpoint', 'step', 'mark checkpoint done', 'skip checkpoint'."
+allowed-tools: Read, Edit
+argument-hint: "[show|mark-done <id>|skip <id> <reason>|reset <id>]"
+---
+
+# Step
+
+Navigate and update checkpoint state for the active task. Reads `references/checkpoint-catalog.md` for canonical checkpoint names and entry conditions.
+
+## Usage
+
+```
+/drupal-dev-framework:step                                        # Show current state
+/drupal-dev-framework:step mark-done 2.4                          # Mark a checkpoint done
+/drupal-dev-framework:step skip 1.5 meta-task, no Drupal core     # Skip with justification (multi-word ok)
+/drupal-dev-framework:step reset 2.3                              # Revert to pending
+```
+
+## Instructions
+
+### Step 1 — Resolve active task
+
+Read the per-workspace session file:
+
+```bash
+WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+```
+
+If the session file does not exist: tell the user `"No active task for this workspace. Run /drupal-dev-framework:next to select one."` Stop.
+
+If the session file exists but `taskPath` is null or does not point to an existing folder: tell the user `"Session points to a task that no longer exists. Run /drupal-dev-framework:next to re-select."` Stop.
+
+### Step 2 — Parse arguments
+
+Parse `$ARGUMENTS`:
+
+- No argument or first token is `show` → go to **Show state**
+- First token is `mark-done` → second token is `<id>`; go to **Mark done**
+- First token is `skip` → second token is `<id>`; rest-of-line is `<reason>`; go to **Skip**
+- First token is `reset` → second token is `<id>`; go to **Reset**
+- Anything else → print usage block (see Usage above) and stop
+
+**ID validation (applies to all mutating sub-commands):** the `<id>` token must match `^\d+\.\d+$` (e.g., `1.1`, `2.4`, `3.7`). Normalize by stripping surrounding whitespace. Reject anything else with `"Invalid checkpoint ID '{id}'. Expected format: <phase>.<step>, e.g., 1.3"`. This prevents path-like or malformed IDs from reaching file operations.
+
+## Show state (default)
+
+1. Read task.md. If no YAML frontmatter exists OR frontmatter lacks a `checkpoints` key → **grandfather-mode output:**
+   ```
+   Task: {task_name}
+   Phase: {from body Phase Status checklist, or "unknown"} — grandfather mode (no checkpoint schema)
+
+   Legacy Phase Status:
+     Phase 1: {x or blank}
+     Phase 2: {x or blank}
+     Phase 3: {x or blank}
+
+   Checkpoint schema not in use for this task. Add a `checkpoints:` key to the frontmatter
+   following references/checkpoint-catalog.md to enable per-checkpoint tracking.
+   ```
+
+2. Otherwise, build the report from frontmatter + `references/checkpoint-catalog.md`:
+   - Normalize all `status` values to lowercase for display and counting
+   - Treat `skipped` entries without a non-empty `justification` as effectively `pending` (show with a `[?]` marker)
+
+   ```
+   Task: {task_name}
+   Phase: {phase} ({done_count}/{total_count} checkpoints done)
+
+   Current: {first in_progress, else first pending} — {name}
+   Next:    {next pending after current} — {name}
+
+   Recent (last 3):
+     [done] {id}  {name}  ({evidence or "—"})
+     [skip] {id}  {name}  ({justification})
+     [done] {id}  {name}
+
+   Upcoming in this phase (next 3):
+     [....] {id}  {name}
+     [....] {id}  {name}
+
+   To advance:
+     Complete {current id} by {human-readable hint from catalog entry condition}, then:
+     /drupal-dev-framework:step mark-done {current id}
+   ```
+
+Output is **human-first** — readable prose + boxed structure. Include the suggested next command literally so the user can copy-paste. Cap `Recent` and `Upcoming` at 3 entries each.
+
+## Mark done
+
+1. Validate `<id>` matches `^\d+\.\d+$` (Step 2 already did this if reached here).
+2. Validate `<id>` exists for the task's current phase in `references/checkpoint-catalog.md`. If not: print valid IDs for the current phase and stop.
+3. Read task.md. If no `checkpoints` frontmatter: refuse with `"Task is in grandfather mode. Add a checkpoints: frontmatter block first (see references/checkpoint-catalog.md for schema)."`
+4. Verify prior checkpoints in the same phase have normalized status `done` OR (`skipped` with non-empty `justification`). If any earlier ID is still pending or `skipped` without justification: list them and stop. Do not mark out of order.
+5. If the target ID is already `done`: print `"{id} is already marked done — no change."` Do NOT touch the existing `evidence` field. Stop.
+6. **Use `Edit` (not `Write`)** to change the single checkpoint entry's `status` to `done`. This preserves the surrounding frontmatter and avoids clobbering other concurrent edits. Do NOT add an `evidence` field automatically — evidence is added manually by the user or authoring agent when it's meaningful.
+7. Print one-line confirmation + next recommended checkpoint.
+
+## Skip
+
+1. Validate `<id>` (same as mark-done step 1-2).
+2. `<reason>` must be non-empty, trimmed of leading/trailing whitespace, contain at least one non-whitespace character, and be ≤ 500 characters. Reject:
+   - empty / whitespace-only → `"Skip requires a written justification: /drupal-dev-framework:step skip <id> <reason>"`
+   - > 500 chars → `"Skip reason too long (max 500 chars). Trim and retry."`
+3. **YAML-safe the reason before writing:**
+   - Reject if the reason contains raw newlines or control characters (ASCII < 0x20 except tab). Single-line only.
+   - Reject if the reason contains a literal `"---"` sequence (could split the frontmatter block).
+   - Escape all `"` as `\"` and all backslashes as `\\`.
+   - Always write the justification inside double quotes: `justification: "…"`.
+4. **Use `Edit`** to update the checkpoint entry: `status: skipped, justification: "{escaped_reason}"`. Preserve other fields.
+5. Print one-line confirmation + next recommended checkpoint.
+
+## Reset
+
+1. Validate `<id>`.
+2. **Use `Edit`** to set the entry to `status: pending` and remove any `evidence` and `justification` fields from that single entry. Do not touch other entries.
+3. Print one-line confirmation.
+
+## Output Style
+
+- **Show state output is human-first** — prose, boxes, copy-pasteable commands
+- **Mark-done / skip / reset confirmations are short** — one line of confirmation + one line of next action
+
+## Do Not
+
+- Do not invent checkpoint IDs. If user passes an ID not in the catalog for the current phase, print valid IDs and stop.
+- Do not use `Write` on task.md — always `Edit`, to reduce clobber risk on concurrent operations.
+- Do not mark completion without verifying prior-checkpoint dependencies.
+- Do not accept skip reasons with newlines, control chars, or `"---"` sequences.
+- Do not auto-fill `evidence` — let humans or authoring agents write meaningful evidence.
+
+## Related Commands
+
+- `/drupal-dev-framework:status` — full task overview (all phases)
+- `/drupal-dev-framework:next` — recommend next command (macro-level)
+- `/drupal-dev-framework:design <task>` — enter Phase 2 (invokes checkpoint-gate)
+- `/drupal-dev-framework:implement <task>` — enter Phase 3 (invokes checkpoint-gate)

--- a/drupal-dev-framework/references/checkpoint-catalog.md
+++ b/drupal-dev-framework/references/checkpoint-catalog.md
@@ -1,0 +1,72 @@
+# Checkpoint Catalog
+
+Canonical checkpoint sequences per phase. Each task.md frontmatter `checkpoints` key references these IDs.
+
+## Phase 1: Research (7 checkpoints)
+
+| ID  | Name | Entry Condition | Evidence |
+|-----|------|-----------------|----------|
+| 1.1 | Load user project constraints | Task folder exists | Constraints referenced in research.md or "none defined" noted |
+| 1.2 | Identify task domain + expected guides | 1.1 done/skipped | Expected-guides list in research.md |
+| 1.3 | Load guides via guide-integrator | 1.2 done | Loaded guide names listed in research.md |
+| 1.4 | Contrib research | 1.3 done/skipped | Contrib modules evaluated in research.md |
+| 1.5 | Core pattern research | 1.3 done/skipped | Core patterns cited in research.md |
+| 1.6 | Write research.md with guide citations | 1.4, 1.5 done/skipped | research.md exists, cites guides from 1.3 |
+| 1.7 | Verify all expected guides cited | 1.6 done | Citations match 1.2 expected list |
+
+## Phase 2: Architecture (6 checkpoints)
+
+| ID  | Name | Entry Condition | Evidence |
+|-----|------|-----------------|----------|
+| 2.1 | Re-inject loaded-guides summary | Phase 1 complete | Active guide list in context at phase start |
+| 2.2 | Load SOLID/DRY/architecture guides | 2.1 done | Architecture-domain guides loaded |
+| 2.3 | Draft architecture.md | 2.2 done | architecture.md created with Components section |
+| 2.4 | SOLID self-check | 2.3 done | All 5 principles addressed or N/A-justified in architecture.md |
+| 2.5 | DRY self-check | 2.3 done | Reusable pieces identified, duplication risks noted |
+| 2.6 | Cite guides for each decision | 2.3, 2.4, 2.5 done | Every major decision in architecture.md references a guide or notes "no guide applies" |
+
+## Phase 3: Implementation (8 checkpoints, 3–5 loop per acceptance criterion)
+
+| ID  | Name | Entry Condition | Evidence |
+|-----|------|-----------------|----------|
+| 3.1 | Load all prior phase context | Phase 2 complete | research.md + architecture.md referenced in implementation.md |
+| 3.2 | Load security + coding-standards guides | 3.1 done | Security/standards guides loaded |
+| 3.3 | **Red** — write failing test (per AC) | 3.2 done, AC not yet done | Failing test exists in repo |
+| 3.4 | **Green** — implement minimum to pass | 3.3 done for current AC | Test passes |
+| 3.5 | **Refactor** — SOLID/DRY cleanup | 3.4 done for current AC | Code refactored, test still passes |
+| —   | *Loop 3.3–3.5 per acceptance criterion* | — | — |
+| 3.6 | All acceptance criteria complete | 3.3–3.5 done for every AC | Every AC in task.md marked done |
+| 3.7 | Security review | 3.6 done | Security check noted in implementation.md (SQL, XSS, access) |
+| 3.8 | Constraint citations in implementation.md | 3.6, 3.7 done | Implementation cites guides + user patterns applied |
+
+## Status Values
+
+- `pending` — not yet started, entry conditions may or may not be met
+- `in_progress` — actively being worked on
+- `done` — evidence produced, entry conditions met for dependents
+- `skipped` — deliberately not applicable; **REQUIRES a non-empty `justification` field**. A `skipped` entry without `justification` is treated as `pending` by checkpoint-gate (does NOT satisfy phase-entry checks).
+
+Status values are **case-insensitive**. `Done`, `DONE`, `done` are equivalent. Canonical form for writing is lowercase.
+
+## Frontmatter Schema
+
+Checkpoints live in task.md YAML frontmatter under the `checkpoints` key:
+
+```yaml
+---
+task: <task_name>
+phase: 1
+checkpoints:
+  phase_1:
+    - {id: "1.1", status: done, evidence: "research.md#constraints"}
+    - {id: "1.2", status: done}
+    - {id: "1.3", status: in_progress}
+    - {id: "1.5", status: skipped, justification: "meta-task, no Drupal core applies"}
+  phase_2: []
+  phase_3: []
+---
+```
+
+## Grandfather Mode (pre-MVP tasks)
+
+Tasks without a `checkpoints` key in frontmatter fall back to the legacy Phase Status checklist. Existing completed tasks are unaffected. New tasks and tasks resumed after v3.9.0 should adopt the checkpoint schema.

--- a/drupal-dev-framework/skills/checkpoint-gate/SKILL.md
+++ b/drupal-dev-framework/skills/checkpoint-gate/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: checkpoint-gate
+description: Enforce phase entry requirements by verifying prior-phase checkpoints are done or skipped before /design or /implement proceed. Called internally by those commands; blocks with guidance when checkpoints are incomplete.
+user-invocable: false
+version: 1.0.0
+model: haiku
+---
+
+# Checkpoint Gate
+
+Enforce that all required prior-phase checkpoints are complete before entering the next phase.
+
+## When Called
+
+Invoked by `/design` (target_phase=2) and `/implement` (target_phase=3) at the very start, before any other work.
+
+Receives:
+- `task_path` — absolute path to task folder
+- `target_phase` — must be integer `2` or `3`
+
+## Action
+
+### Step 0 — Validate inputs
+
+If `target_phase` is not `2` or `3` (including `1`, `4`, missing, string, null): return `error` with message `"checkpoint-gate: invalid target_phase {value}. Expected 2 or 3."` Exit non-zero.
+
+If `$TASK_PATH/task.md` does not exist: return `error` with message `"checkpoint-gate: task.md not found at {task_path}"`. Exit non-zero.
+
+### Step 1 — Read task.md frontmatter
+
+Parse YAML frontmatter from `$TASK_PATH/task.md`. Use `yq` if available, otherwise Python:
+
+```bash
+yq -r '.checkpoints // "none"' "$TASK_PATH/task.md" 2>/dev/null \
+  || python3 -c "import yaml,sys; d=yaml.safe_load(open('$TASK_PATH/task.md').read().split('---')[1]); print(d.get('checkpoints','none'))"
+```
+
+If parsing fails (malformed YAML): return `block` with message `"checkpoint-gate: cannot parse task.md frontmatter. Fix YAML syntax or remove the frontmatter block to use grandfather mode."` Exit non-zero.
+
+If no frontmatter block exists OR `checkpoints` key is absent: go to **Step 2 (Grandfather mode)**.
+
+Otherwise: go to **Step 3 (Checkpoint mode)**.
+
+### Step 2 — Grandfather mode
+
+Check the body of task.md in this order:
+
+1. **`## Phase Status` checklist present:**
+   - target_phase=2 → require `[x]` on the "Phase 1: Research" line
+   - target_phase=3 → require `[x]` on both the Phase 1 and Phase 2 lines
+2. **`## Phase Status` absent, but phase files present (last-resort heuristic):**
+   - target_phase=2 → require `research.md` exists in the task folder
+   - target_phase=3 → require `research.md` AND `architecture.md` exist
+3. **Neither signal available:** return `block` with:
+   ```
+   checkpoint-gate: no phase tracking found in task.md.
+   Add a `## Phase Status` checklist with:
+     - [x] Phase 1: Research
+     - [ ] Phase 2: Architecture
+     - [ ] Phase 3: Implementation
+   Or adopt the checkpoint frontmatter schema (see references/checkpoint-catalog.md).
+   ```
+
+Success in grandfather mode → return `proceed` with message: `"Checkpoint gate: grandfather mode — Phase {prior} verified via {Phase Status checklist|phase file existence}. Entering Phase {target}."`
+
+### Step 3 — Checkpoint mode
+
+Load `references/checkpoint-catalog.md` from the plugin root to resolve IDs to names. If the catalog is missing, continue with raw IDs in messages (do not block on catalog absence).
+
+**Normalize:** lowercase every `status` value read from frontmatter before comparison (`Done` and `DONE` → `done`).
+
+**Define "satisfying statuses":**
+- `done` — always satisfies
+- `skipped` — satisfies ONLY IF the entry also has a non-empty `justification` field; otherwise treat as `pending`
+
+**Collect required phase arrays:**
+- target_phase=2 → required = `phase_1` array
+- target_phase=3 → required = `phase_1` array + `phase_2` array
+
+**Check for empty arrays:** if any required phase array is empty or missing, return `block` with:
+```
+checkpoint-gate: Phase {N} has no checkpoints defined. A phase with no checkpoints cannot be considered complete. Add the canonical checkpoints from references/checkpoint-catalog.md (Phase {N} section) to task.md frontmatter.
+```
+
+**Check each required checkpoint:** collect any whose normalized status is not in the satisfying set. Also flag `skipped` entries with empty or missing `justification`.
+
+If all required checkpoints satisfy: return `proceed` with:
+```
+Checkpoint gate: Phase {prior} complete ({done_count}/{total_count} done, {skipped_count} skipped with justification). Entering Phase {target}.
+```
+
+Otherwise: return `block` with:
+```
+Checkpoint gate: Cannot enter Phase {target}.
+
+Incomplete checkpoints in Phase {prior}:
+  - {id}: {name} ({current_status})
+  - {id}: {name} ({current_status})
+Skipped without justification (will not count):
+  - {id}: {name}
+
+Next action:
+  1. Complete the pending checkpoints, or
+  2. Skip them explicitly with: /drupal-dev-framework:step skip <id> <reason>
+  3. Then re-run /{design|implement} {task_name}
+```
+
+Prefer the `PermissionDenied {retry: true}` return mechanism if the runtime supports it (makes Claude retry after correction). Otherwise exit non-zero with the message above.
+
+## Do Not
+
+- Do not write to task.md — this skill is read-only
+- Do not invoke other skills — keep the gate tight and predictable
+- Do not block on checkpoints beyond the required prior phases (target_phase=2 does not require Phase 2 or 3 checkpoints)
+- Do not guess checkpoint IDs — resolve from the catalog or report raw IDs
+- Do not treat `status: skipped` without a `justification` field as satisfying — this would let users bypass the gate silently
+
+## Conflict resolution
+
+If a task has BOTH `checkpoints` frontmatter AND a legacy `## Phase Status` checklist, **checkpoint frontmatter wins.** Only fall back to the checklist when the frontmatter is absent.
+
+## Output Contract
+
+- `proceed` — exit 0, short confirmation line (format above)
+- `block` — exit non-zero with structured guidance; calling command halts
+- `error` — exit non-zero with concise error; used for malformed input or missing files

--- a/drupal-dev-framework/skills/phase-detector/SKILL.md
+++ b/drupal-dev-framework/skills/phase-detector/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phase-detector
-description: Use when determining task phase - analyzes task file to identify Phase 1, 2, or 3 for a specific task
-version: 3.0.0
+description: Use when determining task phase - analyzes task file to identify Phase 1, 2, or 3 for a specific task. Reads checkpoint frontmatter (v3.9.0+) when present, falls back to Phase Status checklist + phase files for grandfather tasks.
+version: 3.9.0
 user-invocable: false
 allowed-tools: Read, Glob
 ---
@@ -60,6 +60,23 @@ If neither exists, check for **v2.x single file** (backward compatibility):
 If nothing found, task hasn't started yet → Phase 0 (Not Started)
 
 ### 3. Analyze Task Content
+
+**v3.9.0+: Checkpoint Frontmatter (preferred)**
+
+Read `{task_name}/task.md` frontmatter. If a `checkpoints` key is present, use it as the authoritative phase signal. Normalize all `status` values to lowercase before comparing. Treat `skipped` entries WITHOUT a non-empty `justification` as `pending` (do not count them as complete):
+
+- **Phase 1 complete** = every `phase_1` checkpoint's normalized status is `done` OR (`skipped` with justification). Empty `phase_1` array → phase NOT complete (not started).
+- **Phase 2 complete** = Phase 1 complete AND every `phase_2` checkpoint satisfies the same rule. Empty `phase_2` array → phase NOT complete.
+- **Phase 3 in progress** = Phase 1 and Phase 2 complete; any `phase_3` checkpoint is `in_progress` or further
+- **Phase 3 complete** = every `phase_3` checkpoint satisfies the rule AND all acceptance criteria in task.md body marked done
+
+When checkpoint frontmatter drives the phase decision, include the checkpoint progress in the result (e.g., "Phase 2 — 3/6 checkpoints done, 1 skipped").
+
+If the task has BOTH checkpoint frontmatter AND a legacy `## Phase Status` checklist, **checkpoint frontmatter wins.**
+
+**Grandfather mode (no checkpoint frontmatter):**
+
+Fall back to the legacy signals below.
 
 **v3.0.0 Folder Structure:**
 


### PR DESCRIPTION
## Summary

Foundation task from the `dev_framework_improvements_epic`. Expands the 3-phase workflow with explicit checkpoints per phase, enforced at phase entry.

- **7 checkpoints** in Phase 1 (Research)
- **6 checkpoints** in Phase 2 (Architecture)
- **8 checkpoints** in Phase 3 (Implementation, loops 3.3–3.5 per acceptance criterion)

## What's new

- **`references/checkpoint-catalog.md`** — canonical checkpoint IDs, names, entry conditions, status semantics
- **`skills/checkpoint-gate/`** — internal skill enforcing phase-entry; blocks `/design` / `/implement` if prior-phase checkpoints are incomplete
- **`commands/step.md`** — `/step show | mark-done <id> | skip <id> <reason> | reset <id>`
- **Checkpoint frontmatter** in task.md — YAML `checkpoints:` key tracks status per checkpoint

## Wired in
- `/design` step 0: invokes `checkpoint-gate` with `target_phase=2`
- `/implement` step 0: invokes `checkpoint-gate` with `target_phase=3`
- `phase-detector`: reads checkpoint frontmatter when present

## Paper-tested before commit

Found and fixed before commit:
- YAML parsing method was unspecified → now specifies `yq` → python fallback
- Status comparison now case-insensitive
- `skipped` without `justification` is treated as `pending` (can't bypass gate silently)
- `target_phase` validated (must be 2 or 3)
- Empty prior-phase array blocks (was vacuously true)
- `/step` uses `Edit` not `Write` for concurrent-safety
- Skip reason YAML-escaped, length-capped, rejects control chars
- Removed `--force` refs and `/step migrate` suggestions (not in MVP)
- Grandfather mode has 2-tier fallback (checklist → phase-file heuristic)

## Backward compatible

Tasks without `checkpoints` frontmatter continue working via grandfather mode. Completed tasks unaffected.

## Shipping plan context

This is **MVP** of 3 increments:
- MVP (this PR): frontmatter schema, hard-block phase gates, `/step` command, catalog
- v2 (after `dev_framework_task_process_adherence`): UserPromptSubmit continuous reminders, evidence sections, guide citation enforcement
- v3 (after `dev_framework_isolated_validators`): isolated background validators, expert skip flows, per-task-type catalogs

## Test plan

- [ ] Restart Claude Code so new skill/command register
- [ ] On a grandfather task (no checkpoint frontmatter), verify `/step` shows grandfather-mode output
- [ ] On a grandfather task with Phase 1 `[x]` in Phase Status, verify `/design` proceeds
- [ ] On a grandfather task without Phase 1 `[x]`, verify `/design` blocks with guidance
- [ ] On a v3.9.0 task with checkpoint frontmatter, verify `/step` shows checkpoint-mode output
- [ ] Try `/step mark-done 2.4` when 2.3 is pending — should be blocked
- [ ] Try `/step skip 1.5` with no reason — should be rejected
- [ ] Try `/step skip 1.5 meta-task, no Drupal applies` — should accept
- [ ] Try `/step foo` (unknown sub-command) — should print usage
- [ ] Verify dogfood: `dev_framework_phase_checkpoints/task.md` now has real checkpoint frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)