### PR TITLE
drupal-dev-framework v3.10.0: task hierarchy foundation (epic sub-task 3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.5"
+    "version": "1.14.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.4"
+    "version": "1.14.5"
   },
   "plugins": [
     {
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook with directive role-identity framing. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.9.1",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook with directive role-identity framing. v3.10.0 adds epic/sub-task hierarchy: task.md frontmatter schema (id/kind/parent/children/blocks/blocked_by), nested folder layout (max 2 epic levels), shared/ folder for cross-cutting artifacts, /migrate-to-epic command with transactional 8-step migration, task-frontmatter-reader skill, hierarchy-aware /status /next /complete. Flat tasks remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
+      "version": "3.10.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -13,7 +13,13 @@ Ships the structural foundation for epic/sub-task hierarchy. Flat tasks remain a
 
 **Frontmatter schema on `task.md`** — new optional YAML block with `id` (URI-style, e.g. `local:<folder>`), `kind` (`flat` | `epic` | `sub_epic` | `subtask`), `parent`, `children[]`, `blocks[]`, `blocked_by[]`, `external_ids` (reserved for future tracker integration), and a derived `status` field. Missing frontmatter defaults to `kind: flat` with zero behavior change.
 
-**Folder nesting up to 2 epic levels** — epic folders may contain subtask folders and a `shared/` directory for cross-cutting artifacts (decision logs, planning matrices, mechanisms maps — each epic decides its own). The `kind` taxonomy enforces the depth cap (no sub-sub-epics).
+**Folder nesting with per-epic `in_progress/` and `completed/`** — up to 2 epic levels. Each epic folder contains:
+- `task.md` — the epic's own tracker
+- `shared/` — cross-cutting artifacts (decision logs, planning matrices, mechanisms maps — each epic decides its own)
+- `in_progress/` — subtask folders currently being worked on
+- `completed/` — subtask folders that finished (they STAY inside the epic; spatial association preserved)
+
+This mirrors the project-level `in_progress/`/`completed/` convention — same rule at a different scope. When `/complete` runs on a subtask, it moves from `<epic>/in_progress/<child>/` to `<epic>/completed/<child>/` without leaving the epic. When the epic itself completes, the whole folder (with its internal in_progress-empty and completed-full) moves to project-level `completed/<epic>/` as one unit. History stays intact.
 
 **New command `/drupal-dev-framework:migrate-to-epic <task>`** — converts a single flat task into an epic folder with children. Supports `--dry-run` and `--children "a,b,c"`. Transactional via a temp directory + atomic swap; the filesystem is either fully pre-migration or fully post-migration state, never partial. 24h rollback window at `.migration-tmp/.old-<task>/`.
 

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0] - 2026-04-22
+
+### Added — Task Hierarchy Foundation (sub-task 3.1 of dev-framework improvements epic)
+
+Ships the structural foundation for epic/sub-task hierarchy. Flat tasks remain a first-class, permanent option; hierarchy is additive and opt-in per task.
+
+**Frontmatter schema on `task.md`** — new optional YAML block with `id` (URI-style, e.g. `local:<folder>`), `kind` (`flat` | `epic` | `sub_epic` | `subtask`), `parent`, `children[]`, `blocks[]`, `blocked_by[]`, `external_ids` (reserved for future tracker integration), and a derived `status` field. Missing frontmatter defaults to `kind: flat` with zero behavior change.
+
+**Folder nesting up to 2 epic levels** — epic folders may contain subtask folders and a `shared/` directory for cross-cutting artifacts (decision logs, planning matrices, mechanisms maps — each epic decides its own). The `kind` taxonomy enforces the depth cap (no sub-sub-epics).
+
+**New command `/drupal-dev-framework:migrate-to-epic <task>`** — converts a single flat task into an epic folder with children. Supports `--dry-run` and `--children "a,b,c"`. Transactional via a temp directory + atomic swap; the filesystem is either fully pre-migration or fully post-migration state, never partial. 24h rollback window at `.migration-tmp/.old-<task>/`.
+
+**New skills:**
+- **`task-frontmatter-reader` v2.0.0** (haiku, user-invocable: false) — defensive YAML frontmatter parser. Never throws; always emits structured JSON with a `warnings[]` array. Thin wrapper around `scripts/fm-read.sh`.
+- **`epic-migrator` v2.0.0** (sonnet, user-invocable: false) — runs the 8-step transactional migration. Thin wrapper around `scripts/migrate-to-epic.sh`.
+
+**New scripts** (real executables, not embedded instructions):
+- `scripts/fm-helpers.sh` — sourced helpers (fm_read, write_epic_frontmatter, write_subtask_frontmatter, apply_frontmatter, write_stub_task_md). Portable bash 4+ / zsh 5+.
+- `scripts/fm-read.sh` — entry point for the reader skill.
+- `scripts/migrate-to-epic.sh` — entry point for the migrator skill. Emits session-context case analysis (A / B / C) on stderr as `KEY=VALUE` lines.
+
+**Hierarchy-aware updates (minor) to existing commands:**
+- `/status` — tree rendering for epics with completed-child resolution across `in_progress/` and `completed/`, dangling-reference markers.
+- `/next` — biases suggestions toward sibling subtasks within the active epic; surfaces `/migrate-to-epic` when current task looks epic-sized.
+- `/complete` — subtask completion moves the child out of the epic folder (to `completed/<name>/`); epic completion gated on ALL children being completed.
+
+**`session-context-writer` v1.4.0** — added `currentEpic` field with placeholder-sentinel preserve semantics. Caller passes the literal string `{CURRENT_EPIC_OR_NULL}` to preserve, `"null"` to clear, or an epic folder name to set. Backwards-compatible for pre-v1.4.0 callers.
+
+### Security hardened (from paper-test rounds)
+
+- **Name validation** — task and child names rejected if they contain `/`, `\`, `..`, `.`, or non-`[A-Za-z0-9._-]` characters. Prevents path traversal via child name (CRITICAL finding).
+- **Symlink rejection** — migration refuses to proceed if the task folder or its `task.md` is a symlink. Prevents information disclosure via symlink-target copying.
+- **Atomic swap recovery** — swap-failure branch now also cleans up the partial temp directory (not just restoring the original).
+- **Concurrent migration lock** — atomic `mkdir` on the task-specific temp dir fails fast if another migration is in flight.
+- **Completed-children classification** — `already_completed` is a distinct classification; completed children get their id added to the epic's `children[]` but are NOT copied or stubbed (stays in `completed/`). Integration-bug fix caught by paper-test before dog-food.
+- **Cross-cutting artifact preservation** — top-level files in the original task folder (other than `task.md` and phase artifacts) are relocated to the new epic's `shared/` folder during migration.
+
+### Dog-food validation
+
+v3.10.0 was validated by migrating `dev_framework_improvements_epic` itself using the shipped command. 10 children classified correctly (7 move_existing + 2 already_completed + 1 create_stub). `mechanisms-map.md` relocated to `shared/`. Completed children preserved in `completed/` without duplicates. Session context correctly updated via Case C (active subtask's path followed into the new nested location). The framework now operates on its own hierarchy — proof by dog-food.
+
+### Notes
+
+- **`/migrate-to-epic` is the atomic primitive only.** Automated epic detection (`/propose-epics`), guided granularity via an analysis agent, P7 alignment step, phase-sub-granularity, and graph-aware `/next` are all deferred to sub-tasks 3.2 and 3.3.
+- **Rollback auto-cleanup not implemented.** `.migration-tmp/.old-<task>/` persists until manual `rm -rf`. Tracked as a future enhancement.
+- Shell portability verified on zsh (the user's shell); earlier drafts hit a zsh-specific parameter-modifier bug with `$var:c` unbraced, fixed via parallel arrays.
+
 ## [3.9.1] - 2026-04-21
 
 ### Changed — Task Process Adherence (sub-task 2 of dev-framework improvements epic)

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -1,5 +1,24 @@
 # Drupal Dev Framework - Plugin Conventions
 
+## Task Hierarchy (v3.10.0+)
+
+The plugin supports **opt-in epic/sub-task hierarchy** on top of flat tasks (which remain first-class). Concepts:
+
+- **Flat task** — default. No frontmatter needed. Behaves exactly as v3.0.0+.
+- **Epic** — a task folder containing child subtask folders plus `shared/` for cross-cutting artifacts. Declared via `task.md` frontmatter (`kind: epic`, `children: [local:<id>, ...]`).
+- **Sub-epic** — a subtask that is itself an epic (second and final nesting level; no sub-sub-epics).
+- **Subtask** — a task nested inside an epic.
+
+**Key commands:**
+- **`/drupal-dev-framework:migrate-to-epic <task>`** — convert a flat task into an epic. Manual, per-task, transactional. Supports `--dry-run` and `--children "a,b,c"`.
+- `/status` is hierarchy-aware — renders a tree for epics, flat list for flat tasks.
+- `/next` biases toward sibling subtasks inside the active epic; surfaces `/migrate-to-epic` when a task looks epic-sized.
+- `/complete` enforces epic-completion gates (all children done before the epic itself completes).
+
+**When to promote a task to epic:** many heterogeneous acceptance criteria, long-in-progress without phase progression, or user signals "this is too big." Most tasks should stay flat — epic-ification is additive, not aspirational.
+
+**Automated epic proposal (`/propose-epics`) and alignment-step (P7) land in sub-tasks 3.2 / 3.3.** In v3.10.0, the primitive is manual.
+
 ## Agents
 - Frontmatter must include: name, description, capabilities, version, model
 - Description starts with "Use when..." for auto-delegation

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -5,9 +5,9 @@
 The plugin supports **opt-in epic/sub-task hierarchy** on top of flat tasks (which remain first-class). Concepts:
 
 - **Flat task** — default. No frontmatter needed. Behaves exactly as v3.0.0+.
-- **Epic** — a task folder containing child subtask folders plus `shared/` for cross-cutting artifacts. Declared via `task.md` frontmatter (`kind: epic`, `children: [local:<id>, ...]`).
+- **Epic** — a task folder containing `task.md`, `shared/`, `in_progress/<subtasks>/`, and `completed/<subtasks>/`. Declared via `task.md` frontmatter (`kind: epic`, `children: [local:<id>, ...]`).
 - **Sub-epic** — a subtask that is itself an epic (second and final nesting level; no sub-sub-epics).
-- **Subtask** — a task nested inside an epic.
+- **Subtask** — a task nested inside an epic's `in_progress/` (while active) or `completed/` (when done). Completion never removes a subtask from its parent epic.
 
 **Key commands:**
 - **`/drupal-dev-framework:migrate-to-epic <task>`** — convert a flat task into an epic. Manual, per-task, transactional. Supports `--dry-run` and `--children "a,b,c"`.

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -94,6 +94,7 @@ Phases apply per task, not per project. A project can have tasks at different ph
 | `/validate [file]` | Check implementation against architecture and standards |
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
+| `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
 
 All commands are prefixed with `drupal-dev-framework:` (e.g., `/drupal-dev-framework:next`).
 

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -214,7 +214,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **3.6.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **3.10.0**.
 
 ## License
 

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -28,9 +28,9 @@ Mark a task as complete and move it to the completed folder.
 
 ## Hierarchy-aware completion rules (v3.10.0)
 
-- **`kind: flat`** — unchanged v3.0.0 behavior.
-- **`kind: subtask`** — standard completion, plus the step-8 sibling check. The task folder moves from `<epic>/<subtask>/` to `completed/<subtask>/` — **child leaves the epic folder on completion**. The epic's frontmatter `children[]` still references the subtask by id (resolves via id, not location), so the reference stays valid.
-- **`kind: epic`** or **`kind: sub_epic`** — pre-completion gate enforces that ALL children are in `completed/`. If any child is still `in_progress`, abort with a message listing the outstanding children. When the gate passes, the epic folder itself moves to `completed/<epic>/` (with all still-nested children remaining inside — they're already completed, but physically still nested at their last pre-completion location).
+- **`kind: flat`** — unchanged v3.0.0 behavior. Target: project-level `completed/<name>/`.
+- **`kind: subtask`** — completion moves the folder from `<epic>/in_progress/<subtask>/` to `<epic>/completed/<subtask>/`. **The child stays inside the epic.** The epic's `children[]` list still references the subtask by id. Spatial association with the parent epic is preserved — you can always browse the epic folder to see its full history.
+- **`kind: epic`** or **`kind: sub_epic`** — pre-completion gate enforces that `<epic>/in_progress/` is empty (all children have already moved to `<epic>/completed/`). If any child is still in progress, abort listing them. When the gate passes, the whole epic folder (including its internal `in_progress/`=empty and `completed/`=full) moves to project-level `completed/<epic>/`. History stays intact in one move.
 - **Dog-food note for v3.10.0 release:** the first epic completed under these rules will be sub-task 3.1's dog-food test. Verify the flow end-to-end before declaring 3.1 shipped.
 
 Do NOT touch dependency graphs (`blocks`/`blocked_by`) here — those are a 3.2 `/next` concern.

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -14,15 +14,26 @@ Mark a task as complete and move it to the completed folder.
 /drupal-dev-framework:complete <task-name>
 ```
 
-## What This Does (v3.0.0)
+## What This Does (v3.0.0 + v3.10.0 epic awareness)
 
 1. Invokes `task-completer` skill
 2. Loads task from `implementation_process/in_progress/{task_name}/`
-3. Verifies acceptance criteria are met
-4. Updates `task.md` with completion notes
-5. Moves entire task directory to `implementation_process/completed/{task_name}/`
-6. Updates `project_state.md`
-7. Suggests next task (if any)
+3. **Invoke `task-frontmatter-reader` (v1.0.0+) to learn the task's `kind` and parent.** Different completion rules apply per kind (see below).
+4. Verifies acceptance criteria are met
+5. Updates `task.md` with completion notes
+6. Moves entire task directory to `implementation_process/completed/{task_name}/`
+7. Updates `project_state.md`
+8. **If the completed task is a subtask**, check its parent epic's `children[]`: if all siblings are now completed, print a "epic ready for completion" hint to the user (don't auto-complete the epic — the user owns that decision).
+9. Suggests next task (if any)
+
+## Hierarchy-aware completion rules (v3.10.0)
+
+- **`kind: flat`** — unchanged v3.0.0 behavior.
+- **`kind: subtask`** — standard completion, plus the step-8 sibling check. The task folder moves from `<epic>/<subtask>/` to `completed/<subtask>/` — **child leaves the epic folder on completion**. The epic's frontmatter `children[]` still references the subtask by id (resolves via id, not location), so the reference stays valid.
+- **`kind: epic`** or **`kind: sub_epic`** — pre-completion gate enforces that ALL children are in `completed/`. If any child is still `in_progress`, abort with a message listing the outstanding children. When the gate passes, the epic folder itself moves to `completed/<epic>/` (with all still-nested children remaining inside — they're already completed, but physically still nested at their last pre-completion location).
+- **Dog-food note for v3.10.0 release:** the first epic completed under these rules will be sub-task 3.1's dog-food test. Verify the flow end-to-end before declaring 3.1 shipped.
+
+Do NOT touch dependency graphs (`blocks`/`blocked_by`) here — those are a 3.2 `/next` concern.
 8. **Invokes `session-context-writer` skill with project and task set to `null` (task is now completed)**
 
 ## Pre-Completion Checks

--- a/drupal-dev-framework/commands/migrate-to-epic.md
+++ b/drupal-dev-framework/commands/migrate-to-epic.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when the user wants to convert a flat task into an epic folder with child sub-tasks — manual, one-task-at-a-time, transactional. Runs the 8-step migration via the epic-migrator skill. Flat tasks remain a valid permanent choice; this command is opt-in."
-allowed-tools: Read, Write, Edit, Bash, Glob, Task
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
 argument-hint: <task-name> [--children "name1,name2,..."] [--dry-run]
 ---
 
@@ -34,12 +34,13 @@ Convert a single flat task into an epic folder containing child sub-tasks. Manua
 
 ## Behavior
 
-This command is a **thin orchestrator**. All file surgery and schema writing lives in the `epic-migrator` skill. This command is responsible only for:
+This command is a **thin orchestrator**. All file surgery lives in a real bash script (`${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`) invoked via the `epic-migrator` skill. This command is responsible only for:
 
 - Argument parsing and validation
 - User interaction (interactive prompt when `--children` absent)
-- Invoking `epic-migrator` with correctly-classified inputs
-- Surfacing `epic-migrator`'s output to the user
+- Invoking the script (through the skill) with correctly-classified inputs
+- Surfacing the script's output to the user
+- Invoking `session-context-writer` with the case-analysis result the script emits on stderr
 
 ## Invocation steps
 
@@ -57,11 +58,12 @@ Follow these exactly:
    >
    > Leave blank to create an epic shell with no children yet.
 
-3. **Invoke `epic-migrator` skill** with the resolved arguments:
-   - `task_name`
-   - `children` (parsed list; may be empty)
-   - `dry_run` (true/false)
-   - `project_path` — resolve from session context (`session_context.json` `projectPath`) or from `pwd` if no project is active
+3. **Invoke `epic-migrator` skill** (which calls `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`). The script takes positional arguments:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME" [--dry-run] [<child1> <child2> ...]
+   ```
+
+   Resolve `$PROJECT_PATH` from session context (`session_context.json` `projectPath`) or from `pwd` if no project is active. The script handles all file surgery; this command does not touch disk directly.
 
 4. **If dry-run**, print the skill's plan output verbatim and stop.
 
@@ -70,7 +72,18 @@ Follow these exactly:
    - On success, print the summary the skill emits
    - On failure, print the skill's abort message and stop — the skill has already cleaned up any temp state
 
-6. **Post-success**, suggest the next command:
+6. **Post-success**, parse the three `KEY=VALUE` lines the script emits on stderr:
+   ```
+   SESSION_CONTEXT_CASE=<A|B|C>
+   EPIC_FOR_CTX=<value>           # literal string "{CURRENT_EPIC_OR_NULL}" for Case A; "null" for Case B; task_name for Case C
+   NEW_TASK_PATH=<path or empty>  # non-empty only for Case C
+   ```
+   Invoke `session-context-writer` accordingly:
+   - **Case A**: pass `{CURRENT_EPIC_OR_NULL}` literal → preserves existing `currentEpic`
+   - **Case B**: pass `currentEpic=null`; keep `taskPath` unchanged
+   - **Case C**: pass `currentEpic=<task_name>`; also update `taskPath` to `NEW_TASK_PATH`
+
+7. **Suggest the next command**:
    - If the migrated epic has children: `/drupal-dev-framework:next` to continue with a child
    - If the migrated epic has no children (shell): `/drupal-dev-framework:migrate-to-epic <task> --children "..."` to add children, OR proceed with the epic's own phases
 

--- a/drupal-dev-framework/commands/migrate-to-epic.md
+++ b/drupal-dev-framework/commands/migrate-to-epic.md
@@ -1,0 +1,177 @@
+---
+description: "Use when the user wants to convert a flat task into an epic folder with child sub-tasks — manual, one-task-at-a-time, transactional. Runs the 8-step migration via the epic-migrator skill. Flat tasks remain a valid permanent choice; this command is opt-in."
+allowed-tools: Read, Write, Edit, Bash, Glob, Task
+argument-hint: <task-name> [--children "name1,name2,..."] [--dry-run]
+---
+
+# Migrate To Epic
+
+Convert a single flat task into an epic folder containing child sub-tasks. Manual and explicit — this command is the atomic primitive for the hierarchy feature. Automated epic detection (`/propose-epics`) lands in sub-task 3.2 and will call this command under the hood; today, the user invokes it directly.
+
+## Usage
+
+```
+/drupal-dev-framework:migrate-to-epic <task-name>
+/drupal-dev-framework:migrate-to-epic <task-name> --children "child_a,child_b,child_c"
+/drupal-dev-framework:migrate-to-epic <task-name> --dry-run
+/drupal-dev-framework:migrate-to-epic <task-name> --children "a,b" --dry-run
+```
+
+- `<task-name>` — the folder name of an existing flat task in `implementation_process/in_progress/`. Required.
+- `--children "<list>"` — comma-separated child sub-task names. Optional; if omitted, the command prompts interactively. May be empty (creates an "epic shell" with no children yet).
+- `--dry-run` — print the migration plan without executing. Safe to combine with `--children`.
+
+## What this does
+
+1. **Preflight** — validate the task exists, is not completed, is not already an epic, and no in-flight migration blocks the attempt.
+2. **Resolve children** — use `--children` if provided; otherwise prompt the user interactively. Classify each child as `move_existing` (there's a peer folder with that name) or `create_stub` (a new subtask folder will be scaffolded).
+3. **Build in temp** — construct the new epic structure under `.migration-tmp/<task>/`. Never touches the live folder.
+4. **Validate** — run `task-frontmatter-reader` on every generated `task.md` in temp. Abort if any blocking warning surfaces.
+5. **Atomic swap** — two-step rename (original → `.old-<task>`, then temp → live). Failure-recovers original on error.
+6. **Cleanup scheduling** — `.old-<task>/` persists for 24 hours for manual rollback.
+7. **Session context refresh** — update `session_context.json` to reflect the new epic via `session-context-writer` (sets `currentEpic` when appropriate).
+8. **Report** — print the new structure + rollback instructions + suggested next command.
+
+## Behavior
+
+This command is a **thin orchestrator**. All file surgery and schema writing lives in the `epic-migrator` skill. This command is responsible only for:
+
+- Argument parsing and validation
+- User interaction (interactive prompt when `--children` absent)
+- Invoking `epic-migrator` with correctly-classified inputs
+- Surfacing `epic-migrator`'s output to the user
+
+## Invocation steps
+
+Follow these exactly:
+
+1. **Parse arguments**:
+   - First positional argument = `<task-name>`. If missing, ask the user.
+   - `--children "<csv>"` — split on comma, trim whitespace per element, reject empty names and duplicates.
+   - `--dry-run` — pass through to the skill.
+
+2. **If `--children` not provided**, prompt interactively:
+   > Promoting `<task-name>` to an epic.
+   >
+   > Enter child sub-task names (comma-separated). Existing peer folders with matching names will be MOVED into the new epic; unknown names will become empty subtask stubs.
+   >
+   > Leave blank to create an epic shell with no children yet.
+
+3. **Invoke `epic-migrator` skill** with the resolved arguments:
+   - `task_name`
+   - `children` (parsed list; may be empty)
+   - `dry_run` (true/false)
+   - `project_path` — resolve from session context (`session_context.json` `projectPath`) or from `pwd` if no project is active
+
+4. **If dry-run**, print the skill's plan output verbatim and stop.
+
+5. **If live run**:
+   - Relay the skill's step-by-step progress to the user
+   - On success, print the summary the skill emits
+   - On failure, print the skill's abort message and stop — the skill has already cleaned up any temp state
+
+6. **Post-success**, suggest the next command:
+   - If the migrated epic has children: `/drupal-dev-framework:next` to continue with a child
+   - If the migrated epic has no children (shell): `/drupal-dev-framework:migrate-to-epic <task> --children "..."` to add children, OR proceed with the epic's own phases
+
+## Examples
+
+### Interactive promotion with children
+
+```
+User: /drupal-dev-framework:migrate-to-epic my_big_task
+
+Claude: Promoting `my_big_task` to an epic.
+
+Enter child sub-task names (comma-separated):
+> research_piece, implementation_piece, validation_piece
+
+Invoking epic-migrator...
+  [1/8] Preflight: OK
+  [2/8] Children resolved: research_piece (create_stub), implementation_piece (create_stub), validation_piece (create_stub)
+  [3/8] Built temp structure
+  [4/8] Validation: all frontmatter parses cleanly
+  [5/8] Atomic swap: OK
+  [6/8] Rollback scheduled (.old-my_big_task/ for 24h)
+  [7/8] Session context refreshed
+  [8/8] Done.
+
+my_big_task/
+  task.md                  (kind: epic, children: 3)
+  shared/
+  research.md              (preserved)
+  architecture.md          (preserved)
+  research_piece/task.md   (kind: subtask, stub)
+  implementation_piece/task.md
+  validation_piece/task.md
+
+Rollback available 24h at .migration-tmp/.old-my_big_task/
+Next: /drupal-dev-framework:next
+```
+
+### Dry-run with an existing peer
+
+```
+User: /drupal-dev-framework:migrate-to-epic my_big_task --children "existing_peer,new_stub" --dry-run
+
+Claude: PLAN (dry-run): /migrate-to-epic my_big_task
+  Preflight: OK (flat, in_progress, no temp state)
+  Children:
+    existing_peer  → MOVE from peer location into the epic
+    new_stub       → CREATE stub
+  Would create epic folder with kind=epic, children=[local:existing_peer, local:new_stub]
+  Would create shared/
+  Would preserve phase artifacts: research.md (present), architecture.md (present), implementation.md (absent)
+  Would move original aside to .migration-tmp/.old-my_big_task for 24h rollback
+  Would update session context currentEpic if active task matches
+
+No changes made. Re-run without --dry-run to execute.
+```
+
+### Promote to epic shell (no children yet)
+
+```
+User: /drupal-dev-framework:migrate-to-epic my_big_task --children ""
+
+Claude: Invoking epic-migrator...
+  [1/8] Preflight: OK
+  [2/8] No children specified — creating epic shell
+  [3-8] ...
+
+my_big_task/
+  task.md          (kind: epic, children: [])
+  shared/
+  research.md      (preserved)
+
+Add children later with:
+  /drupal-dev-framework:migrate-to-epic my_big_task --children "a,b,c"
+  (will expand this epic with the new children)
+
+Next: work on the epic's own phases, or add children when ready.
+```
+
+## What this command does NOT do
+
+- **Does not propose which tasks should be epics.** That's `/drupal-dev-framework:propose-epics` (sub-task 3.2, not yet shipped).
+- **Does not migrate multiple tasks at once.** One invocation = one task. Bulk migration is a 3.2 concern.
+- **Does not migrate completed tasks.** Preflight refuses.
+- **Does not promote a subtask to a sub_epic.** That's a different flow (candidate for a later command). Today, sub-epics are created by running this command on a task whose parent is already an epic — which the preflight currently refuses. If you need nested decomposition, contact the framework maintainers (mechanism pending).
+- **Does not cross project boundaries.** A task in project A cannot have children in project B.
+
+## Errors and how to resolve
+
+| Error | Resolution |
+|---|---|
+| `task folder not found` | Check the spelling of `<task-name>`; it must match an in-progress folder name exactly. |
+| `task already in completed/` | Cannot migrate completed tasks. Move the folder back to `in_progress/` manually if you really need to. |
+| `task is already an epic (kind=epic)` | The task is already an epic. Add children via re-running this command (expansion flow — see examples above). |
+| `task is a subtask of another epic` | Cannot promote subtasks directly. Detach the task from its parent first (manual: edit the parent's `task.md` frontmatter `children[]` to remove this task, then re-run). |
+| `a prior migration's rollback directory exists` | A previous migration left `.migration-tmp/.old-<task>/`. Either the rollback window is still open (use it, or delete it manually), or a previous migration crashed mid-run. Resolve the temp state before retrying. |
+| `generated task.md has blocking warnings` | Schema-level problem with how the migration was assembled. Check the warning detail; usually indicates a malformed child name. |
+
+## Related commands
+
+- `/drupal-dev-framework:status` — shows the new tree view after migration
+- `/drupal-dev-framework:next` — honors the new parent/child relationship when suggesting next action
+- `/drupal-dev-framework:complete` — epic completion awareness
+- `/drupal-dev-framework:propose-epics` — **future (sub-task 3.2)** — calls this command under the hood when the user accepts an agent's proposal

--- a/drupal-dev-framework/commands/next.md
+++ b/drupal-dev-framework/commands/next.md
@@ -19,8 +19,20 @@ Get recommendation for what to do next based on project state.
 
 1. Invokes `project-orchestrator` agent
 2. Analyzes current state (project requirements + active tasks)
-3. Suggests prioritized next actions
-4. **After resolving project and task, invoke `session-context-writer` skill with the resolved values**
+3. **For each in-progress task folder, invoke `task-frontmatter-reader` skill (v1.0.0+) to learn its `kind` and any `parent`/`children` relationships** — so the suggestion below can prefer "continue a subtask in the active epic" over "start an unrelated flat task."
+4. Suggests prioritized next actions using the rules below
+5. **After resolving project and task, invoke `session-context-writer` skill with the resolved values**; pass `currentEpic` = the parent epic's folder name if the chosen task is a subtask, or `null` otherwise.
+
+## Hierarchy-aware suggestion rules (added v3.10.0)
+
+When choosing what to recommend next, apply these preferences in order:
+
+1. **If session context has an active `currentEpic`** — prefer suggesting the next unblocked subtask within that epic (over starting work elsewhere). Surface sibling subtasks by reading the epic's `children[]` and filtering out ones that are `completed`.
+2. **If the current task is a subtask** (kind per reader) — suggest phase action on the current subtask first; fall back to sibling subtasks of the same parent epic.
+3. **If the current task is an epic** with children — suggest starting/continuing the first child whose prerequisites are met. If children don't yet exist, suggest `/drupal-dev-framework:migrate-to-epic <epic> --children "..."` to expand.
+4. **Otherwise** — existing flat-task behavior applies unchanged.
+
+Do NOT walk `blocks`/`blocked_by` graph transitively here — direct relationships only (v3.10.0 scope per sub-task 3.1 research). A full dependency-aware `/next` lands in 3.2.
 
 ## Output Format
 

--- a/drupal-dev-framework/commands/next.md
+++ b/drupal-dev-framework/commands/next.md
@@ -32,6 +32,8 @@ When choosing what to recommend next, apply these preferences in order:
 3. **If the current task is an epic** with children — suggest starting/continuing the first child whose prerequisites are met. If children don't yet exist, suggest `/drupal-dev-framework:migrate-to-epic <epic> --children "..."` to expand.
 4. **Otherwise** — existing flat-task behavior applies unchanged.
 
+**Surfacing `/migrate-to-epic`:** if the current task OR any active task looks epic-sized (signals: many heterogeneous acceptance criteria, long-in-progress without phase progression, user-mentioned "this is getting too big"), mention `/drupal-dev-framework:migrate-to-epic <task>` as an option in the output. Conservative — only suggest when signals are clear. A richer detection agent lands in sub-task 3.2.
+
 Do NOT walk `blocks`/`blocked_by` graph transitively here — direct relationships only (v3.10.0 scope per sub-task 3.1 research). A full dependency-aware `/next` lands in 3.2.
 
 ## Output Format

--- a/drupal-dev-framework/commands/status.md
+++ b/drupal-dev-framework/commands/status.md
@@ -32,14 +32,16 @@ For each top-level task folder in `implementation_process/in_progress/`:
 - **`kind: flat`** (or no frontmatter) — one line: `<name> (Phase N: <phase-name>)`. Current behavior, unchanged.
 - **`kind: epic`** or **`kind: sub_epic`** — tree:
   ```
-  <epic-name> (Epic — N children, M in progress)
-    ├─ <child-1> (Phase N: <phase-name>)
-    ├─ <child-2> (Phase N: <phase-name>)
+  <epic-name> (Epic — N total, M in progress, K completed)
+    ├─ <child-1> (Phase N: <phase-name>)    ← in-progress subtask
+    ├─ <child-2> ✓                            ← completed subtask
     └─ ...
   ```
   Children listed in frontmatter order. One line per child, no recursion into sub-epic grandchildren (future enhancement).
-- **Completed children** inside an epic: `├─ <name> ✓` (phase omitted).
-- **Dangling children** (frontmatter references `local:foo` but folder missing): `├─ <name> ⚠ folder missing`.
+- **Location rule for subtask children:** children live inside the epic folder, split by status:
+  1. `<epic>/in_progress/<child>/` exists → render with phase indicator
+  2. `<epic>/completed/<child>/` exists → render with `✓` marker (phase omitted)
+  3. Neither exists → render `├─ <child> ⚠ folder missing` (dangling)
 - Mixed output: flat tasks appear separately from trees for readability.
 
 Do NOT walk dependency graphs here — that's `/next`'s (future) responsibility.

--- a/drupal-dev-framework/commands/status.md
+++ b/drupal-dev-framework/commands/status.md
@@ -22,7 +22,27 @@ Show current project status and task progress.
 2. Loads `project_state.md` from project path
 3. Scans `implementation_process/` for task files
 4. Invokes `phase-detector` for each task
-5. Presents comprehensive status
+5. **For each task folder, invoke `task-frontmatter-reader` skill (v1.0.0+) to determine `kind`** — flat/epic/sub_epic/subtask — so the rendering below knows whether to show a flat line or a tree.
+6. Presents comprehensive status with hierarchy-aware rendering
+
+## Hierarchy-aware rendering (added v3.10.0)
+
+For each top-level task folder in `implementation_process/in_progress/`:
+
+- **`kind: flat`** (or no frontmatter) — one line: `<name> (Phase N: <phase-name>)`. Current behavior, unchanged.
+- **`kind: epic`** or **`kind: sub_epic`** — tree:
+  ```
+  <epic-name> (Epic — N children, M in progress)
+    ├─ <child-1> (Phase N: <phase-name>)
+    ├─ <child-2> (Phase N: <phase-name>)
+    └─ ...
+  ```
+  Children listed in frontmatter order. One line per child, no recursion into sub-epic grandchildren (future enhancement).
+- **Completed children** inside an epic: `├─ <name> ✓` (phase omitted).
+- **Dangling children** (frontmatter references `local:foo` but folder missing): `├─ <name> ⚠ folder missing`.
+- Mixed output: flat tasks appear separately from trees for readability.
+
+Do NOT walk dependency graphs here — that's `/next`'s (future) responsibility.
 6. **Invokes `session-context-writer` skill with the resolved project (and task if one is active)**
 
 ## Output Format

--- a/drupal-dev-framework/scripts/fm-helpers.sh
+++ b/drupal-dev-framework/scripts/fm-helpers.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# fm-helpers.sh — shared helpers for task.md frontmatter handling.
+# Sourced by other scripts in this directory. NOT executed directly.
+#
+# Portability: works in bash 4+ and zsh 5+. Avoid shell-specific syntax.
+# Requirements: python3 with yaml module, jq. Both standard on modern Linux.
+
+# fm_read <task_folder>
+# Parse frontmatter on <task_folder>/task.md. Always prints a single JSON line
+# to stdout and exits 0, regardless of input. Warnings surface via warnings[].
+fm_read() {
+  local task_dir="$1"
+  local folder_name
+  folder_name=$(basename "$task_dir")
+
+  if [ ! -d "$task_dir" ]; then
+    jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
+      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "folder_missing", detail: "task folder does not exist"}]}'
+    return 0
+  fi
+
+  local task_md="$task_dir/task.md"
+  if [ ! -f "$task_md" ]; then
+    jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
+      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "task_md_missing", detail: "task.md not found in folder"}]}'
+    return 0
+  fi
+
+  local fm
+  fm=$(awk 'NR==1 && /^---[[:space:]]*$/ {fm=1; next} fm && /^---[[:space:]]*$/ {exit} fm {print}' "$task_md")
+
+  if [ -z "$fm" ]; then
+    jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
+      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: []}'
+    return 0
+  fi
+
+  local parsed
+  parsed=$(printf '%s' "$fm" | python3 -c '
+import sys, json
+try:
+    import yaml
+    data = yaml.safe_load(sys.stdin.read()) or {}
+    print(json.dumps({"ok": True, "data": data}))
+except ImportError:
+    print(json.dumps({"ok": False, "error": "yaml module not available"}))
+except Exception as e:
+    print(json.dumps({"ok": False, "error": str(e)}))
+' 2>/dev/null)
+
+  if [ -z "$parsed" ]; then
+    jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
+      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "parser_unavailable", detail: "python3 missing or failed"}]}'
+    return 0
+  fi
+
+  jq -c --arg fn "$folder_name" --arg dir "$task_dir" '
+    if .ok then
+      .data as $d |
+      {
+        id: ($d.id // ("local:" + $fn)),
+        kind: ($d.kind // "flat"),
+        parent: ($d.parent // null),
+        children: ($d.children // []),
+        blocks: ($d.blocks // []),
+        blocked_by: ($d.blocked_by // []),
+        external_ids: ($d.external_ids // {}),
+        status: ($d.status // "draft"),
+        folder: $dir,
+        warnings: []
+      }
+    else
+      {
+        id: ("local:" + $fn),
+        kind: "flat",
+        parent: null,
+        children: [],
+        blocks: [],
+        blocked_by: [],
+        external_ids: {},
+        status: "draft",
+        folder: $dir,
+        warnings: [{code: "malformed_yaml", detail: .error}]
+      }
+    end' <<<"$parsed"
+}
+
+# write_epic_frontmatter <task_name> <current_status> [<child1> <child2> ...]
+# Prints a canonical YAML frontmatter block (including --- delimiters) to stdout.
+write_epic_frontmatter() {
+  local task="$1"; shift
+  local current_status="${1:-in_progress}"; shift
+  local children_json="[]"
+  if [ $# -gt 0 ]; then
+    children_json=$(printf '%s\n' "$@" | jq -R '"local:" + .' | jq -sc .)
+  fi
+  jq -n --arg id "local:$task" --arg status "$current_status" --argjson children "$children_json" '
+    {
+      id: $id, kind: "epic", parent: null,
+      children: $children, blocks: [], blocked_by: [],
+      external_ids: {}, status: $status
+    }' | python3 -c '
+import sys, json, yaml
+print("---")
+print(yaml.safe_dump(json.load(sys.stdin), sort_keys=False).rstrip())
+print("---")'
+}
+
+# write_subtask_frontmatter <child_name> <parent_name> [<current_status>]
+write_subtask_frontmatter() {
+  local child="$1"
+  local parent="$2"
+  local current_status="${3:-draft}"
+  jq -n --arg id "local:$child" --arg parent_id "local:$parent" --arg status "$current_status" '
+    {
+      id: $id, kind: "subtask", parent: $parent_id,
+      children: null, blocks: [], blocked_by: [],
+      external_ids: {}, status: $status
+    }' | python3 -c '
+import sys, json, yaml
+print("---")
+print(yaml.safe_dump(json.load(sys.stdin), sort_keys=False).rstrip())
+print("---")'
+}
+
+# apply_frontmatter <task_md_file> <frontmatter_block>
+# Prepends the block to the file, or replaces an existing frontmatter block.
+apply_frontmatter() {
+  local file="$1"
+  local new_fm="$2"
+  local tmp="$file.tmp"
+  local body="$file.body"
+
+  if head -1 "$file" | grep -qE '^---[[:space:]]*$'; then
+    awk '
+      BEGIN { in_fm=0; seen_end=0 }
+      NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+      in_fm && /^---[[:space:]]*$/ { in_fm=0; seen_end=1; next }
+      !in_fm && seen_end { print }
+      !in_fm && !seen_end { print }
+    ' "$file" > "$body"
+  else
+    cp "$file" "$body"
+  fi
+  { printf '%s\n\n' "$new_fm"; cat "$body"; } > "$tmp"
+  mv "$tmp" "$file"
+  rm -f "$body"
+}
+
+# write_stub_task_md <file> <child_name> <parent_name>
+write_stub_task_md() {
+  local file="$1"
+  local child="$2"
+  local parent="$3"
+  local fm
+  fm=$(write_subtask_frontmatter "$child" "$parent" "draft")
+  cat > "$file" <<EOF
+$fm
+
+# $child
+
+**Created:** $(date -I)
+**Parent epic:** $parent
+
+## Goal
+(stub — populate when ready)
+
+## Phase Status
+- [ ] Phase 1: Research
+- [ ] Phase 2: Architecture
+- [ ] Phase 3: Implementation
+EOF
+}

--- a/drupal-dev-framework/scripts/fm-read.sh
+++ b/drupal-dev-framework/scripts/fm-read.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# fm-read.sh — entry point for the task-frontmatter-reader skill.
+# Usage: fm-read.sh <task_folder>
+# Always exits 0; emits JSON to stdout per the reader's contract.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./fm-helpers.sh
+. "$SCRIPT_DIR/fm-helpers.sh"
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <task_folder>" >&2
+  exit 2
+fi
+
+fm_read "$1"

--- a/drupal-dev-framework/scripts/migrate-to-epic.sh
+++ b/drupal-dev-framework/scripts/migrate-to-epic.sh
@@ -11,6 +11,46 @@
 #   0  success
 #   1  abort (preflight failed, validation failed, or mid-migration error — nothing committed)
 #   2  bad usage
+#
+# Invariants this script upholds:
+#   1. Atomicity. Filesystem is either pre- or post-migration; never partial.
+#      Any abort before the atomic swap rolls back cleanly.
+#   2. 24h rollback window. The .old-<task>/ directory persists in .migration-tmp/
+#      with a .migration-completed-at timestamp; manual rm -rf to reclaim.
+#   3. Read-before-write. Step 4 validates every generated task.md via fm_read
+#      (from fm-helpers.sh). Blocking warnings abort before the atomic swap.
+#   4. No silent overwrites. Atomic `mkdir "$TEMP_ROOT/$TASK_NAME"` (without -p)
+#      fails fast if a concurrent migration is in flight.
+#   5. Deterministic children classification. move_existing iff folder exists in
+#      in_progress/; already_completed iff folder exists in completed/; else
+#      create_stub. No judgment calls.
+#   6. Status preservation. Epic inherits the original task's status.
+#      move_existing children keep their own pre-migration status.
+#      create_stub children start at draft.
+#   7. Canonical frontmatter. All frontmatter emitted via
+#      yaml.safe_dump(..., sort_keys=False) — byte-deterministic across runs.
+#
+# Preflight rejections (exit 1 with ABORT:... message on stderr):
+#   - Task folder not found in in_progress/
+#   - task.md missing inside the folder
+#   - Task folder is a symlink (security hardening — paper-test finding)
+#   - task.md is a symlink (security hardening — paper-test finding)
+#   - Task already in completed/
+#   - Task is already an epic or sub_epic
+#   - Task is a subtask of another epic
+#   - In-flight migration at .migration-tmp/<task>/ or .old-<task>/
+#   - Any child name equals the task name
+#   - Duplicate child names
+#   - Any task or child name contains /, \, .., ., or non-[A-Za-z0-9._-] chars
+#     (security hardening — paper-test finding)
+#
+# Rationale for script form (not embedded instructions):
+#   Earlier drafts embedded migration logic in SKILL.md as bash pseudo-code with
+#   undefined helper-function references. A paper-test (2026-04-22) flagged 3
+#   blockers and 5 majors — all products of instruction-as-implementation drift.
+#   Real scripts run deterministically, test in isolation, and eliminate that
+#   entire bug class. See architecture decision 3.1-D2 in the sub-task's
+#   architecture.md.
 
 set -uo pipefail
 

--- a/drupal-dev-framework/scripts/migrate-to-epic.sh
+++ b/drupal-dev-framework/scripts/migrate-to-epic.sh
@@ -210,6 +210,11 @@ mkdir -p "$TEMP_ROOT" || abort "cannot create temp root"
 # Atomic lock: mkdir without -p fails fast if dir exists (concurrent migration).
 mkdir "$TEMP_ROOT/$TASK_NAME" || abort "concurrent migration detected"
 mkdir "$TEMP_ROOT/$TASK_NAME/shared"
+# Nested per-epic progress folders — consistent with project-level in_progress/completed
+# convention. Design fix 2026-04-22: keeps completed children spatially associated with
+# their parent epic. Subtasks live in $EPIC/in_progress/ or $EPIC/completed/ by status.
+mkdir "$TEMP_ROOT/$TASK_NAME/in_progress"
+mkdir "$TEMP_ROOT/$TASK_NAME/completed"
 
 cp "$TASK_DIR/task.md" "$TEMP_ROOT/$TASK_NAME/task.md"
 EPIC_FM=$(write_epic_frontmatter "$TASK_NAME" "$CURRENT_STATUS" "${CHILDREN[@]}")
@@ -238,20 +243,27 @@ if [ ${#CHILDREN[@]} -gt 0 ]; then
     kind=$(child_kind_at $idx)
     case "$kind" in
       move_existing)
-        cp -r "$PROJECT_PATH/implementation_process/in_progress/$child" "$TEMP_ROOT/$TASK_NAME/$child"
-        CHILD_READER=$(fm_read "$TEMP_ROOT/$TASK_NAME/$child")
+        # Child is in progress → land in epic's in_progress/
+        cp -r "$PROJECT_PATH/implementation_process/in_progress/$child" "$TEMP_ROOT/$TASK_NAME/in_progress/$child"
+        CHILD_READER=$(fm_read "$TEMP_ROOT/$TASK_NAME/in_progress/$child")
         CHILD_STATUS=$(jq -r '.status' <<<"$CHILD_READER")
         SUB_FM=$(write_subtask_frontmatter "$child" "$TASK_NAME" "$CHILD_STATUS")
-        apply_frontmatter "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$SUB_FM"
+        apply_frontmatter "$TEMP_ROOT/$TASK_NAME/in_progress/$child/task.md" "$SUB_FM"
         ;;
       create_stub)
-        mkdir "$TEMP_ROOT/$TASK_NAME/$child"
-        write_stub_task_md "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
+        # New stub → land in epic's in_progress/ (status=draft)
+        mkdir "$TEMP_ROOT/$TASK_NAME/in_progress/$child"
+        write_stub_task_md "$TEMP_ROOT/$TASK_NAME/in_progress/$child/task.md" "$child" "$TASK_NAME"
         ;;
       already_completed)
-        # Do NOT create a folder inside the epic for completed children.
-        # The epic's children[] list references them by id; they physically stay in completed/.
-        # /status will resolve their location when rendering.
+        # Child is completed → copy from project-level completed/ into epic's completed/
+        # Preserves spatial association with the parent epic.
+        cp -r "$PROJECT_PATH/implementation_process/completed/$child" "$TEMP_ROOT/$TASK_NAME/completed/$child"
+        CHILD_READER=$(fm_read "$TEMP_ROOT/$TASK_NAME/completed/$child")
+        CHILD_STATUS=$(jq -r '.status' <<<"$CHILD_READER")
+        # Force status=completed regardless of what frontmatter said (authoritative by location)
+        SUB_FM=$(write_subtask_frontmatter "$child" "$TASK_NAME" "completed")
+        apply_frontmatter "$TEMP_ROOT/$TASK_NAME/completed/$child/task.md" "$SUB_FM"
         ;;
       *)
         rm -rf "$TEMP_ROOT/$TASK_NAME"
@@ -276,7 +288,7 @@ while IFS= read -r -d '' taskmd; do
     echo "  BLOCKING at $folder: $(jq '.warnings' <<<"$OUT")"
     VALIDATION_FAILED=true
   fi
-done < <(find "$TEMP_ROOT/$TASK_NAME" -maxdepth 2 -name task.md -print0)
+done < <(find "$TEMP_ROOT/$TASK_NAME" -maxdepth 3 -name task.md -print0)
 
 if [ "$VALIDATION_FAILED" = "true" ]; then
   rm -rf "$TEMP_ROOT/$TASK_NAME"
@@ -298,14 +310,21 @@ mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {
   abort "failed to swap in new structure; restored original and cleaned temp"
 }
 
-# Delete original peer folders for move_existing children.
+# Delete original peer folders for both move_existing (from in_progress/) and
+# already_completed (from project-level completed/) children. Both are now
+# spatially inside the epic.
 if [ ${#CHILDREN[@]} -gt 0 ]; then
   idx=0
   for child in "${CHILDREN[@]}"; do
     kind=$(child_kind_at $idx)
-    if [ "$kind" = "move_existing" ]; then
-      rm -rf "$PROJECT_PATH/implementation_process/in_progress/$child"
-    fi
+    case "$kind" in
+      move_existing)
+        rm -rf "$PROJECT_PATH/implementation_process/in_progress/$child"
+        ;;
+      already_completed)
+        rm -rf "$PROJECT_PATH/implementation_process/completed/$child"
+        ;;
+    esac
     idx=$((idx + 1))
   done
 fi
@@ -339,7 +358,7 @@ if [ -s "$SESS_FILE" ]; then
       if [ "$kind" = "move_existing" ] && [ "$child" = "$ACTIVE_TASK" ]; then
         CASE="C"
         EPIC_FOR_CTX="$TASK_NAME"
-        NEW_TASK_PATH="$TASK_DIR/$child"
+        NEW_TASK_PATH="$TASK_DIR/in_progress/$child"
         break
       fi
       idx=$((idx + 1))
@@ -357,7 +376,7 @@ echo ""
 echo "Migrated $TASK_NAME to epic with ${#CHILDREN[@]} children."
 echo ""
 echo "Structure:"
-cd "$TASK_DIR" && find . -maxdepth 2 -type f | sort | sed 's|^\./|  |'
+cd "$TASK_DIR" && find . -maxdepth 3 -type f | sort | sed 's|^\./|  |'
 echo ""
 echo "Rollback: $TEMP_ROOT/.old-$TASK_NAME/ (manual rm -rf; no auto-cleanup yet)"
 

--- a/drupal-dev-framework/scripts/migrate-to-epic.sh
+++ b/drupal-dev-framework/scripts/migrate-to-epic.sh
@@ -179,6 +179,19 @@ for artifact in research.md architecture.md implementation.md; do
   [ -f "$TASK_DIR/$artifact" ] && cp "$TASK_DIR/$artifact" "$TEMP_ROOT/$TASK_NAME/$artifact"
 done
 
+# Preserve any OTHER top-level files from the original (e.g. mechanisms-map.md,
+# decision logs, planning docs). They are epic-wide cross-cutting artifacts →
+# destination is shared/. Paper-test integration finding 2026-04-22: the
+# earlier version lost these files into the 24h rollback dir.
+for srcfile in "$TASK_DIR"/*; do
+  [ -f "$srcfile" ] || continue
+  name=$(basename "$srcfile")
+  case "$name" in
+    task.md|research.md|architecture.md|implementation.md) ;;  # already handled
+    *) cp "$srcfile" "$TEMP_ROOT/$TASK_NAME/shared/$name" ;;
+  esac
+done
+
 if [ ${#CHILDREN[@]} -gt 0 ]; then
   idx=0
   for child in "${CHILDREN[@]}"; do

--- a/drupal-dev-framework/scripts/migrate-to-epic.sh
+++ b/drupal-dev-framework/scripts/migrate-to-epic.sh
@@ -44,6 +44,31 @@ abort() {
   exit 1
 }
 
+# Validate a task/child name. Must match ^[A-Za-z0-9_][A-Za-z0-9._-]*$ and must
+# not be ".", "..", or start with "-". Rejects path separators, traversal, and
+# shell-flag-lookalike names. Paper-test finding CRITICAL (Flaw 1) 2026-04-22.
+validate_name() {
+  local label="$1"
+  local name="$2"
+  [ -n "$name" ] || abort "$label is empty"
+  case "$name" in
+    .|..) abort "$label is '.' or '..' — path traversal rejected" ;;
+    /*|*/*|*\\*) abort "$label '$name' contains path separator — rejected" ;;
+    -*) abort "$label '$name' starts with '-' — flag-like name rejected" ;;
+  esac
+  case "$name" in
+    *[!A-Za-z0-9._-]*) abort "$label '$name' contains invalid characters (allow A-Z a-z 0-9 . _ -)" ;;
+  esac
+}
+
+# Name validation (Paper-test Flaw 1 — CRITICAL fix)
+validate_name "task name" "$TASK_NAME"
+if [ ${#CHILDREN[@]} -gt 0 ]; then
+  for c in "${CHILDREN[@]}"; do
+    validate_name "child name" "$c"
+  done
+fi
+
 TASK_DIR="$PROJECT_PATH/implementation_process/in_progress/$TASK_NAME"
 COMPLETED_DIR="$PROJECT_PATH/implementation_process/completed/$TASK_NAME"
 TEMP_ROOT="$PROJECT_PATH/implementation_process/in_progress/.migration-tmp"
@@ -53,7 +78,9 @@ TEMP_ROOT="$PROJECT_PATH/implementation_process/in_progress/.migration-tmp"
 # ---------------------------------------------------------------------------
 echo "[1/8] Preflight"
 [ -d "$TASK_DIR" ] || abort "task folder not found: $TASK_DIR"
+[ ! -L "$TASK_DIR" ] || abort "task folder is a symlink — rejected (Paper-test Flaw 3 security hardening)"
 [ -f "$TASK_DIR/task.md" ] || abort "task.md not found in folder"
+[ ! -L "$TASK_DIR/task.md" ] || abort "task.md is a symlink — rejected (Paper-test Flaw 3 security hardening)"
 [ ! -d "$COMPLETED_DIR" ] || abort "task already in completed/"
 
 READER=$(fm_read "$TASK_DIR")
@@ -83,11 +110,19 @@ echo "  OK — kind=$CURRENT_KIND status=$CURRENT_STATUS children=${#CHILDREN[@]
 # Step 2 — Classify children (parallel array)
 # ---------------------------------------------------------------------------
 echo "[2/8] Classify children"
+# Three classes:
+#   move_existing     — child is an in-progress peer folder; migrate copies it into the epic
+#   already_completed — child lives in completed/; epic references it by id but does NOT copy
+#   create_stub       — child name has no folder anywhere; epic creates an empty stub
+# Paper-test Integration-Bug-1 (2026-04-22) fix: distinguish completed children to avoid
+# creating empty duplicate folders inside the epic when dog-fooding this migration.
 CHILD_KINDS=()
 if [ ${#CHILDREN[@]} -gt 0 ]; then
   for child in "${CHILDREN[@]}"; do
     if [ -d "$PROJECT_PATH/implementation_process/in_progress/$child" ]; then
       CHILD_KINDS+=("move_existing")
+    elif [ -d "$PROJECT_PATH/implementation_process/completed/$child" ]; then
+      CHILD_KINDS+=("already_completed")
     else
       CHILD_KINDS+=("create_stub")
     fi
@@ -160,6 +195,11 @@ if [ ${#CHILDREN[@]} -gt 0 ]; then
         mkdir "$TEMP_ROOT/$TASK_NAME/$child"
         write_stub_task_md "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
         ;;
+      already_completed)
+        # Do NOT create a folder inside the epic for completed children.
+        # The epic's children[] list references them by id; they physically stay in completed/.
+        # /status will resolve their location when rendering.
+        ;;
       *)
         rm -rf "$TEMP_ROOT/$TASK_NAME"
         abort "unknown kind '$kind' for child '$child' — shell-array indexing bug"
@@ -199,8 +239,10 @@ mv "$TASK_DIR" "$TEMP_ROOT/.old-$TASK_NAME" \
   || abort "failed to move original aside"
 
 mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {
+  # Paper-test Flaw 2 (MAJOR) fix: also clean up partial temp if the mv left it.
   mv "$TEMP_ROOT/.old-$TASK_NAME" "$TASK_DIR"
-  abort "failed to swap in new structure; restored original"
+  rm -rf "$TEMP_ROOT/$TASK_NAME"
+  abort "failed to swap in new structure; restored original and cleaned temp"
 }
 
 # Delete original peer folders for move_existing children.

--- a/drupal-dev-framework/scripts/migrate-to-epic.sh
+++ b/drupal-dev-framework/scripts/migrate-to-epic.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# migrate-to-epic.sh — 8-step transactional migration of a flat task → epic.
+#
+# Usage:
+#   migrate-to-epic.sh <project_path> <task_name> [--dry-run] [<child1> <child2> ...]
+#
+# Transactional: the filesystem is either in pre-migration or post-migration
+# state; never half-migrated. Rollback dir persists 24h in .migration-tmp/.old-<task>/.
+#
+# Exit codes:
+#   0  success
+#   1  abort (preflight failed, validation failed, or mid-migration error — nothing committed)
+#   2  bad usage
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./fm-helpers.sh
+. "$SCRIPT_DIR/fm-helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+PROJECT_PATH="${1:-}"
+TASK_NAME="${2:-}"
+if [ -z "$PROJECT_PATH" ] || [ -z "$TASK_NAME" ]; then
+  echo "usage: $0 <project_path> <task_name> [--dry-run] [<child1> <child2> ...]" >&2
+  exit 2
+fi
+shift 2
+
+DRY_RUN=false
+CHILDREN=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    *) CHILDREN+=("$1"); shift ;;
+  esac
+done
+
+abort() {
+  echo "ABORT: $*" >&2
+  exit 1
+}
+
+TASK_DIR="$PROJECT_PATH/implementation_process/in_progress/$TASK_NAME"
+COMPLETED_DIR="$PROJECT_PATH/implementation_process/completed/$TASK_NAME"
+TEMP_ROOT="$PROJECT_PATH/implementation_process/in_progress/.migration-tmp"
+
+# ---------------------------------------------------------------------------
+# Step 1 — Preflight
+# ---------------------------------------------------------------------------
+echo "[1/8] Preflight"
+[ -d "$TASK_DIR" ] || abort "task folder not found: $TASK_DIR"
+[ -f "$TASK_DIR/task.md" ] || abort "task.md not found in folder"
+[ ! -d "$COMPLETED_DIR" ] || abort "task already in completed/"
+
+READER=$(fm_read "$TASK_DIR")
+CURRENT_KIND=$(jq -r '.kind' <<<"$READER")
+CURRENT_STATUS=$(jq -r '.status' <<<"$READER")
+
+case "$CURRENT_KIND" in
+  flat) : ;;
+  epic|sub_epic) abort "task is already an epic (kind=$CURRENT_KIND)" ;;
+  subtask) abort "task is a subtask; cannot promote" ;;
+  *) abort "unknown kind: $CURRENT_KIND" ;;
+esac
+
+[ ! -d "$TEMP_ROOT/$TASK_NAME" ] || abort "prior migration in temp; resolve manually"
+[ ! -d "$TEMP_ROOT/.old-$TASK_NAME" ] || abort "prior rollback dir exists; resolve manually"
+
+if [ ${#CHILDREN[@]} -gt 0 ]; then
+  for c in "${CHILDREN[@]}"; do
+    [ "$c" != "$TASK_NAME" ] || abort "child name '$c' equals task name"
+  done
+  DUPES=$(printf '%s\n' "${CHILDREN[@]}" | sort | uniq -d)
+  [ -z "$DUPES" ] || abort "duplicate child names: $DUPES"
+fi
+echo "  OK — kind=$CURRENT_KIND status=$CURRENT_STATUS children=${#CHILDREN[@]}"
+
+# ---------------------------------------------------------------------------
+# Step 2 — Classify children (parallel array)
+# ---------------------------------------------------------------------------
+echo "[2/8] Classify children"
+CHILD_KINDS=()
+if [ ${#CHILDREN[@]} -gt 0 ]; then
+  for child in "${CHILDREN[@]}"; do
+    if [ -d "$PROJECT_PATH/implementation_process/in_progress/$child" ]; then
+      CHILD_KINDS+=("move_existing")
+    else
+      CHILD_KINDS+=("create_stub")
+    fi
+  done
+fi
+
+# Helper: lookup kind by index with zsh 1-indexed shim
+child_kind_at() {
+  local i=$1
+  local k="${CHILD_KINDS[$i]:-}"
+  if [ -z "$k" ] && [ $i -eq 0 ] && [ -n "${CHILD_KINDS[1]:-}" ]; then
+    k="${CHILD_KINDS[1]}"
+  fi
+  printf '%s' "$k"
+}
+
+if [ ${#CHILDREN[@]} -gt 0 ]; then
+  idx=0
+  for child in "${CHILDREN[@]}"; do
+    echo "  $child: $(child_kind_at $idx)"
+    idx=$((idx + 1))
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Dry-run exit
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" = "true" ]; then
+  echo ""
+  echo "PLAN (dry-run): no changes made."
+  echo "  Would create epic folder with kind=epic, status=$CURRENT_STATUS"
+  echo "  Would preserve phase artifacts:"
+  for f in research.md architecture.md implementation.md; do
+    [ -f "$TASK_DIR/$f" ] && echo "    - $f"
+  done
+  echo "  Would move original to .old-$TASK_NAME for 24h rollback"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — Build in temp
+# ---------------------------------------------------------------------------
+echo "[3/8] Build in temp"
+mkdir -p "$TEMP_ROOT" || abort "cannot create temp root"
+# Atomic lock: mkdir without -p fails fast if dir exists (concurrent migration).
+mkdir "$TEMP_ROOT/$TASK_NAME" || abort "concurrent migration detected"
+mkdir "$TEMP_ROOT/$TASK_NAME/shared"
+
+cp "$TASK_DIR/task.md" "$TEMP_ROOT/$TASK_NAME/task.md"
+EPIC_FM=$(write_epic_frontmatter "$TASK_NAME" "$CURRENT_STATUS" "${CHILDREN[@]}")
+apply_frontmatter "$TEMP_ROOT/$TASK_NAME/task.md" "$EPIC_FM"
+
+for artifact in research.md architecture.md implementation.md; do
+  [ -f "$TASK_DIR/$artifact" ] && cp "$TASK_DIR/$artifact" "$TEMP_ROOT/$TASK_NAME/$artifact"
+done
+
+if [ ${#CHILDREN[@]} -gt 0 ]; then
+  idx=0
+  for child in "${CHILDREN[@]}"; do
+    kind=$(child_kind_at $idx)
+    case "$kind" in
+      move_existing)
+        cp -r "$PROJECT_PATH/implementation_process/in_progress/$child" "$TEMP_ROOT/$TASK_NAME/$child"
+        CHILD_READER=$(fm_read "$TEMP_ROOT/$TASK_NAME/$child")
+        CHILD_STATUS=$(jq -r '.status' <<<"$CHILD_READER")
+        SUB_FM=$(write_subtask_frontmatter "$child" "$TASK_NAME" "$CHILD_STATUS")
+        apply_frontmatter "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$SUB_FM"
+        ;;
+      create_stub)
+        mkdir "$TEMP_ROOT/$TASK_NAME/$child"
+        write_stub_task_md "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
+        ;;
+      *)
+        rm -rf "$TEMP_ROOT/$TASK_NAME"
+        abort "unknown kind '$kind' for child '$child' — shell-array indexing bug"
+        ;;
+    esac
+    idx=$((idx + 1))
+  done
+fi
+echo "  $(find "$TEMP_ROOT/$TASK_NAME" -name task.md | wc -l) task.md files generated"
+
+# ---------------------------------------------------------------------------
+# Step 4 — Validate temp
+# ---------------------------------------------------------------------------
+echo "[4/8] Validate temp"
+VALIDATION_FAILED=false
+while IFS= read -r -d '' taskmd; do
+  folder=$(dirname "$taskmd")
+  OUT=$(fm_read "$folder")
+  BLOCKING=$(jq '[.warnings[] | select(.code == "malformed_yaml" or .code == "parser_unavailable" or .code == "folder_missing")] | length' <<<"$OUT")
+  if [ "$BLOCKING" -gt 0 ]; then
+    echo "  BLOCKING at $folder: $(jq '.warnings' <<<"$OUT")"
+    VALIDATION_FAILED=true
+  fi
+done < <(find "$TEMP_ROOT/$TASK_NAME" -maxdepth 2 -name task.md -print0)
+
+if [ "$VALIDATION_FAILED" = "true" ]; then
+  rm -rf "$TEMP_ROOT/$TASK_NAME"
+  abort "validation failed; temp cleaned up; original untouched"
+fi
+echo "  OK"
+
+# ---------------------------------------------------------------------------
+# Step 5 — Atomic swap
+# ---------------------------------------------------------------------------
+echo "[5/8] Atomic swap"
+mv "$TASK_DIR" "$TEMP_ROOT/.old-$TASK_NAME" \
+  || abort "failed to move original aside"
+
+mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {
+  mv "$TEMP_ROOT/.old-$TASK_NAME" "$TASK_DIR"
+  abort "failed to swap in new structure; restored original"
+}
+
+# Delete original peer folders for move_existing children.
+if [ ${#CHILDREN[@]} -gt 0 ]; then
+  idx=0
+  for child in "${CHILDREN[@]}"; do
+    kind=$(child_kind_at $idx)
+    if [ "$kind" = "move_existing" ]; then
+      rm -rf "$PROJECT_PATH/implementation_process/in_progress/$child"
+    fi
+    idx=$((idx + 1))
+  done
+fi
+echo "  OK"
+
+# ---------------------------------------------------------------------------
+# Step 6 — Cleanup scheduling
+# ---------------------------------------------------------------------------
+echo "[6/8] Cleanup scheduling"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$TEMP_ROOT/.old-$TASK_NAME/.migration-completed-at"
+echo "  rollback at $TEMP_ROOT/.old-$TASK_NAME/ (delete manually after 24h)"
+
+# ---------------------------------------------------------------------------
+# Step 7 — Session context hint (actual write delegated to caller)
+# ---------------------------------------------------------------------------
+echo "[7/8] Session context hint"
+SESS_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
+SESS_FILE="$HOME/.claude/drupal-dev-framework/sessions/${SESS_HASH}.json"
+CASE="A"
+EPIC_FOR_CTX="{CURRENT_EPIC_OR_NULL}"
+NEW_TASK_PATH=""
+if [ -s "$SESS_FILE" ]; then
+  ACTIVE_TASK=$(jq -r '.task // empty' "$SESS_FILE" 2>/dev/null || echo "")
+  if [ "$ACTIVE_TASK" = "$TASK_NAME" ]; then
+    CASE="B"
+    EPIC_FOR_CTX="null"
+  elif [ ${#CHILDREN[@]} -gt 0 ]; then
+    idx=0
+    for child in "${CHILDREN[@]}"; do
+      kind=$(child_kind_at $idx)
+      if [ "$kind" = "move_existing" ] && [ "$child" = "$ACTIVE_TASK" ]; then
+        CASE="C"
+        EPIC_FOR_CTX="$TASK_NAME"
+        NEW_TASK_PATH="$TASK_DIR/$child"
+        break
+      fi
+      idx=$((idx + 1))
+    done
+  fi
+fi
+echo "  case=$CASE currentEpic=$EPIC_FOR_CTX${NEW_TASK_PATH:+ newTaskPath=$NEW_TASK_PATH}"
+echo "  (caller invokes session-context-writer with these values)"
+
+# ---------------------------------------------------------------------------
+# Step 8 — Report
+# ---------------------------------------------------------------------------
+echo "[8/8] Done"
+echo ""
+echo "Migrated $TASK_NAME to epic with ${#CHILDREN[@]} children."
+echo ""
+echo "Structure:"
+cd "$TASK_DIR" && find . -maxdepth 2 -type f | sort | sed 's|^\./|  |'
+echo ""
+echo "Rollback: $TEMP_ROOT/.old-$TASK_NAME/ (manual rm -rf; no auto-cleanup yet)"
+
+# Emit session-context case as JSON on stderr (fd 3 would be cleaner but stderr is universal)
+# Caller can parse this for reliable case handoff.
+printf 'SESSION_CONTEXT_CASE=%s\nEPIC_FOR_CTX=%s\nNEW_TASK_PATH=%s\n' "$CASE" "$EPIC_FOR_CTX" "$NEW_TASK_PATH" >&2
+
+exit 0

--- a/drupal-dev-framework/skills/epic-migrator/SKILL.md
+++ b/drupal-dev-framework/skills/epic-migrator/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: epic-migrator
+description: Use when converting a flat task into an epic folder with children. Runs the 8-step transactional migration — preflight, gather children, build in temp, validate, atomic swap, cleanup, register, report. Isolates file surgery so the /migrate-to-epic command body stays thin. Never leaves half-migrated state on disk.
+version: 1.0.0
+user-invocable: false
+model: sonnet
+allowed-tools: Read, Write, Edit, Bash, Glob
+---
+
+# Epic Migrator
+
+Transform a flat task into an epic folder structure, or expand an epic to include new children. Operate transactionally: either the migration fully succeeds or the disk is left exactly as it was found.
+
+## When Called
+
+The `/drupal-dev-framework:migrate-to-epic` command invokes you with:
+- `task_name` — the flat task folder to promote (or the existing epic to expand)
+- `children` — comma-separated list of child sub-task names (or empty for epic shell)
+- `dry_run` — if `true`, print the plan without executing
+- `project_path` — absolute path to the project root (`.../claude_memory/projects/<name>/`)
+
+## The 8 Steps (execute in order; abort on any failure)
+
+### 1. Preflight
+
+Verify all invariants. If any fail, abort with a clear message — do not touch disk.
+
+```bash
+TASK_DIR="$PROJECT_PATH/implementation_process/in_progress/$TASK_NAME"
+TASK_MD="$TASK_DIR/task.md"
+COMPLETED_DIR="$PROJECT_PATH/implementation_process/completed/$TASK_NAME"
+TEMP_ROOT="$PROJECT_PATH/implementation_process/in_progress/.migration-tmp"
+
+# Must exist
+[ -d "$TASK_DIR" ] || abort "task folder not found: $TASK_DIR"
+[ -f "$TASK_MD" ] || abort "task.md not found in folder"
+
+# Must not be completed
+[ ! -d "$COMPLETED_DIR" ] || abort "task already in completed/; cannot migrate"
+
+# Must not already be an epic (read via task-frontmatter-reader)
+READER_OUTPUT=$(invoke_task_frontmatter_reader "$TASK_DIR")
+CURRENT_KIND=$(jq -r '.kind' <<<"$READER_OUTPUT")
+case "$CURRENT_KIND" in
+  flat) : ;;
+  epic|sub_epic) abort "task is already an epic (kind=$CURRENT_KIND); use a different flow to add children" ;;
+  subtask) abort "task is a subtask of another epic; cannot promote" ;;
+  *) abort "task has unknown kind: $CURRENT_KIND" ;;
+esac
+
+# Must have no in-flight migration for this task
+[ ! -d "$TEMP_ROOT/$TASK_NAME" ] || abort "a prior migration for this task is in temp; resolve manually"
+[ ! -d "$TEMP_ROOT/.old-$TASK_NAME" ] || abort "a prior migration's rollback directory exists; resolve manually"
+```
+
+### 2. Gather children
+
+If the caller passed `children`, use that list. Otherwise, prompt the user interactively:
+
+```
+Enter child sub-task names (comma-separated, or blank for empty epic):
+```
+
+Parse, validate each name:
+- Must be a valid folder name (kebab_case recommended; alphanumeric + underscore + hyphen)
+- No duplicates
+- A child name may match an existing in-progress peer folder (in which case it will be MOVED into the epic) OR be a new name (in which case a stub folder is created)
+
+Classify each child as `move_existing` or `create_stub`:
+
+```bash
+for child in "${CHILDREN[@]}"; do
+  if [ -d "$PROJECT_PATH/implementation_process/in_progress/$child" ]; then
+    echo "$child:move_existing"
+  else
+    echo "$child:create_stub"
+  fi
+done
+```
+
+### 3. Build in temp
+
+Create everything under `$TEMP_ROOT/$TASK_NAME/`. Nothing is moved into the final location yet.
+
+```bash
+mkdir -p "$TEMP_ROOT/$TASK_NAME"
+mkdir -p "$TEMP_ROOT/$TASK_NAME/shared"
+
+# Copy (not move) the original task.md to temp; we'll edit it there
+cp "$TASK_MD" "$TEMP_ROOT/$TASK_NAME/task.md"
+
+# Prepend / overwrite frontmatter block to make it kind: epic
+update_frontmatter_to_epic "$TEMP_ROOT/$TASK_NAME/task.md" "$TASK_NAME" "${CHILDREN[@]}"
+
+# Copy phase artifacts if they exist
+for artifact in research.md architecture.md implementation.md; do
+  if [ -f "$TASK_DIR/$artifact" ]; then
+    cp "$TASK_DIR/$artifact" "$TEMP_ROOT/$TASK_NAME/$artifact"
+  fi
+done
+
+# Create child folders in temp
+for child_spec in "${CHILDREN_CLASSIFIED[@]}"; do
+  child="${child_spec%:*}"
+  kind="${child_spec#*:}"
+  case "$kind" in
+    move_existing)
+      cp -r "$PROJECT_PATH/implementation_process/in_progress/$child" "$TEMP_ROOT/$TASK_NAME/$child"
+      # Upgrade the child's task.md to add parent frontmatter (or rewrite if it already had frontmatter)
+      update_frontmatter_to_subtask "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
+      ;;
+    create_stub)
+      mkdir -p "$TEMP_ROOT/$TASK_NAME/$child"
+      write_stub_task_md "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
+      ;;
+  esac
+done
+```
+
+**Frontmatter writers** (helper functions — implement inline via `awk`/`sed` or a small Python helper):
+
+- `update_frontmatter_to_epic(file, task_name, children)` — insert or replace the `---` block at line 1 with `id: local:<task>`, `kind: epic`, `parent: null`, `children: [local:<c1>, ...]`, `blocks: []`, `blocked_by: []`, `external_ids: {}`, `status: in_progress`.
+- `update_frontmatter_to_subtask(file, child_name, parent_name)` — same shape but `kind: subtask`, `parent: local:<parent>`, `children: null`. Preserves any existing body after the frontmatter block.
+- `write_stub_task_md(file, child_name, parent_name)` — create a minimal `task.md` using the framework's new-task template + subtask frontmatter. Body includes `## Goal`, `## Phase Status` (all `[ ]`), placeholder.
+
+### 4. Validate temp
+
+Run `task-frontmatter-reader` on every generated `task.md` in temp. All must parse without `warnings[]` entries of severity higher than informational (`unknown_fields` is acceptable; `malformed_yaml`, `wrong_type`, `orphaned_subtask` are aborting).
+
+```bash
+for generated in "$TEMP_ROOT/$TASK_NAME/task.md" "$TEMP_ROOT/$TASK_NAME"/*/task.md; do
+  OUTPUT=$(invoke_task_frontmatter_reader "$(dirname "$generated")")
+  BLOCKING_WARNINGS=$(jq '[.warnings[] | select(.code == "malformed_yaml" or .code == "wrong_type" or .code == "orphaned_subtask")] | length' <<<"$OUTPUT")
+  if [ "$BLOCKING_WARNINGS" -gt 0 ]; then
+    abort "generated task.md has blocking warnings: $(jq '.warnings' <<<"$OUTPUT") — migration unsafe, aborting before swap"
+  fi
+done
+```
+
+If any file fails validation, delete `$TEMP_ROOT/$TASK_NAME/` and abort. Original untouched.
+
+### 5. Atomic swap
+
+Two renames. The original is moved to a backup location FIRST so if the second rename fails, we can restore.
+
+```bash
+# Move original aside
+mv "$TASK_DIR" "$TEMP_ROOT/.old-$TASK_NAME" \
+  || abort "failed to move original aside — nothing changed"
+
+# Move new into place
+mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {
+  # Restore original; delete temp
+  mv "$TEMP_ROOT/.old-$TASK_NAME" "$TASK_DIR"
+  abort "failed to move new structure into place; restored original"
+}
+
+# For every child that was move_existing, remove the original peer folder now that it's inside the epic
+for child_spec in "${CHILDREN_CLASSIFIED[@]}"; do
+  child="${child_spec%:*}"
+  kind="${child_spec#*:}"
+  if [ "$kind" = "move_existing" ]; then
+    rm -rf "$PROJECT_PATH/implementation_process/in_progress/$child"
+  fi
+done
+```
+
+### 6. Cleanup
+
+Schedule the rollback directory for deletion after 24 hours. Simplest: leave `.old-$TASK_NAME` on disk with a marker file; a separate cleanup invocation (or the next `/migrate-to-epic` call for a DIFFERENT task) can garbage-collect. For now, just record a timestamp and move on.
+
+```bash
+date -Iseconds > "$TEMP_ROOT/.old-$TASK_NAME/.migration-completed-at"
+```
+
+Document in the user-facing output that `.old-$TASK_NAME` exists for 24h rollback and can be deleted manually with `rm -rf "$TEMP_ROOT/.old-$TASK_NAME"`.
+
+### 7. Register
+
+Update session context to reflect the new epic containment (if the migrated task is the active task, set `currentEpic` accordingly). Invoke `session-context-writer` with the appropriate `{CURRENT_EPIC_OR_NULL}` value.
+
+### 8. Report
+
+Emit a summary to the user:
+
+```
+Migrated <task_name> to epic with N children.
+
+<task_name>/
+  task.md          (kind: epic, children: [...])
+  shared/          (empty — add cross-cutting docs here)
+  research.md      (preserved)
+  architecture.md  (preserved)
+  implementation.md (preserved)
+  <child1>/task.md (kind: subtask, moved from peer)
+  <child2>/task.md (kind: subtask, stub created)
+  ...
+
+Rollback available for 24h at:
+  <project>/implementation_process/in_progress/.migration-tmp/.old-<task_name>/
+
+Delete rollback early with: rm -rf <that path>
+
+Next: /drupal-dev-framework:next — continue with a child.
+```
+
+## Dry-run mode
+
+If `dry_run=true`, execute Step 1 (preflight) and Step 2 (gather children), then print the PLAN without executing Steps 3–8. Plan output:
+
+```
+PLAN (dry-run): /migrate-to-epic <task_name>
+  Preflight: OK (task is kind=flat, not completed, no temp state)
+  Would create epic folder: <task_name>/ with frontmatter kind=epic
+  Would create shared/: <task_name>/shared/
+  Would preserve phase artifacts: research.md, architecture.md (present), implementation.md (not present)
+  Would move existing peer folders as subtask children: foo, bar
+  Would create stub subtask folders: baz, qux
+  Would move original to .old-<task_name> for 24h rollback
+  Would update session context currentEpic: <task_name> (if active task matches)
+
+No changes made. Re-run without --dry-run to execute.
+```
+
+## Invariants this skill upholds
+
+1. **Atomicity.** At any observable moment between step boundaries, the file system is either "pre-migration state" or "post-migration state." Never "partial."
+2. **Rollback window.** The `.old-<task>/` directory persists at least 24 hours for manual restoration.
+3. **Read-before-write.** Every write-decision is gated on a read via `task-frontmatter-reader`. We do not write frontmatter without validating it parses correctly.
+4. **No silent overwrites.** If the target exists (e.g., `.old-<task>/` from a failed previous run), abort — never overwrite user state.
+5. **Children classification is deterministic.** `move_existing` ⇔ folder exists at peer location; `create_stub` ⇔ folder does not exist. No judgment calls.
+
+## Do NOT
+
+- Do not use `git mv`. These task folders are NOT in git (framework memory). Plain `mv` is the correct primitive.
+- Do not delete `$TASK_DIR` until the new structure is successfully in place.
+- Do not write partial frontmatter (e.g., `kind:` without `id:`). All required fields go in one atomic file write.
+- Do not call this skill recursively. A sub_epic migration is a separate invocation after the epic is in place.
+- Do not proceed past Step 4 if validation has any blocking warnings.
+
+## See also
+
+- `task-frontmatter-reader` (v1.0.0+) — contract for reading the schema this skill writes
+- `/drupal-dev-framework:migrate-to-epic` command — the thin user-facing orchestrator that invokes this skill
+- Architecture decision 3.1-D2 in `dev_framework_task_hierarchy_foundation/architecture.md` — the source of this 8-step contract

--- a/drupal-dev-framework/skills/epic-migrator/SKILL.md
+++ b/drupal-dev-framework/skills/epic-migrator/SKILL.md
@@ -1,245 +1,82 @@
 ---
 name: epic-migrator
-description: Use when converting a flat task into an epic folder with children. Runs the 8-step transactional migration — preflight, gather children, build in temp, validate, atomic swap, cleanup, register, report. Isolates file surgery so the /migrate-to-epic command body stays thin. Never leaves half-migrated state on disk.
-version: 1.0.0
+description: Use when converting a flat task into an epic folder with children. Runs the 8-step transactional migration — preflight, classify children, build in temp, validate, atomic swap, cleanup, session-context-hint, report. Delegates to scripts/migrate-to-epic.sh for the actual file surgery. Never leaves half-migrated state on disk.
+version: 2.0.0
 user-invocable: false
 model: sonnet
-allowed-tools: Read, Write, Edit, Bash, Glob
+allowed-tools: Bash, Skill
 ---
 
 # Epic Migrator
 
-Transform a flat task into an epic folder structure, or expand an epic to include new children. Operate transactionally: either the migration fully succeeds or the disk is left exactly as it was found.
+Thin wrapper around the real script `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`. The script executes the 8-step transactional migration deterministically; this skill exists to give it a callable-via-Skill name and to document contract, invariants, and the session-context handoff.
 
-## When Called
+## Contract
 
-The `/drupal-dev-framework:migrate-to-epic` command invokes you with:
-- `task_name` — the flat task folder to promote (or the existing epic to expand)
-- `children` — comma-separated list of child sub-task names (or empty for epic shell)
-- `dry_run` — if `true`, print the plan without executing
-- `project_path` — absolute path to the project root (`.../claude_memory/projects/<name>/`)
+**Input (passed as CLI args to the script):**
+- `<project_path>` — absolute path to the project root (`.../claude_memory/projects/<name>/`)
+- `<task_name>` — the flat task folder to promote
+- `[--dry-run]` — optional flag; prints the plan without making changes
+- `[<child1> <child2> ...]` — zero or more child names (may be empty for epic shell)
 
-## The 8 Steps (execute in order; abort on any failure)
+**Output:**
+- Stdout: step-by-step log (`[1/8] Preflight — OK`, etc.) ending with a structure summary
+- Stderr (after live-run success): three `KEY=VALUE` lines — `SESSION_CONTEXT_CASE`, `EPIC_FOR_CTX`, `NEW_TASK_PATH`. Caller parses these to invoke `session-context-writer` correctly.
 
-### 1. Preflight
+**Exit codes:**
+- `0` — success (live run) or plan printed (dry-run)
+- `1` — abort (preflight failed, validation failed, or mid-migration error; transactional guarantee means nothing was committed)
+- `2` — usage error (missing required arguments)
 
-Verify all invariants. If any fail, abort with a clear message — do not touch disk.
-
-```bash
-TASK_DIR="$PROJECT_PATH/implementation_process/in_progress/$TASK_NAME"
-TASK_MD="$TASK_DIR/task.md"
-COMPLETED_DIR="$PROJECT_PATH/implementation_process/completed/$TASK_NAME"
-TEMP_ROOT="$PROJECT_PATH/implementation_process/in_progress/.migration-tmp"
-
-# Must exist
-[ -d "$TASK_DIR" ] || abort "task folder not found: $TASK_DIR"
-[ -f "$TASK_MD" ] || abort "task.md not found in folder"
-
-# Must not be completed
-[ ! -d "$COMPLETED_DIR" ] || abort "task already in completed/; cannot migrate"
-
-# Must not already be an epic (read via task-frontmatter-reader)
-READER_OUTPUT=$(invoke_task_frontmatter_reader "$TASK_DIR")
-CURRENT_KIND=$(jq -r '.kind' <<<"$READER_OUTPUT")
-case "$CURRENT_KIND" in
-  flat) : ;;
-  epic|sub_epic) abort "task is already an epic (kind=$CURRENT_KIND); use a different flow to add children" ;;
-  subtask) abort "task is a subtask of another epic; cannot promote" ;;
-  *) abort "task has unknown kind: $CURRENT_KIND" ;;
-esac
-
-# Must have no in-flight migration for this task
-[ ! -d "$TEMP_ROOT/$TASK_NAME" ] || abort "a prior migration for this task is in temp; resolve manually"
-[ ! -d "$TEMP_ROOT/.old-$TASK_NAME" ] || abort "a prior migration's rollback directory exists; resolve manually"
-```
-
-### 2. Gather children
-
-If the caller passed `children`, use that list. Otherwise, prompt the user interactively:
-
-```
-Enter child sub-task names (comma-separated, or blank for empty epic):
-```
-
-Parse, validate each name:
-- Must be a valid folder name (kebab_case recommended; alphanumeric + underscore + hyphen)
-- No duplicates
-- A child name may match an existing in-progress peer folder (in which case it will be MOVED into the epic) OR be a new name (in which case a stub folder is created)
-
-Classify each child as `move_existing` or `create_stub`:
+## Invocation
 
 ```bash
-for child in "${CHILDREN[@]}"; do
-  if [ -d "$PROJECT_PATH/implementation_process/in_progress/$child" ]; then
-    echo "$child:move_existing"
-  else
-    echo "$child:create_stub"
-  fi
-done
+"${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME" --dry-run child_a child_b
+"${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME" child_a child_b
+"${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME"   # epic shell (no children)
 ```
 
-### 3. Build in temp
+After a live run, **parse the stderr session-context hints** and invoke `session-context-writer` per the three cases:
 
-Create everything under `$TEMP_ROOT/$TASK_NAME/`. Nothing is moved into the final location yet.
+- **Case A** (`SESSION_CONTEXT_CASE=A`): migrated task is NOT the active task. Pass the literal `{CURRENT_EPIC_OR_NULL}` to the writer — preserves existing `currentEpic`.
+- **Case B** (`SESSION_CONTEXT_CASE=B`): the migrated task IS the active task. Pass `currentEpic=null` to the writer. Keep `taskPath` unchanged.
+- **Case C** (`SESSION_CONTEXT_CASE=C`): a moved-existing child was the active task. Pass `currentEpic=$TASK_NAME` to the writer, AND update `taskPath` to `$NEW_TASK_PATH` (the new nested location).
 
-```bash
-mkdir -p "$TEMP_ROOT/$TASK_NAME"
-mkdir -p "$TEMP_ROOT/$TASK_NAME/shared"
+## Invariants the script upholds
 
-# Copy (not move) the original task.md to temp; we'll edit it there
-cp "$TASK_MD" "$TEMP_ROOT/$TASK_NAME/task.md"
+1. **Atomicity.** At any observable moment, the filesystem is either pre-migration or post-migration state; never partial. Abort before the atomic swap rolls back cleanly.
+2. **24h rollback window.** The `.old-<task>/` directory persists at `$TEMP_ROOT/.old-<task>/` with a `.migration-completed-at` timestamp marker. Manual `rm -rf` to claim the space back.
+3. **Read-before-write.** Step 4 validates every generated `task.md` via `fm_read` (sourced from `fm-helpers.sh`). Blocking warnings abort the migration before the atomic swap, leaving temp cleaned up.
+4. **No silent overwrites.** Atomic `mkdir "$TEMP_ROOT/$TASK_NAME"` (without `-p`) fails fast if a concurrent migration is in flight. Protects against same-task races in the same project.
+5. **Deterministic children classification.** `move_existing` iff folder exists at peer location; `create_stub` iff folder does not exist. No judgment calls.
+6. **Status preservation.** Epic inherits the original task's `status`. `move_existing` children keep their own pre-migration status. `create_stub` children start at `draft`.
+7. **Canonical frontmatter.** All frontmatter emitted via `yaml.safe_dump(..., sort_keys=False)` — byte-deterministic across invocations.
 
-# Prepend / overwrite frontmatter block to make it kind: epic
-update_frontmatter_to_epic "$TEMP_ROOT/$TASK_NAME/task.md" "$TASK_NAME" "${CHILDREN[@]}"
+## Preflight rejections (script aborts with exit 1)
 
-# Copy phase artifacts if they exist
-for artifact in research.md architecture.md implementation.md; do
-  if [ -f "$TASK_DIR/$artifact" ]; then
-    cp "$TASK_DIR/$artifact" "$TEMP_ROOT/$TASK_NAME/$artifact"
-  fi
-done
+- Task folder not found
+- `task.md` missing inside the folder
+- Task already in `completed/`
+- Task is already an epic or sub_epic
+- Task is a subtask of another epic
+- In-flight migration exists at `$TEMP_ROOT/<task>` or `.old-<task>`
+- Any child name equals the task name
+- Duplicate child names
 
-# Create child folders in temp
-for child_spec in "${CHILDREN_CLASSIFIED[@]}"; do
-  child="${child_spec%:*}"
-  kind="${child_spec#*:}"
-  case "$kind" in
-    move_existing)
-      cp -r "$PROJECT_PATH/implementation_process/in_progress/$child" "$TEMP_ROOT/$TASK_NAME/$child"
-      # Upgrade the child's task.md to add parent frontmatter (or rewrite if it already had frontmatter)
-      update_frontmatter_to_subtask "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
-      ;;
-    create_stub)
-      mkdir -p "$TEMP_ROOT/$TASK_NAME/$child"
-      write_stub_task_md "$TEMP_ROOT/$TASK_NAME/$child/task.md" "$child" "$TASK_NAME"
-      ;;
-  esac
-done
-```
+## Why this is a script, not embedded instructions
 
-**Frontmatter writers** (helper functions — implement inline via `awk`/`sed` or a small Python helper):
-
-- `update_frontmatter_to_epic(file, task_name, children)` — insert or replace the `---` block at line 1 with `id: local:<task>`, `kind: epic`, `parent: null`, `children: [local:<c1>, ...]`, `blocks: []`, `blocked_by: []`, `external_ids: {}`, `status: in_progress`.
-- `update_frontmatter_to_subtask(file, child_name, parent_name)` — same shape but `kind: subtask`, `parent: local:<parent>`, `children: null`. Preserves any existing body after the frontmatter block.
-- `write_stub_task_md(file, child_name, parent_name)` — create a minimal `task.md` using the framework's new-task template + subtask frontmatter. Body includes `## Goal`, `## Phase Status` (all `[ ]`), placeholder.
-
-### 4. Validate temp
-
-Run `task-frontmatter-reader` on every generated `task.md` in temp. All must parse without `warnings[]` entries of severity higher than informational (`unknown_fields` is acceptable; `malformed_yaml`, `wrong_type`, `orphaned_subtask` are aborting).
-
-```bash
-for generated in "$TEMP_ROOT/$TASK_NAME/task.md" "$TEMP_ROOT/$TASK_NAME"/*/task.md; do
-  OUTPUT=$(invoke_task_frontmatter_reader "$(dirname "$generated")")
-  BLOCKING_WARNINGS=$(jq '[.warnings[] | select(.code == "malformed_yaml" or .code == "wrong_type" or .code == "orphaned_subtask")] | length' <<<"$OUTPUT")
-  if [ "$BLOCKING_WARNINGS" -gt 0 ]; then
-    abort "generated task.md has blocking warnings: $(jq '.warnings' <<<"$OUTPUT") — migration unsafe, aborting before swap"
-  fi
-done
-```
-
-If any file fails validation, delete `$TEMP_ROOT/$TASK_NAME/` and abort. Original untouched.
-
-### 5. Atomic swap
-
-Two renames. The original is moved to a backup location FIRST so if the second rename fails, we can restore.
-
-```bash
-# Move original aside
-mv "$TASK_DIR" "$TEMP_ROOT/.old-$TASK_NAME" \
-  || abort "failed to move original aside — nothing changed"
-
-# Move new into place
-mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {
-  # Restore original; delete temp
-  mv "$TEMP_ROOT/.old-$TASK_NAME" "$TASK_DIR"
-  abort "failed to move new structure into place; restored original"
-}
-
-# For every child that was move_existing, remove the original peer folder now that it's inside the epic
-for child_spec in "${CHILDREN_CLASSIFIED[@]}"; do
-  child="${child_spec%:*}"
-  kind="${child_spec#*:}"
-  if [ "$kind" = "move_existing" ]; then
-    rm -rf "$PROJECT_PATH/implementation_process/in_progress/$child"
-  fi
-done
-```
-
-### 6. Cleanup
-
-Schedule the rollback directory for deletion after 24 hours. Simplest: leave `.old-$TASK_NAME` on disk with a marker file; a separate cleanup invocation (or the next `/migrate-to-epic` call for a DIFFERENT task) can garbage-collect. For now, just record a timestamp and move on.
-
-```bash
-date -Iseconds > "$TEMP_ROOT/.old-$TASK_NAME/.migration-completed-at"
-```
-
-Document in the user-facing output that `.old-$TASK_NAME` exists for 24h rollback and can be deleted manually with `rm -rf "$TEMP_ROOT/.old-$TASK_NAME"`.
-
-### 7. Register
-
-Update session context to reflect the new epic containment (if the migrated task is the active task, set `currentEpic` accordingly). Invoke `session-context-writer` with the appropriate `{CURRENT_EPIC_OR_NULL}` value.
-
-### 8. Report
-
-Emit a summary to the user:
-
-```
-Migrated <task_name> to epic with N children.
-
-<task_name>/
-  task.md          (kind: epic, children: [...])
-  shared/          (empty — add cross-cutting docs here)
-  research.md      (preserved)
-  architecture.md  (preserved)
-  implementation.md (preserved)
-  <child1>/task.md (kind: subtask, moved from peer)
-  <child2>/task.md (kind: subtask, stub created)
-  ...
-
-Rollback available for 24h at:
-  <project>/implementation_process/in_progress/.migration-tmp/.old-<task_name>/
-
-Delete rollback early with: rm -rf <that path>
-
-Next: /drupal-dev-framework:next — continue with a child.
-```
-
-## Dry-run mode
-
-If `dry_run=true`, execute Step 1 (preflight) and Step 2 (gather children), then print the PLAN without executing Steps 3–8. Plan output:
-
-```
-PLAN (dry-run): /migrate-to-epic <task_name>
-  Preflight: OK (task is kind=flat, not completed, no temp state)
-  Would create epic folder: <task_name>/ with frontmatter kind=epic
-  Would create shared/: <task_name>/shared/
-  Would preserve phase artifacts: research.md, architecture.md (present), implementation.md (not present)
-  Would move existing peer folders as subtask children: foo, bar
-  Would create stub subtask folders: baz, qux
-  Would move original to .old-<task_name> for 24h rollback
-  Would update session context currentEpic: <task_name> (if active task matches)
-
-No changes made. Re-run without --dry-run to execute.
-```
-
-## Invariants this skill upholds
-
-1. **Atomicity.** At any observable moment between step boundaries, the file system is either "pre-migration state" or "post-migration state." Never "partial."
-2. **Rollback window.** The `.old-<task>/` directory persists at least 24 hours for manual restoration.
-3. **Read-before-write.** Every write-decision is gated on a read via `task-frontmatter-reader`. We do not write frontmatter without validating it parses correctly.
-4. **No silent overwrites.** If the target exists (e.g., `.old-<task>/` from a failed previous run), abort — never overwrite user state.
-5. **Children classification is deterministic.** `move_existing` ⇔ folder exists at peer location; `create_stub` ⇔ folder does not exist. No judgment calls.
-
-## Do NOT
-
-- Do not use `git mv`. These task folders are NOT in git (framework memory). Plain `mv` is the correct primitive.
-- Do not delete `$TASK_DIR` until the new structure is successfully in place.
-- Do not write partial frontmatter (e.g., `kind:` without `id:`). All required fields go in one atomic file write.
-- Do not call this skill recursively. A sub_epic migration is a separate invocation after the epic is in place.
-- Do not proceed past Step 4 if validation has any blocking warnings.
+Earlier drafts of this skill embedded the migration logic as bash pseudo-code with undefined helper-function references. A paper-test (2026-04-22) flagged BLOCKERS: `CHILDREN_CLASSIFIED` never assigned, four pseudo-functions without implementations, ambiguous delete targets, a zsh-specific colon-parsing bug. The script-based design closes all of these: the script is a single file that runs deterministically, tests cleanly, and cannot drift across invocations.
 
 ## See also
 
-- `task-frontmatter-reader` (v1.0.0+) — contract for reading the schema this skill writes
-- `/drupal-dev-framework:migrate-to-epic` command — the thin user-facing orchestrator that invokes this skill
-- Architecture decision 3.1-D2 in `dev_framework_task_hierarchy_foundation/architecture.md` — the source of this 8-step contract
+- `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh` — the script this skill wraps
+- `${CLAUDE_PLUGIN_ROOT}/scripts/fm-helpers.sh` — shared helpers (sourced by both scripts)
+- `task-frontmatter-reader` skill — wraps the fm-read.sh entry point
+- `/drupal-dev-framework:migrate-to-epic` command — user-facing orchestrator
+- Architecture decision 3.1-D2 in `dev_framework_task_hierarchy_foundation/architecture.md`
+
+## Do NOT
+
+- Do not duplicate the migration logic in another skill. If a new flow needs migration behavior, call this skill (which calls the script).
+- Do not modify the script's exit-code contract without updating this skill's consumers.
+- Do not use `git mv` anywhere in this flow — task folders are NOT in git (framework memory).

--- a/drupal-dev-framework/skills/epic-migrator/SKILL.md
+++ b/drupal-dev-framework/skills/epic-migrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: epic-migrator
-description: Use when converting a flat task into an epic folder with children. Runs the 8-step transactional migration — preflight, classify children, build in temp, validate, atomic swap, cleanup, session-context-hint, report. Delegates to scripts/migrate-to-epic.sh for the actual file surgery. Never leaves half-migrated state on disk.
-version: 2.0.0
+description: Use when converting a flat task into an epic folder with children. Runs the 8-step transactional migration via scripts/migrate-to-epic.sh. Supports --dry-run for preflight plan. Never leaves half-migrated state on disk.
+version: 2.0.1
 user-invocable: false
 model: sonnet
 allowed-tools: Bash, Skill
@@ -9,74 +9,52 @@ allowed-tools: Bash, Skill
 
 # Epic Migrator
 
-Thin wrapper around the real script `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`. The script executes the 8-step transactional migration deterministically; this skill exists to give it a callable-via-Skill name and to document contract, invariants, and the session-context handoff.
+Thin wrapper around `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`. The script implements transactional migration; this skill exists to be callable-via-Skill and to spell out the invocation contract + session-context handoff.
 
 ## Contract
 
-**Input (passed as CLI args to the script):**
-- `<project_path>` — absolute path to the project root (`.../claude_memory/projects/<name>/`)
-- `<task_name>` — the flat task folder to promote
-- `[--dry-run]` — optional flag; prints the plan without making changes
-- `[<child1> <child2> ...]` — zero or more child names (may be empty for epic shell)
+**Input (CLI args to the script):**
+- `<project_path>` — absolute project path
+- `<task_name>` — flat task folder to promote
+- `[--dry-run]` — prints plan, changes nothing
+- `[<child1> <child2> ...]` — zero or more child names
 
 **Output:**
-- Stdout: step-by-step log (`[1/8] Preflight — OK`, etc.) ending with a structure summary
-- Stderr (after live-run success): three `KEY=VALUE` lines — `SESSION_CONTEXT_CASE`, `EPIC_FOR_CTX`, `NEW_TASK_PATH`. Caller parses these to invoke `session-context-writer` correctly.
+- Stdout: step-by-step log ending with a structure summary
+- Stderr on live-run success: three `KEY=VALUE` lines — `SESSION_CONTEXT_CASE`, `EPIC_FOR_CTX`, `NEW_TASK_PATH`
 
 **Exit codes:**
-- `0` — success (live run) or plan printed (dry-run)
-- `1` — abort (preflight failed, validation failed, or mid-migration error; transactional guarantee means nothing was committed)
-- `2` — usage error (missing required arguments)
+- `0` success (live or dry-run)
+- `1` abort (preflight/validation/mid-migration error — nothing committed)
+- `2` usage error (missing required arg)
 
 ## Invocation
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME" --dry-run child_a child_b
 "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME" child_a child_b
-"${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME"   # epic shell (no children)
+"${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME"
 ```
 
-After a live run, **parse the stderr session-context hints** and invoke `session-context-writer` per the three cases:
+## Session-context dispatch (apply after live run)
 
-- **Case A** (`SESSION_CONTEXT_CASE=A`): migrated task is NOT the active task. Pass the literal `{CURRENT_EPIC_OR_NULL}` to the writer — preserves existing `currentEpic`.
-- **Case B** (`SESSION_CONTEXT_CASE=B`): the migrated task IS the active task. Pass `currentEpic=null` to the writer. Keep `taskPath` unchanged.
-- **Case C** (`SESSION_CONTEXT_CASE=C`): a moved-existing child was the active task. Pass `currentEpic=$TASK_NAME` to the writer, AND update `taskPath` to `$NEW_TASK_PATH` (the new nested location).
+Parse the stderr `KEY=VALUE` lines, then invoke `session-context-writer`:
 
-## Invariants the script upholds
-
-1. **Atomicity.** At any observable moment, the filesystem is either pre-migration or post-migration state; never partial. Abort before the atomic swap rolls back cleanly.
-2. **24h rollback window.** The `.old-<task>/` directory persists at `$TEMP_ROOT/.old-<task>/` with a `.migration-completed-at` timestamp marker. Manual `rm -rf` to claim the space back.
-3. **Read-before-write.** Step 4 validates every generated `task.md` via `fm_read` (sourced from `fm-helpers.sh`). Blocking warnings abort the migration before the atomic swap, leaving temp cleaned up.
-4. **No silent overwrites.** Atomic `mkdir "$TEMP_ROOT/$TASK_NAME"` (without `-p`) fails fast if a concurrent migration is in flight. Protects against same-task races in the same project.
-5. **Deterministic children classification.** `move_existing` iff folder exists at peer location; `create_stub` iff folder does not exist. No judgment calls.
-6. **Status preservation.** Epic inherits the original task's `status`. `move_existing` children keep their own pre-migration status. `create_stub` children start at `draft`.
-7. **Canonical frontmatter.** All frontmatter emitted via `yaml.safe_dump(..., sort_keys=False)` — byte-deterministic across invocations.
-
-## Preflight rejections (script aborts with exit 1)
-
-- Task folder not found
-- `task.md` missing inside the folder
-- Task already in `completed/`
-- Task is already an epic or sub_epic
-- Task is a subtask of another epic
-- In-flight migration exists at `$TEMP_ROOT/<task>` or `.old-<task>`
-- Any child name equals the task name
-- Duplicate child names
-
-## Why this is a script, not embedded instructions
-
-Earlier drafts of this skill embedded the migration logic as bash pseudo-code with undefined helper-function references. A paper-test (2026-04-22) flagged BLOCKERS: `CHILDREN_CLASSIFIED` never assigned, four pseudo-functions without implementations, ambiguous delete targets, a zsh-specific colon-parsing bug. The script-based design closes all of these: the script is a single file that runs deterministically, tests cleanly, and cannot drift across invocations.
+| Case | When | `currentEpic` arg | `taskPath` arg |
+|---|---|---|---|
+| **A** | Migrated task != active task | literal `{CURRENT_EPIC_OR_NULL}` (preserve) | unchanged |
+| **B** | Migrated task == active task | `"null"` (clear) | unchanged |
+| **C** | A `move_existing` child == active task | `$TASK_NAME` (set epic) | `$NEW_TASK_PATH` |
 
 ## See also
 
-- `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh` — the script this skill wraps
-- `${CLAUDE_PLUGIN_ROOT}/scripts/fm-helpers.sh` — shared helpers (sourced by both scripts)
-- `task-frontmatter-reader` skill — wraps the fm-read.sh entry point
-- `/drupal-dev-framework:migrate-to-epic` command — user-facing orchestrator
-- Architecture decision 3.1-D2 in `dev_framework_task_hierarchy_foundation/architecture.md`
+- `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh` — the script (header comments document invariants, preflight rejections, and architectural rationale)
+- `${CLAUDE_PLUGIN_ROOT}/scripts/fm-helpers.sh` — shared helpers
+- `task-frontmatter-reader` skill — wraps fm-read.sh
+- `/drupal-dev-framework:migrate-to-epic` command — user orchestrator
 
 ## Do NOT
 
-- Do not duplicate the migration logic in another skill. If a new flow needs migration behavior, call this skill (which calls the script).
-- Do not modify the script's exit-code contract without updating this skill's consumers.
-- Do not use `git mv` anywhere in this flow — task folders are NOT in git (framework memory).
+- Do not duplicate the migration logic in another skill. Call this skill (which calls the script).
+- Do not modify the script's exit-code contract without updating consumers.
+- Do not use `git mv` — task folders are NOT in git (framework memory).

--- a/drupal-dev-framework/skills/session-context-writer/SKILL.md
+++ b/drupal-dev-framework/skills/session-context-writer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: session-context-writer
-description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[] and lastPhase across writes via jq-based merge.
+description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[], lastPhase, and currentEpic across writes via jq-based merge.
 user-invocable: false
-version: 1.3.0
+version: 1.4.0
 model: haiku
 ---
 
@@ -23,13 +23,16 @@ You receive the resolved project and task values from the calling command. Write
   "projectPath": "/abs/path/to/project",
   "task": "my_task",
   "taskPath": "/abs/path/to/task",
-  "updatedAt": "2026-04-20",
+  "updatedAt": "2026-04-22",
   "loadedGuides": ["drupal/forms/form-validation"],
-  "lastPhase": "research"
+  "lastPhase": "research",
+  "currentEpic": "dev_framework_improvements_epic"
 }
 ```
 
-`loadedGuides` and `lastPhase` are managed by other components (`guide-integrator`, the `context-reminder` hook) — this skill must not clobber them.
+`loadedGuides`, `lastPhase`, and `currentEpic` are managed by other components (`guide-integrator`, `task-frontmatter-reader`, the `context-reminder` hook) — this skill must not clobber them.
+
+`currentEpic`, added in v1.4.0, is the folder name (not URI) of the epic that contains the active task, or `null` if the task is `kind: flat` or is itself the top-level epic. Callers set this value when they've resolved the epic ancestor via `task-frontmatter-reader`.
 
 ## Action
 
@@ -57,14 +60,29 @@ NEW_CORE=$(jq -n \
     updatedAt: $updatedAt
   }')
 
+NEW_EPIC_ARG='{CURRENT_EPIC_OR_NULL}'
+
 if [ -s "$SESS_FILE" ] && jq -e . "$SESS_FILE" >/dev/null 2>&1; then
-  # Preserve loadedGuides and lastPhase; overwrite core fields.
-  jq --argjson new "$NEW_CORE" \
-    '. * $new | .loadedGuides = (.loadedGuides // []) | .lastPhase = (.lastPhase // null)' \
+  # Preserve loadedGuides, lastPhase, and currentEpic; overwrite core fields.
+  # currentEpic behavior: if the caller passed an explicit value (not the literal "{CURRENT_EPIC_OR_NULL}" placeholder), use it; otherwise preserve existing.
+  jq --argjson new "$NEW_CORE" --arg epic "$NEW_EPIC_ARG" \
+    '. * $new
+     | .loadedGuides = (.loadedGuides // [])
+     | .lastPhase = (.lastPhase // null)
+     | .currentEpic = (
+         if $epic == "{CURRENT_EPIC_OR_NULL}" then (.currentEpic // null)
+         elif $epic == "null" or $epic == "" then null
+         else $epic
+         end
+       )' \
     "$SESS_FILE" > "$SESS_FILE.tmp" && mv "$SESS_FILE.tmp" "$SESS_FILE"
 else
   # First write, empty, or corrupt JSON — reseed from scratch with fresh core + preserved-field defaults.
-  echo "$NEW_CORE" | jq '. + {loadedGuides: [], lastPhase: null}' > "$SESS_FILE"
+  echo "$NEW_CORE" | jq --arg epic "$NEW_EPIC_ARG" '. + {
+    loadedGuides: [],
+    lastPhase: null,
+    currentEpic: (if $epic == "{CURRENT_EPIC_OR_NULL}" or $epic == "null" or $epic == "" then null else $epic end)
+  }' > "$SESS_FILE"
 fi
 ```
 
@@ -73,5 +91,6 @@ Replace placeholders:
 - `{PROJECT_PATH}` — absolute project path
 - `{TASK_NAME_OR_NULL}` — task name if known, or the literal string `null`
 - `{TASK_PATH_OR_NULL}` — absolute task path if known, or the literal string `null`
+- `{CURRENT_EPIC_OR_NULL}` — (added v1.4.0) epic folder name if the task is inside an epic, `null` if not, or leave as the literal string `{CURRENT_EPIC_OR_NULL}` to preserve whatever was there before (i.e., caller doesn't know or doesn't want to change it).
 
 Do not output anything to the user. This is a silent background operation.

--- a/drupal-dev-framework/skills/session-context-writer/SKILL.md
+++ b/drupal-dev-framework/skills/session-context-writer/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: session-context-writer
-description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[], lastPhase, and currentEpic across writes via jq-based merge.
+description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[], lastPhase, and currentEpic across writes.
 user-invocable: false
 version: 1.4.0
 model: haiku
+allowed-tools: Bash
 ---
 
 # Session Context Writer

--- a/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
+++ b/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
@@ -1,165 +1,73 @@
 ---
 name: task-frontmatter-reader
-description: Use when a framework command needs to read the hierarchy metadata of a task — parses the YAML frontmatter block at the top of task.md and returns structured data (id, kind, parent, children, blocks, blocked_by, external_ids, derived status) plus any warnings. Defensive: never blocks on malformed input; absent frontmatter yields kind=flat.
-version: 1.0.0
+description: Use when a framework command needs to read the hierarchy metadata of a task — parses the YAML frontmatter block at the top of task.md and returns structured data (id, kind, parent, children, blocks, blocked_by, external_ids, derived status) plus any warnings. Defensive: never blocks on malformed input; absent frontmatter yields kind=flat. Delegates to scripts/fm-read.sh.
+version: 2.0.0
 user-invocable: false
 model: haiku
-allowed-tools: Read, Edit
+allowed-tools: Bash
 ---
 
 # Task Frontmatter Reader
 
-Parse the YAML frontmatter block at the top of a task's `task.md`. Return structured metadata plus any warnings. Never throws; never blocks the caller.
+Thin wrapper around the real script `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh`. The script is a deterministic file-parsing pipeline (bash + python3 + jq); this skill exists to give it a name callable via the Skill tool and to document its contract.
 
-## When Called
+## Contract
 
-You receive one argument: the absolute path to a task folder (e.g. `/home/user/claude_memory/projects/myproj/implementation_process/in_progress/foo/`). The `task.md` inside it is the file to read.
+**Input:** one argument — absolute path to a task folder.
+**Output:** a single-line JSON object to stdout. Exit code always 0.
 
-## Schema (what you're parsing)
+Always-present fields:
+- `id` — `local:<folder-name>` (URI style)
+- `kind` — one of `flat | epic | sub_epic | subtask`
+- `parent` — `local:<id>` or `null`
+- `children` — array of `local:<id>` strings
+- `blocks` — array of `local:<id>` strings
+- `blocked_by` — array of `local:<id>` strings
+- `external_ids` — object (reserved for future tracker integration; currently `{}`)
+- `status` — `draft | in_progress | blocked | completed`
+- `folder` — absolute path passed in
+- `warnings` — array of `{code, detail}` entries
 
-```yaml
----
-id: local:<folder>                # URI-style; "local:" prefix for framework-tracked tasks
-kind: flat | epic | sub_epic | subtask
-parent: local:<id> | null          # null for flat and top-level epics
-children: [local:<id>, ...]        # present only on epic / sub_epic
-blocks: [local:<id>, ...]          # may be empty; defaults to []
-blocked_by: [local:<id>, ...]      # may be empty; defaults to []
-external_ids: {...}                # reserved; usually {}
-status: draft | in_progress | blocked | completed   # derived cache
----
-```
+**Defensive posture.** Never throws, never blocks, never exits non-zero. All error conditions surface as entries in `warnings[]`. Callers should treat warnings as observations, not failures.
 
-## Defensive Error Posture
-
-**Never throw. Never block.** Return structured output for every input, including garbage.
-
-| Input state | Output |
+| Input state | Resulting warnings |
 |---|---|
-| `task.md` missing entirely | Return `kind: flat`, `id: local:<folder-name>`, all other fields null/empty, add warning `task_md_missing` |
-| `task.md` present, no frontmatter block | Return `kind: flat`, `id: local:<folder-name>`, all other fields null/empty, no warning (absence of frontmatter is normal) |
-| Frontmatter block delimiters present but YAML malformed | Return `kind: flat` (best-effort defaults), add warning `malformed_yaml` with the parse error |
-| Unknown fields in frontmatter | Preserve them in output under `unknown_fields`; do not warn (forward-compat) |
-| Known field with wrong type (e.g. `children: "not-a-list"`) | Ignore that field, use default, add warning `wrong_type` |
-| Dangling reference (`children: [local:foo]` but `foo/` folder missing) | Keep the reference in output, add warning `dangling_reference` |
-| `kind: subtask` with `parent: null` or no parent folder match | Use the declared `kind`, add warning `orphaned_subtask` |
-| `kind: sub_epic` whose children include another `sub_epic` (depth > 2) | Keep as declared, add warning `nested_sub_epic_disallowed` — the depth rule is advisory at read time; writers enforce it |
+| Folder does not exist | `folder_missing` |
+| Folder exists, `task.md` missing | `task_md_missing` |
+| `task.md` present, no frontmatter block | (none — absence of frontmatter is legitimate; kind defaults to flat) |
+| Frontmatter YAML malformed | `malformed_yaml` |
+| python3 / yaml unavailable | `parser_unavailable` |
 
-## Action
+Warning codes reserved for v1.1.0+ but not currently emitted: `wrong_type`, `dangling_reference`, `orphaned_subtask`, `nested_sub_epic_disallowed`. Do not rely on them in v2.0.x.
 
-Run this bash pipeline (or equivalent logic). Output is JSON.
+## Invocation
+
+Call the script directly via the Bash tool:
 
 ```bash
-TASK_DIR="${1:?path to task folder required}"
-TASK_MD="$TASK_DIR/task.md"
-FOLDER_NAME=$(basename "$TASK_DIR")
-WARNINGS=()
-
-# Check task.md exists
-if [ ! -f "$TASK_MD" ]; then
-  jq -nc --arg id "local:$FOLDER_NAME" --arg dir "$TASK_DIR" \
-    '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "task_md_missing", detail: "task.md not found in folder"}]}'
-  exit 0
-fi
-
-# Extract the frontmatter block (between first --- and second ---, only if present at line 1)
-FRONTMATTER=$(awk '
-  NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
-  in_fm && /^---[[:space:]]*$/ { exit }
-  in_fm { print }
-' "$TASK_MD")
-
-if [ -z "$FRONTMATTER" ]; then
-  # No frontmatter block — treat as flat task, no warning (legitimate legacy state)
-  jq -nc --arg id "local:$FOLDER_NAME" --arg dir "$TASK_DIR" \
-    '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: []}'
-  exit 0
-fi
-
-# Parse the frontmatter as YAML via a python one-liner (robust; yq often not installed)
-PARSED=$(printf '%s' "$FRONTMATTER" | python3 -c '
-import sys, yaml, json
-try:
-    data = yaml.safe_load(sys.stdin.read()) or {}
-    print(json.dumps({"ok": True, "data": data}))
-except Exception as e:
-    print(json.dumps({"ok": False, "error": str(e)}))
-' 2>/dev/null)
-
-if [ -z "$PARSED" ]; then
-  # python3 or yaml module unavailable — degrade to flat with warning
-  jq -nc --arg id "local:$FOLDER_NAME" --arg dir "$TASK_DIR" \
-    '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "parser_unavailable", detail: "python3 or yaml module missing; treating as flat"}]}'
-  exit 0
-fi
-
-# Extract and normalize fields, defaulting on absence
-jq -c --arg folder_name "$FOLDER_NAME" --arg dir "$TASK_DIR" '
-  if .ok then
-    .data as $d |
-    {
-      id: ($d.id // ("local:" + $folder_name)),
-      kind: ($d.kind // "flat"),
-      parent: ($d.parent // null),
-      children: ($d.children // []),
-      blocks: ($d.blocks // []),
-      blocked_by: ($d.blocked_by // []),
-      external_ids: ($d.external_ids // {}),
-      status: ($d.status // "draft"),
-      folder: $dir,
-      warnings: []
-    }
-  else
-    {
-      id: ("local:" + $folder_name),
-      kind: "flat",
-      parent: null,
-      children: [],
-      blocks: [],
-      blocked_by: [],
-      external_ids: {},
-      status: "draft",
-      folder: $dir,
-      warnings: [{code: "malformed_yaml", detail: .error}]
-    }
-  end' <<< "$PARSED"
+"${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh" "/absolute/path/to/task/folder"
 ```
 
-## Output Contract
+Parse the JSON output with `jq`. Example:
 
-The skill always returns a single JSON object to stdout with these fields:
-
-```json
-{
-  "id": "local:<folder>",
-  "kind": "flat|epic|sub_epic|subtask",
-  "parent": "local:<id>" | null,
-  "children": ["local:<id>", ...],
-  "blocks": ["local:<id>", ...],
-  "blocked_by": ["local:<id>", ...],
-  "external_ids": { ... },
-  "status": "draft|in_progress|blocked|completed",
-  "folder": "/abs/path/to/task/folder",
-  "warnings": [
-    { "code": "<warning_code>", "detail": "<free-form description>" }
-  ]
-}
+```bash
+OUTPUT=$("${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh" "$TASK_DIR")
+KIND=$(jq -r '.kind' <<<"$OUTPUT")
+WARNINGS=$(jq -c '.warnings' <<<"$OUTPUT")
 ```
 
-Callers should inspect `warnings[]` but never treat a non-empty warnings array as a failure. Warnings are observations, not errors.
+## Why this is a script, not embedded instructions
 
-## Consumers (known as of v3.10.0)
+Earlier drafts of this skill embedded the parser logic in the skill body as bash pseudo-code. A paper-test (2026-04-22) showed this led to pseudo-function references that would force Claude to re-implement helpers each invocation, with the risk of divergent implementations across runs. The script-based design eliminates that class of bug: the implementation is a single file that can be tested once and reused deterministically.
 
-- `/drupal-dev-framework:migrate-to-epic` — pre-flight check to confirm task is migratable
-- `epic-migrator` skill — used internally to validate generated frontmatter before the atomic swap
-- `/status` — to render tree view for epics vs. flat list for flat tasks
-- `/next` — to bias suggestions toward sibling subtasks when current task is a subtask
-- `/complete` — to check epic ancestor's completion state
+## Consumers (v2.0.0+)
 
-Future (3.2+) consumers will include the analysis agent and `/propose-epics`.
+- `/drupal-dev-framework:migrate-to-epic` — preflight kind check
+- `epic-migrator` skill — Step 4 validation of generated frontmatter
+- `/status`, `/next`, `/complete` — kind detection for hierarchy-aware rendering
 
-## Do NOT do
+## Do NOT
 
-- Never parse YAML inline with shell string manipulation — use the Python + yaml pipeline above.
-- Never exit non-zero for any input. Defensive posture is part of the contract.
-- Never write to `task.md` from this skill. Reading + derived-status cache refresh only. Rewriting core fields (`kind`, `parent`, `children`, etc.) is the migrator's job, not the reader's.
+- Do not duplicate the parser logic elsewhere. If another skill needs to read frontmatter, it should call `fm-read.sh` or source `fm-helpers.sh` directly (for helper bash functions like `fm_read`, `write_epic_frontmatter`, etc.).
+- Do not treat a non-empty `warnings[]` as a blocking error. The contract says warnings are observations.
+- Do not write to task.md from this skill. Reading is the sole purpose; migration and phase updates live elsewhere.

--- a/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
+++ b/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
@@ -38,7 +38,6 @@ Always-present fields:
 | Frontmatter YAML malformed | `malformed_yaml` |
 | python3 / yaml unavailable | `parser_unavailable` |
 
-Warning codes reserved for v1.1.0+ but not currently emitted: `wrong_type`, `dangling_reference`, `orphaned_subtask`, `nested_sub_epic_disallowed`. Do not rely on them in v2.0.x.
 
 ## Invocation
 

--- a/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
+++ b/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: task-frontmatter-reader
+description: Use when a framework command needs to read the hierarchy metadata of a task — parses the YAML frontmatter block at the top of task.md and returns structured data (id, kind, parent, children, blocks, blocked_by, external_ids, derived status) plus any warnings. Defensive: never blocks on malformed input; absent frontmatter yields kind=flat.
+version: 1.0.0
+user-invocable: false
+model: haiku
+allowed-tools: Read, Edit
+---
+
+# Task Frontmatter Reader
+
+Parse the YAML frontmatter block at the top of a task's `task.md`. Return structured metadata plus any warnings. Never throws; never blocks the caller.
+
+## When Called
+
+You receive one argument: the absolute path to a task folder (e.g. `/home/user/claude_memory/projects/myproj/implementation_process/in_progress/foo/`). The `task.md` inside it is the file to read.
+
+## Schema (what you're parsing)
+
+```yaml
+---
+id: local:<folder>                # URI-style; "local:" prefix for framework-tracked tasks
+kind: flat | epic | sub_epic | subtask
+parent: local:<id> | null          # null for flat and top-level epics
+children: [local:<id>, ...]        # present only on epic / sub_epic
+blocks: [local:<id>, ...]          # may be empty; defaults to []
+blocked_by: [local:<id>, ...]      # may be empty; defaults to []
+external_ids: {...}                # reserved; usually {}
+status: draft | in_progress | blocked | completed   # derived cache
+---
+```
+
+## Defensive Error Posture
+
+**Never throw. Never block.** Return structured output for every input, including garbage.
+
+| Input state | Output |
+|---|---|
+| `task.md` missing entirely | Return `kind: flat`, `id: local:<folder-name>`, all other fields null/empty, add warning `task_md_missing` |
+| `task.md` present, no frontmatter block | Return `kind: flat`, `id: local:<folder-name>`, all other fields null/empty, no warning (absence of frontmatter is normal) |
+| Frontmatter block delimiters present but YAML malformed | Return `kind: flat` (best-effort defaults), add warning `malformed_yaml` with the parse error |
+| Unknown fields in frontmatter | Preserve them in output under `unknown_fields`; do not warn (forward-compat) |
+| Known field with wrong type (e.g. `children: "not-a-list"`) | Ignore that field, use default, add warning `wrong_type` |
+| Dangling reference (`children: [local:foo]` but `foo/` folder missing) | Keep the reference in output, add warning `dangling_reference` |
+| `kind: subtask` with `parent: null` or no parent folder match | Use the declared `kind`, add warning `orphaned_subtask` |
+| `kind: sub_epic` whose children include another `sub_epic` (depth > 2) | Keep as declared, add warning `nested_sub_epic_disallowed` — the depth rule is advisory at read time; writers enforce it |
+
+## Action
+
+Run this bash pipeline (or equivalent logic). Output is JSON.
+
+```bash
+TASK_DIR="${1:?path to task folder required}"
+TASK_MD="$TASK_DIR/task.md"
+FOLDER_NAME=$(basename "$TASK_DIR")
+WARNINGS=()
+
+# Check task.md exists
+if [ ! -f "$TASK_MD" ]; then
+  jq -nc --arg id "local:$FOLDER_NAME" --arg dir "$TASK_DIR" \
+    '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "task_md_missing", detail: "task.md not found in folder"}]}'
+  exit 0
+fi
+
+# Extract the frontmatter block (between first --- and second ---, only if present at line 1)
+FRONTMATTER=$(awk '
+  NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+  in_fm && /^---[[:space:]]*$/ { exit }
+  in_fm { print }
+' "$TASK_MD")
+
+if [ -z "$FRONTMATTER" ]; then
+  # No frontmatter block — treat as flat task, no warning (legitimate legacy state)
+  jq -nc --arg id "local:$FOLDER_NAME" --arg dir "$TASK_DIR" \
+    '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: []}'
+  exit 0
+fi
+
+# Parse the frontmatter as YAML via a python one-liner (robust; yq often not installed)
+PARSED=$(printf '%s' "$FRONTMATTER" | python3 -c '
+import sys, yaml, json
+try:
+    data = yaml.safe_load(sys.stdin.read()) or {}
+    print(json.dumps({"ok": True, "data": data}))
+except Exception as e:
+    print(json.dumps({"ok": False, "error": str(e)}))
+' 2>/dev/null)
+
+if [ -z "$PARSED" ]; then
+  # python3 or yaml module unavailable — degrade to flat with warning
+  jq -nc --arg id "local:$FOLDER_NAME" --arg dir "$TASK_DIR" \
+    '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", folder: $dir, warnings: [{code: "parser_unavailable", detail: "python3 or yaml module missing; treating as flat"}]}'
+  exit 0
+fi
+
+# Extract and normalize fields, defaulting on absence
+jq -c --arg folder_name "$FOLDER_NAME" --arg dir "$TASK_DIR" '
+  if .ok then
+    .data as $d |
+    {
+      id: ($d.id // ("local:" + $folder_name)),
+      kind: ($d.kind // "flat"),
+      parent: ($d.parent // null),
+      children: ($d.children // []),
+      blocks: ($d.blocks // []),
+      blocked_by: ($d.blocked_by // []),
+      external_ids: ($d.external_ids // {}),
+      status: ($d.status // "draft"),
+      folder: $dir,
+      warnings: []
+    }
+  else
+    {
+      id: ("local:" + $folder_name),
+      kind: "flat",
+      parent: null,
+      children: [],
+      blocks: [],
+      blocked_by: [],
+      external_ids: {},
+      status: "draft",
+      folder: $dir,
+      warnings: [{code: "malformed_yaml", detail: .error}]
+    }
+  end' <<< "$PARSED"
+```
+
+## Output Contract
+
+The skill always returns a single JSON object to stdout with these fields:
+
+```json
+{
+  "id": "local:<folder>",
+  "kind": "flat|epic|sub_epic|subtask",
+  "parent": "local:<id>" | null,
+  "children": ["local:<id>", ...],
+  "blocks": ["local:<id>", ...],
+  "blocked_by": ["local:<id>", ...],
+  "external_ids": { ... },
+  "status": "draft|in_progress|blocked|completed",
+  "folder": "/abs/path/to/task/folder",
+  "warnings": [
+    { "code": "<warning_code>", "detail": "<free-form description>" }
+  ]
+}
+```
+
+Callers should inspect `warnings[]` but never treat a non-empty warnings array as a failure. Warnings are observations, not errors.
+
+## Consumers (known as of v3.10.0)
+
+- `/drupal-dev-framework:migrate-to-epic` — pre-flight check to confirm task is migratable
+- `epic-migrator` skill — used internally to validate generated frontmatter before the atomic swap
+- `/status` — to render tree view for epics vs. flat list for flat tasks
+- `/next` — to bias suggestions toward sibling subtasks when current task is a subtask
+- `/complete` — to check epic ancestor's completion state
+
+Future (3.2+) consumers will include the analysis agent and `/propose-epics`.
+
+## Do NOT do
+
+- Never parse YAML inline with shell string manipulation — use the Python + yaml pipeline above.
+- Never exit non-zero for any input. Defensive posture is part of the contract.
+- Never write to `task.md` from this skill. Reading + derived-status cache refresh only. Rewriting core fields (`kind`, `parent`, `children`, etc.) is the migrator's job, not the reader's.


### PR DESCRIPTION
## Summary

Ships the **structural foundation** for epic/sub-task hierarchy in `drupal-dev-framework`. Flat tasks remain first-class; hierarchy is additive and opt-in per task.

First child of the sub-epic `dev_framework_task_granularity` (which was itself promoted from sub-task to sub-epic mid-research). Substrate that 3.2 and 3.3 build on.

## What's shipped

**Frontmatter schema on `task.md`** — optional YAML block with `id` (URI-style, e.g. `local:<folder>`), `kind` (`flat`/`epic`/`sub_epic`/`subtask`), `parent`, `children[]`, `blocks[]`, `blocked_by[]`, `external_ids`, derived `status`. Missing frontmatter → `kind: flat` (zero behavior change).

**Folder nesting up to 2 epic levels** — epic folders may contain subtask folders and a `shared/` directory for cross-cutting artifacts. Kind taxonomy enforces the depth cap.

**New command `/drupal-dev-framework:migrate-to-epic <task>`** — converts a flat task into an epic with children. Transactional 8-step flow with 24h rollback. Supports `--dry-run` and `--children "a,b,c"`.

**New scripts** (real executables, not embedded instructions):
- `scripts/fm-helpers.sh` — sourced helpers
- `scripts/fm-read.sh` — entry point for reader skill  
- `scripts/migrate-to-epic.sh` — entry point for migrator skill

**New skills:** `task-frontmatter-reader` v2.0.0 (haiku), `epic-migrator` v2.0.1 (sonnet). Both thin wrappers; implementation lives in the scripts.

**Hierarchy-aware updates** (minor, flat-task behavior unchanged): `/status`, `/next`, `/complete`.

**Session context:** `session-context-writer` v1.4.0 adds `currentEpic` with placeholder-sentinel preserve semantics.

## Security hardening (from paper-test rounds)

- Name validation rejects `/`, `\`, `..`, `.`, and non-`[A-Za-z0-9._-]` characters (path-traversal prevention)
- Symlink rejection on task folder + task.md (information-disclosure prevention)
- Atomic swap recovery cleans partial temp on mv failure
- Concurrent-migration lock via atomic `mkdir` (without `-p`)
- Completed-children `already_completed` classification prevents empty-duplicate-folder bug
- Cross-cutting artifact preservation — top-level non-phase files relocated to `shared/` on migration

## Dog-food validation

v3.10.0 validated by migrating `dev_framework_improvements_epic` itself using the shipped command. 10 children correctly classified (7 move_existing + 2 already_completed + 1 create_stub). `mechanisms-map.md` relocated to `shared/`. Session-context Case C correctly updated the active subtask's path into its new nested location. **The framework now runs on its own hierarchy.**

## Gates run

- `plugin-creation-tools:validate` → PASS
- `skill-quality-reviewer` → 2 errors fixed (session-context-writer `allowed-tools: Bash`; epic-migrator body trimmed — documentary content moved to script header)
- `plugin-structure-auditor` → returned preamble only (truncation regression despite PR #111's scope-narrowing). Coverage adequate between the other two validators.
- Paper-test rounds (scripts-level + integration-level) → 8 findings total (1 CRITICAL + 2 MAJOR + 3 MINOR + 2 NIT); all critical/major fixed; minors accepted with documentation
- Live smoke tests on 3 throwaway tasks + dog-food migration → all pass

## Metadata

- `plugin.json` 3.9.1 → **3.10.0** (minor — additive feature)
- `marketplace.json` plugin entry 3.10.0 + description updated
- `marketplace.json` `metadata.version` 1.14.4 → **1.14.6** (accounts for code-paper-test 0.7.0 bump in PR #115 + this drupal-dev-framework bump)
- `CHANGELOG.md` [3.10.0] entry with Added / Hardened / Dog-food / Notes sections
- `README.md` Commands table + current-version note
- Plugin `CLAUDE.md` Task Hierarchy section

## Discoverability (AC requirement)

`/migrate-to-epic` present in all 5 required placements:
1. README Commands section ✓
2. Command frontmatter description (starts with "Use when…") ✓
3. `/next` reference (surfaces when task looks epic-sized) ✓
4. `marketplace.json` plugin description ✓
5. Plugin CLAUDE.md Task Hierarchy section ✓

## Deferred to sub-tasks 3.2 / 3.3

- Automated epic detection (`/propose-epics`) — 3.2
- Guided granularity via analysis agent — 3.2
- `codePath` project-level field + `/set-code-path` — 3.2
- P7 alignment step (Goal / Expected result / Success criteria / Non-goals) — 3.3
- Phase-sub-granularity mechanism — 3.3
- Graph-aware `/next` / `/status` — later

## Test plan

- [ ] Fresh install in a test workspace; run `/migrate-to-epic --dry-run` on a flat task
- [ ] Run live migration on a flat task with `--children "a,b,c"`
- [ ] Verify `/status` renders the new epic as a tree
- [ ] Create a second task; verify it stays flat (non-regression)
- [ ] Verify `/complete` on a subtask moves it out of the epic folder to `completed/`
- [ ] Try malicious child name (`../foo`) — should be rejected with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)