### PR TITLE
feat(plugin-creation-tools): v3.2.0 — Agent SDK, Plugin Dependencies, Permission Modes, hook if field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Complete guide for creating Claude Code plugins \u2014 skills, commands, agents, hooks, MCP servers, and configuration. Covers 22 hook events, 4 hook types, effort field, ${CLAUDE_PLUGIN_DATA} persistence, plugin agent restrictions, CLAUDE_CODE_PLUGIN_SEED_DIR, 9 validation rules, marketplace distribution, and pushy description optimization.",
-      "version": "3.1.0",
+      "description": "Complete guide for creating Claude Code plugins \u2014 skills, commands, agents, hooks, MCP servers, and configuration. Covers 26 hook events, the if pre-spawn filter, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
+      "version": "3.2.0",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-creation-tools",
-  "description": "Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
+  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 26 hook events (with the `if` pre-spawn filter), MCP servers, plugin dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
   "version": "3.2.0",
   "author": {
     "name": "camoa"

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "Complete guide for creating Claude Code plugins - skills, commands, agents, hooks, MCP servers, and configuration. Supersedes skill-creation-tools.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-04-20
+
+### Added — Hooks (Track B)
+- **4 new hook events** documented: `PermissionDenied`, `CwdChanged`, `FileChanged`, `TaskCreated` (total now 26).
+- **`if` pre-spawn filter** section in `writing-hooks.md` — avoids the "spawn a process just to check and exit 0" anti-pattern on tool events.
+- **Permission Mode Interaction** section in `writing-hooks.md` covering `default`/`acceptEdits`/`plan`/`auto`/`dontAsk`/`bypassPermissions`.
+- New hook patterns: FileChanged watch-mode lint, PermissionDenied retry/escalate, TaskCreated tracking.
+- `asyncRewake` handler field and `once` frontmatter-scoping caveat.
+- `hooks.json.template` demonstrates the `if` field.
+
+### Added — Configuration (Track C)
+- **Plugin Dependencies** (`08-configuration/plugin-json.md`): `dependencies` array, semver ranges, `{name}--v{version}` tag convention, intersection resolution, and the three official error codes (`range-conflict`, `dependency-version-unsatisfied`, `no-matching-tag`).
+- **Marketplace-author responsibilities** (`08-configuration/marketplace-json.md`): tagging releases, allowlisting cross-marketplace dependencies via `hostPattern`/`pathPattern`, validator behavior.
+- **NEW `08-configuration/permission-modes.md`**: full reference for the six permission modes, hook-behavior-per-mode table, auto-mode classifier rules, subagent inheritance, protected paths, plugin-author guidance.
+- Cross-links from `05-agents/writing-agents.md` and `05-agents/agent-tools.md` to `permission-modes.md`. Plugin-agent caveat noted (`permissionMode`/`hooks`/`mcpServers` silently ignored in plugin-packaged agents).
+
+### Added — Overview + Testing + Philosophy (Track D)
+- **NEW `01-overview/claude-directory.md`**: canonical layout for `~/.claude/` and `<project>/.claude/`, precedence tables (settings; skills/commands/hooks; subagents; MCP), and `--add-dir` interaction.
+- **NEW `09-testing/errors.md`**: plugin-loading errors (dependencies + manifest) and runtime errors plugin authors hit (auto mode, auth, usage limits, request errors). Validator-alignment checklist.
+- **`02-philosophy/core-philosophy.md`**: replaced the stale 2%/16K skill-description budget claim with upstream-documented numbers — **1% dynamic budget**, **8,000-char fallback**, **1,536-char per-entry cap**, **500-line SKILL.md soft cap**, **5,000-tokens-per-skill** and **25,000 tokens total** post-compaction. Added "what survives compaction" table.
+
+### Added — Agent SDK directory (Track A)
+New `references/11-agent-sdk/` directory (9 files):
+- `overview.md`: when to use SDK vs CLI vs Anthropic Client SDK; `.claude/` loading defaults; authentication; plugin-author testing pattern.
+- `migration.md`: Claude Code SDK → Agent SDK. Package/type renames, `ClaudeCodeOptions` → `ClaudeAgentOptions`, two breaking default changes (minimal system prompt, no `.claude/` auto-load), and a grep-checklist.
+- `custom-tools.md`: `tool()` / `@tool`, `createSdkMcpServer`, `mcp__{server}__{tool}` naming, optional parameters per language, `isError`, `readOnlyHint` for parallel execution, three plugin-author patterns.
+- `subagents-sdk.md`: field parity between Markdown frontmatter and `AgentDefinition`, what subagents inherit, automatic vs explicit invocation, dynamic factory pattern, sessions.
+- `permissions.md`: evaluation order (hooks → deny → mode → allow → canUseTool), `allowed_tools` vs `disallowed_tools` with `bypassPermissions` gotcha, `canUseTool` callback patterns.
+- `structured-outputs.md`: `output_format` with JSON Schema, Zod/Pydantic generation, validator-output-contract pattern, paper-test harness pattern.
+- `tool-search.md`: `ENABLE_TOOL_SEARCH` modes, 30–50 tool accuracy threshold, optimization guidance, the <10-tool opt-out case.
+- `observability.md`: OpenTelemetry-via-CLI-child-process model, three signals (metrics/logs/traces), env-merge-vs-replace semantics across languages, sensitive-data controls.
+- `agent-loop.md`: 5-step loop, 5 message types with Python/TS access patterns, budget caps, `effort` pass-through, context-window behavior through compaction.
+
+Global rename pass (`Claude Code SDK` → `Agent SDK`): no stale references existed outside of intentional historical mentions in `migration.md`.
+
+### Added — Distribution (Track E)
+- **NEW `10-distribution/review-md-v2.md`**: the two-file model (`CLAUDE.md` vs `REVIEW.md`), what to tune, 40-line starter `REVIEW.md` scoped to plugin-repo concerns, `/ultrareview` callout.
+- **NEW `10-distribution/routines-auto-validate.md`**: GitHub-triggered Routine that runs `/plugin-creation-tools:validate` on every PR — full creation walkthrough and footgun list. Closes the loop on the repeated "forgot to validate" feedback.
+- Cross-links from `packaging.md` to both new files; fixed broken relative path to `09-testing/debugging.md`.
+
+### Changed — Plugin self-improvement (Track F)
+- **`commands/validate.md`**: added Plugin Dependencies checks (dependencies array shape, semver syntax, cross-marketplace allowlist, official error names). Expanded hook-event recognition list to all 26 events. Added quoted-`$CLAUDE_PROJECT_DIR` check. Added best-practice suggestion: broad tool-event matchers should use the `if` field. Added version-drift check between `plugin.json` and root `marketplace.json`. Added SDK-rename checks (`Claude Code SDK`, `ClaudeCodeOptions`) and imperatives/`!`-injection preservation checks.
+- **`agents/skill-quality-reviewer.md`**: expanded rubric to include trigger-phrase enumeration, concrete action verbs, synonym coverage, quoted-YAML form, the 1,536-char per-entry cap. Added a "regression flags" section (stripped `PROACTIVELY`/`MUST`/`NEVER` imperatives; dropped `` !`command` `` dynamic-context injections; trimmed domain-intelligence prose; weakened triggers). Added "rename flags" for stale SDK references.
+- **`agents/plugin-structure-auditor.md`**: added Performance-Review item for broad hook matchers without `if`. Added new sections for Dependency Review and SDK Rename Review.
+
+### Notes
+- Plan deviation: upstream Skills guide states the dynamic skill-description budget is **1% / 8,000 chars** (per-entry cap **1,536 chars**), not the 2%/16K the planning doc initially listed. Used upstream numbers per the plan's "Upstream doc wins" rule.
+
 ## [3.1.0] - 2026-04-08
 
 ### Changed

--- a/plugin-creation-tools/agents/plugin-structure-auditor.md
+++ b/plugin-creation-tools/agents/plugin-structure-auditor.md
@@ -41,6 +41,18 @@ You are a plugin structure auditor. Perform a comprehensive audit beyond the sta
 - Agents have appropriate maxTurns limits
 - Heavy operations use `context: fork` or `isolation: worktree`
 - Hook timeouts are reasonable
+- **Broad hook matchers use the `if` field** — handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) with `matcher: "*"`, `""`, omitted, or `.*` should use `if` to pre-filter. Flag every broad-matcher handler without `if` as a suggestion: "Add `if: \"Tool(pattern)\"` to avoid spawning a process on every tool call." Reference `references/06-hooks/writing-hooks.md#the-if-field`.
+
+### 6. Dependency Review
+- `plugin.json` `dependencies` array (if present) uses valid semver-range syntax (`~`, `^`, `>=`, `=`, hyphen, `||`)
+- Cross-marketplace dependencies (entries with a `marketplace` field) are allowlisted in the root marketplace's `strictKnownMarketplaces`
+- Each declared dependency's marketplace uses the `{name}--v{version}` tag convention
+- Error names used in docs/comments match the official list: `range-conflict`, `dependency-version-unsatisfied`, `no-matching-tag`
+
+### 7. SDK Rename Review
+- No stale `Claude Code SDK` / `claude-code-sdk` / `@anthropic-ai/claude-code` (not followed by `-`) references anywhere in the plugin
+- Python examples use `ClaudeAgentOptions`, not `ClaudeCodeOptions`
+- If the plugin includes any SDK usage at all, it links or refers to the migration guide at `references/11-agent-sdk/migration.md`
 
 ## Output Format
 

--- a/plugin-creation-tools/agents/plugin-structure-auditor.md
+++ b/plugin-creation-tools/agents/plugin-structure-auditor.md
@@ -26,9 +26,9 @@ You are a plugin structure auditor. Perform a comprehensive audit beyond the sta
 - plugin.json complete with all recommended fields (name, version, description, author, license)
 - CHANGELOG.md follows Keep a Changelog format
 - README.md includes installation and usage instructions
-- marketplace.json present if intended for marketplace distribution
+- marketplace.json present at plugin root OR covered by a repo-root marketplace that lists this plugin (for multi-plugin marketplaces)
 - Version follows semantic versioning
-- settings.json present if plugin provides agents
+- If skill `version:` frontmatter is present, it matches the `version` in `plugin.json` (version drift between the two is a distribution bug)
 
 ### 4. Security Review
 - No hardcoded secrets or API keys
@@ -54,6 +54,14 @@ You are a plugin structure auditor. Perform a comprehensive audit beyond the sta
 - Python examples use `ClaudeAgentOptions`, not `ClaudeCodeOptions`
 - If the plugin includes any SDK usage at all, it links or refers to the migration guide at `references/11-agent-sdk/migration.md`
 
+**Exemptions** (do NOT flag these — they intentionally contain the old name):
+- Any file inside `references/11-agent-sdk/` (this directory's purpose is to document the rename)
+- `CHANGELOG.md` entries describing past or current rename work
+- Files whose job is to detect or explain the rename (e.g. the validator command, this auditor's own checklist, `skill-quality-reviewer.md`'s rubric)
+- Any quoted grep pattern or regex string whose purpose is to match the forbidden term
+
+Apply a first-character match heuristic: if the surrounding prose frames the string as a target for detection/migration, treat it as intentional.
+
 ## Output Format
 
 ## Plugin Audit: {name} v{version}
@@ -73,5 +81,11 @@ You are a plugin structure auditor. Perform a comprehensive audit beyond the sta
 ### Performance: {score}/10
 {findings}
 
-### Overall: {total}/50
+### Dependency Review: {score}/10 — or N/A if `dependencies` array absent
+{findings}
+
+### SDK Rename Review: {score}/10
+{findings}
+
+### Overall: {total}/70 (or /60 if Dependency Review is N/A)
 ### Recommendation: READY / NEEDS WORK / NOT READY

--- a/plugin-creation-tools/agents/skill-quality-reviewer.md
+++ b/plugin-creation-tools/agents/skill-quality-reviewer.md
@@ -12,10 +12,13 @@ You are a skill quality reviewer. When invoked, analyze SKILL.md files for quali
 
 1. **Description quality**
    - Starts with "Use when" or follows three-part structure (What + When + Capabilities)
-   - Includes trigger phrases matching common user language
+   - Includes trigger-phrase enumeration — the `Use when user says 'X', 'Y', 'Z'` pattern measurably improves activation
+   - Uses concrete action verbs that describe what the skill **produces**, not just the domain ("scaffolds plugin directories, generates SKILL.md files" beats "for plugin work")
+   - Includes synonym coverage (e.g. "landing page" + "web page" + "UI components", not just "HTML page")
    - Includes negative scope boundaries ("NOT for...")
-   - Under 1024 characters
+   - Combined with `when_to_use`, stays under **1,536 characters** (per-entry cap; anything over is truncated in the skill listing)
    - Third person voice (no "you")
+   - Uses quoted YAML form `description: "..."` for multi-sentence descriptions to avoid colon/comma YAML edge cases
 
 2. **Body structure**
    - Written as instructions (imperative voice), not documentation
@@ -31,8 +34,23 @@ You are a skill quality reviewer. When invoked, analyze SKILL.md files for quali
    - Consider `hooks` for skill-scoped lifecycle events
 
 4. **Context budget awareness**
-   - Description is concise enough to not waste context budget (2% of window / 16K chars)
-   - Balance "pushy" triggering with description length
+   - Dynamic budget is **1% of context window** with an **8,000-character fallback** across all skill descriptions combined; `SLASH_COMMAND_TOOL_CHAR_BUDGET` raises the limit
+   - Per-entry cap is **1,536 characters** (description + `when_to_use` combined) — truncation lands in the middle, so front-load the key use case
+   - Balance activation strength with description length
+
+## Regression flags (do NOT treat these as improvements)
+
+The following "simplifications" frequently come from scoring tools and degrade the skill:
+
+- **Stripped `PROACTIVELY` / `MUST` / `NEVER` imperatives** — these are deliberate activation-strength modifiers. When they're in the prior version of the description, keep them. Only flag for removal if they're clearly spammy or unmotivated.
+- **Dropped `` !`command` `` dynamic-context injections** — these are a documented Claude Code skill feature that executes the command and injects its output. Do not treat them as noise or stripable syntax.
+- **Trimmed domain-intelligence body prose** — creative/design/artistic skills encode quality bars in prose (movements, anti-convergence rules, craftsmanship mantras). Generic "verbose = bad" scoring degrades output quality for these skills.
+- **Weakened aggressive triggers to hit a score** — if the CLAUDE.md or skill context says a skill must fire proactively before a class of work, the description should reflect that even when a linter flags it as "pushy".
+
+## Rename flags
+
+- **`Claude Code SDK` mentions** — the SDK was renamed to Agent SDK. Flag any remaining `Claude Code SDK` / `claude-code-sdk` / `@anthropic-ai/claude-code` (not followed by `-`) as a regression; point to `references/11-agent-sdk/migration.md`.
+- **`ClaudeCodeOptions`** — renamed to `ClaudeAgentOptions`. Flag any Python examples still using the old type.
 
 ## Output Format
 
@@ -41,4 +59,6 @@ For each skill reviewed:
 - Strengths (what's done well)
 - Issues (must fix)
 - Suggestions (improvements)
+- Regression flags (anything from the "do NOT treat as improvement" list)
+- Rename flags (stale SDK references)
 - Rewritten description (if needed)

--- a/plugin-creation-tools/agents/skill-quality-reviewer.md
+++ b/plugin-creation-tools/agents/skill-quality-reviewer.md
@@ -8,6 +8,8 @@ maxTurns: 15
 
 You are a skill quality reviewer. When invoked, analyze SKILL.md files for quality and adherence to best practices.
 
+**Scope note:** The "Description quality" section of the rubric is specific to YAML-frontmatter skill descriptions. When reviewing **reference documentation** (files under `references/`, not `SKILL.md`), skip "Description quality" entirely and focus on body structure, regression flags (usually N/A for reference docs — say so explicitly), rename flags, cross-link validity, and **accuracy**: spot-check specific numbers (character caps, context budgets, event names, API fields) against the upstream source guides at `~/workspace/claude_memory/guides/claude/` or the linked upstream URL.
+
 ## Review Checklist
 
 1. **Description quality**

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -79,7 +79,7 @@ Validate a plugin's structure and components against best practices.
 - [ ] No `http` type hooks — `http` hooks only work in `settings.json`, not `hooks.json` (error if found)
 - [ ] Command hooks reference executable files
 - [ ] Timeouts are reasonable (< 120s for sync hooks)
-- [ ] `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` usage is quoted in all command strings (paths with spaces break otherwise)
+- [ ] `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` / `$CLAUDE_PLUGIN_ROOT` / `${CLAUDE_PLUGIN_ROOT}` / `$CLAUDE_PLUGIN_DATA` / `${CLAUDE_PLUGIN_DATA}` usage is quoted in all command strings (paths with spaces break otherwise)
 - [ ] **Warning**: hook handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) with a broad matcher (`*`, `""`, omitted, or `.*`) should include an `if` field to pre-filter. Emit a **suggestion** (not error): "Consider adding an `if` field to this handler to avoid spawning a process on every tool call."
 - [ ] `if` field is only valid on tool events — flag as warning if set on non-tool events (silently ignored at runtime)
 
@@ -89,7 +89,7 @@ Validate a plugin's structure and components against best practices.
 - [ ] Agents specify `model:` for cost optimization
 - [ ] Skills consider `model:` field
 - [ ] Hook scripts are executable (chmod +x)
-- [ ] Skills cross-checked against `references/03-skills/anthropic-skill-standards.md`
+- [ ] (plugin-creation-tools repo only) Skills cross-checked against `references/03-skills/anthropic-skill-standards.md` — skip this item when validating external plugins that don't ship that reference file
 - [ ] No stale `Claude Code SDK` / `claude-code-sdk` / `@anthropic-ai/claude-code` references — the SDK was renamed to Agent SDK (`claude-agent-sdk` / `@anthropic-ai/claude-agent-sdk`). Flag any hit as a warning pointing to `references/11-agent-sdk/migration.md`.
 - [ ] Skill descriptions preserve `PROACTIVELY`, `MUST`, and `NEVER` imperatives from prior versions when present (do not auto-strip)
 - [ ] Skill descriptions preserve `` !`command` `` dynamic-context injections when present (these are a documented Claude Code feature — do not treat as noise)

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -33,6 +33,15 @@ Validate a plugin's structure and components against best practices.
 - [ ] Plugin source objects use `"source"` as the discriminator key — flag `"type"` as an error (e.g., `{"source": "github", ...}` not `{"type": "github", ...}`)
 - [ ] No `..` path traversal in source paths (error if found)
 - [ ] No duplicate plugin names within the plugins array (error if found)
+- [ ] Each plugin's `version` in the marketplace entry matches the `version` in its `.claude-plugin/plugin.json` (error if drifted — reference `feedback_marketplace_json`)
+
+### Plugin Dependencies (if `dependencies` is declared in `plugin.json`)
+- [ ] `dependencies` is an array
+- [ ] Each entry is either a bare string (plugin name) or an object with a required `name` field
+- [ ] Object entries with a `version` field use valid semver-range syntax (`~2.1.0`, `^2.0`, `>=1.4`, `=2.1.0`, hyphen ranges, `||` unions) — flag `range-conflict` on invalid syntax
+- [ ] Object entries with a `marketplace` field: flag as error if the referenced marketplace is not in the root marketplace's `strictKnownMarketplaces` allowlist
+- [ ] Pre-release ranges are only matched when the range opts in with a pre-release suffix (e.g. `^2.0.0-0`)
+- [ ] Use official error names when reporting: `range-conflict`, `dependency-version-unsatisfied`, `no-matching-tag` (align with `claude plugin list` output)
 
 ### Skills (for each skill in `skills/*/`)
 - [ ] `SKILL.md` exists with valid YAML frontmatter — invalid frontmatter causes skill to load with no metadata at runtime
@@ -65,11 +74,14 @@ Validate a plugin's structure and components against best practices.
 
 ### Hooks (`hooks/hooks.json`)
 - [ ] Valid JSON structure — **Note:** malformed hooks.json prevents the entire plugin from loading
-- [ ] Each event name is a recognized event
+- [ ] Each event name is one of the 26 recognized events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
 - [ ] Each hook entry has `type` (command, prompt, or agent) and matching field
 - [ ] No `http` type hooks — `http` hooks only work in `settings.json`, not `hooks.json` (error if found)
 - [ ] Command hooks reference executable files
 - [ ] Timeouts are reasonable (< 120s for sync hooks)
+- [ ] `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` usage is quoted in all command strings (paths with spaces break otherwise)
+- [ ] **Warning**: hook handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) with a broad matcher (`*`, `""`, omitted, or `.*`) should include an `if` field to pre-filter. Emit a **suggestion** (not error): "Consider adding an `if` field to this handler to avoid spawning a process on every tool call."
+- [ ] `if` field is only valid on tool events — flag as warning if set on non-tool events (silently ignored at runtime)
 
 ### Best Practices (warnings, not errors)
 - [ ] Skills use progressive disclosure (references for details)
@@ -78,6 +90,9 @@ Validate a plugin's structure and components against best practices.
 - [ ] Skills consider `model:` field
 - [ ] Hook scripts are executable (chmod +x)
 - [ ] Skills cross-checked against `references/03-skills/anthropic-skill-standards.md`
+- [ ] No stale `Claude Code SDK` / `claude-code-sdk` / `@anthropic-ai/claude-code` references — the SDK was renamed to Agent SDK (`claude-agent-sdk` / `@anthropic-ai/claude-agent-sdk`). Flag any hit as a warning pointing to `references/11-agent-sdk/migration.md`.
+- [ ] Skill descriptions preserve `PROACTIVELY`, `MUST`, and `NEVER` imperatives from prior versions when present (do not auto-strip)
+- [ ] Skill descriptions preserve `` !`command` `` dynamic-context injections when present (these are a documented Claude Code feature — do not treat as noise)
 
 ## Output Format
 

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-creation
-version: 3.0.0
+version: 3.2.0
 description: Use when creating Claude Code plugins - covers skills, commands, agents, hooks, MCP servers, and plugin configuration. Use when user says "create plugin", "make a skill", "add command", "add hooks", "skill authoring", "SKILL.md", "plugin components", "package reusable behavior", "distribute skills", "scaffold plugin", "plugin structure", "write a skill description". NOT for: using existing plugins, installing plugins, plugin marketplace browsing. !`ls .claude-plugin/ 2>/dev/null`
 ---
 

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -144,7 +144,7 @@ When user says "add agent", "create agent", "make agent":
 When user says "add hooks", "setup hooks", "event handlers":
 
 1. Read `references/06-hooks/writing-hooks.md`
-2. Read `references/06-hooks/hook-events.md` for all 18 events
+2. Read `references/06-hooks/hook-events.md` for all 26 events
 3. Copy template from `templates/hooks/hooks.json.template`
 4. Key events:
    - `PreToolUse` - before tool execution (can block)

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/.claude-plugin/plugin.json
@@ -1,11 +1,14 @@
 {
   "name": "full-featured-example",
   "version": "1.0.0",
-  "description": "Example plugin demonstrating all component types - skills, commands, hooks",
+  "description": "Example plugin demonstrating all component types - skills, commands, hooks, and a constrained plugin dependency.",
   "author": {
     "name": "Your Name"
   },
   "license": "MIT",
   "repository": "https://github.com/your-org/full-featured-example",
-  "keywords": ["example", "demo", "tutorial"]
+  "keywords": ["example", "demo", "tutorial"],
+  "dependencies": [
+    { "name": "simple-greeter", "version": "^1.0.0" }
+  ]
 }

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/README.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/README.md
@@ -85,7 +85,18 @@ Review my code for quality issues
 3. **Cross-platform hooks** - The polyglot `.cmd` wrapper
 4. **Output directory setup** - SessionStart hook pattern
 5. **Operation logging** - PostToolUse hook pattern
-6. **Local development** - marketplace.json for testing
+6. **`if` pre-spawn filter** - A `PreToolUse` handler with `if: "Bash(rm *)"` that only spawns when Claude runs a destructive `rm` command. See `references/06-hooks/writing-hooks.md#the-if-field` for the pattern.
+7. **Plugin dependency** - Declares a trivial constrained dependency on `simple-greeter` via `dependencies` in `plugin.json`. See `references/08-configuration/plugin-json.md#dependencies-version-constrained`.
+8. **Local development** - marketplace.json for testing
+
+## Building SDK-driven companion code
+
+If you later build an SDK companion app for this plugin (test harness, CI runner, programmatic driver), start with the Agent SDK directory at `references/11-agent-sdk/`:
+
+- `overview.md` — when to use the SDK
+- `migration.md` — if you were on the old Claude Code SDK
+- `structured-outputs.md` — how to make CI-consumable output
+- `permissions.md` — how permission modes interact with your plugin's hooks
 
 ## Extending This Example
 

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json
@@ -23,6 +23,21 @@
           }
         ]
       }
+    ],
+
+    "_comment_if_field": "The 'if' field pre-filters tool-event handlers before spawn — avoids running the hook on every Bash call.",
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(rm *)",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" guard-rm.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin-creation-tools/skills/plugin-creation/references/01-overview/claude-directory.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/01-overview/claude-directory.md
@@ -1,0 +1,124 @@
+# The `.claude/` Directory
+
+Plugins extend Claude Code by dropping files into this directory. Before authoring one, know what's already there and who wins when two components collide.
+
+Claude Code reads configuration from two roots:
+
+- **`~/.claude/`** — personal/global, applies across all projects
+- **`<project>/.claude/`** — project-local, commit to git to share with the team
+
+If `CLAUDE_CONFIG_DIR` is set, `~/.claude` resolves to that path instead.
+
+## Layout
+
+```
+~/.claude/                           # global (per-machine)
+├── CLAUDE.md                        # global instructions
+├── settings.json                    # your defaults — permissions, hooks, model
+├── .claude.json                     # app state, OAuth, personal MCP servers
+├── keybindings.json                 # custom shortcuts
+├── rules/<name>.md                  # topic-scoped instructions
+├── skills/<name>/SKILL.md           # global skills
+├── commands/<name>.md               # global commands
+├── agents/<name>.md                 # global subagents
+├── agent-memory/<name>/MEMORY.md    # persistent memory for subagents (memory: user)
+├── output-styles/<name>.md          # custom system-prompt sections
+├── plugins/                         # installed marketplaces + plugin data
+│   ├── cache/                       # cloned plugin sources (wiped on update)
+│   └── data/<plugin-id>/            # ${CLAUDE_PLUGIN_DATA} — survives updates
+└── projects/<project>/memory/       # auto-memory per-project (Claude's own notes)
+
+<project-root>/
+├── CLAUDE.md                        # team-shared instructions
+├── .mcp.json                        # team-shared MCP servers
+├── .worktreeinclude                 # gitignored files to copy into worktrees
+└── .claude/
+    ├── settings.json                # committed project settings
+    ├── settings.local.json          # personal overrides (auto-gitignored)
+    ├── rules/<name>.md              # path-scoped instructions
+    ├── skills/<name>/SKILL.md       # project skills
+    ├── commands/<name>.md           # project commands
+    ├── agents/<name>.md             # project subagents
+    ├── agent-memory/<name>/         # subagent memory (memory: project)
+    └── output-styles/<name>.md
+```
+
+### Files not under `.claude/`
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `managed-settings.json` | OS-specific system path | Enterprise-enforced, uneditable |
+| `CLAUDE.local.md` | Project root | Personal per-project preferences; manually created, add to `.gitignore` |
+| Installed plugins | `~/.claude/plugins/` | Cloned marketplaces; managed by `claude plugin` commands |
+
+## Precedence order
+
+When the same type of configuration exists at multiple levels, this is the order of resolution.
+
+### Settings (`settings.json`)
+
+Highest wins. Later entries override earlier:
+
+1. **Command-line flags** (`--permission-mode`, `--settings`, etc.)
+2. **Managed policy settings** — organization-deployed, no override
+3. **`<project>/.claude/settings.local.json`** — your personal project overrides
+4. **`<project>/.claude/settings.json`** — committed project settings
+5. **`~/.claude/settings.json`** — your user settings
+6. **Plugin settings** — shipped with installed plugins
+
+Some environment variables override their equivalent setting — varies per variable.
+
+### Skills, commands, hooks
+
+`managed > user > project > plugin`
+
+The first match wins for invocation. If `~/.claude/skills/deploy/` and `.claude/skills/deploy/` both exist, the user-level one activates. Plugin skills are overridden by any local skill of the same name.
+
+### Subagents
+
+`managed > CLI flag > project > user > plugin`
+
+Subagents have a different precedence because `--agent-file` and project-scoped definitions need to win over your personal agents for repo-specific workflows.
+
+### MCP servers
+
+Additive, scoped by config file — `<project>/.mcp.json` (team), `~/.claude.json` (personal), and plugin-declared servers merge rather than override. Conflicting server names are resolved in scope order (project > user > plugin).
+
+## `--add-dir` interaction
+
+The `--add-dir <path>` CLI flag extends Claude's working-directory access without switching the project root. Important effects:
+
+- **Read/write permissions**: files under added directories are treated like the working directory for edit auto-approval (in `acceptEdits` and `auto` modes).
+- **Skill/rule loading**: `.claude/` inside an `--add-dir` path is **not** auto-loaded. Only the project root's `.claude/` and `~/.claude/` load skills and rules.
+- **`additionalDirectories` setting**: same effect as `--add-dir` but persistent in `settings.json`.
+
+For plugins, this matters when your hooks or skills need to reference files outside the project root — use `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}` instead of relying on the user adding the directory manually.
+
+## Check what's loaded in a session
+
+| Command | Shows |
+|---------|-------|
+| `/context` | Token usage by category (system prompt, memory, skills, MCP, messages) |
+| `/memory` | Loaded CLAUDE.md and rules files, auto-memory entries |
+| `/agents` | Configured subagents and their settings |
+| `/hooks` | Active hook configurations |
+| `/mcp` | Connected MCP servers and their status |
+| `/skills` | Available skills from project, user, and plugin sources |
+| `/permissions` | Current allow and deny rules |
+| `/doctor` | Installation and configuration diagnostics |
+
+Run `/context` first for the overview, then the specific command for the area.
+
+## Guidance for plugin authors
+
+1. **Ship to `plugins/cache/<plugin-id>/`** via your marketplace — never write directly to the user's `.claude/`.
+2. **Persistent data** goes in `${CLAUDE_PLUGIN_DATA}` (`~/.claude/plugins/data/<plugin-id>/`), which survives plugin updates. `${CLAUDE_PLUGIN_ROOT}` is wiped on update.
+3. **Don't assume precedence.** If your plugin ships a skill named `deploy`, a user skill of the same name overrides it. Use a descriptive, namespaced name (`my-plugin:deploy`) to avoid collisions.
+4. **Don't write to protected paths.** `.git`, `.vscode`, `.idea`, `.husky`, and most of `.claude` are protected in every permission mode. See [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md#protected-paths).
+
+## See Also
+
+- Upstream: [Claude directory](https://docs.claude.com/en/claude-directory)
+- [`../08-configuration/settings.md`](../08-configuration/settings.md) — settings hierarchy in detail
+- [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md) — protected paths
+- [`../08-configuration/plugin-json.md`](../08-configuration/plugin-json.md) — `${CLAUDE_PLUGIN_DATA}` vs `${CLAUDE_PLUGIN_ROOT}`

--- a/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/core-philosophy.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/core-philosophy.md
@@ -81,16 +81,38 @@ Do not modify the script without testing.
 
 ## Context Window Budget
 
-The "context window as public good" principle has specific budget numbers:
+The "context window as public good" principle has specific, upstream-documented budget numbers. Plugin authors should design around all of them:
 
-- **Skill descriptions**: 2% of context window, with a **16,000-character fallback**
-- Skills exceeding the budget are **silently excluded** from the context
-- Run `/context` to check which skills are loaded and which are excluded
-- Override the default budget with the `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable
+### Skill-description budget (at session start)
+
+- **Dynamic budget**: 1% of context window, with an **8,000-character fallback**
+- Claude Code shortens descriptions to fit this budget. Descriptions that get trimmed lose the keywords Claude uses to match your request.
+- **Per-entry cap**: Each skill's combined `description` + `when_to_use` is truncated at **1,536 characters** regardless of the overall budget.
+- **Override**: `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable raises the global limit.
+
+Front-load your skill description: the first sentence matters most because it's what survives trimming.
+
+### Skill-body budget (at invocation)
+
+- **`SKILL.md` soft cap**: Keep under **500 lines**. Move detailed reference material to separate files.
+- **Post-compaction cap**: Invoked skill bodies are re-injected at **5,000 tokens per skill** and **25,000 tokens total**. The oldest invoked skills are dropped first.
+- **Truncation keeps the start**: Put the most important instructions at the top of `SKILL.md` — if the body is truncated, the tail is lost.
+
+### What survives compaction
+
+| Mechanism | After compaction |
+|-----------|------------------|
+| System prompt + output style | Unchanged |
+| Project-root CLAUDE.md, unscoped rules | Re-injected from disk |
+| Auto memory | Re-injected from disk |
+| Path-scoped rules (`paths:` frontmatter) | Lost until a matching file is read again |
+| Nested CLAUDE.md in subdirectories | Lost until a file in that subdirectory is read again |
+| Invoked skill bodies | Re-injected (subject to the caps above) |
+| Hooks | Not applicable — hooks run as code, not context |
+
+**Design implication:** If your plugin ships a rule that must persist across compaction, do **not** use `paths:` frontmatter. Either drop the scope or move it into the project-root CLAUDE.md.
 
 **Frame every addition as**: "Only add context Claude doesn't already have. Challenge each piece: Does Claude really need this?"
-
-This budget applies to skill descriptions specifically. SKILL.md body content is loaded on demand (when the skill triggers), so the description is the critical gatekeeper — it must be informative enough to trigger correctly, but concise enough to fit the budget.
 
 ## Challenge Every Token
 

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/description-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/description-patterns.md
@@ -99,22 +99,88 @@ The "after" version explicitly tells Claude to trigger in edge cases and include
 
 Pushy descriptions must be balanced against the context budget. Skill descriptions consume part of the context window:
 
-- **Budget**: 2% of context window, with a 16,000-character fallback
-- Long descriptions eat into this budget and can cause other skills to be excluded
-- Balance pushiness with brevity — add trigger phrases, but don't pad with filler
+- **Dynamic budget**: 1% of context window across all skill descriptions combined, with an **8,000-character fallback**
+- **Per-entry cap**: Each skill's `description` + `when_to_use` combined is truncated at **1,536 characters** in the skill listing, regardless of budget
+- **Truncation keeps the start**, so **front-load** the key use case — text at the end is first to go
+- Override the global limit with `SLASH_COMMAND_TOOL_CHAR_BUDGET`
 
-Run `/context` to check if skills are being excluded due to budget limits. Override the budget with the `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable if needed.
+Run `/context` to check if skills are being excluded due to budget limits.
+
+## Trigger Phrase Enumeration
+
+Explicitly listing the user utterances that should trigger a skill measurably improves activation. Use the `Use when user says 'X', 'Y', 'Z'` pattern.
+
+**Before** (implicit triggers, relies on Claude inferring):
+```
+description: Audit code quality and security across Drupal and Next.js projects.
+```
+
+**After** (explicit trigger enumeration):
+```
+description: "Run a full code quality and security audit across Drupal and
+Next.js projects. Use when user says 'full audit', 'check everything', 'quality
+report', 'is this production ready', 'pre-merge check', 'audit this plugin'."
+```
+
+The enumerated phrases are the literal utterances users have been observed to say. They don't have to exhaustively cover every phrasing — 3 to 6 phrases that span the common ways of asking are enough.
+
+## Action Verbs + Artifacts
+
+Describe what the skill **produces** or **does**, not the domain it relates to.
+
+| Weak (domain-framed) | Strong (action + artifact) |
+|----------------------|----------------------------|
+| "for design system work" | "scaffolds SDC component directories, generates Twig templates, wires up UI Patterns" |
+| "helps with plugin development" | "creates plugin scaffolding, generates SKILL.md files, configures hooks.json, validates structure before packaging" |
+| "brand content creation" | "generates branded HTML pages, PDFs, and carousels from a brand-philosophy.md using design tokens" |
+
+## Synonym Coverage
+
+Users ask for the same thing in multiple ways. Cover adjacent terms:
+
+- A skill that creates HTML pages should mention **"landing page"**, **"web page"**, **"website"**, and **"UI components"** — not just "HTML page"
+- A skill that authors skills should mention **"skill"**, **"SKILL.md"**, **"skill authoring"**, **"plugin component"**
+- A skill that works with a specific file format should mention both the extension and the common noun (**".docx"** + **"Word document"**)
+
+## Quoted YAML Form
+
+Wrap multi-sentence descriptions in `"..."` to avoid YAML parsing edge cases on colons and commas:
+
+```yaml
+# Unquoted — safe but risky if the string contains a `:` or a leading special char
+description: Run a full audit. Use when user says 'audit'.
+
+# Quoted — always parses correctly
+description: "Run a full audit. Use when user says 'audit', 'check everything'."
+```
+
+Both forms are valid. Quoted is safer as descriptions grow.
+
+## Don't Let Scoring Tools Strip Intent
+
+Automated "description quality" scoring tools sometimes flag intentional activation-strength modifiers as noise. **Preserve these when they're deliberate:**
+
+- **`PROACTIVELY`, `MUST`, `NEVER`** — activation-strength modifiers. A scoring tool that strips `MUST use this skill before design work` to a milder phrasing has **reduced** accuracy, not improved it. If CLAUDE.md says a skill must fire before a class of task, the description should say so — even when a linter calls it "pushy".
+- **`` !`command` `` dynamic-context injections** — these are a documented Claude Code skill feature that executes the command and injects its output into the description. A "simplifier" that deletes `!`... `` treats real functionality as syntax noise.
+- **Domain-intelligence body prose** — creative/design/artistic skills encode quality bars in prose (art movements, craftsmanship mantras, anti-convergence rules). Generic "verbose = bad" scoring degrades output quality for these skills. The length is doing work.
+
+If you review a description and the change is "shorter and milder" without a clear reason, check whether the skill relied on that exact phrasing.
 
 ## Checklist
 
 - [ ] Starts with "Use when..." or action-focused opener, OR uses three-part structure
 - [ ] Written in third person (not "you should")
 - [ ] Includes specific symptoms/triggers
-- [ ] Includes relevant keywords users might search
-- [ ] Under 1024 characters (ideal: 200-500)
+- [ ] Includes enumerated trigger phrases (`Use when user says 'X', 'Y', 'Z'`) where activation needs a boost
+- [ ] Uses concrete action verbs describing what the skill produces
+- [ ] Covers synonyms for the core concept
+- [ ] Quoted YAML form for multi-sentence descriptions
+- [ ] Combined description + `when_to_use` under **1,536 characters** (per-entry cap)
 - [ ] Answers: "Should Claude load this skill right now?"
 - [ ] Includes scope boundaries / negative triggers if skill could overtrigger
 - [ ] Mentions file types if relevant (.pdf, .docx, etc.)
+- [ ] Preserves `PROACTIVELY` / `MUST` / `NEVER` when deliberately present
+- [ ] Preserves `` !`command` `` injections when deliberately present
 
 ## Keywords to Include
 

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
@@ -141,10 +141,13 @@ permissionMode: default
 | Mode | Behavior | Use Case |
 |------|----------|----------|
 | default | Normal prompting | Most agents |
-| acceptEdits | Auto-accept edits | Trusted formatters |
-| dontAsk | Auto-deny all permission prompts | Non-interactive agents |
-| bypassPermissions | Skip all prompts | Automation scripts |
+| acceptEdits | Auto-accept edits + common fs commands | Trusted formatters |
 | plan | Read-only mode | Planning agents |
+| auto | Classifier-gated auto-approval (see note below) | Long tasks on supported plans |
+| dontAsk | Only pre-approved tools; `ask` rules auto-deny | Non-interactive agents, CI |
+| bypassPermissions | Skip all prompts | Automation scripts, isolated envs only |
+
+> **Plugin agent caveat:** `permissionMode` in plugin-packaged agents is silently ignored as a security measure. It works in user/project agents but not in agents shipped inside a plugin. For the full behavior table and auto-mode specifics, see [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md).
 
 ### Default Mode
 

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/writing-agents.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/writing-agents.md
@@ -156,9 +156,12 @@ If omitted, the agent has no persistent memory.
 |------|----------|
 | default | Normal permission handling |
 | acceptEdits | Auto-accept edit suggestions |
-| bypassPermissions | Skip permission prompts |
-| plan | Read-only mode |
-| ignore | Ignore permission system |
+| plan | Read-only planning mode |
+| auto | Classifier-gated auto-approval (subagent frontmatter `permissionMode` is ignored in auto mode) |
+| dontAsk | Only pre-approved tools run; `ask` rules auto-deny |
+| bypassPermissions | Skip permission prompts — isolated environments only |
+
+See [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md) for the full behavior table, auto-mode classifier rules, and plugin-packaged-agent caveats.
 
 ## Hooks
 

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
@@ -1,6 +1,6 @@
 # Hook Events
 
-Complete reference for all 22 hook events in Claude Code.
+Complete reference for all 26 hook events in Claude Code.
 
 ## Event Reference Table
 
@@ -8,30 +8,34 @@ Complete reference for all 22 hook events in Claude Code.
 |-------|---------|-----------|-----------------|
 | SessionStart | Session begins or resumes | No | Yes (startup, resume, clear, compact) |
 | UserPromptSubmit | User submits prompt | Yes | No |
-| PreToolUse | Before tool execution | Yes | Yes (tool name regex) |
+| PreToolUse | Before tool execution | Yes | Yes (tool name) |
 | PermissionRequest | Permission dialog shown | Yes | Yes (tool name) |
-| PostToolUse | After tool succeeds | No | Yes (tool name regex) |
-| PostToolUseFailure | After tool fails | No | Yes (tool name regex) |
+| PermissionDenied | Auto-mode classifier denies a tool call | No (can request retry) | Yes (tool name) |
+| PostToolUse | After tool succeeds | No | Yes (tool name) |
+| PostToolUseFailure | After tool fails | No | Yes (tool name) |
 | Notification | Alert sent | No | Yes (notification type) |
 | SubagentStart | Subagent spawned | No | Yes (agent type) |
 | SubagentStop | Subagent finishes | Yes | Yes (agent type) |
-| Stop | Claude finishes responding | Yes | No |
-| TeammateIdle | Agent team teammate going idle | Yes | No |
+| TaskCreated | Task being created via TaskCreate | Yes | No |
 | TaskCompleted | Task marked complete | Yes | No |
-| PreCompact | Before context compaction | No | Yes (manual, auto) |
-| SessionEnd | Session terminates | No | Yes (clear, logout, prompt_input_exit) |
-| InstructionsLoaded | CLAUDE.md/instructions loaded | No | No |
-| ConfigChange | Configuration changes during session | No | No |
+| Stop | Claude finishes responding | Yes | No |
+| StopFailure | Turn ends due to an API error | No | Yes (error type) |
+| TeammateIdle | Agent team teammate going idle | Yes | No |
+| InstructionsLoaded | CLAUDE.md/instructions loaded | No | Yes (load reason) |
+| ConfigChange | Configuration changes during session | No | Yes (config source) |
+| CwdChanged | Working directory changes (e.g. `cd`) | No | No |
+| FileChanged | Watched file changes on disk | No | Yes (literal filenames) |
 | WorktreeCreate | Worktree created for agent | No | No |
 | WorktreeRemove | Worktree removed after agent completion | No | No |
-| StopFailure | Turn ends due to an API error | No | No |
-| PostCompact | After context compaction completes | No | No |
-| Elicitation | MCP server requests user input via elicitation | No | No |
-| ElicitationResult | User responds to MCP elicitation, before response sent to server | No | No |
+| PreCompact | Before context compaction | No | Yes (manual, auto) |
+| PostCompact | After context compaction completes | No | Yes (manual, auto) |
+| Elicitation | MCP server requests user input via elicitation | No | Yes (MCP server name) |
+| ElicitationResult | User responds to MCP elicitation, before response sent to server | No | Yes (MCP server name) |
+| SessionEnd | Session terminates | No | Yes (reason) |
 
 ## MCP Tool Matcher Syntax
 
-For tool-based events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest), MCP tools use the `mcp__server__tool` pattern:
+For tool-based events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied), MCP tools use the `mcp__server__tool` pattern:
 
 | Pattern | Matches |
 |---------|---------|
@@ -271,6 +275,50 @@ All hook events receive JSON input with the following common fields:
 }
 ```
 
+### PermissionDenied
+
+**Trigger**: When the [auto-mode](../08-configuration/permission-modes.md) classifier denies a tool call. Does **not** fire when a user manually denies a dialog, when a `PreToolUse` hook blocks a call, or when a `deny` rule matches — only for classifier denials in auto mode.
+
+**Matcher**: Tool name (same rules as PreToolUse)
+
+**Can Block**: No — the denial already happened. The hook can tell the model it may retry by returning `{retry: true}`.
+
+**Input Fields**: In addition to common fields, PermissionDenied hooks receive `tool_name`, `tool_input`, `tool_use_id`, and `reason` (the classifier's explanation).
+
+**Use Cases**:
+- Log classifier denials for tuning auto-mode rules
+- Tell the model it may retry with a different approach
+- Escalate repeated denials to monitoring
+
+**Example**:
+```json
+{
+  "PermissionDenied": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-denial-and-retry.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Retry return value** (JSON stdout):
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionDenied",
+    "retry": true
+  }
+}
+```
+
+When `retry: true`, Claude Code adds a message telling the model it may retry the tool call. The denial itself is not reversed. Returning no JSON or `retry: false` leaves the denial in place.
+
 ### Notification
 
 **Trigger**: When Claude sends a notification/alert
@@ -438,6 +486,43 @@ All hook events receive JSON input with the following common fields:
 - Stdout with task description: Assign new work
 - Empty: Allow teammate to go idle
 
+### TaskCreated
+
+**Trigger**: When a task is being created via the `TaskCreate` tool.
+
+**Matcher**: Not supported (fires for every task)
+
+**Can Block**: Yes — exit code 2 rejects task creation; `{"continue": false, "stopReason": "..."}` stops the teammate entirely.
+
+**Input Fields**: In addition to common fields, TaskCreated hooks receive `task_id`, `task_subject`, and optionally `task_description`, `teammate_name`, and `team_name`.
+
+**Use Cases**:
+- Enforce naming conventions on task subjects
+- Require non-empty task descriptions
+- Prevent certain task types from being created
+- Track task creation across teammates for observability
+
+**Example**:
+```json
+{
+  "TaskCreated": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-task.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Return Values**:
+- Exit 0: Accept task creation
+- Exit 2: Reject; stderr is fed back to the model as feedback
+- JSON `{"continue": false, "stopReason": "..."}`: Stop the teammate entirely (matches Stop hook behavior)
+
 ### TaskCompleted
 
 **Trigger**: When a task is marked as complete
@@ -590,6 +675,85 @@ All hook events receive JSON input with the following common fields:
   ]
 }
 ```
+
+### CwdChanged
+
+**Trigger**: When the working directory changes during a session (e.g. Claude runs `cd`). Pairs with `FileChanged` for reactive environment management (direnv-style).
+
+**Matcher**: Not supported (fires on every directory change)
+
+**Can Block**: No
+
+**Handler Types**: Only `type: "command"` is supported.
+
+**Input Fields**: In addition to common fields, CwdChanged hooks receive `old_cwd` and `new_cwd`.
+
+**Special**: Access to `${CLAUDE_ENV_FILE}` — variables written here persist into subsequent Bash commands for the session.
+
+**Use Cases**:
+- Reload environment variables on directory change (direnv integration)
+- Activate project-specific toolchains (pyenv, nvm)
+- Update `FileChanged` watch list dynamically via `watchPaths` output
+
+**Example**:
+```json
+{
+  "CwdChanged": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-cwd-change.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Output** (optional JSON stdout):
+- `watchPaths`: Array of absolute paths. Replaces the dynamic watch list for `FileChanged`. Empty array clears it (typical when entering a new directory).
+
+### FileChanged
+
+**Trigger**: When a watched file changes on disk. Useful for reloading env vars when project configuration files are modified.
+
+**Matcher**: Serves two roles:
+1. **Watch list**: The matcher value is split on `|` and each segment is registered as a **literal filename** in the working directory (`.envrc|.env` watches those two files). Regex patterns are **not** useful here — `^\.env` would watch a file literally named `^\.env`.
+2. **Filter**: When a watched file changes, the same value filters which hook groups run, using standard matcher rules against the changed file's basename.
+
+**Can Block**: No (the change already happened on disk)
+
+**Handler Types**: Only `type: "command"` is supported.
+
+**Input Fields**: In addition to common fields, FileChanged hooks receive `file_path` (absolute) and `event` (`"change"`, `"add"`, or `"unlink"`).
+
+**Special**: Access to `${CLAUDE_ENV_FILE}` — variables written here persist into subsequent Bash commands for the session.
+
+**Use Cases**:
+- Reload environment variables when `.envrc`, `.env`, or config files change
+- Run watch-mode linters/formatters on specific file types
+- Re-read cached data when its source file changes
+
+**Example**:
+```json
+{
+  "FileChanged": [
+    {
+      "matcher": ".envrc|.env",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/reload-env.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Output** (optional JSON stdout):
+- `watchPaths`: Array of absolute paths to add to the dynamic watch list. Paths from the `matcher` are always watched in addition.
 
 ### WorktreeCreate
 
@@ -835,5 +999,5 @@ Multiple matcher groups and multiple hooks per group:
 
 ## See Also
 
-- `writing-hooks.md` -- hook configuration and handler types (references all 22 events)
+- `writing-hooks.md` -- hook configuration and handler types (references all 26 events)
 - `hook-patterns.md` -- common implementation patterns

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
@@ -454,6 +454,156 @@ echo "ask"
 exit 0
 ```
 
+## FileChanged Watch-Mode Lint Pattern
+
+Run a linter automatically when specific config files change on disk:
+
+### hooks.json
+
+```json
+{
+  "FileChanged": [
+    {
+      "matcher": ".eslintrc.json|.prettierrc",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/relint-on-config-change.sh",
+          "async": true,
+          "timeout": 60
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/relint-on-config-change.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.file_path')
+EVENT=$(echo "$INPUT" | jq -r '.event')
+
+# Only react to modifications, not deletions
+[ "$EVENT" = "change" ] || exit 0
+
+# Re-run lint across the project when config changes
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+npx eslint . --quiet 2>&1 | tee -a claude-outputs/logs/lint-reloads.log
+
+exit 0
+```
+
+**Why `async: true`:** Full-project lint can take seconds; `async` keeps Claude responsive and surfaces the result on the next turn.
+
+**Matcher note:** Values in the `matcher` are treated as **literal filenames** for `FileChanged`, not regex. Use `|` to list multiple watched files.
+
+## PermissionDenied Retry Pattern
+
+In auto mode, log classifier denials and tell the model it may retry when appropriate:
+
+### hooks.json
+
+```json
+{
+  "PermissionDenied": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/bash-denial-handler.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/bash-denial-handler.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+REASON=$(echo "$INPUT" | jq -r '.reason // empty')
+
+# Log every denial for audit
+LOG_DIR="$CLAUDE_PROJECT_DIR/claude-outputs/logs"
+mkdir -p "$LOG_DIR"
+jq -n --arg cmd "$COMMAND" --arg reason "$REASON" \
+  '{ts: now, command: $cmd, reason: $reason}' \
+  >> "$LOG_DIR/permission-denials.jsonl"
+
+# For known-safe patterns, tell the model it may retry
+if echo "$COMMAND" | grep -qE '^(git status|git log|ls|cat)'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PermissionDenied",
+      retry: true
+    }
+  }'
+fi
+
+exit 0
+```
+
+**Retry caveat:** `retry: true` does **not** reverse the denial. It adds a message telling the model it may retry with a different approach. If the tool input is identical, the classifier will deny again.
+
+## TaskCreated Tracking Pattern
+
+Enforce task-subject conventions and log created tasks for observability:
+
+### hooks.json
+
+```json
+{
+  "TaskCreated": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/track-task-creation.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/track-task-creation.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+TASK_ID=$(echo "$INPUT" | jq -r '.task_id')
+SUBJECT=$(echo "$INPUT" | jq -r '.task_subject')
+DESCRIPTION=$(echo "$INPUT" | jq -r '.task_description // empty')
+
+# Require non-empty descriptions
+if [ -z "$DESCRIPTION" ]; then
+  echo "Task '$SUBJECT' is missing a description. Add one before creating the task." >&2
+  exit 2  # rejects task creation, feedback goes to the model
+fi
+
+# Require subject to start with a verb (convention)
+if ! echo "$SUBJECT" | grep -qiE '^(add|fix|update|refactor|remove|implement|document)'; then
+  echo "Task subject must start with a verb (add, fix, update, refactor, remove, implement, document)." >&2
+  exit 2
+fi
+
+# Log accepted tasks
+LOG_DIR="$CLAUDE_PROJECT_DIR/claude-outputs/logs"
+mkdir -p "$LOG_DIR"
+echo "$(date -u +%FT%TZ) created $TASK_ID: $SUBJECT" >> "$LOG_DIR/tasks.log"
+
+exit 0
+```
+
+**Strong reject:** Exit 2 with stderr both rejects the task creation and feeds the stderr back to the model as guidance. Return `{"continue": false, "stopReason": "..."}` instead to stop the teammate entirely.
+
 ## Best Practices
 
 1. **Fast hooks**: Keep execution time minimal

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
@@ -47,15 +47,17 @@ Or inline in `plugin.json`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| matcher | string | No | Pattern to match (regex, exact, or `*`) |
-| hooks | array | **Yes** | Array of hook actions |
-| type | string | **Yes** | Hook handler type: `command`, `prompt`, `agent`, or `http` |
+| matcher | string | No | Pattern to filter when the matcher group fires (see Matcher Patterns) |
+| hooks | array | **Yes** | Array of hook handlers |
+| type | string | **Yes** | Handler type: `command`, `prompt`, `agent`, or `http` |
 | command | string | For command | Shell command to execute |
 | prompt | string | For prompt/agent | LLM prompt (`$ARGUMENTS` for context) |
+| if | string | No | Permission-rule syntax (e.g. `"Bash(git *)"`, `"Edit(*.ts)"`) to pre-filter tool events before spawning the handler. See [The `if` Field](#the-if-field). |
 | timeout | number | No | Timeout in seconds (default varies by type) |
 | async | boolean | No | Run in background (command type only) |
+| asyncRewake | boolean | No | Like `async` but wakes Claude on exit-code 2 with stderr as a system reminder. Implies `async`. |
 | statusMessage | string | No | Message shown in the TUI while the hook runs |
-| once | boolean | No | Hook fires only once per session |
+| once | boolean | No | Fires once per session then is removed. Only honored in skill frontmatter; ignored in settings/agent frontmatter. |
 
 ## Hook Handler Types
 
@@ -164,40 +166,123 @@ Command hooks can run asynchronously in the background.
 
 ## Matcher Patterns
 
-| Pattern | Behavior | Example |
-|---------|----------|---------|
-| Exact match | Matches tool name exactly | `Write` |
-| Regex | Pattern match on tool name | `Write\|Edit` |
-| Wildcard | Matches all | `*` |
-| Path pattern | Tool + path constraint | `Read(./docs/**)` |
-| MCP tool | Server + tool pattern | `mcp__memory__.*` |
-| MCP wildcard | Any server, matching tool | `mcp__.*__write.*` |
-| Compound | Multiple patterns combined | `Write\|Edit\|mcp__fs__write` |
-| Omitted | No filter (fires for all) | Don't include the field |
+The `matcher` evaluation mode is determined by the **characters the matcher contains**, not by a flag:
 
-Examples:
+| Matcher value | Evaluated as | Example |
+|---------------|--------------|---------|
+| `"*"`, `""`, or omitted | Match all | Fires on every occurrence of the event |
+| Only letters, digits, `_`, and `\|` | Exact string, or `\|`-separated list of exact strings | `Bash` matches only Bash; `Edit\|Write` matches either tool exactly |
+| Contains any other character | JavaScript regular expression | `^Notebook` matches any tool starting with Notebook; `mcp__memory__.*` matches every tool from the `memory` server |
+
+**Important:** A value like `mcp__memory` contains only letters and underscores, so it is evaluated as an exact string and matches **no** tool. To match all tools from a server you must append `.*` (e.g. `mcp__memory__.*`) so the matcher contains a non-alphanumeric character and is treated as a regex.
+
+### Matcher field per event
+
+Each event matches on a different field. Tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) match on the tool name. Other events match on the value documented in their [hook-events.md](hook-events.md) entry — e.g. `SessionStart` matches `startup|resume|clear|compact`, `Notification` matches `permission_prompt|idle_prompt|auth_success|elicitation_dialog`, `StopFailure` matches error types.
+
+Events with **no matcher support** (`UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCreated`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove`, `CwdChanged`) silently ignore a `matcher` field.
+
+### Examples
+
 ```json
-// Match Write tool only
+// Exact match — no regex chars
 "matcher": "Write"
 
-// Match Write OR Edit
+// Alternation of exact strings — only | is allowed before it's a regex
 "matcher": "Write|Edit"
 
-// Match Bash commands starting with git
-"matcher": "Bash(git:*)"
-
-// Match all tools from memory MCP server
+// Regex — the period forces regex evaluation
 "matcher": "mcp__memory__.*"
 
-// Match any write tool from any MCP server
+// Regex — any server, any write tool
 "matcher": "mcp__.*__write.*"
 
-// Built-in and MCP tools together
-"matcher": "Write|Edit|mcp__fs__write_file"
-
-// Read tool scoped to docs directory
-"matcher": "Read(./docs/**)"
+// Regex — starts-with anchor
+"matcher": "^Notebook"
 ```
+
+To filter more narrowly than the matcher allows — for example, "only `Bash` calls that run `git`" — use the `if` field on the handler. The `matcher` is a coarse event-level filter; `if` is a cheap per-handler pre-spawn filter.
+
+## The `if` Field
+
+The `if` field on a hook handler is a **pre-spawn filter** evaluated before the handler runs. It uses [permission-rule syntax](../08-configuration/permission-modes.md) (same as Claude Code's permission rules), so it can match the tool name and arguments together.
+
+**Only evaluated on tool events**: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`. On any other event, a hook with `if` set never runs.
+
+### Why it matters
+
+The `if` field avoids the "spawn a process just to check and exit 0" anti-pattern. Declare hooks against broad matchers, then filter cheaply with `if`:
+
+**Before (spawns on every Bash call):**
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-rm.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+The script itself checks whether the command is `rm *` and exits 0 otherwise. Every `Bash` call spawns the process.
+
+**After (spawns only on `rm *`):**
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "if": "Bash(rm *)",
+          "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-rm.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+Claude Code evaluates `Bash(rm *)` against the tool input and only spawns `block-rm.sh` when it matches.
+
+### Common `if` patterns
+
+```json
+// Only Edit calls on TypeScript files
+"if": "Edit(*.ts)"
+
+// Only git subcommands
+"if": "Bash(git *)"
+
+// Only writes under a specific path
+"if": "Write(src/**)"
+
+// Compound: multiple rules
+"if": "Bash(npm *) || Bash(yarn *)"
+```
+
+See [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md) for the full permission-rule syntax.
+
+## Permission Mode Interaction
+
+Hooks behave differently depending on the active [permission mode](../08-configuration/permission-modes.md):
+
+| Mode | Hook behavior |
+|------|---------------|
+| `default` | All hook return values honored. `PreToolUse` `deny`/`ask` are both respected; `PermissionRequest` hooks run before the user sees a dialog. |
+| `auto` | The classifier may deny tool calls **without ever showing a dialog**. `PermissionDenied` fires for classifier denials. `PreToolUse` still runs and can block. `PermissionRequest` hooks do **not** fire unless a dialog is actually shown. |
+| `dontAsk` | Existing permission rules are honored, but no new dialogs appear. Hook `ask` return values fall back to the configured default. |
+| `bypassPermissions` | All permission checks bypassed. **Hooks still run** — they are the only guardrail. Do not assume the user is reviewing tool calls. |
+
+**Security callout:** In `auto` and `bypassPermissions` modes, a `PreToolUse` hook that silently approves is the primary safety barrier. Write hook scripts defensively:
+- Never assume the user will see or review the tool call
+- Log denied attempts for later audit (PostToolUseFailure / PermissionDenied)
+- Treat broad matchers + `auto` mode as requiring an `if` filter that narrows to known-safe patterns
 
 ## Environment Variables
 
@@ -374,5 +459,5 @@ This pattern checks if `node_modules` exists in the persistent data directory an
 
 ## See Also
 
-- `hook-events.md` -- all 22 available events with return values
+- `hook-events.md` -- all 26 available events with return values
 - `hook-patterns.md` -- common patterns and examples

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/marketplace-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/marketplace-json.md
@@ -342,6 +342,64 @@ For team-wide availability, add to project settings:
 
 Team members are prompted to install when they trust the folder.
 
+## Plugin Dependencies — Marketplace Author Responsibilities
+
+When a plugin in your marketplace declares [dependencies](plugin-json.md#dependencies-version-constrained), your marketplace must support the resolution model:
+
+### 1. Tag releases for version resolution
+
+Version constraints resolve against git tags on the marketplace repository. Each plugin release must be tagged as `{plugin-name}--v{version}`:
+
+```bash
+git tag secrets-vault--v2.1.0
+git tag deploy-kit--v3.1.0
+git push origin --tags
+```
+
+The `{plugin-name}--v` prefix lets one repository host multiple plugins with independent version lines. The `version` tagged must match the `version` field in that commit's `plugin.json`.
+
+**Without matching tags**, dependents fail with `no-matching-tag` and are disabled.
+
+### 2. Allowlist cross-marketplace dependencies
+
+A plugin in your marketplace can depend on a plugin in a different marketplace by setting `"marketplace"` in its dependency entry. Cross-marketplace resolution is **blocked by default** — you must allowlist the target marketplace in your root marketplace's `marketplace.json`.
+
+Allowlist entries can use exact matches or regex-based `hostPattern` and `pathPattern`:
+
+```json
+{
+  "name": "internal-plugins",
+  "strictKnownMarketplaces": {
+    "trusted-upstream": {
+      "source": {
+        "source": "github",
+        "repo": "partner-org/plugin-catalog"
+      }
+    },
+    "all-partner-repos": {
+      "source": {
+        "source": "github",
+        "hostPattern": "^github\\.com$",
+        "pathPattern": "^partner-org/.*"
+      }
+    }
+  }
+}
+```
+
+Dependents that reference a non-allowlisted marketplace are rejected at install time.
+
+### 3. Validator behavior
+
+When a plugin is installed, Claude Code:
+
+1. Reads its `dependencies` array from `plugin.json`
+2. Resolves each entry against the marketplace's tag list (tag-based sources) or declared version (npm/pip)
+3. Intersects the resolved range with constraints from other installed plugins
+4. Fails the install if any error fires (`range-conflict`, `no-matching-tag`, `dependency-version-unsatisfied`)
+
+Surfaced in `claude plugin list`, `/plugin`, and `/doctor`. The affected plugin is disabled until resolved. See [`plugin-json.md`](plugin-json.md#common-dependency-errors) for the full error table.
+
 ## Reserved Marketplace Names
 
 The following names are reserved by Anthropic and cannot be used for custom marketplaces:

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/permission-modes.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/permission-modes.md
@@ -1,0 +1,115 @@
+# Permission Modes
+
+Permission modes control how often Claude pauses to ask before editing files, running commands, or making network requests. Plugin authors need to understand them because hooks, skills, and subagents behave differently in each mode — and some of those differences are load-bearing for security.
+
+## The six modes
+
+| Mode | What runs without asking | Best for |
+|------|--------------------------|----------|
+| `default` | Reads only | Sensitive work, getting started |
+| `acceptEdits` | Reads, file edits, and common filesystem commands (`mkdir`, `touch`, `mv`, `cp`, `rm`, `rmdir`, `sed`) | Iterating on code you're reviewing |
+| `plan` | Reads only — Claude writes a plan but does not edit source | Exploring a codebase before changing it |
+| `auto` | Everything, with a classifier running background safety checks | Long tasks, reducing prompt fatigue |
+| `dontAsk` | Only pre-approved tools (`permissions.allow` rules + [read-only Bash commands](https://docs.claude.com/en/permissions#read-only-commands)) | Locked-down CI and scripts |
+| `bypassPermissions` | Everything except protected paths — no checks, no prompts | Isolated containers and VMs only |
+
+Modes set the **baseline**. [Permission rules](https://docs.claude.com/en/permissions#manage-permissions) (allow/ask/deny) layer on top of every mode except `bypassPermissions`, which skips the permission layer entirely.
+
+## How modes change hook behavior
+
+This is the table plugin authors most need. A hook that's safe in `default` can be silently dangerous in `auto` or `bypassPermissions`.
+
+| Hook event / return | `default` | `acceptEdits` | `plan` | `auto` | `dontAsk` | `bypassPermissions` |
+|---------------------|-----------|---------------|--------|--------|-----------|---------------------|
+| `PreToolUse` fires | yes | yes | yes (reads only) | yes | yes | yes |
+| `PreToolUse` `deny` honored | yes | yes | yes | yes | yes | yes |
+| `PreToolUse` `ask` honored | yes | yes | yes | yes | no — falls back to default | no — bypassed |
+| `PermissionRequest` fires | when dialog shown | when dialog shown | when dialog shown | **only when a prompt actually happens** (rare in auto) | never (no dialogs) | never |
+| `PermissionDenied` fires | no | no | no | **yes** — classifier denials | no | no |
+| `PostToolUse` / `PostToolUseFailure` fires | yes | yes | yes | yes | yes | yes |
+
+**Takeaways:**
+- `PreToolUse` is the only guardrail that runs in every mode. Treat it as the lowest-common-denominator safety hook.
+- `PermissionRequest` hooks only fire when a dialog would have been shown. In `auto` and `dontAsk`, they may never fire — do not rely on them for security-critical logic.
+- `PermissionDenied` is **exclusive to `auto` mode** — it fires when the classifier denies a call. Use it to log denials or tell the model it may retry (`{retry: true}`).
+
+## Auto mode specifics
+
+`auto` is the riskiest mode for plugin authors to design around because it suppresses the prompts that normally surface unsafe actions.
+
+**How it decides** (in order):
+1. Matching `allow` / `deny` rules resolve immediately
+2. Read-only actions and edits to the working directory are auto-approved (except [protected paths](#protected-paths))
+3. Everything else goes to the classifier
+4. The classifier denies anything that escalates beyond the request, targets unrecognized infrastructure, or looks driven by hostile content
+
+**What auto drops on entry:**
+- Blanket `Bash(*)`
+- Wildcarded interpreters like `Bash(python*)`
+- Package-manager run commands
+- `Agent` allow rules
+
+Narrow rules like `Bash(npm test)` carry over. Dropped rules are restored when leaving auto mode.
+
+**Fallback thresholds:**
+- 3 consecutive classifier denials, or 20 total denials → auto pauses, Claude resumes prompting
+- Approving the prompted action resumes auto
+- In `-p` headless mode, repeated blocks abort the session
+
+**Requirements** (auto is gated):
+- Plan: Max, Team, Enterprise, or API (not Pro)
+- Admin enablement on Team/Enterprise
+- Model: Sonnet 4.6, Opus 4.6, or Opus 4.7 (Team/Enterprise/API); Opus 4.7 only on Max
+- Provider: Anthropic API only (not Bedrock, Vertex, or Foundry)
+
+## Subagent inheritance
+
+Subagents inherit the parent's permission mode. `permissionMode` in a subagent's frontmatter is **ignored** in auto mode — the classifier re-evaluates every subagent action against the parent's rules.
+
+The classifier also:
+1. Checks the subagent's task description **before spawn**
+2. Checks each action during execution
+3. Reviews the full action history when the subagent finishes — if something flags, a security warning is prepended to the subagent's results
+
+For plugin agents specifically: `hooks`, `mcpServers`, and `permissionMode` are **silently ignored** in plugin-packaged agents as a security measure, regardless of mode.
+
+## Protected paths (all modes)
+
+Writes to these paths are **never** auto-approved, in any mode. In `default`/`acceptEdits`/`plan`/`bypassPermissions` they prompt; in `auto` they route to the classifier; in `dontAsk` they are denied.
+
+**Directories:**
+- `.git`, `.vscode`, `.idea`, `.husky`
+- `.claude` — except `commands/`, `agents/`, `skills/`, and `worktrees/` subdirectories
+
+**Files:**
+- `.gitconfig`, `.gitmodules`
+- `.bashrc`, `.bash_profile`, `.zshrc`, `.zprofile`, `.profile`
+- `.ripgreprc`
+- `.mcp.json`, `.claude.json`
+
+## Guidance for plugin authors
+
+1. **Write hooks that work in every mode.** Don't assume the user will review a prompt. In `auto` and `bypassPermissions`, hooks are the only barrier.
+2. **Use `PreToolUse` for hard safety, not `PermissionRequest`.** `PermissionRequest` can be skipped entirely in `auto`/`dontAsk`.
+3. **Pair broad matchers with the `if` field.** Narrow the pre-spawn filter so your hook doesn't become a no-op in `auto` where every action reaches you.
+4. **Log `PermissionDenied` in `auto` mode.** Classifier denials are useful signal for tuning allow-rules and spotting false positives.
+5. **Don't rely on `ask` in `dontAsk`.** It silently falls back to the default — your hook logic will never see the approval.
+6. **For `bypassPermissions`, assume zero user oversight.** Document this explicitly in your plugin's README if it ships hooks that matter.
+
+## How users switch modes
+
+- **CLI**: `Shift+Tab` to cycle `default` → `acceptEdits` → `plan`. Optional modes (`auto`, `bypassPermissions`) slot in after `plan` when enabled. `dontAsk` never appears in the cycle — set it with `--permission-mode dontAsk`.
+- **At startup**: `claude --permission-mode plan` (works with `-p` for headless).
+- **As default**: `permissions.defaultMode` in [settings.json](settings.md).
+- **VS Code / Desktop / Web**: mode selector in the UI.
+
+Administrators can lock modes off via [managed settings](https://docs.claude.com/en/permissions#managed-settings):
+- `permissions.disableAutoMode: "disable"` blocks `auto`
+- `permissions.disableBypassPermissionsMode: "disable"` blocks `bypassPermissions`
+
+## See Also
+
+- [`../06-hooks/writing-hooks.md`](../06-hooks/writing-hooks.md) — Permission Mode Interaction section
+- [`../06-hooks/hook-events.md#permissiondenied`](../06-hooks/hook-events.md) — PermissionDenied details
+- [`plugin-json.md`](plugin-json.md) — plugin manifest (plugin-packaged agents strip `permissionMode`)
+- Upstream: [Permission Modes](https://docs.claude.com/en/permission-modes), [Permissions](https://docs.claude.com/en/permissions)

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -261,6 +261,70 @@ Example:
 
 `${CLAUDE_PLUGIN_ROOT}` is substituted at runtime in all path-accepting fields, including nested values in mcpServers and lspServers configurations.
 
+## Dependencies (Version-Constrained)
+
+> **Requires Claude Code v2.1.110 or later.**
+
+A plugin can declare other plugins as dependencies. Without a version constraint, a dependency tracks the latest version shipped in its marketplace, so an upstream breaking change can silently break dependents. Version constraints hold a dependency at a tested range until you choose to move.
+
+### Declaring dependencies
+
+```json
+{
+  "name": "deploy-kit",
+  "version": "3.1.0",
+  "dependencies": [
+    "audit-logger",
+    { "name": "secrets-vault", "version": "~2.1.0" }
+  ]
+}
+```
+
+Each entry is either:
+- A **bare string** (plugin name) — tracks whatever version its marketplace ships
+- An **object** with these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string (required) | Plugin name. Resolves within the same marketplace as the declaring plugin. |
+| `version` | string | A [semver range](https://github.com/npm/node-semver#ranges): `~2.1.0`, `^2.0`, `>=1.4`, `=2.1.0`. The dependency is fetched at the highest tagged version that satisfies the range. |
+| `marketplace` | string | Resolve `name` in a different marketplace. Cross-marketplace dependencies are blocked unless the target marketplace is allowlisted in the root marketplace's `marketplace.json`. |
+
+Pre-release versions like `2.0.0-beta.1` are excluded unless the range opts in with a pre-release suffix (e.g. `^2.0.0-0`).
+
+### How constraints resolve
+
+Version constraints resolve against **git tags on the marketplace repository**. Each release must be tagged using the convention `{plugin-name}--v{version}`:
+
+```bash
+git tag secrets-vault--v2.1.0
+git push origin secrets-vault--v2.1.0
+```
+
+The plugin-name prefix lets one repository host multiple plugins with independent version lines.
+
+When multiple installed plugins constrain the same dependency, Claude Code intersects the ranges and picks the highest satisfying tag:
+
+| Plugin A requires | Plugin B requires | Result |
+|-------------------|-------------------|--------|
+| `^2.0` | `>=2.1` | One install at the highest `2.x` tag ≥ `2.1.0`. Both plugins load. |
+| `~2.1` | `~3.0` | Plugin B install fails with `range-conflict`. Plugin A unchanged. |
+| `=2.1.0` | none | Dependency pinned to `2.1.0`; auto-update skips newer versions. |
+
+Auto-update skips any upstream release that falls outside an active constraint. When the last constraining plugin is uninstalled, the dependency resumes tracking its marketplace entry.
+
+### Common dependency errors
+
+| Error | Meaning | Fix |
+|-------|---------|-----|
+| `range-conflict` | Combined ranges have no common satisfying version, or syntax is invalid. | Uninstall one plugin, widen an upstream range, or fix invalid semver syntax. |
+| `dependency-version-unsatisfied` | Installed version is outside the declared range. | `claude plugin install <dependency>@<marketplace>` to re-resolve. |
+| `no-matching-tag` | Marketplace has no `{name}--v*` tag satisfying the range. | Tag releases using the convention, or relax the range. |
+
+Surfaced in `claude plugin list`, `/plugin`, and `/doctor`. The affected plugin is **disabled** until resolved. For machine-readable output: `claude plugin list --json` (read the `errors` field per plugin).
+
+**npm marketplace sources:** Tag-based resolution does not apply. The constraint is still checked at load time; mismatches disable the plugin with `dependency-version-unsatisfied`.
+
 ## Installation Scopes
 
 Plugins can be installed with different scopes:

--- a/plugin-creation-tools/skills/plugin-creation/references/09-testing/errors.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/09-testing/errors.md
@@ -1,0 +1,98 @@
+# Errors Reference
+
+Plugin authors encounter two categories of errors: **runtime** errors (returned by the Claude Code session when a plugin's component runs) and **plugin-loading** errors (surfaced when a plugin is installed, updated, or loaded at session start).
+
+Your `/plugin-creation-tools:validate` output should use the official error names in this page so users can cross-reference with Claude Code's own diagnostics (`claude plugin list`, `/doctor`).
+
+## Plugin-loading errors
+
+Surfaced in `claude plugin list`, the `/plugin` interface, and `/doctor`. Read programmatically via `claude plugin list --json` — check the `errors` field on each plugin.
+
+### Dependency errors
+
+| Error | Meaning | Resolution |
+|-------|---------|------------|
+| `range-conflict` | Combined version ranges have no common satisfying version, or a range uses invalid semver syntax. | Uninstall or update one of the conflicting plugins; fix invalid `version` strings; simplify long `\|\|` chains. |
+| `dependency-version-unsatisfied` | The installed dependency's version is outside this plugin's declared range. | `claude plugin install <dependency>@<marketplace>` to re-resolve. |
+| `no-matching-tag` | The dependency's repository has no `{name}--v*` tag satisfying the range. | Check upstream tagging convention; relax the range if appropriate. |
+
+See [`../08-configuration/plugin-json.md#dependencies-version-constrained`](../08-configuration/plugin-json.md) for the full resolution model.
+
+### Manifest errors
+
+These fire when `plugin.json` or `marketplace.json` fails validation. Exact error strings vary by Claude Code version; the validator should surface all of them:
+
+| Symptom | What's wrong |
+|---------|--------------|
+| Missing `source` key on a marketplace plugin entry | v3.0.0 renamed `type` → `source`; old entries fail. |
+| `http` hook in `hooks.json` silently ignored | HTTP hooks must be configured in `settings.json`, not plugin `hooks.json`. |
+| Plugin name collides with reserved marketplace names | Rename; reserved list: `claude-code-marketplace`, `claude-code-plugins`, `claude-plugins-official`, `anthropic-marketplace`, `anthropic-plugins`, `agent-skills`, `life-sciences`, `knowledge-work-plugins`. |
+| Plugin name not kebab-case or contains invalid chars | Use kebab-case, no spaces, no slashes. |
+| Path traversal outside plugin root | Symlinks or `../` references fail after install-time cache copy — restructure so all files are under the plugin root. |
+| Duplicate component names (two skills/commands/agents with the same name) | Rename or namespace. |
+| Missing/invalid YAML frontmatter on a skill or agent | Fix the frontmatter block. |
+| `hooks.json` parse failure | Hard-blocks the plugin from loading. JSON-validate before shipping. |
+
+## Runtime errors (session)
+
+Runtime errors surface during session execution — usually while a plugin's hook, skill, or MCP server is active. Most map to an underlying Claude API error; see the [upstream error reference](https://docs.claude.com/en/errors) for HTTP status definitions.
+
+### Auto mode
+
+| Symptom | Category |
+|---------|----------|
+| `<model> is temporarily unavailable, so auto mode cannot determine the safety of <tool>...` | Transient classifier outage. Retry in a few minutes. Not a plugin bug. |
+| Repeated classifier denials (3 consecutive, 20 total) | Auto mode pauses; session resumes prompting. Not a plugin failure — log the `reason` from `PermissionDenied` hooks to tune allow-rules. |
+
+### Authentication
+
+| Error | Meaning |
+|-------|---------|
+| `Not logged in` | User has no active OAuth or API key. Plugins that require Anthropic-hosted features fail here. |
+| `Invalid API key` | Key is present but invalid. Check `env \| grep ANTHROPIC` — direnv/dotenv tools can inject stale keys. |
+| `This organization has been disabled` | Workspace/org issue, not a plugin issue. |
+| `OAuth token revoked or expired` | Re-auth with `claude login`. |
+
+### Usage limits
+
+| Error | Meaning |
+|-------|---------|
+| `You've hit your session limit` | User plan limit. Your plugin cannot recover this. |
+| `Request rejected (429)` | Rate-limited. Back off; retry. |
+| `Credit balance is too low` | User billing issue. |
+
+### Request errors
+
+| Error | Meaning |
+|-------|---------|
+| `Prompt is too long` | Session exceeds the model's context window. See [`../02-philosophy/core-philosophy.md`](../02-philosophy/core-philosophy.md) for plugin-author budget guidance. |
+| `Error during compaction: Conversation too long` | Context compaction failed. Advise the user to `/clear` and restart. |
+| `Request too large` | Usually an oversized file read or tool input; avoid shipping hooks that dump entire files on stdin. |
+| `Extra inputs are not permitted` | Unknown fields in tool/request JSON. Usually a plugin schema mismatch — check your `hooks.json` and `plugin.json` against the latest schema. |
+
+### Model availability
+
+| Error | Meaning |
+|-------|---------|
+| `There's an issue with the selected model` | Model misconfigured for the account/plan. |
+| `Claude Opus is not available with the Claude Pro plan` | Plan-tier restriction. |
+| `thinking.type.enabled is not supported for this model` | Hook using `type: prompt` or `type: agent` set `thinking` on a non-thinking model. |
+| `Thinking budget exceeds output limit` | Adjust `thinking.budget_tokens`. |
+
+## Validator alignment checklist
+
+When writing validator messages in `/plugin-creation-tools:validate`:
+
+- [ ] Use the **exact error name** from the upstream docs (e.g. `range-conflict`, not "dependency version conflict")
+- [ ] Link the user back to the section in this file that explains resolution
+- [ ] For manifest errors, name the failing field and line number where possible
+- [ ] Emit **warnings** (not errors) for best-practice violations like broad matchers without `if` fields
+
+## See Also
+
+- Upstream: [Error reference](https://docs.claude.com/en/errors)
+- [`../08-configuration/plugin-json.md`](../08-configuration/plugin-json.md) — manifest schema
+- [`../08-configuration/marketplace-json.md`](../08-configuration/marketplace-json.md) — marketplace schema
+- [`../06-hooks/hook-events.md`](../06-hooks/hook-events.md) — `PermissionDenied` event for classifier-denial handling
+- [`testing.md`](testing.md) — testing plugins
+- [`debugging.md`](debugging.md) — debugging strategies

--- a/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
@@ -284,4 +284,6 @@ Claude Code checks seed directories before attempting network fetches. Plugins f
 
 - `marketplace.md` - marketplace distribution
 - `versioning.md` - version management
-- `debugging.md` - troubleshooting
+- `review-md-v2.md` - scope code reviews to plugin-specific concerns via REVIEW.md
+- `routines-auto-validate.md` - auto-run `/plugin-creation-tools:validate` on every PR via a Routine
+- `../09-testing/debugging.md` - troubleshooting

--- a/plugin-creation-tools/skills/plugin-creation/references/10-distribution/review-md-v2.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/10-distribution/review-md-v2.md
@@ -1,0 +1,103 @@
+# REVIEW.md for Plugin Repositories
+
+Claude Code's managed Code Review service reads two files from the repo it's reviewing: `CLAUDE.md` (general project context) and `REVIEW.md` (review-only instructions). For plugin-repo maintainers, `REVIEW.md` is the right place to scope reviews to plugin-specific concerns.
+
+## The two-file model
+
+| File | Scope | Priority in review pipeline |
+|------|-------|-----------------------------|
+| `CLAUDE.md` | All Claude Code tasks, not just reviews. Context for how code should look | Read as project context; newly introduced violations flagged as nits |
+| `REVIEW.md` | Review-only instructions | Injected into every review-agent system prompt as the **highest-priority** block |
+
+`REVIEW.md` wins every conflict during reviews. Use it to reshape severity calibration, skip paths, and enforce repo-specific checks that shouldn't apply to interactive sessions.
+
+**`@` import syntax is not expanded** in `REVIEW.md`. Anything you want enforced must be written inline.
+
+## What to tune
+
+| Lever | What it does | Example |
+|-------|--------------|---------|
+| **Severity** | Redefine what "Important" vs "Nit" means for your repo | "Treat missing frontmatter as Important; treat style suggestions as Nit at most." |
+| **Nit volume** | Cap how many yellow/nit comments a single review posts | "Post at most 5 nits inline; mention the rest as a count." |
+| **Skip rules** | Paths, branches, or categories to skip entirely | "Skip `examples/**` and `*.lock`; skip anything CI already enforces." |
+| **Repo-specific checks** | Must-flag-on-every-PR rules | "Every new skill must have valid YAML frontmatter and `description` under 1,536 chars." |
+| **Verification bar** | Require evidence before a class of finding is posted | "Behavior claims need a `file:line` citation, not inference from naming." |
+| **Re-review convergence** | How to behave after round 1 | "After the first review, suppress new nits; post Important findings only." |
+| **Summary shape** | Opening tally / TL;DR format | "Open with a one-line tally: `X factual, Y style`. Lead with 'no factual issues' when true." |
+
+## Starter REVIEW.md for a plugin repo
+
+```markdown
+# Review instructions
+
+## What Important means here
+
+Important is reserved for findings that:
+- Break plugin loading (malformed `plugin.json`, missing frontmatter)
+- Violate the Claude Code plugin schema (unknown keys, invalid event names,
+  broken hook matcher syntax)
+- Introduce a security regression (hooks auto-approving in `auto` mode,
+  shell injection in hook scripts, path traversal in marketplace sources)
+- Break dependency resolution (semver ranges, tag convention violations)
+
+Style, naming, and refactoring suggestions are Nit at most.
+
+## Cap the nits
+
+Report at most 5 nits inline. If there are more, say "plus N similar items"
+in the summary. If everything is a Nit, open with "No blocking issues."
+
+## Do not report
+
+- Anything the `/plugin-creation-tools:validate` command already catches
+  (the PR pipeline runs it — no point duplicating)
+- Lockfiles, generated JSON schemas, and vendored dependencies
+- Files under `examples/**` that intentionally demonstrate anti-patterns
+- Style/formatting checks run by the lint step
+
+## Always check
+
+- Every new skill/agent/command file has a `version` frontmatter field
+- Skill descriptions stay under 1,536 characters combined with `when_to_use`
+- Hook examples using broad matchers include an `if` field where tool-event
+  applicable
+- Any `Claude Code SDK` mention has been updated to `Agent SDK` (link:
+  `references/11-agent-sdk/migration.md`)
+- Plugin-version bumps touch **both** `plugin.json` AND the repo-root
+  `marketplace.json`
+- New dependencies use the `{name}--v{version}` tag convention
+
+## Verification bar
+
+For behavior claims in a new skill description, require a test or a clear
+runtime signal. Inferring from the name is not enough.
+
+## Re-review convergence
+
+After the first review, suppress new nits. Post Important findings only.
+A one-line fix should not reach round three on style.
+
+## Summary shape
+
+Open the summary with a one-line tally:
+`N factual, M style` — or `No factual issues` when that's the case.
+Lead with the shape before the details.
+```
+
+**Keep it focused.** A 300-line `REVIEW.md` dilutes the rules that matter. The example above is ~40 lines of actionable instruction. If your repo grows beyond that, split project context into `CLAUDE.md` and keep `REVIEW.md` for rules that should only fire during review.
+
+## `/ultrareview` for pre-merge deep review
+
+`REVIEW.md` runs automatically on every PR (configurable). For a deeper, multi-agent review before a risky merge, the `/ultrareview` slash command runs a browser-based review session with a dedicated agent team. Use it when:
+
+- Merging a large plugin version bump (major release, schema changes)
+- A PR touches multiple plugins in a shared marketplace
+- A contributor outside the core team is opening their first PR
+
+`/ultrareview` is additive to `REVIEW.md` — it inherits the same rules. The dedicated review agents just work the diff more thoroughly.
+
+## Cross-links
+
+- [`packaging.md`](packaging.md) — how your plugin is packaged before distribution
+- [`routines-auto-validate.md`](routines-auto-validate.md) — auto-run `/plugin-creation-tools:validate` on every PR via a Routine
+- Upstream: [Code Review](https://docs.claude.com/en/code-review), [Ultrareview](https://docs.claude.com/en/ultrareview)

--- a/plugin-creation-tools/skills/plugin-creation/references/10-distribution/routines-auto-validate.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/10-distribution/routines-auto-validate.md
@@ -1,0 +1,127 @@
+# Auto-Validate via Routines
+
+A **Routine** is a Claude Code configuration (prompt + repositories + connectors + triggers) that runs automatically on Anthropic-managed cloud infrastructure. For plugin-repo maintainers, a Routine with a `pull_request.opened` GitHub trigger is the right way to run `/plugin-creation-tools:validate` on every PR — no CI config, no GitHub Action to maintain.
+
+This closes the loop on the repeated `feedback_always_validate_plugins` corrections: validation happens automatically so you can't forget.
+
+## When to use Routines vs GitHub Actions
+
+| Need | Use |
+|------|-----|
+| Run validator on every PR, post inline comments | Routine |
+| Deterministic pass/fail for branch protection | GitHub Action (cheaper, no quota) |
+| LLM-assisted review of plugin changes | Routine |
+| Matrix testing across multiple plugin versions | GitHub Action |
+| One-click "run validator now" on a PR | Routine |
+
+The two aren't mutually exclusive. A common setup pairs a GitHub Action for fast deterministic lint with a Routine for LLM-assisted semantic checks.
+
+## Prerequisites
+
+- Pro, Max, Team, or Enterprise plan with **Claude Code on the web** enabled
+- **Claude GitHub App** installed on the repo (the trigger-setup flow prompts you if not)
+- GitHub connected to your account (`/web-setup` in the CLI, or the web form)
+
+GitHub triggers are configured **from the web UI only** — not from the CLI.
+
+## Create the routine
+
+At [claude.ai/code/routines](https://claude.ai/code/routines), click **New routine**.
+
+### Step 1: Prompt
+
+```
+You are a plugin-validation routine running on every PR opened against this repo.
+
+Your task:
+1. Check out the PR branch in the repository workspace.
+2. Invoke the /plugin-creation-tools:validate skill on the changed plugin(s).
+   Identify which plugin(s) changed by inspecting the diff — each top-level
+   directory under the repo root that contains a `.claude-plugin/plugin.json`
+   is a plugin.
+3. Collect all violations from the validator output.
+4. Post review comments using the Claude GitHub App:
+   - For each Important violation: a blocking inline comment at the
+     file:line where it occurred
+   - For Nit-level issues: summarize in a single top-level comment,
+     capped at 5 inline mentions
+   - If no issues: post a brief "Validator passed — no issues found."
+5. If the validator detected version drift between `plugin.json` and the
+   root `marketplace.json` for the same plugin, flag it as Important.
+
+Success criteria:
+- Every PR that opens or synchronizes receives exactly one set of
+  validator comments within ~5 minutes.
+- Comments reference the specific file:line when available.
+- Severity assignment follows the rules in REVIEW.md at the repo root.
+
+Do not:
+- Push changes to any branch (read-only run).
+- Comment on files unrelated to the PR's diff.
+```
+
+### Step 2: Repository
+
+Select the plugin-marketplace repo. **Do not** enable "Allow unrestricted branch pushes" — this routine is read-only.
+
+### Step 3: Environment
+
+The **Default** environment is sufficient unless your plugin has a custom setup script (e.g. `npm install` for a JS-side validator). If you need dependencies:
+
+- Create a custom environment with a setup script that installs them
+- Setup-script output is cached — dependencies don't reinstall every run
+
+### Step 4: Trigger
+
+- **Trigger type**: GitHub event
+- **Repository**: the one from Step 2
+- **Event**: `Pull request` → `pull_request.opened` (and optionally `pull_request.synchronize` to re-run on new commits)
+- **Filters** (optional):
+  - `Is draft` = `false` — skip drafts so you don't run the validator on half-finished PRs
+  - Base branch `main` — only run on PRs targeting the default branch
+  - Author `is not one of` — skip bots that auto-open PRs (e.g. Dependabot)
+
+### Step 5: Connectors
+
+Remove connectors the routine doesn't need. For a validator routine, you typically only need the GitHub connector. Removing unused connectors reduces the tool surface and keeps the session focused.
+
+### Step 6: Save and test
+
+Click **Create**. Open a test PR and verify the routine fires within a few minutes. The routine's detail page shows every past run — click any run to open the full session and debug if comments didn't post.
+
+## Branch-push permissions
+
+Routines can only push to `claude/`-prefixed branches by default, which prevents accidental writes to protected branches. A validator routine doesn't push at all — the default restriction is exactly what you want. Never enable **Allow unrestricted branch pushes** for a validator routine.
+
+## Footguns
+
+- **Quota**: Research-preview limits apply per-routine and per-account per hour. Events beyond the cap are **dropped** until the window resets. For high-PR-volume repos, consider filtering more aggressively (e.g. skip Dependabot, skip drafts) to stay within the cap.
+- **Token shown once**: API-trigger tokens are shown once at creation. GitHub-trigger routines don't need one, but if you add API triggers later, save the token immediately.
+- **GitHub App is separate from `/web-setup`**: `/web-setup` grants clone access but not webhook delivery. The trigger setup flow installs the Claude GitHub App — don't skip that step.
+- **Your identity**: everything the routine does on GitHub appears as **you**. Comments, check runs, and any (prohibited-here) pushes carry your GitHub user. Teammates don't share routines.
+- **Session reuse disabled for GitHub triggers**: two PR updates produce two independent sessions. The routine can't remember what it said on the first pass. Handle idempotency in the prompt (e.g. "if you already posted comments on this PR, update them instead of duplicating").
+
+## Per-trigger environment scoping
+
+For the `/plugin-creation-tools:validate` routine specifically, the environment should:
+
+- **Network**: default (egress limited) — the validator only needs to read repo files and call the Claude API
+- **Env vars**: none required unless your plugin ships with env-dependent tests
+- **Setup script**: only if the validator has non-trivial install steps
+
+Minimizing what the environment can reach limits blast radius if the prompt is ever hijacked.
+
+## Pairing with REVIEW.md
+
+A Routine that runs `/plugin-creation-tools:validate` handles mechanical checks. A `REVIEW.md` (see [`review-md-v2.md`](review-md-v2.md)) handles semantic review. They complement each other:
+
+- **Routine**: "Does this PR follow the plugin schema? Did the author bump both version fields? Is every new skill's frontmatter valid?"
+- **REVIEW.md**: "Does this change make sense? Is the description pushy enough? Did the author drop a `PROACTIVELY` directive that should be kept?"
+
+Running both on every PR is the recommended setup for a plugin marketplace repo.
+
+## See Also
+
+- [`review-md-v2.md`](review-md-v2.md) — the semantic-review counterpart
+- [`packaging.md`](packaging.md) — how plugins are packaged for distribution
+- Upstream: [Routines](https://docs.claude.com/en/routines), [Code Review](https://docs.claude.com/en/code-review)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/agent-loop.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/agent-loop.md
@@ -1,0 +1,121 @@
+# The Agent Loop
+
+The Agent SDK runs the same execution loop that powers the Claude Code CLI. Plugin authors benefit from understanding it because your plugin's skills, hooks, commands, and agents all participate in this loop — knowing where each one fires is the difference between a plugin that composes cleanly and one that fights the runtime.
+
+## The loop at a glance
+
+Every session follows one cycle, repeated until Claude produces output with no tool calls:
+
+1. **Receive prompt** — Claude receives the prompt + system prompt + tool defs + history. SDK yields `SystemMessage(subtype="init")` with session metadata.
+2. **Evaluate and respond** — Claude replies with text, tool calls, or both. SDK yields an `AssistantMessage`.
+3. **Execute tools** — SDK runs each tool call. [Hooks](../06-hooks/writing-hooks.md) can intercept, modify, or block. Each tool result yields a `UserMessage`.
+4. **Repeat** — steps 2–3 loop. Each full cycle is **one turn**.
+5. **Final** — Claude produces a text-only response. SDK yields the final `AssistantMessage`, then a `ResultMessage` with the final text, tokens, cost, and session ID.
+
+A quick question ("what files are here?") might be 1–2 turns. A complex task ("refactor auth and update tests") can chain dozens.
+
+## Message types
+
+| Type | Yielded when | Plugin relevance |
+|------|--------------|------------------|
+| `SystemMessage` | Session init and compaction boundary | `init` contains session ID, metadata. `compact_boundary` marks where context was compacted. |
+| `AssistantMessage` | After each Claude turn | Text + tool-call blocks. This is where you see what Claude decided. |
+| `UserMessage` | After each tool execution | Contains the tool result fed back to Claude. |
+| `StreamEvent` | Only with partial messages enabled | Raw API streaming deltas. |
+| `ResultMessage` | End of loop | Final text, token usage, cost, subtype (`success` / limit-hit reason). |
+
+**TypeScript nuance:** `AssistantMessage` and `UserMessage` wrap the raw API message — content blocks live at `message.message.content`, not `message.content`. Python accesses them directly.
+
+**Python type check:** `isinstance(msg, ResultMessage)`.
+**TypeScript type check:** `msg.type === "result"`.
+
+## Budget controls
+
+Three caps plugin authors should know about:
+
+| Option | What it caps |
+|--------|--------------|
+| `max_turns` / `maxTurns` | Maximum tool-use turns (final text-only turn not counted) |
+| `max_budget_usd` / `maxBudgetUsd` | Spend cap across the whole session |
+| `max_thinking_tokens` / `maxThinkingTokens` | Extended-thinking budget (when model supports it) |
+
+Without limits, the loop runs until Claude finishes on its own. Fine for well-scoped tasks; risky for open-ended prompts. **Production rule of thumb:** always set a turn cap and a dollar cap.
+
+## Effort level
+
+The SDK honors an `effort` level (low/medium/high) that controls how hard Claude tries. It maps to model selection and thinking budget.
+
+Plugin frontmatter has the same field:
+```yaml
+# skills/my-skill/SKILL.md
+---
+name: my-skill
+description: ...
+effort: medium
+---
+```
+
+When an SDK app loads your plugin, the `effort` value on your skill/agent frontmatter is honored.
+
+## Tool execution
+
+The SDK runs tools **in parallel when safe**. Parallelism requires every tool in a batch to be marked read-only (custom tools via `readOnlyHint: true`, built-ins annotated by the runtime). Without that annotation, the loop serializes.
+
+Plugin-hook interaction: hooks run **before** tool execution (`PreToolUse`) and **after** (`PostToolUse`, `PostToolUseFailure`). See [`../06-hooks/writing-hooks.md`](../06-hooks/writing-hooks.md) for the full sequence.
+
+## Context window behavior
+
+The SDK manages the context window on Claude's behalf. Key things plugin authors should know:
+
+- **Skill descriptions** are loaded upfront (subject to the 1% budget / 8,000-char fallback — see [`../02-philosophy/core-philosophy.md`](../02-philosophy/core-philosophy.md))
+- **Skill bodies** are loaded **on invocation**, not at startup
+- **Compaction** fires automatically when the context nears the limit. Hooks (`PreCompact`, `PostCompact`) can save/restore state
+- **Tool definitions** can be loaded eagerly or on-demand (see [`tool-search.md`](tool-search.md))
+
+After compaction:
+- Path-scoped rules (`paths:` frontmatter) are **lost** until their trigger file is read again
+- Unscoped CLAUDE.md and rules are **re-injected** from disk
+- Invoked skill bodies are **re-injected** at 5,000 tokens/skill, 25,000 total
+
+Design plugins around this: if a rule must persist, don't use `paths:`.
+
+## Sessions and continuity
+
+A single `query()` is one-shot. For multi-turn conversations, use **sessions** (see [`subagents-sdk.md`](subagents-sdk.md) Sessions section). The session's `session_id` (from `SystemMessage(subtype="init")`) lets you resume later.
+
+Subagents spawned via the `Agent` tool get their **own context window** — parent history does not cross over. The only channel is the prompt string written into the Agent tool call.
+
+## Handling the result
+
+```python
+from claude_agent_sdk import query, AssistantMessage, ResultMessage
+
+async for msg in query(prompt="..."):
+    if isinstance(msg, AssistantMessage):
+        # progress update — turn just completed
+        pass
+    if isinstance(msg, ResultMessage):
+        if msg.subtype == "success":
+            print(msg.result)
+        else:
+            print(f"Stopped: {msg.subtype}")  # hit max_turns, budget, etc.
+```
+
+**Don't break on `ResultMessage`** — a small number of trailing system events (`prompt_suggestion`, etc.) can arrive after it. Iterate to completion.
+
+## Why plugin authors care
+
+- **Where does my hook fire?** Step 3, before/after tool execution. See [`../06-hooks/hook-events.md`](../06-hooks/hook-events.md).
+- **Where does my skill activate?** Claude reads skill descriptions at step 1 (loop start) and invokes them in step 2 when they match the prompt.
+- **Where does my subagent run?** The parent calls `Agent`, which spawns the subagent in a fresh context, runs its own mini-loop, and returns the final message verbatim to the parent's step 3.
+- **When does my MCP tool get loaded?** At step 1 (eagerly) or at the first search step (with tool search enabled).
+
+Understanding these four beats makes plugin composition predictable.
+
+## See Also
+
+- [`overview.md`](overview.md) — SDK overview
+- [`../06-hooks/writing-hooks.md`](../06-hooks/writing-hooks.md) — hooks fire inside this loop
+- [`tool-search.md`](tool-search.md) — on-demand tool loading
+- [`../02-philosophy/core-philosophy.md`](../02-philosophy/core-philosophy.md) — context budget numbers
+- Upstream: [How the agent loop works](https://docs.claude.com/en/agent-sdk/agent-loop), [How Claude Code works](https://docs.claude.com/en/how-claude-code-works)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/custom-tools.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/custom-tools.md
@@ -1,0 +1,166 @@
+# Custom Tools (Agent SDK)
+
+The Agent SDK lets you define custom tools programmatically and make them available to Claude in your application. Tools are wrapped in an **in-process SDK MCP server** and passed to `query()`.
+
+For plugin authors, custom tools are relevant when:
+1. Your plugin ships an SDK-based companion app (validator, test runner, deployment tool) that needs its own tool surface.
+2. You're writing test harnesses for your plugin's skills/agents.
+3. You want to expose the same tool to both CLI users (via `.mcp.json`) and SDK users (via `createSdkMcpServer`).
+
+## The four parts of a tool
+
+| Part | Purpose |
+|------|---------|
+| **Name** | Unique identifier Claude uses to call the tool |
+| **Description** | What the tool does — Claude reads this to decide when to call it |
+| **Input schema** | Expected arguments. TS uses Zod; Python uses a dict or JSON Schema |
+| **Handler** | Async function that runs. Returns `{ content, isError? }` |
+
+## Minimal example
+
+```typescript
+import { tool, createSdkMcpServer, query } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const getTemperature = tool(
+  "get_temperature",
+  "Get the current temperature at a location",
+  {
+    latitude: z.number().describe("Latitude coordinate"),
+    longitude: z.number().describe("Longitude coordinate"),
+  },
+  async (args) => {
+    const res = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${args.latitude}&longitude=${args.longitude}&current=temperature_2m`);
+    const data = await res.json();
+    return { content: [{ type: "text", text: `${data.current.temperature_2m}°F` }] };
+  }
+);
+
+const weatherServer = createSdkMcpServer({
+  name: "weather",
+  version: "1.0.0",
+  tools: [getTemperature],
+});
+
+for await (const msg of query({
+  prompt: "Temperature in SF?",
+  options: {
+    mcpServers: { weather: weatherServer },
+    allowedTools: ["mcp__weather__get_temperature"],
+  },
+})) {
+  console.log(msg);
+}
+```
+
+```python
+from claude_agent_sdk import tool, create_sdk_mcp_server, query, ClaudeAgentOptions
+
+@tool(
+    "get_temperature",
+    "Get the current temperature at a location",
+    {"latitude": float, "longitude": float},
+)
+async def get_temperature(args):
+    # ... fetch and return
+    return {"content": [{"type": "text", "text": "..."}]}
+
+weather_server = create_sdk_mcp_server(
+    name="weather", version="1.0.0", tools=[get_temperature],
+)
+
+async for msg in query(
+    prompt="Temperature in SF?",
+    options=ClaudeAgentOptions(
+        mcp_servers={"weather": weather_server},
+        allowed_tools=["mcp__weather__get_temperature"],
+    ),
+):
+    print(msg)
+```
+
+## Tool naming
+
+Registered tools are exposed to Claude as `mcp__{server_name}__{tool_name}`. In the example above the fully qualified name is `mcp__weather__get_temperature`. Use this exact form in `allowedTools` and in hook matchers.
+
+To allow every tool from a server, use `mcp__weather__.*` (the `.*` makes the matcher a regex — see [`../06-hooks/writing-hooks.md`](../06-hooks/writing-hooks.md)).
+
+## Optional parameters
+
+- **TypeScript (Zod):** add `.default(...)` or `.optional()` to the field.
+- **Python (dict schema):** every key is required. For optional parameters, leave them out of the schema, describe them in the tool description, and read with `args.get(...)` in the handler.
+- **Python (JSON Schema dict):** supports enums, ranges, and optional fields directly — use when you need more than the dict shorthand.
+
+## Return value structure
+
+Handlers must return an object with:
+- `content` (required): array of result blocks, each `{ type: "text" | "image" | "resource", ... }`
+- `isError` (optional): `true` to signal failure — Claude reacts to this in the agent loop instead of the call throwing
+
+Example image return:
+```python
+return {
+    "content": [
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "..."}}
+    ]
+}
+```
+
+## Parallel tool calls
+
+Claude can call tools in parallel **only** if every tool in a batch is marked safe. Tools with no side effects should set `readOnlyHint: true`:
+
+```typescript
+tool("lookup_price", "...", schema, handler, { readOnlyHint: true });
+```
+
+Without the annotation, Claude serializes tool calls conservatively. This is the single highest-leverage perf win for tool-heavy agents.
+
+## Error handling pattern
+
+Return an error block instead of throwing:
+
+```python
+return {
+    "isError": True,
+    "content": [{"type": "text", "text": f"Request failed: {error}"}],
+}
+```
+
+Claude sees the error text and can react (retry, try a different input, ask the user). Throwing kills the tool loop.
+
+## Restricting built-in tools
+
+Pass a `tools` array to keep Claude focused:
+
+```typescript
+options: { tools: ["Read", "Grep"] }  // no Write, Edit, Bash, etc.
+```
+
+Combined with custom tools, this is how you build narrow-purpose agents. Omit `tools` to get the full built-in set.
+
+## Plugin-author patterns
+
+### Pattern 1: Shared tool surface
+
+Ship the same tool to both CLI and SDK users:
+- **CLI**: declare it in your plugin's `.mcp.json`
+- **SDK**: re-export the handler and call `createSdkMcpServer` at runtime
+
+This requires the tool's core logic be library code (not tied to MCP transport). Your plugin's MCP entry and the SDK registration both call the same function.
+
+### Pattern 2: Validator harness
+
+Your plugin's `/plugin-creation-tools:validate`-style commands can be implemented as an SDK-based test harness that registers the plugin's components, runs a scripted query, and asserts structured output (see [`structured-outputs.md`](structured-outputs.md)).
+
+### Pattern 3: Tool search for large plugins
+
+If your plugin exposes many tools, register them eagerly eats context. Use [`tool-search.md`](tool-search.md) to load them on demand.
+
+## See Also
+
+- [`tool-search.md`](tool-search.md) — deferred loading for tool-heavy plugins
+- [`structured-outputs.md`](structured-outputs.md) — force JSON responses for CI
+- [`../07-mcp/`](../07-mcp/) — plugin-side MCP server authoring
+- [`../06-hooks/writing-hooks.md`](../06-hooks/writing-hooks.md) — matcher patterns for MCP tool names
+- Upstream: [Custom Tools](https://docs.claude.com/en/agent-sdk/custom-tools)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/migration.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/migration.md
@@ -88,7 +88,7 @@ options: { settingSources: ["user", "project", "local"] }
 ClaudeAgentOptions(setting_sources=["user", "project", "local"])
 ```
 
-> **Caveat:** Current SDK releases have reverted this default for `query()` — omitting the option once again loads user/project/local to match the CLI. Pass `settingSources: []` (TS) or `setting_sources=[]` (Python) if you explicitly need isolated behavior. Python 0.1.59 and earlier treated empty list as omitted; upgrade before relying on it.
+> **Caveat:** Current SDK releases have reverted this default for `query()` — omitting the option once again loads user/project/local to match the CLI. Pass `settingSources: []` (TS) or `setting_sources=[]` (Python) if you explicitly need isolated behavior. Early Python SDK releases treated an empty list the same as omitting the option; upgrade before relying on `setting_sources=[]`.
 
 ## What plugin authors should update
 

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/migration.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/migration.md
@@ -1,0 +1,128 @@
+# Migrating from Claude Code SDK to Agent SDK
+
+The **Claude Code SDK** has been renamed to the **Claude Agent SDK**. The rename is a breaking change that affects every application that imported the old package. This page summarizes the migration for plugin authors — both for your own tooling and for documentation/skills you ship.
+
+For the full upstream guide see [Migration Guide](https://docs.claude.com/en/agent-sdk/migration-guide).
+
+## What changed
+
+| Aspect | Old | New |
+|--------|-----|-----|
+| TS/JS package | `@anthropic-ai/claude-code` | `@anthropic-ai/claude-agent-sdk` |
+| Python package | `claude-code-sdk` | `claude-agent-sdk` |
+| Python options type | `ClaudeCodeOptions` | `ClaudeAgentOptions` |
+| Docs location | Claude Code docs | API Guide → Agent SDK section |
+
+The **Claude Code CLI itself is not affected**. Only the programmatic SDK changes.
+
+## Migrate a TypeScript/JavaScript project
+
+```bash
+npm uninstall @anthropic-ai/claude-code
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+```typescript
+// Before
+import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-code";
+
+// After
+import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+```
+
+Update `package.json`:
+```json
+{ "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.0" } }
+```
+
+Most named exports kept their names. Only the package string changes.
+
+## Migrate a Python project
+
+```bash
+pip uninstall claude-code-sdk
+pip install claude-agent-sdk
+```
+
+```python
+# Before
+from claude_code_sdk import query, ClaudeCodeOptions
+options = ClaudeCodeOptions(model="claude-opus-4-7")
+
+# After
+from claude_agent_sdk import query, ClaudeAgentOptions
+options = ClaudeAgentOptions(model="claude-opus-4-7")
+```
+
+Both the module name (`claude_code_sdk` → `claude_agent_sdk`) and the options type (`ClaudeCodeOptions` → `ClaudeAgentOptions`) changed.
+
+## Breaking behavior changes (v0.1.0)
+
+Beyond the rename, the SDK changed two defaults that affect existing code:
+
+### 1. Minimal system prompt by default
+
+**Before:** SDK inherited Claude Code's CLI system prompt.
+**After:** SDK starts with a minimal system prompt. Your agent runs without Claude Code's coding-focused instructions.
+
+Restore the old behavior:
+```typescript
+options: { systemPrompt: { type: "preset", preset: "claude_code" } }
+```
+```python
+ClaudeAgentOptions(system_prompt={"type": "preset", "preset": "claude_code"})
+```
+
+Or pass a custom string for your own persona.
+
+### 2. No `.claude/` auto-loading
+
+**Before:** SDK read `~/.claude/settings.json`, project `.claude/settings.json`, `.claude/settings.local.json`, `CLAUDE.md`, and custom slash commands.
+**After (v0.1.0):** Nothing loaded unless you opt in.
+
+Opt in:
+```typescript
+options: { settingSources: ["user", "project", "local"] }
+```
+```python
+ClaudeAgentOptions(setting_sources=["user", "project", "local"])
+```
+
+> **Caveat:** Current SDK releases have reverted this default for `query()` — omitting the option once again loads user/project/local to match the CLI. Pass `settingSources: []` (TS) or `setting_sources=[]` (Python) if you explicitly need isolated behavior. Python 0.1.59 and earlier treated empty list as omitted; upgrade before relying on it.
+
+## What plugin authors should update
+
+### In your own tooling
+
+Any test scripts, CI helpers, or validator routines that import the SDK must be updated. Common places to check:
+
+- `scripts/*.py` and `scripts/*.ts` in your plugin root
+- GitHub Actions workflows that run `pip install claude-code-sdk` or `npm install @anthropic-ai/claude-code`
+- Routine configurations that invoke the SDK
+- Internal developer docs for your plugin
+
+### In documentation you ship
+
+If your plugin's `SKILL.md`, references, or examples mention "Claude Code SDK", rewrite to "Agent SDK" and link to [`overview.md`](overview.md). Leaving stale `Claude Code SDK` mentions in skill descriptions reduces retrieval accuracy — the term is no longer canonical.
+
+### Grep your plugin before releasing
+
+```bash
+grep -rn "Claude Code SDK" path/to/your-plugin/
+grep -rn "claude_code_sdk\|claude-code-sdk" path/to/your-plugin/
+grep -rn "@anthropic-ai/claude-code[^-]" path/to/your-plugin/
+grep -rn "ClaudeCodeOptions" path/to/your-plugin/
+```
+
+Every hit is a migration target. See the validator checks added in Track F (`skill-quality-reviewer.md`) — stale `Claude Code SDK` mentions are flagged as regressions.
+
+## Why the rename happened
+
+The original SDK was framed around coding tasks but had evolved into a general-purpose agent framework. The new name reflects that broader scope — building business agents, customer-support agents, SRE bots, etc. — not just coding agents.
+
+For plugin authors this also means: if your plugin is coding-specific, that's still supported, but consider whether the SDK's wider scope opens new distribution channels.
+
+## See Also
+
+- [`overview.md`](overview.md) — current SDK capabilities
+- Upstream: [Migration Guide](https://docs.claude.com/en/agent-sdk/migration-guide)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/observability.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/observability.md
@@ -1,0 +1,86 @@
+# Observability (Agent SDK)
+
+The Agent SDK exports traces, metrics, and log events via **OpenTelemetry (OTLP)**. For plugin authors running production agents based on the SDK, this is the recommended way to get visibility into tool calls, model latency, token usage, and failures.
+
+This is an enterprise-tier feature — most plugin authors shipping to Claude Code users directly won't need it, but plugins bundled into SDK apps should document what signals they emit.
+
+## How telemetry flows
+
+The Agent SDK runs the Claude Code CLI as a child process. The **CLI has OpenTelemetry instrumentation built in** — the SDK itself produces no telemetry. You configure exporters via environment variables, and the CLI exports directly to your collector.
+
+Three independent signals, each with its own enable switch:
+
+| Signal | Contains | Enable with |
+|--------|----------|-------------|
+| **Metrics** | Counters for tokens, cost, sessions, lines of code, tool decisions | `OTEL_METRICS_EXPORTER` |
+| **Log events** | Structured records per prompt, API request, API error, tool result | `OTEL_LOGS_EXPORTER` |
+| **Traces** (beta) | Spans per interaction, model request, tool call, and hook | `OTEL_TRACES_EXPORTER` + `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` |
+
+Master switch: `CLAUDE_CODE_ENABLE_TELEMETRY=1`. Until set, no telemetry is exported regardless of exporter config.
+
+## Minimum OTLP config
+
+```python
+OTEL_ENV = {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",  # for traces
+    "OTEL_TRACES_EXPORTER": "otlp",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318",
+    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer your-token",
+}
+
+options = ClaudeAgentOptions(env=OTEL_ENV)
+```
+
+```typescript
+// TypeScript: options.env *replaces* inherited env — spread process.env
+options: { env: { ...process.env, ...otelEnv } }
+```
+
+**Two places to set env:**
+1. **Process env** (recommended for production) — set in shell, container, or orchestrator. Every `query()` picks them up automatically.
+2. **Per-call `options.env`** — when different agents in the same process need different telemetry settings.
+
+Python merges `env` on top of inherited env. TypeScript **replaces** it — always spread `process.env` first or you'll lose `PATH`, `ANTHROPIC_API_KEY`, etc.
+
+## Compatible backends
+
+Any OTLP-compatible backend: Honeycomb, Datadog, Grafana (Tempo/Loki/Mimir), Langfuse, or a self-hosted OpenTelemetry collector.
+
+**Do not** set `console` as an exporter — the SDK uses stdout as its message channel, so console exporter output would corrupt it. Use a local collector or Jaeger container for local inspection instead.
+
+## Short-lived calls need explicit flush
+
+The OpenTelemetry SDK inside the CLI batches exports. If your agent finishes before the batch interval, telemetry is lost. Flush explicitly when running one-shot scripts — see the upstream guide's flush section.
+
+## Tagging and filtering
+
+Standard OTLP resource attributes apply. Add `OTEL_RESOURCE_ATTRIBUTES` to tag every signal with your app name, environment, and plugin version:
+
+```
+OTEL_RESOURCE_ATTRIBUTES=service.name=my-validator,deployment.environment=prod,plugin.version=3.1.0
+```
+
+In your backend, filter spans by `service.name` to isolate your plugin's activity.
+
+## Sensitive-data control
+
+Prompts and tool results can contain secrets (file contents, env vars, user inputs). Before enabling log-event export in production:
+
+1. Review what the event schema contains — see upstream [Monitoring](https://docs.claude.com/en/monitoring-usage) for the full list
+2. Use the CLI's attribute redaction settings to drop sensitive fields
+3. For high-sensitivity workloads, export **metrics only** — they have no prompt/tool-result content
+
+## Plugin-author guidance
+
+1. **Document the envelope.** If your plugin ships as part of an SDK app, note which `service.name` resource attribute you tag with and which spans/metrics are emitted by your plugin's components.
+2. **Don't add a second telemetry layer.** The CLI already instruments hooks, tool calls, model requests. Your plugin's own hooks show up as spans automatically — no extra code.
+3. **Traces are in beta.** Don't build production dashboards exclusively around trace data yet. Metrics and log events are stable.
+
+## See Also
+
+- Upstream: [Observability](https://docs.claude.com/en/agent-sdk/observability), [Monitoring usage](https://docs.claude.com/en/monitoring-usage)
+- [Track cost and usage](https://docs.claude.com/en/agent-sdk/cost-tracking) — read token/cost from the response stream without a backend

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/overview.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/overview.md
@@ -77,7 +77,7 @@ query({
 ClaudeAgentOptions(setting_sources=["user", "project", "local"])
 ```
 
-> **Caveat:** Current SDK releases have partially reverted this — omitting the option loads `user`/`project`/`local` for `query()` to match CLI behavior. Pass an empty list explicitly if you need the isolated behavior. Python SDK 0.1.59 and earlier treated empty list as omitted; upgrade before relying on it.
+> **Caveat:** Current SDK releases have partially reverted this — omitting the option loads `user`/`project`/`local` for `query()` to match CLI behavior. Pass an empty list explicitly if you need the isolated behavior. Early Python SDK releases treated an empty list the same as omitting the option; upgrade before relying on `setting_sources=[]`.
 
 ## System prompt
 

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/overview.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/overview.md
@@ -1,0 +1,137 @@
+# Agent SDK Overview
+
+The **Agent SDK** (formerly Claude Code SDK) is the programmatic interface to the same tool loop, context management, and skill/hook/plugin machinery that power Claude Code. Use it when you need Claude Code's capabilities inside your own Python or TypeScript application — CI pipelines, headless automation, custom chat surfaces, or production agents.
+
+For plugin authors, the SDK matters because:
+1. **Testing** — you can script your plugin's commands and agents against a real Claude session.
+2. **CI integration** — validator routines and `--json-schema` output let plugin repos automate checks (see [`../10-distribution/`](../10-distribution/)).
+3. **Cross-deployment** — a plugin you ship to Claude Code users may also be consumed by Agent SDK apps that load `.claude/` settings.
+
+## Package names (post-rename)
+
+| Language | Package | Imports |
+|----------|---------|---------|
+| TypeScript / JavaScript | `@anthropic-ai/claude-agent-sdk` | `query`, `tool`, `createSdkMcpServer` |
+| Python | `claude-agent-sdk` | `query`, `ClaudeAgentOptions` |
+
+Old names (`@anthropic-ai/claude-code`, `claude-code-sdk`, `ClaudeCodeOptions`) are **retired**. Existing code must be migrated — see [`migration.md`](migration.md).
+
+## The one-line mental model
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+async for message in query(
+    prompt="Fix the bug in auth.py",
+    options=ClaudeAgentOptions(allowed_tools=["Read", "Edit", "Bash"]),
+):
+    print(message)
+```
+
+Claude autonomously reads files, edits them, runs commands, and returns messages. You don't write the tool-execution loop — the SDK runs it for you.
+
+This is the fundamental difference from the **Anthropic Client SDK** (`anthropic` package), which gives you raw API access and requires you to implement the tool loop yourself.
+
+## When to use SDK vs CLI vs Client SDK
+
+| Need | Use |
+|------|-----|
+| Daily interactive development | Claude Code CLI |
+| One-off terminal task | Claude Code CLI |
+| CI/CD pipeline that needs Claude | Agent SDK |
+| Custom app embedding Claude Code | Agent SDK |
+| Production agent with full autonomy | Agent SDK |
+| Direct API call with your own tool loop | Anthropic Client SDK |
+| No tool use, just completion | Anthropic Client SDK |
+
+## Capabilities overview
+
+The SDK gives you every Claude Code capability, programmable:
+
+- **Built-in tools** — Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, etc.
+- **Custom tools** — register your own tools for the model (see [`custom-tools.md`](custom-tools.md))
+- **Subagents** — delegate to named subagents with their own context window (see [`subagents-sdk.md`](subagents-sdk.md))
+- **Sessions** — multi-turn conversations with state (see [`subagents-sdk.md`](subagents-sdk.md))
+- **Permissions** — the same permission-mode system as the CLI (see [`permissions.md`](permissions.md))
+- **Structured outputs** — force JSON-schema-compliant responses (see [`structured-outputs.md`](structured-outputs.md))
+- **Tool search** — defer tool loading for large tool catalogs (see [`tool-search.md`](tool-search.md))
+- **Hooks** — PreToolUse / PostToolUse / etc. fire inside SDK sessions too
+- **MCP servers** — same `.mcp.json` loading as the CLI
+- **Plugins** — programmatic `plugins` option; `.claude/` auto-loading optional
+- **Observability** — OpenTelemetry traces, cost tracking (see [`observability.md`](observability.md))
+
+## `.claude/` loading behavior
+
+By default the SDK **does not** load filesystem settings (`.claude/`, CLAUDE.md, custom slash commands) unless you opt in. This is the opposite of the CLI default.
+
+Opt in by passing `settingSources` / `setting_sources`:
+
+```typescript
+query({
+  prompt: "...",
+  options: { settingSources: ["user", "project", "local"] }
+})
+```
+
+```python
+ClaudeAgentOptions(setting_sources=["user", "project", "local"])
+```
+
+> **Caveat:** Current SDK releases have partially reverted this — omitting the option loads `user`/`project`/`local` for `query()` to match CLI behavior. Pass an empty list explicitly if you need the isolated behavior. Python SDK 0.1.59 and earlier treated empty list as omitted; upgrade before relying on it.
+
+## System prompt
+
+The SDK also does **not** inherit Claude Code's CLI system prompt by default (v0.1.0+). To get Claude-Code-like behavior:
+
+```typescript
+query({
+  prompt: "...",
+  options: { systemPrompt: { type: "preset", preset: "claude_code" } }
+})
+```
+
+Without this, Claude runs with a minimal system prompt. Use a custom string if your agent needs a specialized persona.
+
+## Authentication
+
+Set one of:
+- `ANTHROPIC_API_KEY` — direct Anthropic API
+- `CLAUDE_CODE_USE_BEDROCK=1` + AWS credentials — Amazon Bedrock
+- `CLAUDE_CODE_USE_VERTEX=1` + Google Cloud credentials — Vertex AI
+- `CLAUDE_CODE_USE_FOUNDRY=1` + Azure credentials — Azure AI Foundry
+
+**Not permitted**: claude.ai login or Pro-tier rate limits from third-party agents unless explicitly approved.
+
+## For plugin authors: testing your plugin via the SDK
+
+```python
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+async def test_plugin():
+    async for message in query(
+        prompt="Run /my-plugin:validate against this directory",
+        options=ClaudeAgentOptions(
+            setting_sources=["project"],
+            allowed_tools=["Read", "Grep", "Bash"],
+        ),
+    ):
+        if hasattr(message, "result"):
+            print(message.result)
+
+asyncio.run(test_plugin())
+```
+
+This is the pattern the [Routines-based auto-validate](../10-distribution/) uses under the hood.
+
+## See Also
+
+- [`migration.md`](migration.md) — migrating from Claude Code SDK
+- [`custom-tools.md`](custom-tools.md) — register your own tools
+- [`subagents-sdk.md`](subagents-sdk.md) — programmatic subagent definitions
+- [`permissions.md`](permissions.md) — permission-mode handling
+- [`structured-outputs.md`](structured-outputs.md) — `--json-schema` for CI
+- [`tool-search.md`](tool-search.md) — deferred tool loading
+- [`observability.md`](observability.md) — tracing and cost tracking
+- [`agent-loop.md`](agent-loop.md) — how the loop actually works
+- Upstream: [Agent SDK Overview](https://docs.claude.com/en/agent-sdk/overview), [Quickstart](https://docs.claude.com/en/agent-sdk/quickstart)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/permissions.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/permissions.md
@@ -1,0 +1,131 @@
+# Permissions in the SDK
+
+The Agent SDK uses the same [permission modes](../08-configuration/permission-modes.md) as the CLI, plus two SDK-specific mechanisms: the `allowed_tools` / `disallowed_tools` options and the `canUseTool` callback.
+
+This page covers how the two layers compose. For mode semantics themselves, see [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md).
+
+## Evaluation order
+
+When Claude requests a tool inside an SDK session:
+
+1. **Hooks** run first (same hook events as CLI). They can allow, deny, or fall through.
+2. **Deny rules** (`disallowed_tools` + `settings.json` deny) — always win, even in `bypassPermissions`.
+3. **Permission mode** decides: `bypassPermissions` approves everything else; `acceptEdits` approves file ops; other modes fall through.
+4. **Allow rules** (`allowed_tools` + `settings.json` allow) — approve if matched.
+5. **`canUseTool` callback** — your code decides. Skipped entirely in `dontAsk` (tool is denied).
+
+## Allow and deny lists
+
+```python
+options = ClaudeAgentOptions(
+    allowed_tools=["Read", "Grep"],        # pre-approved
+    disallowed_tools=["Bash"],             # always denied
+)
+```
+
+**Key nuance:** `allowed_tools` adds entries to the **allow rule list**. It does **not** restrict which tools exist. Unlisted tools fall through to the permission mode.
+
+| Config | Outcome |
+|--------|---------|
+| `allowed_tools=["Read"]`, mode=`default` | `Read` auto-approved; `Bash` falls to `canUseTool` |
+| `allowed_tools=["Read"]`, mode=`bypassPermissions` | `Read` approved; **every other tool also approved** — `bypassPermissions` skips the allow-rule layer |
+| `disallowed_tools=["Bash"]`, mode=`bypassPermissions` | `Bash` denied; everything else approved |
+| `allowed_tools=["Read"]`, mode=`dontAsk` | `Read` approved; everything else denied silently |
+
+**Rule of thumb:** `allowed_tools` pre-approves; `disallowed_tools` hard-blocks. Use both together for a locked-down surface.
+
+## The `canUseTool` callback
+
+`canUseTool` is the SDK's runtime-decision hook. It fires for every tool call that isn't resolved by hooks, deny rules, the mode, or allow rules. Your callback returns an approval decision with optional input modification.
+
+```typescript
+const options = {
+  canUseTool: async (toolName, input) => {
+    if (toolName === "Write" && input.file_path?.includes("/.env")) {
+      return { behavior: "deny", message: "Writes to .env blocked" };
+    }
+    return { behavior: "allow", updatedInput: input };
+  },
+};
+```
+
+```python
+async def can_use_tool(tool_name, input, context):
+    if tool_name == "Write" and "/.env" in input.get("file_path", ""):
+        return {"behavior": "deny", "message": "Writes to .env blocked"}
+    return {"behavior": "allow", "updatedInput": input}
+
+options = ClaudeAgentOptions(can_use_tool=can_use_tool)
+```
+
+Uses:
+- Run a user-facing prompt to approve/deny
+- Enforce app-specific policies the declarative rules don't cover
+- Modify tool input (redact secrets, normalize paths) before execution
+- Log every tool call for audit
+
+In `dontAsk` mode the callback is **skipped** — unmatched tools are denied outright.
+
+## Plugin-author patterns
+
+### Pattern 1: Validator with a locked tool surface
+
+A plugin validator running via the SDK should pin its permissions:
+
+```python
+options = ClaudeAgentOptions(
+    allowed_tools=["Read", "Grep", "Glob"],
+    disallowed_tools=["Write", "Edit", "Bash"],
+    permission_mode="dontAsk",  # denials are silent, no callback needed
+)
+```
+
+This is the minimum surface for a read-only inspection agent.
+
+### Pattern 2: `canUseTool` with a quarantine allowlist
+
+For plugin test harnesses that need Bash but only for a small set of commands:
+
+```python
+SAFE_BASH = {"npm test", "npm run lint", "git status"}
+
+async def can_use_tool(name, input, ctx):
+    if name == "Bash":
+        cmd = input.get("command", "").strip()
+        if cmd in SAFE_BASH:
+            return {"behavior": "allow", "updatedInput": input}
+        return {"behavior": "deny", "message": f"Bash command not in allowlist: {cmd}"}
+    return {"behavior": "allow", "updatedInput": input}
+```
+
+### Pattern 3: Dynamic mode escalation
+
+Start strict, loosen as the session proves safe:
+
+```python
+q = query(prompt="...", options=ClaudeAgentOptions(permission_mode="default"))
+# ... review first few tool calls ...
+await q.set_permission_mode("acceptEdits")  # loosen mid-session
+```
+
+### Pattern 4: Respect plugin-packaged agent restrictions
+
+If your SDK app loads skills and agents from a plugin (via `settingSources=["project"]` + installed plugin), remember:
+- Plugin-packaged agent `permissionMode` frontmatter is **silently ignored**
+- Plugin-packaged agent `hooks` frontmatter is **silently ignored**
+- Plugin-packaged agent `mcpServers` frontmatter is **silently ignored**
+
+These are security restrictions. If your plugin needs per-agent permission overrides, ship as a user/project agent, not inside the plugin.
+
+## Subagent inheritance
+
+When the parent uses `bypassPermissions`, `acceptEdits`, or `auto`, **subagents inherit that mode** and cannot override it. A subagent with a less-constrained prompt can take risky actions under inherited permissions. Audit subagent `prompt` strings with this in mind — and prefer `default` + explicit allow rules for sensitive agents.
+
+See [`subagents-sdk.md`](subagents-sdk.md) for subagent inheritance details.
+
+## See Also
+
+- [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md) — mode behavior table
+- [`../06-hooks/writing-hooks.md`](../06-hooks/writing-hooks.md) — hooks run before allow/deny rules
+- [`subagents-sdk.md`](subagents-sdk.md) — permission inheritance into subagents
+- Upstream: [Configure permissions](https://docs.claude.com/en/agent-sdk/permissions), [canUseTool callback](https://docs.claude.com/en/agent-sdk/user-input)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/structured-outputs.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/structured-outputs.md
@@ -1,0 +1,163 @@
+# Structured Outputs (Agent SDK)
+
+Structured outputs force the agent to return a JSON object conforming to a schema you provide. The result arrives validated and type-checked — no regex parsing of free-form responses.
+
+For plugin authors, this is **how you expose machine-readable output from agent-driven commands**. If your plugin's validator, lint runner, or audit command is implemented via the SDK, structured outputs are what CI consumes.
+
+## Why it matters for plugins
+
+Without structured outputs:
+- CI scripts parse agent prose with regex → brittle
+- Downstream tooling can't consume agent results reliably
+- The agent can phrase the same result fifty ways
+
+With structured outputs:
+- One schema contract between the agent and every consumer
+- `structured_output` is validated before you see it
+- Type-safe parsing with Zod (TS) or Pydantic (Python)
+
+## Quick start
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const schema = {
+  type: "object",
+  properties: {
+    company_name: { type: "string" },
+    founded_year: { type: "number" },
+    headquarters: { type: "string" },
+  },
+  required: ["company_name"],
+};
+
+for await (const msg of query({
+  prompt: "Research Anthropic and return key info",
+  options: {
+    outputFormat: { type: "json_schema", schema },
+  },
+})) {
+  if (msg.type === "result" && msg.subtype === "success" && msg.structured_output) {
+    console.log(msg.structured_output);
+    // { company_name: "Anthropic", founded_year: 2021, headquarters: "San Francisco, CA" }
+  }
+}
+```
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions, ResultMessage
+
+schema = {
+    "type": "object",
+    "properties": {
+        "company_name": {"type": "string"},
+        "founded_year": {"type": "number"},
+        "headquarters": {"type": "string"},
+    },
+    "required": ["company_name"],
+}
+
+async for msg in query(
+    prompt="Research Anthropic and return key info",
+    options=ClaudeAgentOptions(output_format={"type": "json_schema", "schema": schema}),
+):
+    if isinstance(msg, ResultMessage) and msg.structured_output:
+        print(msg.structured_output)
+```
+
+The validated result appears on the `ResultMessage` (Python) / result message (TS) as `structured_output`.
+
+## Schemas via Zod / Pydantic
+
+Writing JSON Schema by hand is tedious and un-type-safe. Generate it from Zod (TS) or Pydantic (Python):
+
+```typescript
+import { z } from "zod";
+
+const FeaturePlanSchema = z.object({
+  summary: z.string(),
+  steps: z.array(z.object({
+    description: z.string(),
+    complexity: z.enum(["low", "medium", "high"]),
+  })),
+  risks: z.array(z.string()),
+});
+
+const jsonSchema = z.toJSONSchema(FeaturePlanSchema);
+// pass jsonSchema to options.outputFormat.schema
+```
+
+```python
+from pydantic import BaseModel
+
+class Step(BaseModel):
+    description: str
+    complexity: str  # "low" | "medium" | "high"
+
+class FeaturePlan(BaseModel):
+    summary: str
+    steps: list[Step]
+    risks: list[str]
+
+# FeaturePlan.model_json_schema() returns the JSON Schema to pass
+```
+
+Both SDKs use **standard JSON Schema** — all basic types, `enum`, `const`, `required`, nested objects, and `$ref` definitions are supported. See the upstream [JSON Schema limitations](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations) page for exceptions.
+
+## `output_format` configuration
+
+| Field | Description |
+|-------|-------------|
+| `type` | Always `"json_schema"` for structured outputs |
+| `schema` | JSON Schema object. Generate from Zod / Pydantic or write inline. |
+
+No other fields are required. The validator runs automatically before your consumer code sees the result.
+
+## Plugin-author patterns
+
+### Pattern 1: Validator output contract
+
+A plugin validator command returns a consistent result shape. Define once, use everywhere:
+
+```python
+from pydantic import BaseModel
+
+class ValidationIssue(BaseModel):
+    file: str
+    line: int | None = None
+    severity: str  # "error" | "warning" | "info"
+    code: str
+    message: str
+
+class ValidationResult(BaseModel):
+    passed: bool
+    total_issues: int
+    issues: list[ValidationIssue]
+
+schema = ValidationResult.model_json_schema()
+# use schema in your plugin's SDK-driven validator
+```
+
+Routines and CI scripts can now parse `structured_output` directly instead of scraping text.
+
+### Pattern 2: REVIEW.md / code-review plugins
+
+Code-review plugins benefit heavily — structured output lets you emit PR review comments deterministically. See [`../10-distribution/`](../10-distribution/) for the REVIEW.md pattern.
+
+### Pattern 3: Paper-test harness
+
+When you're running the `code-paper-test` plugin's `/paper-test` against a plugin component via the SDK, force structured outputs so the harness can aggregate pass/fail across runs.
+
+## Error handling
+
+Two failure modes:
+- **Schema-validation failure** — the agent produced output the schema rejected. Check `msg.subtype` and the error fields on the result message. The agent sometimes needs prompt refinement to match complex schemas.
+- **Runtime error** — underlying API or tool failure. Handle as with any SDK query.
+
+Keep schemas **tight but not rigid**: required fields for things the agent must always produce, optional fields for things it might not find. Over-constrained schemas cause repeated validation failures.
+
+## See Also
+
+- [`overview.md`](overview.md) — Agent SDK overview
+- [`../10-distribution/`](../10-distribution/) — CI integration patterns
+- Upstream: [Structured Outputs](https://docs.claude.com/en/agent-sdk/structured-outputs), [Build with Claude — structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/subagents-sdk.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/subagents-sdk.md
@@ -1,0 +1,135 @@
+# Subagents in the SDK
+
+Plugin authors defining subagents inside a plugin use Markdown frontmatter (`.claude/agents/*.md`) — see [`../05-agents/writing-agents.md`](../05-agents/writing-agents.md). The Agent SDK offers a **programmatic** alternative: define subagents inline in your code. The two approaches are complementary, not competing.
+
+Use programmatic definitions when:
+- Your plugin ships an SDK-based companion that builds agents dynamically at runtime
+- Agent configuration depends on user input or runtime state
+- You need different agents per request (e.g. strict vs lenient reviewer based on risk)
+- You're writing test harnesses that spawn throwaway agents
+
+## Markdown vs programmatic — field parity
+
+| Markdown frontmatter | SDK `AgentDefinition` | Notes |
+|----------------------|-----------------------|-------|
+| `description:` | `description` | Natural-language activation trigger |
+| body (system prompt) | `prompt` | Required in SDK; Markdown body is the system prompt |
+| `tools:` | `tools` | Array of allowed tool names |
+| `model:` | `model` | `sonnet` / `opus` / `haiku` / `inherit` |
+| `skills:` | `skills` | Named skills loaded into the subagent |
+| `memory:` | `memory` | `user` / `project` / `local` (Python only) |
+| `mcpServers:` | `mcpServers` | Name reference or inline config |
+| `permissionMode:` | — inherited from parent | SDK subagents inherit parent's permission mode; frontmatter value is ignored in plugin-packaged Markdown agents too |
+| `hooks:` | — via parent `hooks` option | Scope hooks via the parent's config; plugin-packaged agent `hooks` are silently ignored |
+
+Programmatic definitions **take precedence** when both exist with the same name.
+
+## Minimum programmatic example
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+for await (const msg of query({
+  prompt: "Review auth.ts for security issues",
+  options: {
+    allowedTools: ["Read", "Grep", "Glob", "Agent"],  // Agent required to spawn subagents
+    agents: {
+      "code-reviewer": {
+        description: "Security-focused code reviewer. Use for quality and security audits.",
+        prompt: "You are a security reviewer...",
+        tools: ["Read", "Grep", "Glob"],
+        model: "sonnet",
+      },
+    },
+  },
+})) {
+  if ("result" in msg) console.log(msg.result);
+}
+```
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions, AgentDefinition
+
+async for msg in query(
+    prompt="Review auth.py for security issues",
+    options=ClaudeAgentOptions(
+        allowed_tools=["Read", "Grep", "Glob", "Agent"],
+        agents={
+            "code-reviewer": AgentDefinition(
+                description="Security-focused code reviewer. Use for quality and security audits.",
+                prompt="You are a security reviewer...",
+                tools=["Read", "Grep", "Glob"],
+                model="sonnet",
+            ),
+        },
+    ),
+):
+    if hasattr(msg, "result"):
+        print(msg.result)
+```
+
+The **`Agent` tool** must be in `allowedTools` — it's the mechanism Claude uses to spawn subagents. Without it, defining agents has no effect.
+
+## What subagents inherit
+
+A subagent starts with a **fresh context window**. The only channel from parent to subagent is the prompt string the parent writes into the `Agent` tool call.
+
+| Subagent receives | Subagent does NOT receive |
+|-------------------|---------------------------|
+| Its own system prompt (`AgentDefinition.prompt`) + the Agent-tool prompt | Parent conversation history or tool results |
+| Project `CLAUDE.md` (only if `settingSources` includes `project`) | Skills — unless listed in `skills` |
+| Tool definitions (inherited or restricted via `tools`) | Parent's system prompt |
+
+**Design implication:** include every file path, error message, or decision the subagent needs **in the `Agent` tool prompt**. The parent's memory of the task is not transferred.
+
+## Automatic vs explicit invocation
+
+- **Automatic**: Claude reads each `description` and routes tasks that match. Write specific, action-oriented descriptions to improve routing.
+- **Explicit**: mention the subagent by name in your prompt — `"Use the code-reviewer agent to..."` — to bypass auto-routing.
+
+## Dynamic configuration pattern
+
+Factory functions return `AgentDefinition` based on runtime state. Useful for:
+- Plan-tier escalation (cheap model for free users, stronger for paid)
+- Strictness flags (lenient vs strict reviewer)
+- Per-tenant customization
+
+```python
+def create_security_agent(level: str) -> AgentDefinition:
+    is_strict = level == "strict"
+    return AgentDefinition(
+        description="Security code reviewer",
+        prompt=f"You are a {'strict' if is_strict else 'balanced'} reviewer...",
+        tools=["Read", "Grep", "Glob"],
+        model="opus" if is_strict else "sonnet",
+    )
+
+options = ClaudeAgentOptions(
+    allowed_tools=["Read", "Grep", "Glob", "Agent"],
+    agents={"security-reviewer": create_security_agent("strict")},
+)
+```
+
+## Sessions
+
+The SDK also exposes **sessions** — multi-turn conversations with state. A single `query()` call is a one-shot; sessions let you keep a conversation alive across prompts:
+
+- **Python**: create a session object and call `.send()` / iterate messages; persist state across interactions
+- **TypeScript**: similar pattern via the session helpers in `@anthropic-ai/claude-agent-sdk`
+
+Sessions are what power long-running agent applications (customer-support bots, IDE integrations). For one-off scripted runs (CI validators, test harnesses), `query()` is enough.
+
+See [Sessions guide](https://docs.claude.com/en/agent-sdk/sessions) for the full API.
+
+## Caveats
+
+- **Subagents cannot spawn subagents.** Do not include `Agent` in a subagent's `tools` array.
+- **`general-purpose` is available by default.** Even without custom agents, if `Agent` is in `allowedTools` Claude can spawn the built-in general-purpose subagent.
+- **Permission inheritance is strict.** When the parent uses `bypassPermissions`, `acceptEdits`, or `auto`, subagents inherit that mode and cannot override it. Subagents with less-constrained prompts can take dangerous actions under inherited permissions — audit your `AgentDefinition.prompt` strings with this in mind.
+
+## See Also
+
+- [`permissions.md`](permissions.md) — SDK permission handling
+- [`../05-agents/writing-agents.md`](../05-agents/writing-agents.md) — Markdown-defined agents in plugins
+- [`../08-configuration/permission-modes.md`](../08-configuration/permission-modes.md) — mode inheritance rules
+- Upstream: [Subagents in the SDK](https://docs.claude.com/en/agent-sdk/subagents), [Sessions](https://docs.claude.com/en/agent-sdk/sessions)

--- a/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/tool-search.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/11-agent-sdk/tool-search.md
@@ -1,0 +1,95 @@
+# Tool Search (Agent SDK)
+
+Tool search lets the agent work with **hundreds or thousands of tools** without loading every tool definition into context. The agent searches a catalog and loads the 3–5 most relevant tools on demand.
+
+This matters for plugin authors when:
+- Your plugin exposes dozens of MCP tools and you don't want them all in every user's context
+- You're building an SDK app that connects to multiple remote MCP servers
+- Tool selection accuracy matters (degrades past ~30–50 tools loaded at once)
+
+Tool search is **enabled by default** in the SDK.
+
+## The problem it solves
+
+Two scaling problems hit plugin authors around ~30–50 tools:
+
+1. **Context bloat.** 50 tools can use **10–20K tokens** of context just for definitions — before any actual work happens.
+2. **Selection accuracy.** Past ~30–50 tools in context, Claude's ability to pick the right tool drops noticeably.
+
+Tool search trades one upfront **search round-trip** for a smaller context on every turn. For small tool sets (<~10 tools), eager loading is still faster — use `ENABLE_TOOL_SEARCH=false` in that case.
+
+## Configuration
+
+Via the `ENABLE_TOOL_SEARCH` environment variable (set in process env or `options.env`):
+
+| Value | Behavior |
+|-------|----------|
+| unset / `true` | Always on. Tool defs never loaded into context upfront. Default. |
+| `auto` | Activates when tool defs exceed **10%** of the context window; otherwise loads all upfront. |
+| `auto:N` | Same as `auto` with threshold `N%`. `auto:5` activates at 5%, lower values activate sooner. |
+| `false` | Always off. All tool defs loaded every turn. |
+
+## Minimum example
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+for await (const msg of query({
+  prompt: "Find and run the appropriate database query",
+  options: {
+    mcpServers: {
+      "enterprise-tools": { type: "http", url: "https://tools.example.com/mcp" },
+    },
+    allowedTools: ["mcp__enterprise-tools__*"],  // wildcard pre-approves all
+    env: { ENABLE_TOOL_SEARCH: "auto:5" },
+  },
+})) {
+  // ...
+}
+```
+
+```python
+options = ClaudeAgentOptions(
+    mcp_servers={"enterprise-tools": {"type": "http", "url": "https://tools.example.com/mcp"}},
+    allowed_tools=["mcp__enterprise-tools__*"],
+    env={"ENABLE_TOOL_SEARCH": "auto:5"},
+)
+```
+
+## Optimize tool discovery
+
+Search matches against tool **names** and **descriptions**. Plugin-author takeaways:
+
+1. **Use descriptive tool names.** `search_slack_messages` surfaces on more queries than `query_slack`.
+2. **Write keyword-rich descriptions.** "Search Slack messages by keyword, channel, or date range" beats "Query Slack" by a wide margin.
+3. **Categorize in your system prompt.** Add a hint: `"You can search for tools to interact with Slack, GitHub, and Jira."` — this gives the agent context about what's searchable.
+
+## Limits
+
+- **Maximum tools**: 10,000 per catalog
+- **Search returns**: 3–5 most relevant tools per search
+- **Model support**: Sonnet 4+, Opus 4+ — **no Haiku**
+
+## Plugin-author patterns
+
+### Pattern 1: Many MCP tools in one plugin
+
+If your plugin exposes 20+ MCP tools, tool search is how users get acceptable performance. Document the `ENABLE_TOOL_SEARCH=auto:5` env var in your plugin README.
+
+### Pattern 2: Deferred over eager
+
+The Claude Code harness also has a "deferred tools" mechanism exposed via `ToolSearch`. The SDK's tool search operates on the **same idea at the MCP layer**: tool definitions aren't loaded until the agent searches for them. Use this when a plugin bundles a large tool catalog alongside a thin user-facing skill.
+
+### Pattern 3: Small-set opt-out
+
+If your plugin exposes <10 tools and the user is running through the SDK, set `ENABLE_TOOL_SEARCH=false` to skip the search round-trip. Faster first response, same context cost.
+
+## Compaction interaction
+
+When the SDK compacts earlier messages to free context, **previously discovered tools may be removed** from the active set. The agent will search again as needed. This is usually transparent, but for very long sessions you may see repeated searches for the same tool.
+
+## See Also
+
+- [`custom-tools.md`](custom-tools.md) — building tools the search catalog covers
+- [`../02-philosophy/core-philosophy.md`](../02-philosophy/core-philosophy.md) — context-budget guidance
+- Upstream: [Tool Search](https://docs.claude.com/en/agent-sdk/tool-search), [Tool Search in the API](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)

--- a/plugin-creation-tools/skills/plugin-creation/templates/hooks/hooks.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/hooks/hooks.json.template
@@ -24,6 +24,20 @@
         ]
       }
     ],
+
+    "// if field example": "Use 'if' for cheap per-handler pre-spawn filtering on tool events. Avoids spawning a process just to check and exit 0.",
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(rm *)",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-destructive-rm.sh"
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/plugin-creation-tools/skills/plugin-creation/templates/skill/SKILL.md.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/skill/SKILL.md.template
@@ -1,7 +1,23 @@
 ---
 name: skill-name
-description: Use when [specific triggers] - [what it does in third person]. Use when user says "[trigger phrase]".
+description: "[Action verb phrase — what the skill produces or does, third person]. Use when user says '[phrase 1]', '[phrase 2]', '[phrase 3]'. [Optional negative trigger: Do NOT use for X.]"
 ---
+
+<!--
+  Description tips:
+  - Quoted YAML form is safer for multi-sentence descriptions.
+  - Enumerate 3-6 literal user utterances after "Use when user says".
+  - Use concrete action verbs + artifacts, not domain labels.
+  - Combined description + when_to_use is capped at 1,536 characters
+    in the skill listing — front-load the key use case.
+  - Preserve PROACTIVELY / MUST / NEVER imperatives if your skill
+    genuinely needs strong activation. Don't strip them to hit a
+    "conciseness" score.
+  - If you use !`command` dynamic injections, keep them — they are
+    a documented Claude Code feature.
+  See references/03-skills/description-patterns.md for details.
+-->
+
 
 # Skill Name
 


### PR DESCRIPTION
## Summary

Brings `plugin-creation-tools` from v3.1.0 → **v3.2.0** to match the 132-guide pinned snapshot of the Claude Code docs as of 2026-04-19. This is the reference plugin for authoring Claude Code plugins, so accuracy matters — it's consumed by `/plugin-creation-tools:create`, `/plugin-creation-tools:add-component`, and `/plugin-creation-tools:validate` in both camoa-skills and palcera_skills.

Plan: [`plugin-creation-tools-improvement-plan.md`](../../../claude_code_projects/claude_docs/docs/improvements/plugin-creation-tools-improvement-plan.md) (local)
Findings: [`plugin-creation-tools-findings.md`](../../../claude_code_projects/claude_docs/docs/improvements/plugin-creation-tools-findings.md) (local)

## Tracks landed

- [x] **Track B — Hooks**: 4 new events (`PermissionDenied`, `CwdChanged`, `FileChanged`, `TaskCreated`, total 26). New `if` pre-spawn filter section with before/after. Matcher semantics rewrite (exact-string-vs-regex-by-character-content). Permission Mode Interaction section. New patterns for FileChanged watch-mode lint / PermissionDenied retry / TaskCreated tracking. `if` demonstrated in `hooks.json.template`.
- [x] **Track C — Configuration**: Plugin Dependencies in `plugin-json.md` (`dependencies` array, semver ranges, `{name}--v{version}` tag convention, resolution intersection, the three official error codes). Marketplace-author responsibilities in `marketplace-json.md`. New `permission-modes.md` with the full six-mode behavior table and hook-per-mode matrix. Cross-links from `05-agents/`.
- [x] **Track D — Overview + Testing + Philosophy**: New `claude-directory.md` with precedence tables and `--add-dir` interaction. New `09-testing/errors.md` aligned with upstream error-code taxonomy. `core-philosophy.md` rewritten with the upstream-documented context-budget numbers.
- [x] **Track A — Agent SDK**: New `references/11-agent-sdk/` directory (9 files): `overview`, `migration`, `custom-tools`, `subagents-sdk`, `permissions`, `structured-outputs`, `tool-search`, `observability`, `agent-loop`. Global `Claude Code SDK` → `Agent SDK` rename pass (no stale non-intentional hits).
- [x] **Track E — Distribution**: New `review-md-v2.md` (two-file model, starter REVIEW.md scoped to plugin-repo concerns, `/ultrareview` callout) and `routines-auto-validate.md` (GitHub-triggered Routine that runs `/plugin-creation-tools:validate` on every PR — closes the `feedback_always_validate_plugins` loop).
- [x] **Track F — Plugin self-improvement**: `validate.md` expanded (dependencies checks, all 26 event names, version-drift between plugin.json and marketplace.json, SDK rename checks, imperative/`!`-injection preservation checks, broader `$CLAUDE_PROJECT_DIR`/`PLUGIN_ROOT`/`PLUGIN_DATA` quoting check). `plugin-structure-auditor.md` extended with Performance Review for broad matchers without `if`, new Dependency Review + SDK Rename Review sections with self-documentation exemptions. `skill-quality-reviewer.md` rubric expanded with findings §14 anti-patterns and a scope note for reference docs.
- [x] **Track H — Skill description quality patterns**: Trigger Phrase Enumeration, Action Verbs + Artifacts, Synonym Coverage, Quoted YAML Form, and a "Don't Let Scoring Tools Strip Intent" callout in `description-patterns.md`. SKILL.md template updated with the authoring checklist.
- [x] **Track G — Examples**: `full-featured-plugin` now demonstrates the `if` field (PreToolUse `Bash(rm *)` guard) and a constrained plugin dependency (`simple-greeter ^1.0.0`). README points to the new 11-agent-sdk directory. `simple-greeter` verified still passes (no changes needed).

## Version bumps

| File | From | To |
|------|------|-----|
| `plugin-creation-tools/.claude-plugin/plugin.json` → `version` | 3.1.0 | **3.2.0** |
| `plugin-creation-tools/skills/plugin-creation/SKILL.md` frontmatter → `version` | 3.0.0 | **3.2.0** |
| Root `.claude-plugin/marketplace.json` → plugin entry `version` | 3.1.0 | **3.2.0** |
| Root `.claude-plugin/marketplace.json` → `metadata.version` | 1.13.0 | **1.14.0** |
| CHANGELOG.md | — | new `[3.2.0] - 2026-04-20` entry stacked above the existing `[3.1.0]` |

Metadata version bump triggers auto-update for installed users.

## Validation

Run before opening this PR:

- [x] TODO/FIXME grep across all new reference files: **zero hits**
- [x] Cold `/plugin-creation-tools:validate` audit on `dev-guides-navigator` using the v3.2.0 validator: PASS, 3 minor warnings — validator's own feedback surfaced 2 scope bugs (`CLAUDE_PLUGIN_ROOT` quoting, anthropic-skill-standards scope), both fixed in `0ae62a7`
- [x] Cold `plugin-structure-auditor` run on `plugin-creation-tools` itself using the v3.2.0 auditor: 52/60 — feedback surfaced 4 auditor issues (SDK rename self-documenting-file exemption, false `settings.json` requirement, marketplace.json criterion scope, output format missing new section slots), all fixed in `676f605`
- [x] Cold `skill-quality-reviewer` run on `11-agent-sdk/overview.md` + `08-configuration/permission-modes.md`: A- / A — feedback surfaced 1 accuracy issue (overly-specific SDK version number) and 1 rubric applicability issue (reviewer was SKILL.md-overfit), both fixed in `676f605`
- [x] `grep -rn "Claude Code SDK" plugin-creation-tools/` — remaining hits are all intentional (migration.md, auditor/validator/reviewer checklists that detect the rename, CHANGELOG, this PR body)
- [x] `plugin.json` and `hooks.json` in `examples/full-featured-plugin/` parse as valid JSON with the new `dependencies` entry and `if`-field handler
- [x] Branch is 12 ahead of `origin/main`, **0 behind** — no main commits missed

## Plan deviations (from the plan's Source-Doc-Wins rule)

1. **Skill-description budget**: Plan stated 2% context window / 16,000-character fallback. Upstream `Skills` guide says **1% / 8,000-char fallback / 1,536-char per-entry cap**. Used upstream numbers across `core-philosophy.md`, `description-patterns.md`, `skill-quality-reviewer.md`, and `claude-directory.md`. Plan D3 and findings §9 already updated.
2. **Version number**: Plan said `3.0.0 → 3.1.0`. By the time execution started, `3.1.0` had already shipped on 2026-04-08 for an unrelated PreCompact-hook change. Bumped to **3.2.0** instead; preserved the existing `[3.1.0]` CHANGELOG entry untouched and stacked the `[3.2.0]` entry above it.

## Test plan

- [ ] Reviewer skims `references/11-agent-sdk/overview.md` + `migration.md` to spot-check the Agent SDK rename coverage
- [ ] Reviewer skims `references/08-configuration/permission-modes.md` for the hook-per-mode table accuracy
- [ ] Reviewer confirms `examples/full-featured-plugin/hooks/hooks.json` has valid `if: "Bash(rm *)"` syntax
- [ ] Reviewer confirms `plugin.json` + marketplace `version` entries both read `3.2.0`
- [ ] Optional: run `/plugin-creation-tools:validate` against another plugin in this marketplace after merge and confirm the new checks (dependencies, 26 events, SDK rename, `if`-suggestion) fire as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)