### PR TITLE
feat(dev-guides-navigator): v0.4.0 — Summary-column awareness + fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.1"
+    "version": "1.14.2"
   },
   "plugins": [
     {
       "name": "dev-guides-navigator",
       "source": "./dev-guides-navigator",
       "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "camoa"
       },

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guides-navigator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"

--- a/dev-guides-navigator/CHANGELOG.md
+++ b/dev-guides-navigator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.0 (2026-04-20)
+
+### Added
+- Awareness of `tldr:` frontmatter and Summary column in topic routing tables
+- Pre-filter workflow step to pick between candidate guides without fetching each
+
+### Fixed
+- SKILL.md frontmatter version was 0.2.0, out of sync with plugin.json 0.3.0
+- Example in SKILL.md referenced non-existent `drupal/solid/` topic (actual: `drupal/solid-principles/`); also corrected the "NOT" reference from `dev-solid-principles` to `development/solid-principles`
+
 ## 0.3.0 (2026-04-08)
 
 ### Changed

--- a/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-guides-navigator
 description: Use when ANY development task might benefit from a guide. Use when user says "how do I", "best practice", "pattern for", "guide for", "Drupal form", "entity type", "plugin type", "routing", "caching", "config management", "SDC component", "design system", "Bootstrap mapping", "Radix theme", "JSX to Twig", "Tailwind tokens", "SOLID", "DRY", "TDD", "security", "CSS", "Next.js". Use PROACTIVELY before any design, architecture, or implementation work. MUST be invoked before writing code that touches Drupal APIs, theming, design systems, or security. NEVER skip guide check — patterns prevent bugs.
-version: 0.2.0
+version: 0.4.0
 allowed-tools: Read, Bash, Glob, Grep, Write
 user-invocable: true
 ---
@@ -75,7 +75,20 @@ The `guide-meta:` in the topic's frontmatter provides:
 | stories.yml preview | drupal/storybook | drupal/ui-patterns | reverse |
 | inline blocks | drupal/layout-builder | drupal/blocks | "inline blocks" in blocks' not |
 
-### 5. Fetch Specific Guide
+### 5. Pre-filter by Summary (NEW)
+
+The routing table in `index.md` now has 3 columns: **I need to... | Guide | Summary**.
+
+When the user's request maps to multiple candidate rows:
+- Read the Summary column for each candidate (already in the fetched `index.md` — no new fetch)
+- Pick the guide whose Summary best matches the user's specific need
+- Then fetch that one guide (step 6)
+
+When only one row matches: skip to step 6.
+
+**Do NOT fetch individual guides just to read their `tldr:`** — that's the same cost as fetching the full guide. The Summary column exists so you don't have to.
+
+### 6. Fetch Specific Guide
 
 From the "I need to..." routing table, select the guide that matches the task. The routing table lists guide filenames. Fetch the raw markdown:
 
@@ -87,7 +100,7 @@ Example: `curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/d
 
 **Do NOT use WebFetch on GitHub Pages URLs** — you'll get rendered HTML, not the guide content.
 
-### 6. Apply the Guide (Critical)
+### 7. Apply the Guide (Critical)
 
 **Do NOT just read and summarize.** Extract and apply:
 
@@ -104,6 +117,7 @@ Example: `curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/d
 | Find topic | Match task keywords in cached `llms.txt` |
 | Get routing table | `curl -s` raw GitHub URL for topic `index.md` |
 | Disambiguate | Check `guide-meta:` concepts/not fields |
+| Pre-filter | Read Summary column in routing table; pick best-match guide |
 | Get guide | `curl -s` raw GitHub URL for specific guide `.md` |
 | Apply | Extract patterns and implement, don't summarize |
 
@@ -125,7 +139,8 @@ Example: `curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/d
 | "Add a story.yml for my component" | Match "story.yml" → check guide-meta → `drupal/ui-patterns/` (NOT storybook) |
 | "Set up responsive images" | Match "responsive image" → `drupal/image-styles/` (NOT drupal/media) |
 | "How do I use Config Split?" | Match "Config Split" → `drupal/config-management/` |
-| "I need SOLID architecture for my module" | Drupal context → `drupal/solid/` (NOT generic dev-solid-principles) |
+| "I need SOLID architecture for my module" | Drupal context → `drupal/solid-principles/` (NOT generic `development/solid-principles`) |
+| "Build a FormBase vs ConfigFormBase" | index.md routing table has both → read Summary column → FormBase Summary mentions entity forms, ConfigFormBase mentions config → pick based on user context |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Implements the [dev-guides-navigator improvement plan](../../claude_code_projects/claude_docs/docs/improvements/dev-guides-navigator-improvement-plan.md) (v0.3.0 → v0.4.0). Documentation-only change driven by sibling `camoa/dev-guides` now shipping `tldr:` frontmatter + Summary column in every topic routing table.

- **Track A** — Teach skill to pre-filter candidates via the Summary column (new step 5 between KG Metadata and Fetch Guide; renumbered downstream steps; Quick Reference row added; new FormBase-vs-ConfigFormBase example).
- **Track B** — Sync SKILL.md frontmatter version (0.2.0 → 0.4.0) with plugin.json (0.3.0 → 0.4.0); bump marketplace entry to 0.4.0 and marketplace metadata 1.14.1 → 1.14.2 (patch, per pointer-update rule). Fixed dead example `drupal/solid/` → `drupal/solid-principles/` and `dev-solid-principles` → `development/solid-principles`. CHANGELOG 0.4.0 entry.
- **Track C** — References audit no-op. `cache-format.md` and `manifest-schema.md` do not reference old first-match/fetch-to-compare behavior; no edits required.

## URL verification (all 200)

```
drupal/solid-principles/index.md        → 200
development/solid-principles/index.md   → 200
llms.hash                                → 200
llms.txt                                 → 200
drupal/forms/index.md                    → 200
```

## Quality gates

- `plugin-creation-tools:validate` — structural checks pass (JSON valid, versions sync across SKILL.md / plugin.json / marketplace entry, all 0.4.0)
- `plugin-creation-tools:skill-quality-reviewer` — A grade. One issue raised (Quick Reference missing new step) — fixed in same commit.

## Test plan

- [ ] SKILL.md `version:` and plugin.json `"version"` both `0.4.0`
- [ ] marketplace.json entry for `dev-guides-navigator` is `0.4.0`; metadata.version `1.14.2`
- [ ] New step 5 "Pre-filter by Summary" between KG Metadata and Fetch Specific Guide; subsequent steps renumbered (6, 7)
- [ ] Quick Reference table includes "Pre-filter" row
- [ ] `grep "drupal/solid/\|dev-solid-principles"` in SKILL.md returns nothing
- [ ] CHANGELOG 0.4.0 entry present

## Out of scope

- `.worktrees/` gitignore addition (plan flags as separate follow-up; no `.gitignore` exists in repo yet).
- 2026-04-19 Claude Code refresh features (Agent SDK, Plugin Dependencies, Permission Modes, new hook events) — none apply to this plugin's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)