### PR TITLE
feat(code-paper-test): v0.7.0 — structured JSON output + plugin-creation-tools D-A-D pairing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.4"
+    "version": "1.14.5"
   },
   "plugins": [
     {
@@ -129,8 +129,8 @@
     {
       "name": "code-paper-test",
       "source": "./code-paper-test",
-      "description": "Systematically test code, skills, commands, and configs through mental execution \u2014 trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase single agent (50\u2013300 lines), or 3-agent competing team with isolated worktrees (300+ lines, security-critical, skills).",
-      "version": "0.6.0",
+      "description": "Systematically test code, skills, commands, and configs through mental execution \u2014 trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase single agent (50\u2013300 lines), or 3-agent competing team with isolated worktrees (300+ lines, security-critical, skills). Supports `--json` output for CI integration.",
+      "version": "0.7.0",
       "author": {
         "name": "camoa"
       },

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-22
+
+### Added
+- **`--json` output mode** on both `/paper-test` and `/code-paper:test-team` for CI integration and programmatic consumption. Versioned schema (`schema_version: "1.0"`) matching the camoa-skills ecosystem convention established by code-quality-tools. Severity rubric preserved (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO`) — no new terms introduced.
+- **New reference:** `skills/paper-test/references/json-output-schema.md` — full schema, finding-object shape, team-report extensions, skill/config category vocabulary, optional `rubric_score` block, CI gate patterns, and schema-versioning contract (match `^1\.`, never exact).
+- **Deterministic + Agentic pairing section** in `skill-and-config-testing.md` — documents running `plugin-creation-tools:skill-quality-reviewer` before paper-test when testing skills/commands/agents, so mechanical issues (stale SDK refs, missing imperatives, frontmatter gaps) clear cheaply before semantic analysis.
+- **SKILL.md trigger phrases** expanded: `"test this agent"`, `"walk through this code"`, `"step through this"`, `"dry run"`, `"sanity check"`, `"red team this"`, `"poke holes in this"` — cover natural phrasings the prior list missed.
+
+### Changed
+- **`/code-paper:test-team` command** — new `--json` argument handling. Each teammate writes `{role}-analysis.json` alongside the markdown report when the flag is set; the lead aggregates per the schema into `paper-test-team-report.json` with per-teammate breakdowns (`team.happy_path` / `team.edge_case` / `team.red_team`), cross-challenge outcomes (`confirmed_by_multiple`, `disputed`, `unanimous_clean_areas`), and per-finding `found_by` / `disputed` fields.
+- **PreCompact hook** now surfaces both `.md` and `.json` reports in `.reports/`.
+- **SKILL.md** frontmatter `version: 0.5.0` → `0.7.0` (corrects the intentional drift left during the v0.6.0 hook-only bump).
+
+### Fixed
+- SKILL.md / plugin.json version drift — both now `0.7.0`.
+- SKILL.md frontmatter gained `model: sonnet` to match the plugin's own convention (`CLAUDE.md` lists `model` as required; previously missing).
+
 ## [0.6.0] - 2026-04-08
 
 ### Changed

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -1,7 +1,7 @@
 ---
 description: Paper test code or skills with competing agent team (Happy Path + Edge Case + Red Team). Use when user says "test team", "3 perspectives", "competing testers", "thorough paper test", "security review", "deep code analysis", "test this skill with team". Best for large code (300+ lines), security-critical paths, or skill/command testing where perspective diversity matters most. For 50-300 line files, the single-agent structured 3-phase mode in /paper-test is more cost-effective. Each tester runs in isolated worktree.
 allowed-tools: Read, Write, Glob, Grep, WebSearch
-argument-hint: <file-path> [file-path...]
+argument-hint: [--json] <file-path> [file-path...]
 ---
 
 # Test Team
@@ -11,8 +11,10 @@ Paper test code from 3 competing perspectives using an agent team. A Happy Path 
 ## Usage
 
 ```
-/code-paper:test-team <file-path> [file-path...]
+/code-paper:test-team [--json] <file-path> [file-path...]
 ```
+
+Pass `--json` to emit a CI-consumable JSON report alongside the markdown report. Schema: `skills/paper-test/references/json-output-schema.md` (`schema_version: "1.0"`).
 
 ## What This Does
 
@@ -22,9 +24,14 @@ Spawns a 3-teammate agent team that paper-tests the specified code files from co
 
 When this command is invoked with `$ARGUMENTS`:
 
-### Step 1 — Check Target Exists
+### Step 1 — Parse Arguments and Check Target Exists
 
-Parse `$ARGUMENTS` as one or more file paths. Verify each file exists using the Read tool.
+Parse `$ARGUMENTS`:
+
+- If the first token is `--json`, set `JSON_MODE=true` and consume it. Remaining tokens are file paths.
+- Otherwise `JSON_MODE=false`. All tokens are file paths.
+
+Verify each file exists using the Read tool.
 
 If no arguments provided:
 > What code should the team test? Provide one or more file paths:
@@ -100,7 +107,7 @@ Create a team and these tasks:
 
 ### Step 5 — Spawn Teammates
 
-Spawn 3 teammates using the prompt templates below. After spawning:
+Spawn 3 teammates using the prompt templates below. Substitute `{target_dir}` with the directory computed in Step 1, `{list each file path}` with the validated targets, and interpolate `JSON_MODE={true|false}` near the top of each spawn prompt (so the teammate knows whether to emit the parallel `.json` report). After spawning:
 
 1. Tell the user: "Team spawned. Teammates are working — I'll synthesize when they finish."
 2. If running inside tmux, teammates appear in split panes (visible output). Otherwise they run in-process (background).
@@ -112,7 +119,8 @@ When all teammates finish:
 
 - Read `{target_dir}/happy-path-analysis.md`, `{target_dir}/edge-case-analysis.md`, `{target_dir}/red-team-analysis.md`
 - Write `{target_dir}/paper-test-team-report.md` using the Output Format below
-- Tell the user: "Paper test team complete. Report saved to `{target_dir}/paper-test-team-report.md`"
+- **If `JSON_MODE=true`:** also read `{target_dir}/happy-path-analysis.json`, `{target_dir}/edge-case-analysis.json`, `{target_dir}/red-team-analysis.json` (each teammate writes both markdown and JSON when `--json` is passed — see spawn prompts). Aggregate per the schema in `skills/paper-test/references/json-output-schema.md` and write `{target_dir}/paper-test-team-report.json`. Honor the invariants: `findings` is always an array, severity values are uppercase (`CRITICAL` etc.), `status` is `fail` if any CRITICAL or HIGH finding exists, `warning` if only MEDIUM/LOW findings, `pass` only if no MEDIUM-or-higher findings. Each aggregated finding includes `found_by` (union of teammate roles whose per-teammate JSON reported the same file + line span + category) and `disputed` (boolean — `true` iff the cross-challenge markdown report lists this finding in its "Disputed Findings" table). See the schema's "Team-specific finding fields" section for the precise field contract.
+- Tell the user: "Paper test team complete. Report saved to `{target_dir}/paper-test-team-report.md`" (append "and `paper-test-team-report.json`" when `JSON_MODE=true`).
 
 ---
 
@@ -151,6 +159,15 @@ Trace the code with ideal inputs and document expected behavior. Your lens: "Doe
 
 WRITE your analysis to:
   {target_dir}/happy-path-analysis.md
+
+If JSON_MODE=true (the lead will pass this in the spawn prompt), ALSO write a parallel structured report to:
+  {target_dir}/happy-path-analysis.json
+
+JSON shape — match `skills/paper-test/references/json-output-schema.md` exactly:
+- `schema_version: "1.0"`, `tool: "test-team"`, `mode: "test-team"`, `target_type` per target type, `target_files`, `timestamp` (ISO 8601 UTC)
+- `summary` with counts by severity (CRITICAL/HIGH/MEDIUM/LOW/INFO — uppercase), `total_findings`, `scenarios_traced`, `dependencies_verified`, `contracts_verified`
+- `findings` is always an array; each finding has `severity`, `category`, `file`, `line_start`, `line_end`, `title`, `description`, `fix_suggestion`, `scoring_factors {reach, impact, reversibility, exploitability}` (1-3 each; omit only for INFO), and `found_by: ["happy_path"]`
+- Do NOT include `disputed`, `team`, or cross-challenge data — the lead aggregates those later
 
 Use this format:
 
@@ -243,6 +260,11 @@ For each scenario:
 WRITE your analysis to:
   {target_dir}/edge-case-analysis.md
 
+If JSON_MODE=true, ALSO write the structured report to:
+  {target_dir}/edge-case-analysis.json
+
+Match `skills/paper-test/references/json-output-schema.md`. Use `found_by: ["edge_case"]` on each finding. `summary` should also include `categories_tested` (int 0-6). Omit `disputed`/`team`/cross-challenge.
+
 Use this format:
 
 # Edge Case Analysis
@@ -331,6 +353,11 @@ For each attack:
 
 WRITE your analysis to:
   {target_dir}/red-team-analysis.md
+
+If JSON_MODE=true, ALSO write the structured report to:
+  {target_dir}/red-team-analysis.json
+
+Match `skills/paper-test/references/json-output-schema.md`. Use `found_by: ["red_team"]` on each finding. `summary` should also include `attack_categories_tested` (int 0-7), `exploitable` (int), `blocked` (int). Omit `disputed`/`team`/cross-challenge.
 
 Use this format:
 

--- a/code-paper-test/hooks/pre-compact.sh
+++ b/code-paper-test/hooks/pre-compact.sh
@@ -11,9 +11,16 @@ if [ -z "$REPORTS_DIR" ] || [ ! -d "$REPORTS_DIR" ]; then
   exit 0
 fi
 
-# Check if any test team reports exist
+# Check if any test team reports exist (markdown or JSON)
+REPORTS=(
+  happy-path-analysis.md happy-path-analysis.json
+  edge-case-analysis.md edge-case-analysis.json
+  red-team-analysis.md red-team-analysis.json
+  paper-test-team-report.md paper-test-team-report.json
+)
+
 FOUND=false
-for report in happy-path-analysis.md edge-case-analysis.md red-team-analysis.md paper-test-team-report.md; do
+for report in "${REPORTS[@]}"; do
   if [ -f "$REPORTS_DIR/$report" ]; then
     FOUND=true
     break
@@ -28,9 +35,11 @@ echo "## Pre-Compaction Context (code-paper-test)"
 echo ""
 echo "Test reports found in \`$REPORTS_DIR\`."
 echo ""
-echo "To restore context after compaction:"
-for report in happy-path-analysis.md edge-case-analysis.md red-team-analysis.md paper-test-team-report.md; do
+echo "To restore context after compaction, read the relevant report on demand:"
+for report in "${REPORTS[@]}"; do
   if [ -f "$REPORTS_DIR/$report" ]; then
     echo "- Read \`$REPORTS_DIR/$report\`"
   fi
 done
+echo ""
+echo "JSON reports (if present) follow schema_version 1.x — see \`skills/paper-test/references/json-output-schema.md\`."

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: paper-test
-description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "validate this implementation", "review this logic", "check dependencies", "check this config". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
-version: 0.5.0
+description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "test this agent", "validate this implementation", "review this logic", "check dependencies", "check this config", "walk through this code", "step through this", "dry run", "sanity check", "red team this", "poke holes in this". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
+version: 0.7.0
+model: sonnet
 allowed-tools: Read, Glob, Grep, Bash
 user-invocable: true
 ---
@@ -445,6 +446,35 @@ EDGE CASES TO TEST:
 
 ---
 
+## JSON Output Mode (`--json`)
+
+For CI integration, aggregation, or programmatic consumption, invoke with `--json` to emit a stable, versioned JSON document instead of the markdown report.
+
+- Available on `/paper-test` (quick and structured-3-phase modes) and `/code-paper:test-team` (lead synthesis).
+- Schema is pinned at `schema_version: "1.0"` with an additive-only minor-version contract. CI should pin `^1\.`, not exact match.
+- Severity values match the existing rubric exactly: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`.
+- `findings` is always an array — `[]` when clean, never `null` or omitted.
+- `status` is the overall gate verdict: `pass` / `warning` / `fail`. Use `pass` only when no MEDIUM-or-higher findings exist and the run completed fully.
+
+**Use JSON mode for:** CI gates, dashboards, pipelines chaining into `jq` or monitoring. **Stay in markdown for:** interactive analysis and educational traces. Full schema, finding-object shape, team-report extensions, skill/config categories, optional `rubric_score` block, and CI gate patterns: see `references/json-output-schema.md`.
+
+Invocation:
+
+```
+/paper-test --json src/Service/UserService.php
+/code-paper:test-team --json src/Service/PaymentService.php
+```
+
+The team command writes `{target_dir}/paper-test-team-report.json` alongside the existing `.md`; each teammate also emits `{role}-analysis.json` so the lead aggregates without re-parsing markdown.
+
+---
+
+## Pairing with `skill-quality-reviewer` for Skill Testing
+
+When paper-testing a skill, command, or agent file, run `plugin-creation-tools:skill-quality-reviewer` first (deterministic: stale SDK refs, dropped imperatives, frontmatter gaps) then paper-test for the semantic analysis (instruction fidelity, trigger coverage, context budget). See `references/skill-and-config-testing.md` §"Deterministic + Agentic pairing".
+
+---
+
 ## References
 
 All detailed guides are in `references/` directory:
@@ -460,15 +490,5 @@ All detailed guides are in `references/` directory:
 - `references/blind-ab-comparison.md` - Comparing two implementations side by side
 - `references/rubric-scoring.md` - Structured grading for code quality assessment
 - `references/skill-and-config-testing.md` - Testing skills, commands, agents, and configs
+- `references/json-output-schema.md` - Stable JSON schema for `--json` mode (CI integration)
 
----
-
-## Progressive Disclosure
-
-The SKILL.md provides the core workflow. For detailed guidance:
-
-- Complete methodology → `references/core-method.md`
-- Dependency verification patterns → `references/dependency-verification.md`
-- Contract verification (extends, implements, DI, plugins, etc.) → `references/contract-patterns.md`
-- AI code specific checks → `references/ai-code-auditing.md`
-- Module testing strategy → `references/hybrid-testing.md`

--- a/code-paper-test/skills/paper-test/references/json-output-schema.md
+++ b/code-paper-test/skills/paper-test/references/json-output-schema.md
@@ -1,0 +1,280 @@
+# JSON Output Schema (`--json` mode)
+
+Stable, versioned schema for CI integration, aggregation, and programmatic consumption. Emitted by `/paper-test --json <file>` and `/code-paper:test-team --json <file>`.
+
+Shape follows the camoa-skills ecosystem convention established by `code-quality-tools/skills/code-quality-audit/references/json-schemas.md` — the same envelope fields (`schema_version`, `timestamp`, `target`, `status`, `summary`, `findings`) so downstream tooling can treat reports from both plugins uniformly.
+
+## Invariants (CI pipelines rely on these)
+
+1. **`findings` is always an array.** Zero findings = `[]`, never `null`, never omitted. Downstream `jq '.findings[]'` must never fail on "clean trace with no flaws."
+2. **`status` reflects the gate verdict** — `fail` if any finding is `CRITICAL` or `HIGH`; `warning` if any finding is `MEDIUM`, `LOW`, or `INFO` but none are `CRITICAL` / `HIGH`; `pass` only when `findings` is empty. Untested, aborted, or prematurely stopped runs use `status: "warning"` (never `pass`).
+3. **`schema_version` is semver on the schema itself**, independent of plugin version. Additive changes bump minor (`1.0` → `1.1`); breaking changes bump major (`1.0` → `2.0`).
+
+   > **CI pinning:** match `^1\.` (`jq: test("^1\\.")`), NOT `== "1.0"` exactly — additive minor bumps are back-compat and should not break your gate.
+   > ```bash
+   > echo "$result" | jq -e '.schema_version | test("^1\\.")' >/dev/null || exit 1
+   > ```
+4. **String fields are JSON-escaped.** Newlines, quotes, and backslashes in `title`, `description`, `fix_suggestion`, and file excerpts must not corrupt the document. Validate with `echo "$OUTPUT" | jq .` before trusting it in a gate.
+5. **Severity values match the existing rubric exactly** — `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO` (uppercase). Do not introduce new terms. See `severity-scoring.md`.
+
+## Common envelope
+
+All paper-test JSON reports share this shape:
+
+```json
+{
+  "schema_version": "1.0",
+  "tool": "paper-test | test-team",
+  "mode": "quick | structured-3-phase | test-team",
+  "target_type": "code | skill | config",
+  "target_files": ["path/to/file.php"],
+  "timestamp": "2026-04-22T12:00:00Z",
+  "status": "pass | warning | fail",
+  "summary": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "info": 0,
+    "total_findings": 0,
+    "scenarios_traced": 0,
+    "dependencies_verified": 0,
+    "contracts_verified": 0
+  },
+  "findings": []
+}
+```
+
+## Finding object
+
+Every entry in `findings[]`:
+
+```json
+{
+  "severity": "CRITICAL",
+  "category": "data-flow",
+  "file": "src/Service/PaymentService.php",
+  "line_start": 87,
+  "line_end": 92,
+  "title": "Unvalidated amount leaks to downstream charge call",
+  "description": "User-controlled $amount is not bounds-checked before being passed to $gateway->charge(). Negative values pass type validation but reverse the transaction.",
+  "fix_suggestion": "Add `if ($amount <= 0) throw new InvalidArgumentException()` before line 89.",
+  "scoring_factors": {
+    "reach": 3,
+    "impact": 3,
+    "reversibility": 3,
+    "exploitability": 3
+  }
+}
+```
+
+### Field notes
+
+- **`severity`** — one of `CRITICAL | HIGH | MEDIUM | LOW | INFO`. Derived from `scoring_factors` sum per the matrix in `severity-scoring.md`.
+- **`category`** — short kebab-case string. Standard values for code targets: `data-flow`, `error-propagation`, `dependency-verification`, `contract-violation`, `null-access`, `edge-case`, `performance`, `security`, `ai-hallucination`, `state-issue`, `flow-issue`. Skill/config targets use the list in the "Skill/Config target_type" section below. Other values allowed — consumers should treat as opaque strings.
+- **`line_end`** — equals `line_start` for single-line findings. Always present.
+- **`fix_suggestion`** — one-line actionable fix. May include code snippets (remember invariant 4).
+- **`scoring_factors`** — all four keys required (`reach`, `impact`, `reversibility`, `exploitability`), each `1`, `2`, or `3`. Omit the object only for `INFO` findings where scoring doesn't apply.
+
+## `/paper-test --json` output
+
+Quick-trace and structured-3-phase modes emit the common envelope directly. Write location: stdout (or `--output <path>` to write to a file sibling to the target).
+
+Example for a passing trace with one low-severity finding:
+
+```json
+{
+  "schema_version": "1.0",
+  "tool": "paper-test",
+  "mode": "structured-3-phase",
+  "target_type": "code",
+  "target_files": ["src/Service/UserService.php"],
+  "timestamp": "2026-04-22T12:00:00Z",
+  "status": "warning",
+  "summary": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 1,
+    "info": 0,
+    "total_findings": 1,
+    "scenarios_traced": 7,
+    "dependencies_verified": 4,
+    "contracts_verified": 2
+  },
+  "findings": [
+    {
+      "severity": "LOW",
+      "category": "null-access",
+      "file": "src/Service/UserService.php",
+      "line_start": 42,
+      "line_end": 42,
+      "title": "Missing null check on optional email lookup",
+      "description": "loadByEmail() returns User|null but line 42 accesses ->getId() without guard.",
+      "fix_suggestion": "Wrap in `if ($user !== null)` or use nullsafe `?->getId()`.",
+      "scoring_factors": {"reach": 1, "impact": 2, "reversibility": 1, "exploitability": 1}
+    }
+  ]
+}
+```
+
+## `/code-paper:test-team --json` output
+
+Test-team mode emits the common envelope PLUS a `team` section holding per-teammate breakdowns and the cross-challenge debate outcome. Write location: `{target_dir}/paper-test-team-report.json` (sibling to the existing `paper-test-team-report.md`). Each teammate also writes `{role}-analysis.json` in `{target_dir}` so the lead can aggregate without re-parsing markdown.
+
+The example below shows the shape only — the individual counts (`confirmed_by_multiple`, per-teammate `findings_count`, etc.) are illustrative and will not be cross-consistent with the single truncated finding shown.
+
+```json
+{
+  "schema_version": "1.0",
+  "tool": "test-team",
+  "mode": "test-team",
+  "target_type": "code",
+  "target_files": ["src/Service/PaymentService.php"],
+  "timestamp": "2026-04-22T12:00:00Z",
+  "status": "fail",
+  "summary": {
+    "critical": 1,
+    "high": 2,
+    "medium": 3,
+    "low": 4,
+    "info": 0,
+    "total_findings": 10,
+    "scenarios_traced": 18,
+    "dependencies_verified": 7,
+    "contracts_verified": 3
+  },
+  "team": {
+    "happy_path": {
+      "scenarios": 5,
+      "findings_count": 1,
+      "source": "happy-path-analysis.json"
+    },
+    "edge_case": {
+      "scenarios": 8,
+      "categories_tested": 6,
+      "findings_count": 5,
+      "source": "edge-case-analysis.json"
+    },
+    "red_team": {
+      "attack_categories_tested": 7,
+      "exploitable": 2,
+      "blocked": 3,
+      "findings_count": 4,
+      "source": "red-team-analysis.json"
+    },
+    "cross_challenge": {
+      "confirmed_by_multiple": 6,
+      "disputed": 2,
+      "unanimous_clean_areas": ["src/Service/PaymentService.php:100-140"]
+    }
+  },
+  "findings": [
+    {
+      "severity": "CRITICAL",
+      "category": "security",
+      "file": "src/Service/PaymentService.php",
+      "line_start": 87,
+      "line_end": 92,
+      "title": "SQL injection via unescaped order_id",
+      "description": "...",
+      "fix_suggestion": "...",
+      "scoring_factors": {"reach": 3, "impact": 3, "reversibility": 3, "exploitability": 3},
+      "found_by": ["red_team", "edge_case"],
+      "disputed": false
+    }
+  ]
+}
+```
+
+### Team-specific finding fields
+
+When `tool` is `"test-team"`, each finding gains:
+
+- **`found_by`** — array of teammate roles that flagged this finding: any of `"happy_path"`, `"edge_case"`, `"red_team"`.
+- **`disputed`** — boolean. `true` if another teammate challenged the finding during cross-challenge. Dispute resolution narrative lives in the markdown report; JSON only records whether dispute occurred.
+
+## Skill/config `target_type`
+
+When `target_type` is `"skill"` or `"config"`, `findings[].category` uses instruction-testing vocabulary instead of code-testing vocabulary:
+
+- `trigger-analysis` — will Claude invoke this skill on the intended phrases? See `skill-and-config-testing.md` §1.
+- `instruction-fidelity` — will Claude follow step N after executing step M? Step drift, missed conditionals.
+- `frontmatter-verification` — declared `allowed-tools` / `model` / `description` match the body's actual tool use and claims.
+- `context-budget` — instruction/reference size vs. likely context window at invocation time.
+- `tool-reference-existence` — does every tool, file, skill, or agent named in the body actually exist?
+- `dependency-verification` — for configs, do the keys the consuming code reads actually exist and have the expected types?
+
+Example skill finding:
+
+```json
+{
+  "severity": "MEDIUM",
+  "category": "instruction-fidelity",
+  "file": "skills/my-skill/SKILL.md",
+  "line_start": 78,
+  "line_end": 82,
+  "title": "Step 5 references file that step 2 never wrote",
+  "description": "Step 5 instructs Claude to Read `.reports/analysis.md` but no prior step writes that file.",
+  "fix_suggestion": "Add explicit Write step before step 5, or change step 5 to conditional on file existence.",
+  "scoring_factors": {"reach": 2, "impact": 2, "reversibility": 1, "exploitability": 1}
+}
+```
+
+## Optional `rubric_score` block
+
+When the rubric-scoring methodology runs (see `rubric-scoring.md`), the envelope gains a `rubric_score` field:
+
+```json
+{
+  "rubric_score": {
+    "content_total": 20,
+    "structure_total": 22,
+    "overall": 42,
+    "grade": "Good",
+    "quality_gate": "PASS",
+    "content_breakdown": {
+      "correctness": 5,
+      "completeness": 4,
+      "edge_cases": 3,
+      "error_handling": 4,
+      "security": 4
+    },
+    "structure_breakdown": {
+      "readability": 5,
+      "separation": 4,
+      "dry": 4,
+      "testability": 4,
+      "extensibility": 5
+    }
+  }
+}
+```
+
+`quality_gate` values: `"PASS"` (overall ≥ 35) | `"FAIL"` (< 35). See `rubric-scoring.md` for the full scoring rubric.
+
+## CI gate patterns
+
+**Fail the build on any HIGH or CRITICAL:**
+
+```bash
+result=$(/paper-test --json src/Service/PaymentService.php)
+echo "$result" | jq -e '.status != "fail"' >/dev/null || exit 1
+```
+
+**Aggregate team report into a summary:**
+
+```bash
+jq '{
+  target: .target_files[0],
+  grade: (.rubric_score.grade // "ungraded"),
+  critical: .summary.critical,
+  high: .summary.high,
+  disputed_count: [.findings[] | select(.disputed == true)] | length
+}' paper-test-team-report.json
+```
+
+## Schema versioning contract
+
+- **1.x** — current. Additive only. New optional fields, new category strings, new severity-neutral envelope fields. Consumers pinning `^1\.` stay safe.
+- **2.0** — reserved for breaking changes. Examples of breaking: renaming `findings` to `issues`, changing severity casing to lowercase, removing `scoring_factors`. Any such change requires a new major and a migration note in the plugin CHANGELOG.

--- a/code-paper-test/skills/paper-test/references/rubric-scoring.md
+++ b/code-paper-test/skills/paper-test/references/rubric-scoring.md
@@ -115,3 +115,37 @@ QUALITY GATE: FAIL
   Below-minimum: Edge cases (2), Error handling (2)
   Action: Fix edge case handling and error messages before deployment
 ```
+
+---
+
+## JSON Output (`--json` mode)
+
+When rubric-scoring runs under `--json`, the envelope gains a `rubric_score` block alongside `summary` and `findings`:
+
+```json
+{
+  "rubric_score": {
+    "content_total": 20,
+    "structure_total": 18,
+    "overall": 38,
+    "grade": "Good",
+    "quality_gate": "PASS",
+    "content_breakdown": {
+      "correctness": 5,
+      "completeness": 4,
+      "edge_cases": 3,
+      "error_handling": 4,
+      "security": 4
+    },
+    "structure_breakdown": {
+      "readability": 4,
+      "separation": 3,
+      "dry": 4,
+      "testability": 4,
+      "extensibility": 3
+    }
+  }
+}
+```
+
+`quality_gate` values: `"PASS"` (overall ≥ 35) | `"FAIL"` (< 35). Full schema: `references/json-output-schema.md`.

--- a/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
+++ b/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
@@ -2,6 +2,29 @@
 
 Extend paper testing to non-code artifacts by tracing instructions through Claude instead of code through a CPU.
 
+## Deterministic + Agentic Pairing (Recommended Order)
+
+Before paper-testing a skill, command, or agent file, run the deterministic reviewer from `plugin-creation-tools` — it catches mechanical issues in seconds that would otherwise burn paper-test cycles.
+
+**Order:**
+
+1. **`plugin-creation-tools:skill-quality-reviewer` (deterministic, fast)** — grep-level checks: stale `claude-code-sdk` / `ClaudeCodeOptions` references, missing trigger phrases, dropped `MUST` / `PROACTIVELY` imperatives, removed `!`-backtick injections, frontmatter field gaps, broken internal links.
+2. **`paper-test` (semantic, deeper)** — trace the instructions as Claude would execute them: does step 5 reference a file step 2 never wrote? Is the context budget realistic? Do trigger phrases actually cover the intended user phrasings? Can adversarial `$ARGUMENTS` derail the workflow?
+
+Invocation:
+
+```
+# Step 1 — deterministic pass
+Use the plugin-creation-tools:skill-quality-reviewer agent on <skill/command/agent file>
+
+# Step 2 — semantic pass
+/paper-test <skill/command/agent file>
+# or for skills ≥ 300 lines or agent definitions:
+/code-paper:test-team <skill/command/agent file>
+```
+
+The reviewer typically clears within a single turn; paper-test then focuses on the harder semantic problems it cannot detect. Skipping step 1 means paper-test wastes effort flagging things a grep could have caught.
+
 ## The Mapping
 
 | Code Concept | Skill/Config Equivalent |
@@ -363,3 +386,20 @@ FLAWS FOUND:
   2. No reliable way to detect "already loaded" state
   3. Missing allowed-tools in frontmatter
 ```
+
+---
+
+## JSON Output (`--json` mode)
+
+When paper-testing a skill/command/agent/config with `--json`, the schema's `target_type` is `"skill"` or `"config"` and `findings[].category` uses instruction-testing vocabulary instead of code-testing vocabulary:
+
+| Category | What it covers |
+|----------|---------------|
+| `trigger-analysis` | Undertriggers/overtriggers, competing-skill conflicts, phrasing coverage (§1 above) |
+| `instruction-fidelity` | Steps that silently drop, reference unset state, or depend on prior-turn memory (§2) |
+| `frontmatter-verification` | `allowed-tools` / `model` / `description` match the body's actual claims (§3) |
+| `context-budget` | Skill + references vs. likely window size at invocation (§5) |
+| `tool-reference-existence` | Does every tool, file, skill, or agent named in the body exist? (§4) |
+| `dependency-verification` | For configs: do keys the consuming code reads exist with expected types? |
+
+Severity stays on the same `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO` rubric. Full schema: `references/json-output-schema.md`.


### PR DESCRIPTION
## Summary

Implements the [code-paper-test v0.6.0 → v0.7.0 plan](../../claude_code_projects/claude_docs/docs/improvements/code-paper-test-improvement-plan.md). Two tracks, single commit.

- **Track A — Structured JSON output (primary):** `--json` flag on `/paper-test` and `/code-paper:test-team` emits a stable, versioned schema (`schema_version: "1.0"`) matching the camoa-skills convention established by code-quality-tools. Enables CI integration, aggregation, and programmatic consumption. Severity rubric preserved (CRITICAL/HIGH/MEDIUM/LOW/INFO uppercase) — no new terms introduced.
- **Track B — plugin-creation-tools v3.2.0 cross-reference:** Documents the Deterministic + Agentic pairing in `skill-and-config-testing.md` — run `skill-quality-reviewer` first (catches stale SDK refs, missing imperatives, frontmatter gaps deterministically), then `paper-test` for semantic analysis (instruction fidelity, tool-ref existence, context budget).
- **Track C — Version bump & fixes:** plugin.json 0.6.0 → 0.7.0; SKILL.md 0.5.0 → 0.7.0 (drift fix); marketplace entry 0.7.0; metadata 1.14.4 → 1.14.5 (patch, pointer update). Added `model: sonnet` to SKILL.md frontmatter to match plugin's own CLAUDE.md convention. Seven new natural trigger phrases on the skill description.

## Quality gates

- `/plugin-creation-tools:validate` — **PASS** (worktree target)
- `skill-quality-reviewer` on SKILL.md, test-team.md, json-output-schema.md — **A** grade each. Issues raised (Progressive Disclosure duplication, bash fence on slash commands, wording ambiguity in invariant 2, missing illustrative-values note) all fixed in the same commit.

## Smoke tests

Sample paper-test and team JSON docs (see hidden details) validated against every invariant:

```
paper-test sample:  jq valid | findings is array | status warning on LOW-only | schema_version ^1\. match | severity uppercase in allowed set | CI gate would pass
test-team sample:   jq valid | status fail on CRITICAL | team has all 3 roles + cross_challenge | findings have found_by + disputed | CI gate correctly rejects | aggregate jq query produces expected shape
```

## Items landed checklist

- [x] A1 — `references/json-output-schema.md` (NEW, 280 lines)
- [x] A2 — SKILL.md "JSON Output Mode" section
- [x] A3 — `commands/test-team.md` `--json` argument parsing, per-teammate JSON files, lead aggregation step
- [x] A4 — `skill-and-config-testing.md` skill/config category table
- [x] A5 — `hooks/pre-compact.sh` surfaces `.json` reports
- [x] A6 — `rubric-scoring.md` `rubric_score` JSON block
- [x] B1 — `skill-and-config-testing.md` "Deterministic + Agentic Pairing" section at top
- [x] B2 — SKILL.md pointer to the pairing
- [x] C1 — SKILL.md `version: 0.5.0 → 0.7.0`
- [x] C2 — `plugin.json 0.6.0 → 0.7.0`
- [x] C3 — marketplace entry 0.7.0; metadata 1.14.4 → 1.14.5
- [x] C4 — CHANGELOG 0.7.0 entry
- [x] Bonus — `model: sonnet` added to SKILL.md to fix pre-existing convention gap caught by `/validate`
- [x] Bonus — 7 new trigger phrases on SKILL.md description (from user-feedback audit: "walk through", "step through", "dry run", "sanity check", "red team this", "poke holes in this", "test this agent")

## Plan deviations

- **Metadata bump was 1.14.4 → 1.14.5**, not 1.14.3 → 1.14.4 as the plan anticipated — two prior PRs (#110, #111) already incremented the metadata version since the plan was written. No structural change.
- **Added `model: sonnet` to SKILL.md frontmatter.** Not in the plan, but the validator flagged a pre-existing convention gap (plugin's own `CLAUDE.md` lists `model` as required but SKILL.md never had it). One-line fix, same PR.
- **Added 7 trigger phrases to SKILL.md description.** Not in the plan. Emerged from a mid-session audit of actual user phrasings; plan conventions say to preserve imperatives (which this does), and the additions are intent-distinct rather than padding.

## Out of scope (per plan)

- Agent SDK migration of the team command — markdown pattern works; no demand signal.
- Routines / Desktop Scheduled Tasks / `/loop` templates — paper-test is about novel code; CI-triggered recurring runs belong to code-quality-tools.
- Computer Use, skill-scoped hooks, REVIEW.md v2 — out-of-scope for this plugin's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)