### PR TITLE
drupal-dev-framework v3.9.0: task phase guidance (epic sub-task 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging. Requires: dev-guides-navigator.",
-      "version": "3.8.0",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
+      "version": "3.9.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,11 +1,14 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams"]
+  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams"],
+  "dependencies": [
+    "dev-guides-navigator"
+  ]
 }

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2026-04-20
+
+### Added — Task Phase Guidance (sub-task 1 of dev-framework improvements epic)
+
+- **`context-reminder` UserPromptSubmit hook** (`hooks/context-reminder.sh`) — injects a compact task-context block into Claude's context on every user prompt when a framework task is active in the current workspace. Emits structured `additionalContext` JSON per the `UserPromptSubmit` spec. Surfaces:
+  - Active task name and current phase
+  - Task folder path and the v3.0.0 file convention (`task.md` / `research.md` / `architecture.md` / `implementation.md`) with a `◀ current` marker on the active-phase line
+  - Session-loaded dev-guides (capped at 20 with "+N more" suffix)
+  - Next recommended command
+  - Directly addresses: (a) Claude drifting back to monolithic task docs instead of the folder convention, (b) loaded dev-guides being ignored as context decays, (c) users losing track of which phase command comes next.
+- **`loadedGuides[]` and `lastPhase`** fields added to per-workspace `session_context.json`. Managed by `guide-integrator` (append on load, idempotent) and read by the `context-reminder` hook. Never clobbered by `session-context-writer` on subsequent writes (jq-based merge preserves existing values).
+- **Phase-transition soft nudge** in `/design` and `/implement` commands — on command entry, reads `## Phase Status` in `task.md`; if the prior phase isn't `[x]`, prints a one-line warning that points the user at the missing command, then proceeds. Never blocks — users remain in control.
+- **Plugin Dependency on `dev-guides-navigator`** declared in `.claude-plugin/plugin.json` (`dependencies: ["dev-guides-navigator"]`). Missing-dependency failures now surface at install time instead of silently at runtime. **Requires Claude Code v2.1.110 or later.**
+
+### Changed
+
+- **`session-context-writer` skill v1.3.0** — now uses `jq`-based merge to preserve `loadedGuides[]` and `lastPhase` across writes. Seeds both fields on first-write.
+- **`guide-integrator` skill v4.1.0** — records each loaded guide into `loadedGuides[]` using stable IDs (`plugin:<basename>` for methodology refs, topic paths for dev-guides). Checks `loadedGuides[]` before fetching — skips re-loads. This is the source-of-truth for "already loaded," replacing conversation-context heuristics.
+
+### Removed
+
+- **SessionStart soft dependency check** in `hooks/session-start.sh` — removed the 21-line runtime check that warned when `dev-guides-navigator` wasn't installed. Superseded by install-time enforcement via the new `dependencies` field.
+
+### Hardening (post-paper-test)
+
+- **10K-char truncation guard** added in `context-reminder.sh` before emit — Claude Code caps `additionalContext` at 10,000 chars and replaces overflow with a file-preview pointer; the guard ensures the reminder text always reaches the model.
+- **Phase-matching regex hardened** in `context-reminder.sh` — anchored to list-item lines (`^- [x] Phase N`) and requires `Phase N[^0-9]` so `n=1` no longer spuriously matches "Phase 10"/"Phase 11". Also accepts uppercase `[X]` checkboxes (normalized to `[x]` internally) and rejects prose lines that happen to contain `[x]` near the word "Phase".
+- **Corrupt-session self-heal** in `session-context-writer` — if the existing `session_context.json` fails `jq -e .` validation, the skill now reseeds from scratch instead of failing silently every subsequent write.
+- **Empty-guide-ID guard** in `guide-integrator` — an empty `{GUIDE_ID}` now exits early instead of polluting `loadedGuides[]` with `""`.
+- **Phase-nudge clarification** in `/design` and `/implement` — `{task_name}` placeholder explicitly marked as a substitution target (was "print exactly as shown", which conflicted with interpolation intent). `/implement` now evaluates Phase 1 and Phase 2 independently so a user who somehow has Phase 2 done but Phase 1 skipped still gets the Phase 1 warning.
+
+### Notes
+
+- Hook performance measured in-workspace: ~3ms for the no-session gate, ~17ms for the no-task gate, ~43ms for a full active-task render. Payload target ≤500 tokens.
+- `UserPromptSubmit` does not support `matcher` or the `if` pre-spawn filter (non-tool event). Workspace-level gating lives inside the script, using the per-workspace `session_context.json` hash (`md5("$PWD")`) as the implicit scope marker.
+- **Concurrent-write safety** (deferred): `session-context-writer` and `guide-integrator` both follow the `jq FILE > FILE.tmp && mv FILE.tmp FILE` pattern. In a two-window-same-workspace scenario, a race could drop one update. `flock` would eliminate it; not added since (a) session files are keyed per-workspace (different windows typically → different workspaces → different files) and (b) within a single Claude Code turn the skills run sequentially. Flag for follow-up if observed.
+
 ## [3.8.0] - 2026-04-08
 
 ### Fixed

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -20,17 +20,18 @@ Phases apply per task, not per project. A project can have tasks at different ph
 
 ## Installation
 
+**Requires Claude Code v2.1.110 or later** — the plugin declares `dev-guides-navigator` as a dependency in `plugin.json`, which is enforced at install time on CLI v2.1.110+. Earlier CLI versions will not resolve the dependency automatically; install `dev-guides-navigator` manually and upgrade the CLI.
+
 ```bash
 # Add marketplace
 /plugin marketplace add https://github.com/camoa/claude-skills
 
-# Install (both required)
-/plugin install dev-guides-navigator@camoa-skills
+# Install (installing drupal-dev-framework pulls dev-guides-navigator automatically on v2.1.110+)
 /plugin install drupal-dev-framework@camoa-skills
 ```
 
-**Required plugin:**
-- `dev-guides-navigator` — online guide discovery with caching (60+ Drupal/CSS/design guides). The framework loads these proactively at every phase.
+**Declared dependency:**
+- `dev-guides-navigator` — online guide discovery with caching (60+ Drupal/CSS/design guides). Enforced via `plugin.json` `dependencies`. Missing-dependency failures surface at install time.
 
 **Recommended companion plugins:**
 - `superpowers` — TDD enforcement, brainstorming, verification workflows

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -14,6 +14,20 @@ Design architecture for a specific task (Phase 2 of a task).
 /drupal-dev-framework:design <task-name>
 ```
 
+## Phase Transition Check (run FIRST, before any other step)
+
+Before doing anything else for this command, verify the prior phase is marked complete.
+
+1. Read `implementation_process/in_progress/{task_name}/task.md`.
+2. Locate the `## Phase Status` section.
+3. If the **Phase 1: Research** checkbox is not `[x]`, print this soft-nudge line to the user with `{task_name}` replaced by the actual task name passed to this command:
+
+   > ⚠ Phase 1 (Research) is not marked complete in `task.md`. Continuing with `/design` anyway. If research is incomplete, consider `/drupal-dev-framework:research {task_name}` first. (This is a nudge, not a block.)
+
+4. If Phase 1 is `[x]`, proceed silently.
+
+Never block the command on this check — the user is in control. The nudge exists so they notice out-of-order invocations without being fought by the tool.
+
 ## What This Does (v3.0.0)
 
 1. Loads task from `implementation_process/in_progress/{task_name}/`

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -14,6 +14,26 @@ Start implementing a specific task with full context loaded (Phase 3 of a task).
 /drupal-dev-framework:implement <task-name>
 ```
 
+## Phase Transition Check (run FIRST, before any other step)
+
+Before doing anything else for this command, verify the prior phases are marked complete.
+
+1. Read `implementation_process/in_progress/{task_name}/task.md`.
+2. Locate the `## Phase Status` section.
+3. Evaluate Phase 1 and Phase 2 independently. In each of the following lines, replace `{task_name}` with the actual task name passed to this command.
+
+4. If **Phase 2: Architecture** is not `[x]`, print this soft-nudge line:
+
+   > ⚠ Phase 2 (Architecture) is not marked complete in `task.md`. Continuing with `/implement` anyway. If architecture is incomplete, consider `/drupal-dev-framework:design {task_name}` first. (This is a nudge, not a block.)
+
+5. If **Phase 1: Research** is not `[x]`, also print this line (independent of whether Phase 2 was checked):
+
+   > ⚠ Phase 1 (Research) is not marked complete in `task.md`. Running `/implement` without research is unusual — consider `/drupal-dev-framework:research {task_name}` first. (Nudge, not a block.)
+
+6. If both phases are `[x]`, proceed silently (no output from this check).
+
+Never block the command on this check — the user is in control. The nudge exists so they notice out-of-order invocations without being fought by the tool.
+
 ## What This Does (v3.0.0)
 
 1. Loads task from `implementation_process/in_progress/{task_name}/`

--- a/drupal-dev-framework/hooks/context-reminder.sh
+++ b/drupal-dev-framework/hooks/context-reminder.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook — continuous task-context reminder.
+#
+# Fires on every user prompt (UserPromptSubmit has no matcher support and `if`
+# filters do not apply to non-tool events). Gating lives inside this script:
+# the per-workspace session file is the scope marker. When no framework task is
+# active in the current workspace, the script exits 0 in ~5ms without output.
+#
+# Output: JSON with hookSpecificOutput.additionalContext per the
+# UserPromptSubmit spec. Cap is 10,000 chars; target ≤500 tokens.
+
+set -eu
+
+WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
+SESS="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+
+# Fast gate — no session file means no active task in this workspace.
+[ -s "$SESS" ] || exit 0
+
+# Read all needed session fields in one jq invocation (TSV — safe for these values).
+SESSION_TSV=$(jq -r '[
+    .task        // "",
+    .taskPath    // "",
+    .project     // "",
+    ((.loadedGuides // []) | join(","))
+  ] | @tsv' "$SESS" 2>/dev/null) || exit 0
+
+IFS=$'\t' read -r TASK TASK_PATH PROJECT GUIDES_CSV <<<"$SESSION_TSV"
+
+# Fast gate — no active task.
+[ -n "$TASK" ] && [ -n "$TASK_PATH" ] && [ -d "$TASK_PATH" ] || exit 0
+
+TASK_MD="$TASK_PATH/task.md"
+
+# Derive per-phase checkbox state from task.md.
+# Matches the first "[ ]", "[x]", or "[~]" on a line that mentions "Phase N".
+phase_state() {
+  local n="$1"
+  if [ -f "$TASK_MD" ]; then
+    # Only match list-item lines like "- [x] Phase 1: Research" (or [X]/[~]/space).
+    # Anchoring to "- " at line start prevents prose lines from matching, and
+    # "Phase N[^0-9]" prevents n=1 from matching "Phase 10", "Phase 11", etc.
+    awk -v n="$n" '
+      $0 ~ ("^[[:space:]]*-[[:space:]]+\\[[ xX~]\\][[:space:]]+Phase " n "([^0-9]|$)") {
+        if (match($0, /\[[ xX~]\]/)) {
+          cb = substr($0, RSTART, RLENGTH)
+          # Normalize [X] to [x] for the downstream comparisons.
+          gsub(/X/, "x", cb)
+          print cb
+          exit
+        }
+      }
+    ' "$TASK_MD" 2>/dev/null || true
+  fi
+}
+
+P1=$(phase_state 1); P1=${P1:-[ ]}
+P2=$(phase_state 2); P2=${P2:-[ ]}
+P3=$(phase_state 3); P3=${P3:-[ ]}
+
+# Current-phase logic: first non-[x] phase is current.
+# [~] (in progress) wins over [ ] (not started) at the same index.
+current_phase() {
+  if [ "$P1" != "[x]" ]; then echo 1
+  elif [ "$P2" != "[x]" ]; then echo 2
+  elif [ "$P3" != "[x]" ]; then echo 3
+  else echo "done"
+  fi
+}
+CUR=$(current_phase)
+
+case "$CUR" in
+  1)    CUR_LABEL="Phase 1: Research"       ; NEXT_CMD="/drupal-dev-framework:research $TASK" ;;
+  2)    CUR_LABEL="Phase 2: Architecture"   ; NEXT_CMD="/drupal-dev-framework:design $TASK"   ;;
+  3)    CUR_LABEL="Phase 3: Implementation" ; NEXT_CMD="/drupal-dev-framework:implement $TASK" ;;
+  done) CUR_LABEL="All phases complete"     ; NEXT_CMD="/drupal-dev-framework:complete $TASK" ;;
+esac
+
+# Mark the current phase line with an arrow for at-a-glance reading.
+arrow() { [ "$CUR" = "$1" ] && printf '◀ current' || printf '' ; }
+
+# Truncate loaded-guides list to 20 entries to keep payload bounded.
+if [ -z "$GUIDES_CSV" ]; then
+  GUIDES_LINE="(none loaded this session)"
+else
+  GUIDE_COUNT=$(awk -F, '{print NF}' <<<"$GUIDES_CSV")
+  if [ "$GUIDE_COUNT" -gt 20 ]; then
+    GUIDES_HEAD=$(awk -F, '{for (i=1;i<=20;i++) printf "%s%s", $i, (i<20?", ":"")}' <<<"$GUIDES_CSV")
+    GUIDES_LINE="$GUIDES_HEAD … (+$((GUIDE_COUNT - 20)) more)"
+  else
+    GUIDES_LINE=$(tr ',' ' ' <<<"$GUIDES_CSV" | awk '{for(i=1;i<=NF;i++)printf "%s%s", $i, (i<NF?", ":"")}')
+  fi
+fi
+
+BLOCK=$(cat <<EOF
+**Drupal Dev Framework — Active Task Context**
+
+- Task: \`$TASK\` — $CUR_LABEL
+- Project: \`$PROJECT\`
+- Task folder: \`$TASK_PATH/\`
+  - \`task.md\` (tracker)
+  - \`research.md\`       $P1 Phase 1 $(arrow 1)
+  - \`architecture.md\`   $P2 Phase 2 $(arrow 2)
+  - \`implementation.md\` $P3 Phase 3 $(arrow 3)
+- Loaded guides: $GUIDES_LINE
+- Next: \`$NEXT_CMD\`
+
+Write each phase's content to its own \`.md\` file in the task folder. Do not merge phases into a monolithic document.
+EOF
+)
+
+# Hard-cap the injected block at 9500 chars. Claude Code caps additionalContext
+# at 10,000 chars — anything over gets replaced with a file-preview pointer,
+# which would drop the reminder text. 9500 leaves headroom for the JSON envelope.
+BLOCK=$(printf %s "$BLOCK" | head -c 9500)
+
+# Emit the documented UserPromptSubmit JSON envelope.
+jq -nc --arg ctx "$BLOCK" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'

--- a/drupal-dev-framework/hooks/hooks.json
+++ b/drupal-dev-framework/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/context-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/drupal-dev-framework/hooks/session-start.sh
+++ b/drupal-dev-framework/hooks/session-start.sh
@@ -6,27 +6,10 @@
 WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
 rm -f "$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
 
-# Check required plugin: dev-guides-navigator
-SETTINGS_FILES=("$HOME/.claude/settings.json" ".claude/settings.json")
-DEV_GUIDES_FOUND=false
-
-for settings in "${SETTINGS_FILES[@]}"; do
-  if [ -f "$settings" ] && jq -e '.plugins // .installedPlugins // empty' "$settings" 2>/dev/null | grep -q "dev-guides-navigator"; then
-    DEV_GUIDES_FOUND=true
-    break
-  fi
-done
-
-if [ "$DEV_GUIDES_FOUND" = false ]; then
-  # Check if loaded as a plugin directory
-  if [ -z "$(find "$HOME/.claude" -path "*/dev-guides-navigator/.claude-plugin/plugin.json" 2>/dev/null | head -1)" ]; then
-    echo "⚠️ **Required plugin missing: dev-guides-navigator**"
-    echo ""
-    echo "drupal-dev-framework requires dev-guides-navigator for Drupal domain knowledge."
-    echo "Install: \`/plugin install dev-guides-navigator@camoa-skills\`"
-    echo ""
-  fi
-fi
+# Note: dev-guides-navigator presence is now enforced at install time via the
+# `dependencies` field in .claude-plugin/plugin.json. The former soft runtime
+# check was removed once that declaration landed — install-time enforcement
+# supersedes it and makes missing-dependency failures loud instead of silent.
 
 REGISTRY="$HOME/.claude/drupal-dev-framework/active_projects.json"
 

--- a/drupal-dev-framework/skills/guide-integrator/SKILL.md
+++ b/drupal-dev-framework/skills/guide-integrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guide-integrator
-description: "Use when designing features - loads plugin methodology refs and delegates to dev-guides-navigator for online Drupal domain knowledge. Trigger: 'load guides', 'get reference docs', 'methodology references'. Use proactively during Phase 2 design — loads SOLID, Library-First, DRY, TDD, Security guides."
-version: 4.0.0
+description: "Use when designing features - loads plugin methodology refs and delegates to dev-guides-navigator for online Drupal domain knowledge. Records each loaded guide into session_context.json loadedGuides[] so the context-reminder hook can surface them and re-loads are skipped. Trigger: 'load guides', 'get reference docs', 'methodology references'. Use proactively during Phase 2 design — loads SOLID, Library-First, DRY, TDD, Security guides."
+version: 4.1.0
 user-invocable: false
 ---
 
@@ -33,7 +33,7 @@ Activate when:
 - Architecture drafting for any feature
 - Auto-triggered by `architecture-drafter` agent
 
-**Skip if:** The relevant guide was already loaded earlier in this session (check conversation context).
+**Skip if:** The relevant guide is already listed in `loadedGuides[]` of the per-workspace `session_context.json` (see "Record Loaded Guide" below). The conversation context is an unreliable fallback; the file is the source of truth.
 
 ## Auto-Load Rules (Plugin References)
 
@@ -50,19 +50,49 @@ Activate when:
 ### 1. Load Plugin References (Methodology)
 
 Based on detected keywords in the task:
-1. Identify which methodology references apply (see Auto-Load Rules)
-2. Read each applicable reference file
-3. Extract patterns relevant to current task
+1. Check `loadedGuides[]` (see "Record Loaded Guide" below). If the ID (e.g. `plugin:solid-drupal`) is already present, skip.
+2. Identify which methodology references apply (see Auto-Load Rules)
+3. Read each applicable reference file
+4. Record the guide ID via the snippet in "Record Loaded Guide"
+5. Extract patterns relevant to current task
 
 ### 2. Delegate Online Guides to Navigator
 
-For Drupal-specific architecture decisions, invoke the `dev-guides-navigator` skill with the task keywords. The navigator handles:
+For Drupal-specific architecture decisions, invoke the `dev-guides-navigator` skill with the task keywords. For each topic the navigator returns:
+1. Check `loadedGuides[]`. If the topic ID (e.g. `drupal/forms/form-validation`) is already present, skip re-fetching.
+2. Fetch via the navigator (which handles its own content caching of `llms.txt`).
+3. Record the topic ID via the snippet in "Record Loaded Guide".
+
+The navigator handles:
 - Hash-based caching of `llms.txt` (no redundant fetches)
 - Topic matching with KG metadata disambiguation
 - Routing to the correct guide via topic `index.md`
 - Fetching the specific guide content
 
 Do NOT fetch `llms.txt` or dev-guides URLs directly — the navigator does this with caching and disambiguation.
+
+### 2b. Record Loaded Guide
+
+For every guide actually loaded (methodology or dev-guide), append its ID to the per-workspace `session_context.json` `loadedGuides[]`. Idempotent — skip if already present.
+
+Guide ID conventions:
+- Plugin methodology refs: `plugin:<basename>` (e.g. `plugin:solid-drupal`, `plugin:tdd-workflow`)
+- Dev-guides topics: the topic path as returned by `dev-guides-navigator` (e.g. `drupal/forms/form-validation`, `design-systems/radix-sdc`)
+
+Run this after each successful load, substituting `{GUIDE_ID}`:
+
+```bash
+GUIDE_ID="{GUIDE_ID}"
+[ -n "$GUIDE_ID" ] || exit 0   # guard against empty IDs polluting the list
+WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+SESS_FILE=~/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json
+[ -s "$SESS_FILE" ] || exit 0
+jq --arg g "$GUIDE_ID" \
+  'if (.loadedGuides // []) | index($g) then . else .loadedGuides = ((.loadedGuides // []) + [$g]) end' \
+  "$SESS_FILE" > "$SESS_FILE.tmp" && mv "$SESS_FILE.tmp" "$SESS_FILE"
+```
+
+If `session_context.json` does not yet exist, skip silently — the next framework command will create it via `session-context-writer` and future loads will be recorded.
 
 ### 3. Extract Applicable Patterns
 

--- a/drupal-dev-framework/skills/session-context-writer/SKILL.md
+++ b/drupal-dev-framework/skills/session-context-writer/SKILL.md
@@ -1,42 +1,77 @@
 ---
 name: session-context-writer
-description: Write per-workspace session_context.json with active project/task so compaction hooks can restore context. Called by framework commands after resolving project and task.
+description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[] and lastPhase across writes via jq-based merge.
 user-invocable: false
-version: 1.2.0
+version: 1.3.0
 model: haiku
 ---
 
 # Session Context Writer
 
-Write session context keyed by the current workspace so compaction hooks can restore the correct project context. Each Claude Code window gets its own session file — no conflicts between windows.
+Persist session context keyed by the current workspace so hooks can restore the correct project/task context. Each Claude Code window gets its own session file — no conflicts between windows.
 
 ## When Called
 
-You receive the resolved project and task values from the calling command. Write them immediately.
+You receive the resolved project and task values from the calling command. Write them immediately. Preserve any `loadedGuides` and `lastPhase` already in the file.
+
+## File Shape
+
+```json
+{
+  "workspace": "/abs/path/to/cwd",
+  "project": "my_project",
+  "projectPath": "/abs/path/to/project",
+  "task": "my_task",
+  "taskPath": "/abs/path/to/task",
+  "updatedAt": "2026-04-20",
+  "loadedGuides": ["drupal/forms/form-validation"],
+  "lastPhase": "research"
+}
+```
+
+`loadedGuides` and `lastPhase` are managed by other components (`guide-integrator`, the `context-reminder` hook) — this skill must not clobber them.
 
 ## Action
 
-Run this bash command with the provided values:
+Run this bash command with the provided values. It merges the new core fields over any existing file, seeding `loadedGuides: []` and `lastPhase: null` only when the file is first created.
 
 ```bash
 WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
-mkdir -p ~/.claude/drupal-dev-framework/sessions
-cat > ~/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json << EOF
-{
-  "workspace": "$PWD",
-  "project": "{PROJECT_NAME}",
-  "projectPath": "{PROJECT_PATH}",
-  "task": "{TASK_NAME_OR_NULL}",
-  "taskPath": "{TASK_PATH_OR_NULL}",
-  "updatedAt": "$(date -I)"
-}
-EOF
+SESS_DIR=~/.claude/drupal-dev-framework/sessions
+SESS_FILE=$SESS_DIR/${WORKSPACE_HASH}.json
+mkdir -p "$SESS_DIR"
+
+NEW_CORE=$(jq -n \
+  --arg workspace "$PWD" \
+  --arg project "{PROJECT_NAME}" \
+  --arg projectPath "{PROJECT_PATH}" \
+  --arg task "{TASK_NAME_OR_NULL}" \
+  --arg taskPath "{TASK_PATH_OR_NULL}" \
+  --arg updatedAt "$(date -I)" \
+  '{
+    workspace: $workspace,
+    project: $project,
+    projectPath: $projectPath,
+    task: (if $task == "null" or $task == "" then null else $task end),
+    taskPath: (if $taskPath == "null" or $taskPath == "" then null else $taskPath end),
+    updatedAt: $updatedAt
+  }')
+
+if [ -s "$SESS_FILE" ] && jq -e . "$SESS_FILE" >/dev/null 2>&1; then
+  # Preserve loadedGuides and lastPhase; overwrite core fields.
+  jq --argjson new "$NEW_CORE" \
+    '. * $new | .loadedGuides = (.loadedGuides // []) | .lastPhase = (.lastPhase // null)' \
+    "$SESS_FILE" > "$SESS_FILE.tmp" && mv "$SESS_FILE.tmp" "$SESS_FILE"
+else
+  # First write, empty, or corrupt JSON — reseed from scratch with fresh core + preserved-field defaults.
+  echo "$NEW_CORE" | jq '. + {loadedGuides: [], lastPhase: null}' > "$SESS_FILE"
+fi
 ```
 
 Replace placeholders:
-- `{PROJECT_NAME}` — the resolved project name (e.g., `wasatch_update`)
-- `{PROJECT_PATH}` — absolute path to the project directory (e.g., `/home/user/workspace/claude_memory/projects/wasatch_update`)
-- `{TASK_NAME_OR_NULL}` — the task name if known, or `null`
-- `{TASK_PATH_OR_NULL}` — absolute path to the task directory if known, or `null`
+- `{PROJECT_NAME}` — resolved project name (e.g., `wasatch_update`)
+- `{PROJECT_PATH}` — absolute project path
+- `{TASK_NAME_OR_NULL}` — task name if known, or the literal string `null`
+- `{TASK_PATH_OR_NULL}` — absolute task path if known, or the literal string `null`
 
 Do not output anything to the user. This is a silent background operation.


### PR DESCRIPTION
## Summary

- Substrate for continuous task-context awareness in long drupal-dev-framework sessions via a new `UserPromptSubmit` hook (`context-reminder.sh`) that renders active task, v3.0.0 folder convention, phase status, loaded guides, and next command on every prompt.
- Elevates `dev-guides-navigator` from a soft SessionStart warning to a hard `plugin.json` Plugin Dependency (**requires Claude Code v2.1.110+**).
- Adds soft phase-transition nudges at the entry of `/design` and `/implement` (never blocks).
- Schema extension in per-workspace `session_context.json`: `loadedGuides[]` (preserved across writes, idempotent appends via `guide-integrator`) and `lastPhase`.

## Why patch? It's a minor.

`drupal-dev-framework` 3.8.0 → **3.9.0**. New substrate features, additive, no breaking changes. Epic sub-task 1 of 8 (tracker: `dev_framework_improvements_epic`).

## Sub-task 2 (v3.9.1) is stacked on top

This PR's base is `main`. The sibling PR for sub-task 2 (`feature/task-process-adherence-wording`) currently targets **this branch** as its base — when this PR merges, GitHub will auto-retarget sub-task 2's PR to `main`.

## Test plan

- [ ] `plugin install drupal-dev-framework@camoa-skills` on a Claude Code v2.1.110+ session resolves the `dev-guides-navigator` dependency automatically
- [ ] On an older Claude Code version, the dependency declaration is silently ignored (soft failure — documented in CHANGELOG and README)
- [ ] In a workspace with an active framework task, `UserPromptSubmit` hook injects the reminder block on every prompt (~40ms render, no-session gate ~3ms)
- [ ] In a workspace with NO active framework task, hook exits fast without injecting anything
- [ ] `/design` on a task where Phase 1 is not `[x]` prints the soft nudge and continues
- [ ] `/implement` on a task where Phase 2 is not `[x]` prints the soft nudge and continues; Phase 1 warning fires independently
- [ ] `guide-integrator` populates `loadedGuides[]` and the context-reminder surfaces them
- [ ] Re-invoking `guide-integrator` for an already-loaded guide is a no-op (idempotent append)
- [ ] `plugin-creation-tools:validate drupal-dev-framework` → PASS

## Gates run

- `plugin-creation-tools:validate` → PASS
- Cold-context Claude-docs compliance audit (isolated subagent) → SHIP verdict, 6/6 API checks
- Paper-test (isolated subagent) → no blockers; 6 of 7 low-cost findings hardened, concurrent-write `flock` deliberately deferred and documented in CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)