### PR TITLE
drupal-dev-framework v3.9.1: task process adherence batch (recovery — PR #113 landed on stacked base)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.3"
+    "version": "1.14.4"
   },
   "plugins": [
     {
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.9.0",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook with directive role-identity framing. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
+      "version": "3.9.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2026-04-21
+
+### Changed — Task Process Adherence (sub-task 2 of dev-framework improvements epic)
+
+- **Context-reminder wording tuned toward role-identity framing.** The `UserPromptSubmit` reminder now opens with a directive statement ("**drupal-dev-framework protocol is active on this task.** You are on `<task>` — <phase>. Phase sequencing applies… Apply SOLID, TDD, and DRY… Keep `task.md` `## Phase Status` checkboxes current as each phase progresses") instead of a passive title ("Active Task Context"). The structured file-listing, loaded-guides line, next-command line, and monolith-prevention reminder below the opening are unchanged.
+
+### Fixed
+
+- **Workspace-hash consistency across hooks.** `context-reminder.sh` (new in v3.9.0) used `printf %s "$PWD"` for its workspace-hash computation, while the four pre-existing hooks (`session-start.sh`, `pre-compact.sh`, `post-compact.sh`, `stop-failure.sh`) used `echo -n "$PWD"`. For typical paths the two forms produce identical hashes, but `echo -n` has portability edge cases with backslashes and certain special characters. Aligned all five hooks to `printf %s` so the writer and reader of `sessions/<hash>.json` are guaranteed to use identical input across any shell/path combination. Caught by the `plugin-structure-auditor` agent's post-fix re-run.
+
+### Why this is a patch, not a minor
+
+No mechanism changes — same hook event, same JSON envelope shape, same data flow, same session-file gating. The revision is wording inside `additionalContext` plus the hash-consistency alignment. Payload size grows ~80 chars; still far below the 9500-char truncation guard.
+
+### Fixed — auditor fallout (batched in-band)
+
+The `plugin-structure-auditor` gate (newly required by the epic AC) surfaced five pre-existing issues. All are non-breaking and orthogonal to the wording tune, so batched into this patch rather than backlogged:
+
+- **Agents route guide-loading through `guide-integrator` instead of direct `WebFetch`.** `architecture-drafter` and `architecture-validator` previously instructed Claude to `WebFetch https://camoa.github.io/dev-guides/drupal/{topic}/` directly, bypassing the navigator's caching, disambiguation, and the `loadedGuides[]` tracking the v3.9.0 substrate depends on. Both agents now delegate to `guide-integrator`, which invokes `dev-guides-navigator` and records each loaded guide into `session_context.json`.
+- **`task-completer` migrated to v3.0.0 folder structure.** Step 4 previously did `mv` on a `{task}.md` file path and Step 6's glob scanned `*.md` files — both broken on v3 installs (tasks are folders, not single files). Step 4 now moves the task directory; Step 6 lists in-progress task folders via `ls -d`.
+- **`task-completer` now enforces all 5 quality gates.** The table previously listed 4 gates; Gate 5 (task-artifact completeness — acceptance criteria `[x]`, `## Phase Status` 1–3 all `[x]`, all three phase `.md` files present) is now explicit.
+- **`task-completer` Gate 4 security guidance routed through `guide-integrator`.** Was `WebFetch dev-guides/drupal/security/` directly; now delegates to the integrator.
+- **`model:` frontmatter declared across 6 skills.** `session-resume` (sonnet), `memory-manager` (sonnet), `task-completer` (sonnet), `implementation-task-creator` (sonnet), `component-designer` (sonnet), `diagram-generator` (haiku). Previously these skills inherited the invoking context's model, which could be under- or over-powered for their workload.
+- **Skill descriptions re-anchored.** `guide-loader` description rephrased from gerund ("Use when needing…") to condition-clause form ("Use when a framework task requires…") per the plugin's own convention.
+- **`guide-integrator` description tightened** (v4.1.1) — from ~480 chars to ~380 chars by moving trigger phrases and "Use proactively" guidance to the body's Activation section per skill-quality-reviewer feedback.
+
+### Still tracked for follow-up (not in this patch)
+
+- **WARN-1: `/next` command and `project-orchestrator` agent duplicate routing logic.** Fix requires a design decision (which is source of truth) plus an integration test — `/next` is the primary entry point and regression is high-impact. Separate sub-task: `dev_framework_next_orchestrator_dedup`.
+
+### Dismissed (auditor false positive)
+
+- **WARN-5: README `@camoa-skills` install syntax.** Verified: `/plugin install <name>@<marketplace>` is the documented Claude Code install syntax, used consistently across every plugin in this marketplace. Not a deficiency.
+
+### Research-backed scope (from `dev_framework_task_process_adherence` research v3)
+
+Sub-task 2 originally contemplated a 5-layer enforcement scaffolding. That research was flagged as having unverified assumptions and rewritten from scratch. The fresh research (v3) rejected most speculative directions — cross-workspace lookup (parallel-work pattern confirmed functional today), skill-scoped identity hooks (speculative without observed drift), FileChanged/PermissionDenied enforcement (intentionally soft-nudge posture from v3.9.0 preserved) — and narrowed ship-now scope to H1 (wording tune). Checkbox-upkeep language added to the reminder probes the drift hypothesis without building a mechanism for it.
+
 ## [3.9.0] - 2026-04-20
 
 ### Added — Task Phase Guidance (sub-task 1 of dev-framework improvements epic)

--- a/drupal-dev-framework/agents/architecture-drafter.md
+++ b/drupal-dev-framework/agents/architecture-drafter.md
@@ -43,13 +43,13 @@ Before drafting, read these reference files from the plugin's `references/` fold
 
 ### Online Dev-Guides (Drupal Domain)
 
-For Drupal-specific architecture decisions, WebFetch the relevant topic from `https://camoa.github.io/dev-guides/`:
+For Drupal-specific architecture decisions, delegate to `guide-integrator` (which invokes `dev-guides-navigator` internally and records each loaded guide into the session's `loadedGuides[]`). Do NOT WebFetch dev-guides URLs directly — direct fetches bypass caching, disambiguation, and session-level tracking.
 
 1. Match the task's Drupal concepts to a topic (forms, entities, plugins, routing, services, caching, etc.)
-2. WebFetch `https://camoa.github.io/dev-guides/drupal/{topic}/` for the topic index
-3. Identify and WebFetch the specific atomic guide for the decision needed
+2. Invoke the `guide-integrator` skill with the matched topic(s); it routes through the navigator, respects the per-workspace loaded-guides cache, and appends each loaded guide to `session_context.json`'s `loadedGuides[]` so the `context-reminder` hook can surface it.
+3. Read the guide content returned by the integrator and apply it.
 
-Common architecture decisions and their dev-guides topics:
+Common architecture decisions and their dev-guides topics (pass these topic paths to `guide-integrator`):
 
 | Decision | Topic |
 |----------|-------|
@@ -65,7 +65,7 @@ Common architecture decisions and their dev-guides topics:
 
 ## Process
 
-1. **Load references** - Read plugin's `references/solid-drupal.md`, `references/library-first.md`. For Drupal domain decisions, also WebFetch the relevant dev-guides topic.
+1. **Load references** - Read plugin's `references/solid-drupal.md`, `references/library-first.md`. For Drupal domain decisions, invoke the `guide-integrator` skill with the relevant topic (never WebFetch dev-guides URLs directly).
 2. **Review research** - Read existing research from architecture/ folder
 3. **Identify components** - List services, forms, entities, plugins needed
 4. **Apply Library-First** - Ensure services designed BEFORE UI components

--- a/drupal-dev-framework/agents/architecture-validator.md
+++ b/drupal-dev-framework/agents/architecture-validator.md
@@ -51,9 +51,9 @@ Load these from the plugin's `references/` folder:
 
 ### Online Dev-Guides
 
-For security and frontend validation, WebFetch from `https://camoa.github.io/dev-guides/`:
-- Security checks: WebFetch `drupal/security/` topic
-- Frontend/SDC checks: WebFetch `drupal/sdc/` and `drupal/js-development/` topics
+For security and frontend validation, invoke the `guide-integrator` skill (which delegates to `dev-guides-navigator` and records each loaded guide into `session_context.json`'s `loadedGuides[]`). Do NOT WebFetch dev-guides URLs directly — direct fetches bypass caching, disambiguation, and session tracking.
+- Security checks: invoke `guide-integrator` with topic `drupal/security/`
+- Frontend/SDC checks: invoke `guide-integrator` with topics `drupal/sdc/` and `drupal/js-development/`
 
 ## Process
 

--- a/drupal-dev-framework/hooks/context-reminder.sh
+++ b/drupal-dev-framework/hooks/context-reminder.sh
@@ -93,19 +93,19 @@ else
 fi
 
 BLOCK=$(cat <<EOF
-**Drupal Dev Framework — Active Task Context**
+**drupal-dev-framework protocol is active on this task.** You are on \`$TASK\` — $CUR_LABEL. Phase sequencing applies (Research → Architecture → Implementation). Apply SOLID, TDD, and DRY to any code changes. Keep \`task.md\` \`## Phase Status\` checkboxes current as each phase progresses.
 
-- Task: \`$TASK\` — $CUR_LABEL
-- Project: \`$PROJECT\`
-- Task folder: \`$TASK_PATH/\`
-  - \`task.md\` (tracker)
+Task folder: \`$TASK_PATH/\`
+  - \`task.md\` (tracker — update checkboxes here as phases complete)
   - \`research.md\`       $P1 Phase 1 $(arrow 1)
   - \`architecture.md\`   $P2 Phase 2 $(arrow 2)
   - \`implementation.md\` $P3 Phase 3 $(arrow 3)
-- Loaded guides: $GUIDES_LINE
-- Next: \`$NEXT_CMD\`
 
-Write each phase's content to its own \`.md\` file in the task folder. Do not merge phases into a monolithic document.
+Project: \`$PROJECT\`
+Loaded guides: $GUIDES_LINE
+Next: \`$NEXT_CMD\`
+
+Write each phase's content to its own \`.md\` file. Do not merge phases into a monolithic document.
 EOF
 )
 

--- a/drupal-dev-framework/hooks/post-compact.sh
+++ b/drupal-dev-framework/hooks/post-compact.sh
@@ -2,7 +2,7 @@
 # Post-compact hook: Instruct Claude to reload project context after compaction
 # Reads per-workspace session file to find the active project
 
-WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
 SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
 
 # Only output if a framework command was used in this workspace this session

--- a/drupal-dev-framework/hooks/pre-compact.sh
+++ b/drupal-dev-framework/hooks/pre-compact.sh
@@ -2,7 +2,7 @@
 # Pre-compact hook: Instruct Claude to preserve active project context
 # Reads per-workspace session file to find the active project
 
-WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
 SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
 
 # Only output if a framework command was used in this workspace this session

--- a/drupal-dev-framework/hooks/session-start.sh
+++ b/drupal-dev-framework/hooks/session-start.sh
@@ -3,7 +3,7 @@
 # Checks required plugins and registered projects
 
 # Clear stale session context for THIS workspace only
-WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
 rm -f "$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
 
 # Note: dev-guides-navigator presence is now enforced at install time via the

--- a/drupal-dev-framework/hooks/stop-failure.sh
+++ b/drupal-dev-framework/hooks/stop-failure.sh
@@ -11,7 +11,7 @@ TIMESTAMP=$(date -Iseconds)
 PROJECT_NAME=""
 TASK_NAME=""
 
-WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
 SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
 
 if [ -f "$SESSION_FILE" ]; then

--- a/drupal-dev-framework/skills/component-designer/SKILL.md
+++ b/drupal-dev-framework/skills/component-designer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: component-designer
 description: Use when designing a specific module component - creates architecture/component_name.md with purpose, interface, dependencies, and pattern references
-version: 1.1.0
+version: 1.1.1
+model: sonnet
 ---
 
 # Component Designer

--- a/drupal-dev-framework/skills/diagram-generator/SKILL.md
+++ b/drupal-dev-framework/skills/diagram-generator/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: diagram-generator
 description: "Use when visualizing architecture - generates Mermaid diagrams for data flow, service relationships, or entity structures. Trigger: 'draw diagram', 'visualize', 'show relationships', 'mermaid chart'."
-version: 1.1.0
+version: 1.1.1
+model: haiku
 ---
 
 # Diagram Generator

--- a/drupal-dev-framework/skills/guide-integrator/SKILL.md
+++ b/drupal-dev-framework/skills/guide-integrator/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: guide-integrator
-description: "Use when designing features - loads plugin methodology refs and delegates to dev-guides-navigator for online Drupal domain knowledge. Records each loaded guide into session_context.json loadedGuides[] so the context-reminder hook can surface them and re-loads are skipped. Trigger: 'load guides', 'get reference docs', 'methodology references'. Use proactively during Phase 2 design — loads SOLID, Library-First, DRY, TDD, Security guides."
-version: 4.1.0
+description: "Use when designing or researching features — loads plugin methodology refs (SOLID, DRY, TDD, Library-First, Quality Gates, Purposeful Code) and delegates to dev-guides-navigator for online Drupal domain knowledge. Records each loaded guide into session_context.json loadedGuides[] so re-loads are skipped and the context-reminder hook can surface them."
+version: 4.1.1
 user-invocable: false
+model: sonnet
 ---
 
 # Guide Integrator

--- a/drupal-dev-framework/skills/guide-loader/SKILL.md
+++ b/drupal-dev-framework/skills/guide-loader/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: guide-loader
-description: Use when needing specialized guide content - delegates to dev-guides-navigator plugin for online guide discovery with caching and disambiguation
-version: 3.0.0
+description: Use when a framework task requires specialized guide content — delegates to the dev-guides-navigator plugin for online guide discovery with caching and disambiguation.
+version: 3.0.1
 user-invocable: false
+model: haiku
 ---
 
 # Guide Loader

--- a/drupal-dev-framework/skills/implementation-task-creator/SKILL.md
+++ b/drupal-dev-framework/skills/implementation-task-creator/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: implementation-task-creator
 description: Use when breaking down a component for implementation - creates task file in implementation_process/in_progress/ with TDD steps and acceptance criteria
-version: 1.1.0
+version: 1.1.1
+model: sonnet
 ---
 
 # Implementation Task Creator

--- a/drupal-dev-framework/skills/memory-manager/SKILL.md
+++ b/drupal-dev-framework/skills/memory-manager/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: memory-manager
 description: Use after completing any phase activity - updates project_state.md, project registry, ensures files are in correct locations, maintains lean memory
-version: 3.0.0
+version: 3.0.1
 user-invocable: false
+model: sonnet
 ---
 
 # Memory Manager

--- a/drupal-dev-framework/skills/session-resume/SKILL.md
+++ b/drupal-dev-framework/skills/session-resume/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: session-resume
-description: "Use when resuming work on existing project - lists registered projects, reads project_state.md, summarizes current state, identifies where to continue. Trigger: 'pick up where I left off', 'continue project', 'what was I working on', 'resume session'."
-version: 1.2.0
+description: "Use when a user resumes work on an existing project — lists registered projects, reads project_state.md, summarizes current state, identifies where to continue. Trigger: 'pick up where I left off', 'continue project', 'what was I working on', 'resume session'."
+version: 1.2.1
+model: sonnet
 allowed-tools: Read, Glob, Bash
 ---
 

--- a/drupal-dev-framework/skills/task-completer/SKILL.md
+++ b/drupal-dev-framework/skills/task-completer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: task-completer
-description: "Use when finishing a task - moves task to completed/, updates project_state.md, suggests next task. Trigger: 'finish task', 'done with task', 'move to completed'. MUST run ALL 5 quality gates. BLOCK completion if gates fail. Never skip gates."
-version: 2.1.0
+description: "Use when finishing a task — moves the v3.0.0 task folder to completed/, updates project_state.md, suggests next task. Runs all 5 quality gates and blocks completion if any gate fails. Trigger: 'finish task', 'done with task', 'move to completed'."
+version: 2.2.0
+model: sonnet
 ---
 
 # Task Completer
@@ -34,13 +35,14 @@ Activate when you detect:
 | Gate 1 | Code standards (invoke `code-pattern-checker`) | YES |
 | Gate 2 | Tests pass (user confirms) | YES |
 | Gate 3 | Architecture compliance | YES |
-| Gate 4 | Security review | YES |
+| Gate 4 | Security review (invoke `guide-integrator` for `drupal/security/` topic; do NOT WebFetch directly) | YES |
+| Gate 5 | All acceptance criteria in `task.md` are `[x]` and `## Phase Status` shows Phases 1–3 complete | YES |
 
 ## Workflow
 
 ### 1. Verify Completion
 
-Use `Read` on the task file: `{project_path}/implementation_process/in_progress/{task}.md`
+Use `Read` on the task tracker file: `{project_path}/implementation_process/in_progress/{task_name}/task.md` (v3.0.0 folder structure; task.md lives inside the task folder).
 
 Check each acceptance criterion. Ask user:
 ```
@@ -85,11 +87,16 @@ Check against architecture/main.md:
 - [ ] DRY - no code duplication (references/dry-patterns.md)
 - [ ] Library-First pattern used (references/library-first.md)
 
-#### Gate 4: Security — WebFetch `https://camoa.github.io/dev-guides/drupal/security/` for detailed security guidance
+#### Gate 4: Security — invoke `guide-integrator` with topic `drupal/security/` for detailed security guidance (do NOT WebFetch directly)
 - [ ] Input validated via Form API
 - [ ] Output escaped properly
 - [ ] No raw SQL with user input
 - [ ] Access checks on all routes
+
+#### Gate 5: Task Artifacts Complete
+- [ ] All acceptance criteria in `task.md` are `[x]`
+- [ ] `## Phase Status` in `task.md` shows Phases 1, 2, 3 all `[x]`
+- [ ] `research.md`, `architecture.md`, `implementation.md` all present in the task folder
 
 **If ANY blocking gate fails:** Task completion is BLOCKED. Fix issues first.
 
@@ -124,12 +131,16 @@ Use `Edit` to add completion section to the task file:
 {Any implementation notes, deviations, or decisions made}
 ```
 
-### 4. Move Task File
+### 4. Move Task Folder
 
-Use `Bash` to move the task:
+v3.0.0 tasks are folders (task.md + research.md + architecture.md + implementation.md + any component files). Move the entire folder, not a single file.
+
 ```bash
-mv "{project_path}/implementation_process/in_progress/{task}.md" "{project_path}/implementation_process/completed/{task}.md"
+mkdir -p "{project_path}/implementation_process/completed"
+mv "{project_path}/implementation_process/in_progress/{task_name}" "{project_path}/implementation_process/completed/{task_name}"
 ```
+
+(`{task_name}` is the folder name — no `.md` suffix. The folder contains `task.md` and all phase artifacts.)
 
 ### 5. Update project_state.md
 
@@ -149,10 +160,12 @@ Use `Edit` to update:
 
 ### 6. Suggest Next Task
 
-Use `Glob` to find remaining tasks:
+Use `Bash` to list remaining in-progress task directories (v3.0.0 folder structure — tasks are directories, not `.md` files):
+```bash
+ls -1d "{project_path}/implementation_process/in_progress/"*/ 2>/dev/null
 ```
-{project_path}/implementation_process/in_progress/*.md
-```
+
+Each result is a task folder; read its `task.md` to inspect `## Phase Status` and acceptance criteria before ranking.
 
 Analyze dependencies and priorities. Present:
 ```


### PR DESCRIPTION
## Summary

Recovery PR. PR #113 was merged **before** GitHub auto-retargeted its base from `feature/task-phase-guidance` to `main` (the two merges were 11 seconds apart — #112 at 19:45:58, #113 at 19:46:09), so sub-task 2's commits landed on the feature branch instead of main. This PR lands the same content onto main.

Diff vs main is exactly sub-task 2's content (18 files, +103/-45):

- Agents route guide-loading through `guide-integrator` instead of direct `WebFetch`
- `task-completer` migrated to v3.0.0 folder structure + Gate 5 added + Gate 4 routes through `guide-integrator`
- `context-reminder.sh` heredoc reworded (H1 — directive role-identity framing)
- `printf %s` alignment across all 5 hooks
- `model:` frontmatter added on 6 skills
- `guide-loader` description reworded; `guide-integrator` description tightened to 4.1.1
- CHANGELOG [3.9.1] entry; plugin.json 3.9.0→3.9.1; marketplace.json sync (metadata.version currently 1.14.3 on main, was 1.14.4 in the sub-task-2 commit to account for this patch)

## Verifying content equivalence

The commits on this branch are the same ones that were approved and merged in #113, just against a different base. No new review needed if #113 was already approved — this is purely a plumbing recovery.

## Post-merge cleanup

After this merges, delete `feature/task-phase-guidance` and `feature/task-process-adherence-wording` from remote (both will be fully represented on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)