### PR TITLE
drupal-dev-framework v3.11.0 — project codePath + analysis agent (sub-task 3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.6"
+    "version": "1.14.7"
   },
   "plugins": [
     {
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook with directive role-identity framing. v3.10.0 adds epic/sub-task hierarchy: task.md frontmatter schema (id/kind/parent/children/blocks/blocked_by), nested folder layout (max 2 epic levels), shared/ folder for cross-cutting artifacts, /migrate-to-epic command with transactional 8-step migration, task-frontmatter-reader skill, hierarchy-aware /status /next /complete. Flat tasks remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.10.0",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook with directive role-identity framing. v3.10.0 adds epic/sub-task hierarchy: task.md frontmatter schema, nested folder layout (max 2 epic levels), shared/ folder, /migrate-to-epic command, task-frontmatter-reader skill, hierarchy-aware /status /next /complete. v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader skill) and the analysis-agent (read-only, sonnet) with structured-output JSON schema v1.0 consumed by /propose-epics (bulk review of flat tasks for epic-ification) and /research pre-analysis hook (description-mode on strong signals). Flat tasks remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
+      "version": "3.11.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.0] - 2026-04-23
+
+### Added — Project codePath + Analysis Agent (sub-task 3.2 of dev-framework improvements epic)
+
+Two coupled additions: project-level `codePath` metadata infrastructure, and a read-only analysis agent that proposes epic decompositions for flat tasks. All additive; flat tasks and existing commands behave unchanged when these features aren't used.
+
+**Project `codePath` metadata** — projects can now declare where their code lives (distinct from the memory folder). Supports three states: **unknown** (never set — triggers detect+confirm on first use), **docs-only** (intentionally no code — null at runtime, no warnings), **set** (`/abs/path` — validated).
+
+- **`project-state-reader` skill v1.0.0** (haiku, user-invocable: false) — defensive reader for `project_state.md`'s `**Code path:**` line. Emits structured JSON `{project_name, codePath, folder, warnings[]}`. Thin wrapper around `scripts/project-state-read.sh`. Five warning codes: `folder_missing`, `project_state_md_missing`, `code_path_unknown`, `code_path_missing`, `malformed_header`.
+- **`scripts/project-state-read.sh`** — portable bash. `realpath -m` normalization, `(docs-only)` sentinel handling. Never throws.
+- **New command `/drupal-dev-framework:set-code-path [<path>|--docs-only]`** — three invocation modes: explicit path, `--docs-only` sentinel, or interactive detect+confirm. Writes `project_state.md` as source of truth and syncs `active_projects.json` cache. Path-safety filter hard-rejects system roots (`/`, `/etc`, `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/boot`, `/sys`, `/proc`, `/dev`, `/var`, `/opt`, `/root`, `$HOME` ancestors) and warns-but-allows paths outside `$HOME`.
+- **`/new` updated** — new Step 3 captures codePath at project creation time with 4 user options (Y/path/d/s). Detection strategies in `references/code-path-detection.md`.
+- **`project-initializer` v1.4.0** (sonnet) — accepts `code_path` arg; `project_state.md` template emits `**Code path:**` line (or omits if not provided).
+
+**`analysis-agent` v1.0.0** (sonnet, read-only) — assesses whether a flat task is epic-sized and proposes 3-5 children. Tools: `Read`, `Grep`, `Glob`, `Bash` (read-only with mutation-subcommand denylist: `rm`, `mv`, `cp`, `sed`, `tee`, `dd`, `chmod`, `chown`). Never mutates state; never emits user-facing chat. Two input modes:
+
+- **Folder mode** — `task_folder` input; reads task.md / research.md / architecture.md / implementation.md via `task-frontmatter-reader` + Read; full 7-signal evaluation. Used by `/propose-epics`.
+- **Description mode** — `task_description_text` input (folder doesn't exist yet); restricted 3-signal evaluation (`description_length_and_conjunction`, `bullet_count_clustering`, `multiple_code_areas` if code_read). Used by `/research` pre-analysis hook.
+
+Emits structured JSON per `references/analysis-agent-schema.md` v1.0. Seven invariants enforced before emit (proposed_children iff epic_candidate; `confidence: low` REQUIRED when `code_read: false`; signals non-empty on epic_candidate; `schema_version` is a JSON string; child names match `^[A-Za-z0-9_][A-Za-z0-9._-]*$`; rationale ≤400 chars; no literal newlines in string fields).
+
+**New command `/drupal-dev-framework:propose-epics`** — bulk-reviews all flat in-progress tasks. Spawns `analysis-agent` subagents in parallel (one per candidate) via the Task tool. Presents per-task decisions (epic_candidate / keep_flat / insufficient_info) with accept / edit / reject / skip options. Accepted proposals invoke `/migrate-to-epic` under the hood. Summary reports counts including partial failures (invalid JSON, subagent crash, schema mismatch) — no silent drops.
+
+**`/research` pre-analysis hook** — on new-task creation, evaluates three strong signals in the task name + description: length > 500 chars, ≥3 bullets, explicit conjunctions (`and also`, `plus`, `as well as`, `in addition to`). If any fires, invokes `analysis-agent` in description mode BEFORE creating the task directory. On `epic_candidate`, prompts user to create as epic / flat / standard. Conservative — default answer is flat; never creates an epic without explicit confirmation.
+
+**New references:**
+- `references/analysis-agent-schema.md` — canonical JSON Schema v1.0, 7 field contracts, 7 invariants, 7 signal codes, 3 example outputs, versioning policy, input-modes contract.
+- `references/code-path-detection.md` — 2 shipped strategies (`$PWD` markers, sibling-of-memory-folder), priority order, confirm-prompt UI, fallback cold prompt, three-null-states table, safety filter (shared with `/set-code-path`).
+
 ## [3.10.0] - 2026-04-22
 
 ### Added — Task Hierarchy Foundation (sub-task 3.1 of dev-framework improvements epic)

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -17,7 +17,23 @@ The plugin supports **opt-in epic/sub-task hierarchy** on top of flat tasks (whi
 
 **When to promote a task to epic:** many heterogeneous acceptance criteria, long-in-progress without phase progression, or user signals "this is too big." Most tasks should stay flat — epic-ification is additive, not aspirational.
 
-**Automated epic proposal (`/propose-epics`) and alignment-step (P7) land in sub-tasks 3.2 / 3.3.** In v3.10.0, the primitive is manual.
+**Automated epic proposal (`/propose-epics`) landed in v3.11.0** — bulk-review of flat in-progress tasks via `analysis-agent` (read-only, sonnet), per-task accept/edit/reject/skip, accepted proposals invoke `/migrate-to-epic`. Plus `/research` pre-analysis hook that fires on strong signals (description > 500 chars, ≥3 bullets, explicit conjunctions) at new-task creation time. Goal-alignment step (P7) lands in sub-task 3.3.
+
+## Project codePath Metadata (v3.11.0+)
+
+Projects can declare where their code lives, distinct from the memory folder. Three states:
+
+- **unknown** — never set. Features needing code trigger first-use detect+confirm.
+- **docs-only** — user declared no code base. Features needing code skip silently.
+- **set** — `/abs/path`. Used by code-aware features.
+
+Commands: `/set-code-path [<path>|--docs-only]` (explicit/sentinel/interactive), `/new` (captures at project creation).
+
+Consumers distinguish states via warnings, not the null value: `code_path_unknown` warning → trigger detect+confirm; `codePath: null` with no warning → docs-only. See `references/code-path-detection.md` for the three-null-states table and the safety filter (hard-rejects `/`, `/etc`, `/usr`, `$HOME` ancestors, etc.).
+
+## Analysis Agent (v3.11.0+)
+
+`analysis-agent` is read-only (Read/Grep/Glob + Bash with mutation-subcommand denylist). Consumed by `/propose-epics` (folder mode, bulk review) and `/research` pre-analysis hook (description mode, pre-folder-creation). Emits structured JSON per `references/analysis-agent-schema.md` v1.0 — never modifies state, never chats with user. Output is consumed programmatically by the calling command.
 
 ## Agents
 - Frontmatter must include: name, description, capabilities, version, model

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -95,6 +95,8 @@ Phases apply per task, not per project. A project can have tasks at different ph
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
+| `/set-code-path [<path>|--docs-only]` | **(v3.11.0)** Set/update the active project's `codePath` — where its code actually lives (distinct from the memory folder). Supports explicit path, `--docs-only` sentinel, or interactive detect+confirm. Path-safety filter rejects system roots and prompts for paths outside `$HOME`. Writes `project_state.md` + syncs `active_projects.json`. |
+| `/propose-epics` | **(v3.11.0)** Bulk-review flat in-progress tasks — analysis-agent (read-only, sonnet) scans each candidate and proposes epic decompositions with 3-5 children. Per-task accept / edit / reject / skip. Accepted proposals invoke `/migrate-to-epic` under the hood. Counterpart to `/research`'s pre-analysis hook. |
 
 All commands are prefixed with `drupal-dev-framework:` (e.g., `/drupal-dev-framework:next`).
 
@@ -115,7 +117,7 @@ The debate produces a synthesized recommendation with dissenting opinions noted.
 
 ## What's Inside
 
-### Agents (5)
+### Agents (6)
 
 Agents handle complex multi-step tasks with model routing and cost control (`maxTurns` prevents runaway loops):
 
@@ -126,10 +128,11 @@ Agents handle complex multi-step tasks with model routing and cost control (`max
 | `architecture-validator` | sonnet | 20 | Read-only validation in isolated worktree |
 | `pattern-recommender` | sonnet | 15 | Recommends Drupal patterns with core/contrib references |
 | `contrib-researcher` | haiku | 15 | Searches drupal.org and contrib code for existing solutions |
+| `analysis-agent` **(v3.11.0)** | sonnet | 10 | Read-only scope analyzer — proposes epic decomposition as JSON per schema v1.0 |
 
-### Skills (16)
+### Skills (20)
 
-Skills are invoked automatically by commands and agents — 10 are user-invocable, 6 are internal:
+Skills are invoked automatically by commands and agents — 10 are user-invocable, 10 are internal:
 
 | Category | Skills |
 |----------|--------|
@@ -137,7 +140,7 @@ Skills are invoked automatically by commands and agents — 10 are user-invocabl
 | **Architecture** | `component-designer`, `diagram-generator`, `guide-integrator`, `guide-loader` |
 | **Implementation** | `tdd-companion`, `code-pattern-checker`, `task-completer` |
 | **Utility** | `project-initializer`, `requirements-gatherer`, `session-resume`, `implementation-task-creator`, `task-folder-migrator` |
-| **Internal** | `phase-detector`, `memory-manager`, `task-context-loader` |
+| **Internal** | `phase-detector`, `memory-manager`, `task-context-loader`, `session-context-writer`, `task-frontmatter-reader` (v3.10.0), `epic-migrator` (v3.10.0), `project-state-reader` (v3.11.0) |
 
 ### Methodology References (6)
 

--- a/drupal-dev-framework/agents/analysis-agent.md
+++ b/drupal-dev-framework/agents/analysis-agent.md
@@ -4,7 +4,7 @@ description: "Use when a framework flow needs to assess whether a task looks epi
 capabilities: ["task-analysis", "scope-assessment", "epic-proposal", "sub-task-decomposition"]
 version: 1.0.0
 model: sonnet
-disallowedTools: Edit, Write, Bash(rm:*), Bash(mv:*), Bash(cp:*)
+disallowedTools: Edit, Write, Bash(rm:*), Bash(mv:*), Bash(cp:*), Bash(sed:*), Bash(tee:*), Bash(dd:*), Bash(chmod:*), Bash(chown:*)
 maxTurns: 10
 ---
 
@@ -14,32 +14,56 @@ Read-only agent that assesses task scope and proposes decomposition. Consumed by
 
 ## Contract
 
-Input (provided by the caller at invocation):
+Input (provided by the caller at invocation). Exactly ONE of the two input modes:
 
-- `task_folder` — absolute path to the task folder being analyzed
+**Folder mode** (used by `/propose-epics`):
+- `task_folder` — absolute path to an existing task folder
 - `codePath` — absolute path to the project's code, OR `null` for docs-only
-- `schema_version` — expected output schema version; agent rejects mismatches with a clear error (currently `"1.0"`)
+- `schema_version` — expected output schema version (currently `"1.0"`, JSON string)
 
-Output: single JSON object per `references/analysis-agent-schema.md` v1.0. Written to stdout. No file modifications. No user-facing chat — the agent's output is consumed programmatically by the calling command.
+**Description mode** (used by `/research` pre-analysis hook, before task folder exists):
+- `task_description_text` — raw text: task name + full description as typed by user
+- `codePath` — absolute path to the project's code, OR `null` for docs-only
+- `schema_version` — expected output schema version (currently `"1.0"`, JSON string)
+
+See `references/analysis-agent-schema.md` §"Input modes" for the full contract.
+
+Output: single JSON object per `references/analysis-agent-schema.md` v1.0. Written to stdout. `schema_version` MUST be a JSON string (`"1.0"` quoted), never a number. No file modifications. No user-facing chat — the agent's output is consumed programmatically by the calling command.
 
 ## Tools
 
-- `Read` — task.md, research.md, architecture.md, implementation.md at the task folder; `.md` files under `codePath` when present
+- `Read` — task.md, research.md, architecture.md, implementation.md at the task folder (folder mode only); `.md` files under `codePath` when present
 - `Grep` — search within code for module/package boundaries, test directories, etc.
 - `Glob` — enumerate files under `codePath`
+- `Bash` — **read-only only**, with a denylist on mutating subcommands (see frontmatter `disallowedTools`). Required because `task-frontmatter-reader` skill invokes `fm-read.sh` via Bash. NEVER use Bash for file mutation, redirects to files (`>`, `>>`, `tee`), in-place edits (`sed -i`, `awk` with output redirect), or system changes (`chmod`, `chown`, `rm`, `mv`, `cp`, `dd`). If the denylist doesn't cover a mutation you're considering, STOP — the policy is read-only, the denylist is a backstop.
 
-Explicitly NO Edit, Write, or destructive Bash. The agent never mutates state. If it needs to write its proposal, the caller does that (by accepting the proposal and invoking `/migrate-to-epic`).
+Explicitly NO `Edit` or `Write`. The agent never mutates state. If it needs to write its proposal, the caller does that (by accepting the proposal and invoking `/migrate-to-epic`).
 
 ## Workflow
 
-### 1. Read the task
+### 0. Validate input and detect mode
+
+**Validate exactly one of `{task_description_text, task_folder}` is present:**
+
+- Both present → emit `decision: insufficient_info`, `notes: ["input validation failed: pass exactly one of task_description_text or task_folder, not both"]`, exit.
+- Neither present → emit `decision: insufficient_info`, `notes: ["input validation failed: exactly one of task_description_text/task_folder required"]`, exit.
+
+If `task_description_text` was provided (and `task_folder` absent): **description mode**. Skip steps 1-2; go to step 3 with:
+- `task_folder` output field set to `"(pre-creation)"`
+- `task_id` output field set to `"local:(pre-creation)"`
+- Signal evaluation limited to: `description_length_and_conjunction`, `bullet_count_clustering`, `multiple_code_areas` (if code_read)
+- Add to `notes[]`: `"description mode: phase-artifact signals unavailable"`
+
+Otherwise: **folder mode**. Proceed with steps 1-2.
+
+### 1. Read the task (folder mode only)
 
 Invoke `task-frontmatter-reader` skill on `task_folder`. Capture `kind`, `status`, `task_id`.
 
 - If `kind != flat`: abort with `decision: keep_flat`, `notes: ["task is not kind=flat; analysis skipped"]`. Agent only proposes decomposition for flat tasks. (Already-epics and subtasks are not candidates.)
 - If `status == completed`: abort with `decision: keep_flat`, `notes: ["task already completed; no change"]`.
 
-### 2. Read phase artifacts
+### 2. Read phase artifacts (folder mode only)
 
 Read `task.md`, and `research.md` / `architecture.md` / `implementation.md` if present.
 
@@ -65,7 +89,21 @@ If `codePath` is null:
 
 ### 4. Evaluate signals
 
-For each signal code in `references/analysis-agent-schema.md` §Signal codes, determine whether it fires:
+**Mode gate first.** Description mode SKIPS folder-only signals. The evaluable set per mode:
+
+| Signal | Folder mode | Description mode |
+|---|---|---|
+| `many_heterogeneous_criteria` | ✓ (reads task.md AC) | ✗ SKIP (no task.md) |
+| `long_in_progress` | ✓ (file timestamps) | ✗ SKIP (folder doesn't exist) |
+| `research_architecture_fragmented` | ✓ (reads phase artifacts) | ✗ SKIP (no artifacts) |
+| `explicit_user_signal` | ✓ (reads task.md body) | ✗ SKIP (no task.md) |
+| `multiple_code_areas` | ✓ if `code_read: true` | ✓ if `code_read: true` |
+| `description_length_and_conjunction` | ✓ (reads `## Goal` / description section) | ✓ (evaluates `task_description_text`) |
+| `bullet_count_clustering` | ✓ (reads description) | ✓ (evaluates `task_description_text`) |
+
+In description mode, do NOT cite a ✗-SKIP signal in `signals_used[]` — those signals are unevaluable without the task folder. Citing them would be hallucination.
+
+For each signal code that is ✓ in the current mode, determine whether it fires:
 
 - `many_heterogeneous_criteria` — ≥5 acceptance criteria that cluster into distinct groups (by topic, not similarity)
 - `long_in_progress` — task has been `in_progress` ≥21 days without phase progression (check file timestamps; skip if unknown)

--- a/drupal-dev-framework/agents/analysis-agent.md
+++ b/drupal-dev-framework/agents/analysis-agent.md
@@ -1,0 +1,140 @@
+---
+name: analysis-agent
+description: "Use when a framework flow needs to assess whether a task looks epic-sized and propose a decomposition. Reads task docs (task.md + phase artifacts) and optionally the project's codePath to reason about scope. Emits structured JSON per references/analysis-agent-schema.md v1.0. Invoked by /propose-epics for bulk review and by /research pre-analysis hook at new-task creation. Never modifies files."
+capabilities: ["task-analysis", "scope-assessment", "epic-proposal", "sub-task-decomposition"]
+version: 1.0.0
+model: sonnet
+disallowedTools: Edit, Write, Bash(rm:*), Bash(mv:*), Bash(cp:*)
+maxTurns: 10
+---
+
+# Analysis Agent
+
+Read-only agent that assesses task scope and proposes decomposition. Consumed by commands that want structured "should this be an epic?" judgments — specifically `/propose-epics` (bulk review of existing tasks) and `/research` pre-analysis (new-task creation with strong signals).
+
+## Contract
+
+Input (provided by the caller at invocation):
+
+- `task_folder` — absolute path to the task folder being analyzed
+- `codePath` — absolute path to the project's code, OR `null` for docs-only
+- `schema_version` — expected output schema version; agent rejects mismatches with a clear error (currently `"1.0"`)
+
+Output: single JSON object per `references/analysis-agent-schema.md` v1.0. Written to stdout. No file modifications. No user-facing chat — the agent's output is consumed programmatically by the calling command.
+
+## Tools
+
+- `Read` — task.md, research.md, architecture.md, implementation.md at the task folder; `.md` files under `codePath` when present
+- `Grep` — search within code for module/package boundaries, test directories, etc.
+- `Glob` — enumerate files under `codePath`
+
+Explicitly NO Edit, Write, or destructive Bash. The agent never mutates state. If it needs to write its proposal, the caller does that (by accepting the proposal and invoking `/migrate-to-epic`).
+
+## Workflow
+
+### 1. Read the task
+
+Invoke `task-frontmatter-reader` skill on `task_folder`. Capture `kind`, `status`, `task_id`.
+
+- If `kind != flat`: abort with `decision: keep_flat`, `notes: ["task is not kind=flat; analysis skipped"]`. Agent only proposes decomposition for flat tasks. (Already-epics and subtasks are not candidates.)
+- If `status == completed`: abort with `decision: keep_flat`, `notes: ["task already completed; no change"]`.
+
+### 2. Read phase artifacts
+
+Read `task.md`, and `research.md` / `architecture.md` / `implementation.md` if present.
+
+Collect:
+- Goal statement (from `## Goal`)
+- Acceptance criteria (from `## Acceptance Criteria` or `## Success Criteria`)
+- Description text (anything before `## Phase Status`)
+- Research/architecture doc sizes (line counts) and topic clustering
+
+### 3. Read code (if codePath present)
+
+If `codePath` is non-null:
+
+- Glob the top-level structure to understand module boundaries (e.g., `modules/custom/*/`, `packages/*/`, `src/`)
+- Grep for references to the task's declared goal / acceptance criteria terms (cross-check what code areas are implicated)
+- Set `code_read: true` in output
+
+If `codePath` is null:
+
+- Set `code_read: false`
+- Force `confidence: "low"` (per schema invariant 2)
+- Add a note: `"codePath unknown or docs-only; analysis is from task docs alone"`
+
+### 4. Evaluate signals
+
+For each signal code in `references/analysis-agent-schema.md` §Signal codes, determine whether it fires:
+
+- `many_heterogeneous_criteria` — ≥5 acceptance criteria that cluster into distinct groups (by topic, not similarity)
+- `long_in_progress` — task has been `in_progress` ≥21 days without phase progression (check file timestamps; skip if unknown)
+- `research_architecture_fragmented` — research.md or architecture.md > 500 lines OR obvious distinct concerns per section headings
+- `explicit_user_signal` — task.md contains phrases like "getting too big", "could be split", "too much scope" in user-written sections
+- `multiple_code_areas` (requires `code_read: true`) — task's concerns touch ≥2 distinct module/package boundaries per code read
+- `description_length_and_conjunction` — task description > 500 chars AND contains explicit "and also" / "plus" / "as well as" conjunctions
+- `bullet_count_clustering` — description has ≥3 bullets that group into distinct topics
+
+Record all fired signals in `signals_used[]`.
+
+### 5. Decide
+
+Apply decision rules from `references/analysis-agent-schema.md` §"Decision reasoning":
+
+- ≥1 signal fires → `decision: epic_candidate`. Confidence:
+  - ≥3 signals + code_read: `"high"`
+  - 1-2 signals + code_read: `"medium"`
+  - any signals + `code_read: false`: `"low"` (per invariant)
+- 0 signals fire → `decision: keep_flat`, `confidence: "high"` (or `"medium"` if analysis material was thin)
+- task.md/phase artifacts empty or corrupt → `decision: insufficient_info`, notes specify what's missing
+
+### 6. For epic_candidate: propose children
+
+Decompose based on what the signals revealed:
+
+- Signals from clustered acceptance criteria → one proposed child per cluster
+- Signals from fragmented research/architecture → one proposed child per distinct concern
+- Signals from multiple_code_areas → one proposed child per affected code boundary
+- Signals from conjunction phrasing → split at conjunction boundaries
+
+Each proposed child gets:
+- `name` — `^[A-Za-z0-9_][A-Za-z0-9._-]*$` (enforced per invariant 7)
+- `scope_summary` — one line, verb-first ("Migrate form class to ConfigFormBase", "Add validation for new schema")
+- `rationale` — one line, why this child is a separable unit
+
+Target 3-5 proposed children. >5 usually means the agent is over-splitting; step back and group.
+
+### 7. Emit
+
+Produce the JSON per `references/analysis-agent-schema.md`. Schema-version check against the caller's expected version. Write to stdout.
+
+## Invariants (agent enforces before emitting)
+
+From the schema reference, restated for agent convenience:
+
+1. `proposed_children` non-empty iff `decision: epic_candidate`
+2. `confidence: low` REQUIRED when `code_read: false`
+3. `signals_used` non-empty when `decision: epic_candidate`
+4. All child names match the naming regex
+5. `rationale` ≤400 chars
+6. No literal newlines inside JSON string fields
+
+If any invariant would be violated, adjust the decision/output rather than emitting invalid JSON. Common adjustment: a proposed child name with disallowed chars → substitute underscores; a too-long rationale → trim with an ellipsis.
+
+## Do NOT
+
+- Do not modify any file. Tools are read-only; violations are prevented by frontmatter `disallowedTools`.
+- Do not emit chat output to the user. Your output is JSON consumed by the caller.
+- Do not make up signals. Only cite signals you actually verified against the data.
+- Do not propose >5 children unless the evidence is overwhelming. Over-splitting defeats the point.
+- Do not propose children whose names collide with existing sibling folders — check and adjust.
+
+## See also
+
+- `references/analysis-agent-schema.md` — canonical schema and invariants
+- `references/code-path-detection.md` — how codePath got set (context for `code_read`)
+- `task-frontmatter-reader` skill v2.0.0 — read task metadata
+- `project-state-reader` skill v1.0.0 — read project metadata (caller provides codePath; agent doesn't call this itself)
+- `/drupal-dev-framework:propose-epics` command — primary consumer
+- `/drupal-dev-framework:research` command — pre-analysis hook consumer
+- Architecture decisions Q7, Q8, Q9, Q10 in `dev_framework_project_code_path_and_analysis_agent/architecture.md`

--- a/drupal-dev-framework/commands/new.md
+++ b/drupal-dev-framework/commands/new.md
@@ -19,15 +19,34 @@ Initialize a new development project with complete memory structure.
 
 1. Asks for project name (if not provided)
 2. Asks where to store project files (uses saved base path from registry, or asks on first run)
-3. Creates project folder structure:
-   - `project_state.md`
+3. **Asks where the code lives** (v3.11.0+ — see "Code path capture" below). Captures the codePath for downstream framework features (analysis agent, visual check, etc.).
+4. Creates project folder structure:
+   - `project_state.md` (with `**Code path:**` line populated from step 3)
    - `architecture/main.md`
    - `implementation_process/in_progress/`
    - `implementation_process/completed/`
-4. Registers project in `~/.claude/drupal-dev-framework/active_projects.json`
-5. Invokes `project-initializer` skill
-6. Invokes `requirements-gatherer` skill
-7. **Invokes `session-context-writer` skill with the new project name and path**
+5. Registers project in `~/.claude/drupal-dev-framework/active_projects.json` (including the `codePath` field)
+6. Invokes `project-initializer` skill (v1.4.0 accepts a `code_path` arg)
+7. Invokes `requirements-gatherer` skill
+8. **Invokes `session-context-writer` skill with the new project name and path**
+
+## Code path capture (v3.11.0+)
+
+Before creating the project structure, ask the user:
+
+> Where does the code for this project live? This is the path the analysis agent and other code-aware features will use. Options:
+>   [Y] accept detected candidate: `<detected_path>`    (only shown when detection found a candidate)
+>   [path] enter an absolute path to the code
+>   [d] mark this project docs-only (no code base)
+>   [s] skip for now — set later with `/drupal-dev-framework:set-code-path`
+
+Detection strategies (in order, first match wins):
+1. `$PWD` — if it contains `.git/`, `composer.json`, `package.json`, or Drupal markers
+2. Sibling-of-memory-folder — e.g., memory at `~/workspace/claude_memory/projects/foo/` → check `~/workspace/foo/`
+
+If the user skips, the project starts with `codePath` absent — the first framework feature that needs code will trigger detect+confirm again.
+
+Pass the captured value to `project-initializer` as the `code_path` argument.
 
 ## Project Name Requirements
 

--- a/drupal-dev-framework/commands/new.md
+++ b/drupal-dev-framework/commands/new.md
@@ -40,13 +40,11 @@ Before creating the project structure, ask the user:
 >   [d] mark this project docs-only (no code base)
 >   [s] skip for now — set later with `/drupal-dev-framework:set-code-path`
 
-Detection strategies (in order, first match wins):
-1. `$PWD` — if it contains `.git/`, `composer.json`, `package.json`, or Drupal markers
-2. Sibling-of-memory-folder — e.g., memory at `~/workspace/claude_memory/projects/foo/` → check `~/workspace/foo/`
+Detection strategies, priority order, markers, and acceptance/safety rules are defined in `references/code-path-detection.md` — **that is the single source of truth**. Do not re-implement or re-enumerate strategies here; consult the reference.
 
 If the user skips, the project starts with `codePath` absent — the first framework feature that needs code will trigger detect+confirm again.
 
-Pass the captured value to `project-initializer` as the `code_path` argument.
+Pass the captured value to `project-initializer` as the `code_path` argument (absolute path, or the literal string `(docs-only)` for docs-only, or omit for skip).
 
 ## Project Name Requirements
 

--- a/drupal-dev-framework/commands/propose-epics.md
+++ b/drupal-dev-framework/commands/propose-epics.md
@@ -32,7 +32,7 @@ This is the bulk-review counterpart to the inline pre-analysis hook in `/researc
    - `keep_flat` — brief "no change recommended" note; move on
    - `insufficient_info` — ask user for context; skip
 6. **Accepted proposals** → invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<proposed names>"` under the hood. Reports result.
-7. **Summary** — `N analyzed, M accepted+migrated, K kept flat, L deferred/skipped`.
+7. **Summary** — `N analyzed, M accepted+migrated, K kept flat, L deferred/skipped, F failed`. Failed tasks (invalid JSON, schema mismatch, agent timeout, or subagent error) are reported explicitly at the end with the task name + failure reason — they are not silently dropped. Example final line: `Analyzed 7 of 8 (1 failed: settings_form_refactor — invalid JSON). 2 migrated, 4 kept flat, 1 skipped.`
 
 ## User interaction per epic candidate
 
@@ -70,7 +70,7 @@ Options:
 3. **Accept flow** — on accept, build the child-names string (comma-separated) and invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<csv>"`. The migration command handles the transactional work; this command only surfaces the proposal and relays the decision.
 4. **Edit flow** — on edit, show the proposed children as an editable list; user can rename, remove, add. Validate names match `^[A-Za-z0-9_][A-Za-z0-9._-]*$` before passing to `/migrate-to-epic`.
 5. **Reject / skip** — record decision silently; do NOT write to the task. Summary at the end shows counts.
-6. **Schema version check** — parse `schema_version` field from each agent response. If major version differs from the expected `"1.0"`, skip that task with an error note and continue. Don't block the whole run.
+6. **Schema version check** — parse `schema_version` field from each agent response. **Must be a JSON string** (e.g., `"1.0"`) — reject non-string types (number, null, missing) with an error note for that task and continue. If string but major version differs from the expected `"1.0"`, skip that task with an error note and continue. Don't block the whole run.
 
 ## Errors & edge cases
 
@@ -79,7 +79,8 @@ Options:
 | No active project | Prompt to run `/next` first; exit without running analysis |
 | No candidate tasks found | Report "no flat in-progress tasks found" and exit |
 | `codePath` unknown at run time | Trigger detect+confirm flow (shared with `/set-code-path`); persist; resume |
-| Agent returns invalid JSON | Report error for that task; skip; continue with others |
+| Agent returns invalid JSON | Report error for that task; skip; continue with others; count in `F failed` in final summary |
+| Subagent crashes or times out | Report error for that task (with reason); skip; continue; count in `F failed` |
 | Agent returns `decision: insufficient_info` | Report; ask user for context (optional); skip |
 | User rejects mid-review (Ctrl-C) | Save any already-migrated tasks' state; exit cleanly |
 | Task name matches another task's proposed child name | Accept but warn; `/migrate-to-epic` will abort if it would collide |

--- a/drupal-dev-framework/commands/propose-epics.md
+++ b/drupal-dev-framework/commands/propose-epics.md
@@ -1,0 +1,102 @@
+---
+description: "Use when a user wants the framework to scan their in-progress flat tasks and propose which ones might benefit from being decomposed into epics. Bulk-review workflow: analysis-agent examines each candidate, user accepts or rejects per-task, accepted proposals call /migrate-to-epic under the hood. Conservative — skips already-epics, subtasks, completed, and tasks with no signals. Introduced v3.11.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [--only-in-progress]
+---
+
+# Propose Epics
+
+Run the analysis agent over all candidate flat tasks in the active project and present per-task proposals for epic-ification. User accepts or rejects each; accepted proposals invoke `/migrate-to-epic` (from 3.1) to do the file surgery.
+
+This is the bulk-review counterpart to the inline pre-analysis hook in `/research` (which runs at new-task creation). Both consume the same `analysis-agent` with the same JSON Schema v1.0.
+
+## Usage
+
+```
+/drupal-dev-framework:propose-epics
+/drupal-dev-framework:propose-epics --only-in-progress    # (default; reserved flag for future extensions)
+```
+
+## What this does
+
+1. Resolves the active project from `session_context.json`. If no project active, asks user to run `/drupal-dev-framework:next` first.
+2. **Resolves `codePath`** via `project-state-reader` skill. If unknown, runs the detect+confirm flow (shared with `/set-code-path`) and persists the answer.
+3. **Enumerates candidates** — every subfolder of `<project>/implementation_process/in_progress/` that is `kind: flat` (via `task-frontmatter-reader`). Skips:
+   - `kind: epic` / `kind: sub_epic` (already an epic)
+   - `kind: subtask` (inside an epic; subject to different analysis)
+   - `completed/` subtasks (via folder-location check inside any epic's `completed/`)
+   - Empty task folders (no task.md)
+4. **Analyzes each candidate** — invokes `analysis-agent` (via Task tool, one subagent per candidate — they can run in parallel). Each returns structured JSON per `references/analysis-agent-schema.md` v1.0.
+5. **Presents per-task** — for each analyzed task, show the user the agent's decision:
+   - `epic_candidate` — proposed children + rationale → ask user to accept / edit / reject / skip
+   - `keep_flat` — brief "no change recommended" note; move on
+   - `insufficient_info` — ask user for context; skip
+6. **Accepted proposals** → invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<proposed names>"` under the hood. Reports result.
+7. **Summary** — `N analyzed, M accepted+migrated, K kept flat, L deferred/skipped`.
+
+## User interaction per epic candidate
+
+```
+[Analyzing 3 of 7 tasks] settings_form_refactor
+
+Decision: epic_candidate (confidence: high)
+Code read: yes
+
+Signals: many_heterogeneous_criteria, multiple_code_areas, research_architecture_fragmented
+
+Rationale: Scope cuts across 3 distinct concerns (migration, validation, UI testing)
+with little cross-dependency. Proposed decomposition reduces each child to a clear
+deliverable.
+
+Proposed children:
+  1. settings_form_migration    — Move existing form to ConfigFormBase
+     rationale: Self-contained lift and shift
+  2. settings_form_validation   — New validation rules per new schema
+     rationale: Separable once the form class is in place
+  3. settings_form_ui_tests     — Playwright smoke tests for admin flow
+     rationale: UI layer; can ship after form work
+
+Options:
+  [Y] accept as proposed    — invoke /migrate-to-epic with these children
+  [e] edit children list    — add/remove/rename before migrating
+  [n] reject                — keep task flat; report why (optional note)
+  [s] skip for now          — decide later
+```
+
+## Implementation notes (for the command body)
+
+1. **Candidate enumeration** — iterate `<project>/implementation_process/in_progress/*/` and for each subfolder call `task-frontmatter-reader`. Filter to `kind: flat`. Do NOT recurse into epic folders; this run only considers top-level flat tasks.
+2. **Parallel analysis** — Agent SDK Subagents model fits: spawn N subagents (one per candidate) via the Task tool. Each subagent invokes `analysis-agent` and returns the JSON. Parent aggregates. Reference: Claude Code Agent SDK Subagents docs [cite AS-1 in research.md].
+3. **Accept flow** — on accept, build the child-names string (comma-separated) and invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<csv>"`. The migration command handles the transactional work; this command only surfaces the proposal and relays the decision.
+4. **Edit flow** — on edit, show the proposed children as an editable list; user can rename, remove, add. Validate names match `^[A-Za-z0-9_][A-Za-z0-9._-]*$` before passing to `/migrate-to-epic`.
+5. **Reject / skip** — record decision silently; do NOT write to the task. Summary at the end shows counts.
+6. **Schema version check** — parse `schema_version` field from each agent response. If major version differs from the expected `"1.0"`, skip that task with an error note and continue. Don't block the whole run.
+
+## Errors & edge cases
+
+| Scenario | Behavior |
+|---|---|
+| No active project | Prompt to run `/next` first; exit without running analysis |
+| No candidate tasks found | Report "no flat in-progress tasks found" and exit |
+| `codePath` unknown at run time | Trigger detect+confirm flow (shared with `/set-code-path`); persist; resume |
+| Agent returns invalid JSON | Report error for that task; skip; continue with others |
+| Agent returns `decision: insufficient_info` | Report; ask user for context (optional); skip |
+| User rejects mid-review (Ctrl-C) | Save any already-migrated tasks' state; exit cleanly |
+| Task name matches another task's proposed child name | Accept but warn; `/migrate-to-epic` will abort if it would collide |
+
+## Discoverability
+
+- README Commands table
+- Command frontmatter `description`
+- marketplace.json plugin description
+- Plugin CLAUDE.md Analysis Agent section
+- `/drupal-dev-framework:next` mentions this command when the project has multiple long-running flat tasks
+
+## Related
+
+- `analysis-agent` — the subagent this command spawns per candidate
+- `/drupal-dev-framework:migrate-to-epic` — atomic primitive invoked on accept
+- `references/analysis-agent-schema.md` — the JSON output contract
+- `references/code-path-detection.md` — detect+confirm flow for codePath
+- `/drupal-dev-framework:set-code-path` — explicit codePath setter
+- `/drupal-dev-framework:research` — inline pre-analysis hook counterpart

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -122,8 +122,8 @@ If no signal fires: skip pre-analysis entirely and proceed with the standard 8-s
 If a signal fires:
 
 1. Resolve `codePath` via `project-state-reader` on the active project. If unknown, skip detect+confirm here (too intrusive at task-creation time); agent runs with `code_read: false` / `confidence: low`.
-2. Invoke `analysis-agent` (via Task tool) with the task_folder placeholder path, the codePath (or null), and `schema_version: "1.0"`.
-3. Parse the agent's JSON output per `references/analysis-agent-schema.md` v1.0.
+2. Invoke `analysis-agent` (via Task tool) in **description mode** — pass `task_description_text` (the task name + full description as typed by the user), the codePath (or null), and `schema_version: "1.0"`. **Do NOT pass a task_folder** — the folder does not exist yet at pre-analysis time. See `references/analysis-agent-schema.md` §"Input modes".
+3. Parse the agent's JSON output per `references/analysis-agent-schema.md` v1.0. Expect `task_folder: "(pre-creation)"` in the output.
 4. Branch on `decision`:
    - `epic_candidate` → ask the user: *"This task's scope looks like it might warrant being an epic. Agent proposed N children: [list]. Create as epic with these children? [y/n/standard flat task]"*. On `y`, invoke `/drupal-dev-framework:migrate-to-epic <task_name> --children "<proposed names>"` (which will create the epic directly — no flat task created first). On `n` or `standard`, proceed with flat-task research.
    - `keep_flat` → proceed silently with flat-task research.

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -14,15 +14,16 @@ Research existing solutions for a specific task (Phase 1 of a task).
 /drupal-dev-framework:research <task-name>
 ```
 
-## What This Does (v3.0.0)
+## What This Does (v3.0.0, with v3.11.0 pre-analysis hook)
 
-1. Creates task directory: `implementation_process/in_progress/{task_name}/`
-2. Creates `task.md` (tracker with links and acceptance criteria)
-3. **Loads dev-guides** for the task's Drupal domain via `guide-integrator` (unless already loaded this session)
-4. Invokes `contrib-researcher` agent for drupal.org/contrib search
-5. Invokes `core-pattern-finder` skill for core examples
-6. Stores findings in `research.md` file
-7. Updates `task.md` to mark Phase 1 as in progress
+1. **Pre-analysis hook** (v3.11.0+, before anything else) — if strong signals fire in the task name + description, invoke `analysis-agent` to assess whether this should be an epic. See "Pre-analysis hook" section below.
+2. Creates task directory: `implementation_process/in_progress/{task_name}/`
+3. Creates `task.md` (tracker with links and acceptance criteria)
+4. **Loads dev-guides** for the task's Drupal domain via `guide-integrator` (unless already loaded this session)
+5. Invokes `contrib-researcher` agent for drupal.org/contrib search
+6. Invokes `core-pattern-finder` skill for core examples
+7. Stores findings in `research.md` file
+8. Updates `task.md` to mark Phase 1 as in progress
 8. Updates `project_state.md` with current task
 9. **Invokes `session-context-writer` skill with the resolved project and task**
 
@@ -106,6 +107,30 @@ Use / Extend / Build from scratch
 {Research decisions made}
 ```
 
+## Pre-analysis hook (v3.11.0+)
+
+**Before** creating the task directory, inspect the task name + description for "strong signals" that the task is epic-sized. If any fires, invoke the `analysis-agent` to produce a structured assessment.
+
+Strong signals (ANY triggers pre-analysis):
+
+1. Task name + description total length > 500 chars
+2. Description has ≥3 distinct bullet points
+3. Description contains explicit conjunction phrasing (`and also`, `plus`, `as well as`, `in addition to`)
+
+If no signal fires: skip pre-analysis entirely and proceed with the standard 8-step research flow below.
+
+If a signal fires:
+
+1. Resolve `codePath` via `project-state-reader` on the active project. If unknown, skip detect+confirm here (too intrusive at task-creation time); agent runs with `code_read: false` / `confidence: low`.
+2. Invoke `analysis-agent` (via Task tool) with the task_folder placeholder path, the codePath (or null), and `schema_version: "1.0"`.
+3. Parse the agent's JSON output per `references/analysis-agent-schema.md` v1.0.
+4. Branch on `decision`:
+   - `epic_candidate` → ask the user: *"This task's scope looks like it might warrant being an epic. Agent proposed N children: [list]. Create as epic with these children? [y/n/standard flat task]"*. On `y`, invoke `/drupal-dev-framework:migrate-to-epic <task_name> --children "<proposed names>"` (which will create the epic directly — no flat task created first). On `n` or `standard`, proceed with flat-task research.
+   - `keep_flat` → proceed silently with flat-task research.
+   - `insufficient_info` → proceed with flat-task research; the task description alone wasn't sufficient for decomposition judgment (makes sense at creation time — usually the description IS minimal here).
+
+Conservative by design: pre-analysis only fires on strong signals, and even then the default choice presented to the user is to proceed as a flat task. Never creates an epic without explicit confirmation.
+
 ## Next Steps
 
 After research is complete for this task:
@@ -116,3 +141,4 @@ After research is complete for this task:
 
 - `/drupal-dev-framework:design <task>` - Design architecture (Phase 2)
 - `/drupal-dev-framework:next` - See recommended next action
+- `/drupal-dev-framework:propose-epics` - (v3.11.0+) Bulk-review existing tasks for epic-ification candidates; counterpart to this command's inline pre-analysis

--- a/drupal-dev-framework/commands/set-code-path.md
+++ b/drupal-dev-framework/commands/set-code-path.md
@@ -30,12 +30,9 @@ Set or update the `codePath` metadata for the active drupal-dev-framework projec
 
 ## Detect + confirm flow (no arg provided)
 
-When called without arguments, propose a candidate via detection strategies in `references/code-path-detection.md`:
+When called without arguments, propose a candidate via the strategies and priority order defined in `references/code-path-detection.md`. **That reference is the single source of truth** — do not re-enumerate strategies here; consult it for markers, ordering, and acceptance rules.
 
-1. `$PWD` if it contains a git repo marker (`.git/`) or Drupal/Node marker (`composer.json`, `package.json`, `sites/default/`)
-2. Sibling-of-memory-folder check (memory at `~/workspace/claude_memory/projects/foo/` → check `~/workspace/foo/`)
-
-First match wins. If any candidate found:
+Summary: first match wins across the reference's strategy list; if no strategy matches, fall back to the reference's cold-prompt form. If any candidate found, present the confirm prompt:
 
 ```
 Detected codePath candidate: /absolute/path
@@ -73,7 +70,11 @@ Read, modify, write. For the matching project entry, set `codePath` to the resol
 ## Acceptance / rejection rules
 
 - **Path accepted:** must be absolute after `realpath -m`. If the path does not currently exist, warn but allow — user may be declaring a future-work path. Warning: `"Note: /path does not currently exist. Saved anyway; /drupal-dev-framework:set-code-path again when it exists to clear the warning."`
-- **Path rejected:** contains newlines, null bytes, or cannot be normalized. Abort with error.
+- **Path rejected (hard):** any of the following aborts with an error:
+  - Contains newlines or null bytes
+  - Cannot be normalized by `realpath -m`
+  - **Is a dangerous system root:** `/`, `/etc`, `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/boot`, `/sys`, `/proc`, `/dev`, `/var`, `/opt`, `/root`, or any ancestor of `$HOME` (e.g., `/home`). These are never valid code paths and always indicate user error or malicious input.
+- **Path warn-but-allow:** resolves outside `$HOME` but not in the hard-reject list (e.g., `/srv/myapp`, `/mnt/code`). Show: `"Warning: <path> is outside your home directory. Proceed? [y/N]"`. Default no. User must type `y` to accept.
 - **`--docs-only`:** always accepted.
 - **Cancel (user chooses [n]):** no change; exit 0 with "No change."
 

--- a/drupal-dev-framework/commands/set-code-path.md
+++ b/drupal-dev-framework/commands/set-code-path.md
@@ -1,0 +1,134 @@
+---
+description: "Use when a user wants to set, update, or clear a drupal-dev-framework project's codePath — the absolute path to the code the project is editing (distinct from the memory folder). Prompts detect+confirm if no argument given; accepts explicit path or (docs-only) sentinel. Updates project_state.md (source of truth) and syncs registry cache. Introduced v3.11.0."
+allowed-tools: Read, Write, Edit, Bash, Skill
+argument-hint: [<path> | --docs-only]
+---
+
+# Set Code Path
+
+Set or update the `codePath` metadata for the active drupal-dev-framework project. `codePath` tells future framework features (analysis agent, visual check, live-e2e, etc.) where the project's code actually lives — which may be different from the memory folder in claude_code_project workflows.
+
+## Usage
+
+```
+/drupal-dev-framework:set-code-path /absolute/path/to/code
+/drupal-dev-framework:set-code-path --docs-only
+/drupal-dev-framework:set-code-path                       # interactive: detect + confirm
+```
+
+## What this does
+
+1. Resolves the active project from `session_context.json` (`projectPath`). If no project active, prompts the user to pick one via `/drupal-dev-framework:next` first.
+2. **Reads current value** via `project-state-reader` skill (so the confirm prompt can show what's changing).
+3. **Resolves new value:**
+   - With `<path>` arg: `realpath -m` normalize; validate exists (unless `--docs-only` or the path resolves to an acceptable path that may not yet exist; in that case, warn and continue).
+   - With `--docs-only`: set to `(docs-only)` sentinel (null at runtime).
+   - With no arg: run the detect+confirm flow (see below).
+4. **Writes to `project_state.md`** — the `**Code path:**` line (replace if exists, insert in the top metadata block if absent).
+5. **Syncs registry cache** — updates `~/.claude/drupal-dev-framework/active_projects.json`'s matching entry `codePath` field.
+6. **Reports** what changed.
+
+## Detect + confirm flow (no arg provided)
+
+When called without arguments, propose a candidate via detection strategies in `references/code-path-detection.md`:
+
+1. `$PWD` if it contains a git repo marker (`.git/`) or Drupal/Node marker (`composer.json`, `package.json`, `sites/default/`)
+2. Sibling-of-memory-folder check (memory at `~/workspace/claude_memory/projects/foo/` → check `~/workspace/foo/`)
+
+First match wins. If any candidate found:
+
+```
+Detected codePath candidate: /absolute/path
+Current value: (docs-only | /other/path | unknown)
+
+Confirm? Options:
+  [Y] accept the detected candidate
+  [n] cancel (no change)
+  [o] enter a different path
+  [d] mark this project docs-only
+```
+
+If no candidate detected, fall back to cold prompt with the same options.
+
+## What it writes
+
+### project_state.md
+
+In the top metadata block, within the first 10 lines (just after the H1 and `**Created:**`):
+
+```markdown
+# <Project Name>
+
+**Created:** YYYY-MM-DD
+**Code path:** /absolute/path/to/code
+...
+```
+
+If the `**Code path:**` line exists, replace its value. Otherwise insert it after `**Created:**` (or at end of metadata block if `**Created:**` absent).
+
+### active_projects.json
+
+Read, modify, write. For the matching project entry, set `codePath` to the resolved value (absolute path or `null`).
+
+## Acceptance / rejection rules
+
+- **Path accepted:** must be absolute after `realpath -m`. If the path does not currently exist, warn but allow — user may be declaring a future-work path. Warning: `"Note: /path does not currently exist. Saved anyway; /drupal-dev-framework:set-code-path again when it exists to clear the warning."`
+- **Path rejected:** contains newlines, null bytes, or cannot be normalized. Abort with error.
+- **`--docs-only`:** always accepted.
+- **Cancel (user chooses [n]):** no change; exit 0 with "No change."
+
+## Examples
+
+```
+/drupal-dev-framework:set-code-path /home/user/workspace/my-module
+
+→ Reading project at /home/user/.../projects/my_project
+  Current codePath: unknown
+  Setting codePath to: /home/user/workspace/my-module
+  ✓ Updated project_state.md
+  ✓ Synced active_projects.json
+```
+
+```
+/drupal-dev-framework:set-code-path --docs-only
+
+→ Setting codePath to: (docs-only)
+  ✓ Updated project_state.md
+  ✓ Synced active_projects.json
+```
+
+```
+/drupal-dev-framework:set-code-path
+
+→ No argument provided. Running detect+confirm...
+  Detected candidate: /home/user/workspace/adc_theme (git repo at $PWD)
+  Current value: unknown
+
+  Confirm? (Y/n/o/d): Y
+
+  ✓ Updated project_state.md
+  ✓ Synced active_projects.json
+```
+
+## Errors
+
+| Error | Resolution |
+|---|---|
+| `No active project. Run /drupal-dev-framework:next first.` | Select a project via /next, then retry. |
+| `Path '<p>' is not absolute after normalization.` | Provide a valid absolute path. |
+| `Path '<p>' contains invalid characters.` | No newlines or null bytes; re-enter. |
+| `project_state.md not found at <p>` | Ensure the project is properly initialized (should not happen for /new-created projects). |
+
+## Related commands
+
+- `/drupal-dev-framework:new` — also captures codePath during project creation (no need to run set-code-path afterward)
+- `/drupal-dev-framework:propose-epics` — consumes codePath (triggers first-use detect+confirm if unknown)
+- `/drupal-dev-framework:status` — shows codePath in project overview
+
+## Discoverability
+
+- README Commands table
+- Command frontmatter `description` (this file)
+- Plugin CLAUDE.md Project Metadata section (v3.11.0+)
+- marketplace.json description (v3.11.0)
+- `/drupal-dev-framework:next` references when codePath is unknown and a feature needs code

--- a/drupal-dev-framework/references/analysis-agent-schema.md
+++ b/drupal-dev-framework/references/analysis-agent-schema.md
@@ -6,6 +6,19 @@
 
 The analysis agent emits a single JSON object per analyzed task. Schema is versioned via `schema_version`. Future fields may be added at v1.x without breaking v1.0 consumers.
 
+## Input modes
+
+The agent accepts one of two mutually exclusive input modes (caller picks):
+
+| Mode | Input | When used |
+|---|---|---|
+| **folder mode** | `task_folder` (absolute path to an existing task directory) | `/propose-epics` — task folders exist on disk |
+| **description mode** | `task_description_text` (raw text: task name + description, no folder) | `/research` pre-analysis hook — task folder has not been created yet |
+
+Both modes also accept `codePath` (abs path or null) and `schema_version` (expected version). In description mode: `task_folder` in the output is set to the string `"(pre-creation)"`, and `task_id` to `local:(pre-creation)`. The agent cannot read `task.md` / `research.md` / `architecture.md` / `implementation.md` in description mode — it only evaluates signals from the description text + optional code read.
+
+Signals evaluated in description mode: `description_length_and_conjunction`, `bullet_count_clustering`, `multiple_code_areas` (if code_read). Signals that require on-disk phase artifacts (`many_heterogeneous_criteria` from task.md's AC section, `long_in_progress`, `research_architecture_fragmented`, `explicit_user_signal`) are skipped in description mode — the agent notes `"description mode: phase-artifact signals unavailable"` in `notes[]`.
+
 ## Schema
 
 ```json
@@ -34,7 +47,7 @@ The analysis agent emits a single JSON object per analyzed task. Schema is versi
 
 | Field | Type | Values / constraints |
 |---|---|---|
-| `schema_version` | string | Follows semver. `"1.0"` for v3.11.0. Consumers match on major version for compat. |
+| `schema_version` | string | Follows semver. `"1.0"` for v3.11.0. Consumers match on major version for compat. **MUST be a JSON string** (quoted `"1.0"`), never a number — `1.0` (unquoted) becomes `1` in JSON and breaks semver parsing. |
 | `analyzed_at` | string | ISO-8601 UTC timestamp of analysis completion. |
 | `task_id` | string | URI-style `local:<folder_name>`. Matches 3.1's task-frontmatter-reader `id` field. |
 | `task_folder` | string | Absolute path to the task folder at analysis time. |

--- a/drupal-dev-framework/references/analysis-agent-schema.md
+++ b/drupal-dev-framework/references/analysis-agent-schema.md
@@ -1,0 +1,163 @@
+# Analysis Agent — Output Schema v1.0
+
+**Introduced:** drupal-dev-framework v3.11.0
+**Owner:** `agents/analysis-agent.md`
+**Consumers (as of v3.11.0):** `commands/propose-epics.md`, `commands/research.md` (pre-analysis hook)
+
+The analysis agent emits a single JSON object per analyzed task. Schema is versioned via `schema_version`. Future fields may be added at v1.x without breaking v1.0 consumers.
+
+## Schema
+
+```json
+{
+  "schema_version": "1.0",
+  "analyzed_at": "2026-04-23T15:00:00Z",
+  "task_id": "local:<folder_name>",
+  "task_folder": "/abs/path/to/task",
+  "decision": "epic_candidate",
+  "confidence": "high",
+  "signals_used": ["many_heterogeneous_criteria", "long_in_progress"],
+  "proposed_children": [
+    {
+      "name": "suggested_child_name",
+      "scope_summary": "One-line summary of this child's scope",
+      "rationale": "Why this child is its own unit"
+    }
+  ],
+  "rationale": "Free-text explanation of the overall decision (≤400 chars)",
+  "code_read": true,
+  "notes": []
+}
+```
+
+## Field contracts
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `schema_version` | string | Follows semver. `"1.0"` for v3.11.0. Consumers match on major version for compat. |
+| `analyzed_at` | string | ISO-8601 UTC timestamp of analysis completion. |
+| `task_id` | string | URI-style `local:<folder_name>`. Matches 3.1's task-frontmatter-reader `id` field. |
+| `task_folder` | string | Absolute path to the task folder at analysis time. |
+| `decision` | enum | One of `"epic_candidate"`, `"keep_flat"`, `"insufficient_info"`. |
+| `confidence` | enum | One of `"high"`, `"medium"`, `"low"`. |
+| `signals_used` | array of string | Signal codes (see "Signal codes" below). Non-empty when `decision: epic_candidate`; may be empty otherwise. |
+| `proposed_children` | array of object | **Present and non-empty iff** `decision: epic_candidate`. Each entry has `name`, `scope_summary`, `rationale`. |
+| `rationale` | string | Free-text explanation of the decision. ≤400 chars. Single paragraph. |
+| `code_read` | boolean | `true` if agent read files under `codePath`. `false` if docs-only (codePath null or absent). |
+| `notes` | array of string | Optional observations from the agent (e.g., "missing research.md", "architecture.md is empty"). |
+
+## Invariants (enforced in the agent's output contract)
+
+1. `proposed_children` is non-empty iff `decision: "epic_candidate"`. Other decisions have `proposed_children: []`.
+2. `confidence: "low"` is REQUIRED when `code_read: false`. The agent cannot declare high confidence on docs-only input.
+3. `signals_used` is non-empty when `decision: "epic_candidate"`. Provides the "why" for downstream consumers.
+4. `schema_version` follows semver. Consumers key on major version.
+5. All string fields are JSON-escaped (no literal newlines inside strings).
+6. `rationale` is ≤400 chars. Keeps output scannable.
+7. Each `proposed_children[].name` matches `^[A-Za-z0-9_][A-Za-z0-9._-]*$` (consumed by `/migrate-to-epic` which enforces this; the agent must also enforce to avoid proposal failures).
+
+## Signal codes
+
+Signals the agent cites in `signals_used` when it reaches `epic_candidate`:
+
+| Signal | Meaning |
+|---|---|
+| `many_heterogeneous_criteria` | Task's acceptance-criteria section has ≥5 items clustering into distinct groups |
+| `long_in_progress` | Task has been in_progress ≥ threshold (e.g. 21 days) without phase progression |
+| `research_architecture_fragmented` | `research.md` or `architecture.md` exceeds ~500 lines or is split into clearly separable concerns |
+| `explicit_user_signal` | User note in task.md mentions "this is getting too big", "could be split", or similar explicit flag |
+| `multiple_code_areas` | (requires `code_read: true`) Task touches multiple distinct module/package boundaries in the codebase |
+| `description_length_and_conjunction` | Task description has both length > threshold AND explicit conjunction phrasing ("and also", "plus", "as well as") — typical trigger for the `/research` pre-analysis hook |
+| `bullet_count_clustering` | Task description's bullet list has ≥3 bullets that group into distinct topics |
+
+**Signal extensibility:** new codes can be added at v1.x without breaking consumers. Consumers should treat unknown codes as informational (display them; don't error).
+
+## Decision reasoning (how the agent chooses)
+
+This is guidance for the agent, not a consumer-visible field:
+
+- **`epic_candidate`** — requires ≥1 signal from the list above. High confidence when ≥3 signals fire AND code was read. Medium confidence when 1-2 signals fire. Low confidence required if `code_read: false`.
+- **`keep_flat`** — default if no signal fires. Rationale: "task scope looks appropriately bounded."
+- **`insufficient_info`** — task.md is missing, empty, or so minimal that no scope can be inferred. Notes should specify what's missing.
+
+## Consumer guidance
+
+### How `/propose-epics` consumes this
+
+For each task analyzed:
+- `decision: epic_candidate` → render proposed children + rationale to user; collect accept/reject/edit; on accept, call `/migrate-to-epic`.
+- `decision: keep_flat` → report "no change recommended" with brief rationale.
+- `decision: insufficient_info` → report and ask user for context; skip.
+
+### How `/research` pre-analysis hook consumes this
+
+At new-task creation time:
+- `decision: epic_candidate` → ask user "create as epic with children? (y/n)" and branch accordingly.
+- `decision: keep_flat` → proceed with flat task research silently.
+- `decision: insufficient_info` → proceed with flat task research; agent didn't have enough to decide.
+
+## Example outputs
+
+### Happy-path epic candidate
+
+```json
+{
+  "schema_version": "1.0",
+  "analyzed_at": "2026-04-23T15:00:00Z",
+  "task_id": "local:settings_form_refactor",
+  "task_folder": "/abs/.../settings_form_refactor",
+  "decision": "epic_candidate",
+  "confidence": "high",
+  "signals_used": ["many_heterogeneous_criteria", "multiple_code_areas", "research_architecture_fragmented"],
+  "proposed_children": [
+    {"name": "settings_form_migration", "scope_summary": "Move existing form to ConfigFormBase", "rationale": "Self-contained lift and shift"},
+    {"name": "settings_form_validation", "scope_summary": "New validation rules per new schema", "rationale": "Separable once the form class is in place"},
+    {"name": "settings_form_ui_tests", "scope_summary": "Playwright smoke tests for admin flow", "rationale": "UI layer; can ship after form work"}
+  ],
+  "rationale": "Scope cuts across 3 distinct concerns (migration, validation, UI testing) with little cross-dependency. Proposed decomposition reduces each child to a clear deliverable.",
+  "code_read": true,
+  "notes": []
+}
+```
+
+### Keep-flat decision
+
+```json
+{
+  "schema_version": "1.0",
+  "analyzed_at": "2026-04-23T15:00:00Z",
+  "task_id": "local:fix_footer_link",
+  "task_folder": "/abs/.../fix_footer_link",
+  "decision": "keep_flat",
+  "confidence": "high",
+  "signals_used": [],
+  "proposed_children": [],
+  "rationale": "Single clear deliverable (one link fix). No signals suggest multi-unit decomposition.",
+  "code_read": true,
+  "notes": []
+}
+```
+
+### Insufficient info
+
+```json
+{
+  "schema_version": "1.0",
+  "analyzed_at": "2026-04-23T15:00:00Z",
+  "task_id": "local:placeholder_task",
+  "task_folder": "/abs/.../placeholder_task",
+  "decision": "insufficient_info",
+  "confidence": "low",
+  "signals_used": [],
+  "proposed_children": [],
+  "rationale": "task.md has no goal, no acceptance criteria, and no description beyond the heading.",
+  "code_read": false,
+  "notes": ["task.md is 1 line", "no research.md", "no architecture.md"]
+}
+```
+
+## Versioning policy
+
+- **Adding fields at v1.x** — consumers that don't know about them ignore them. No schema bump needed if field is optional.
+- **Changing field semantics** — schema bump to v1.1 with a migration note. Consumers version-check.
+- **Removing fields** — major bump to v2.0. Old consumers fail fast on missing expected fields.

--- a/drupal-dev-framework/references/code-path-detection.md
+++ b/drupal-dev-framework/references/code-path-detection.md
@@ -1,0 +1,83 @@
+# Code Path Detection — Strategies
+
+**Introduced:** drupal-dev-framework v3.11.0
+**Consumers:** `/new` (project creation), `/set-code-path` (interactive detect+confirm), any feature that invokes the first-use flow on a project with unknown `codePath`.
+
+Detection runs when a feature needs `codePath` but the project has none declared. Propose a candidate and let the user confirm. Never auto-accept.
+
+## Strategies, in priority order
+
+First match wins. If no strategy matches, fall back to a cold prompt (no pre-filled candidate).
+
+### Strategy 1 — `$PWD` looks like code
+
+If the current working directory contains any of the following markers, propose `$PWD`:
+
+- `.git/` (any git repository)
+- `composer.json` (Drupal / PHP project)
+- `package.json` (Node / JS project)
+- `sites/default/` (Drupal docroot convention)
+- `docroot/` (Drupal docroot convention, Acquia / DDEV)
+- `web/` + `composer.json` at sibling depth (Drupal recommended layout)
+
+Rationale: user invoked the command from where they intend the code to live. This is the common Pattern-2 case (framework-from-inside-code-base).
+
+### Strategy 2 — Sibling of memory folder
+
+If the active project's memory folder is `~/workspace/claude_memory/projects/<name>/`, check if `~/workspace/<name>/` exists and looks like code (same markers as Strategy 1 applied). Propose it if yes.
+
+This is the common Pattern-1 case (claude_code_project + separate code repo): user has a memory project at one path and its code at a peer location.
+
+### Strategy 3 — Memory folder's parent-of-parent + `/docroot/modules/custom/<project>`
+
+For Drupal-heavy workflows where the memory folder sits under a site's tree. Less common; low priority. Evaluate after shipping v3.11.0 if real-world friction surfaces.
+
+## What to show the user
+
+```
+Detected codePath candidate: /home/user/workspace/adc_theme
+  (git repo at $PWD)
+
+Current value: unknown
+
+Confirm? Options:
+  [Y] accept the detected candidate
+  [n] cancel (no change)
+  [o] enter a different path
+  [d] mark this project docs-only
+```
+
+The "reason" parenthetical (`git repo at $PWD`) is required so the user knows WHY the framework proposed that path. Strategy names:
+
+- Strategy 1: "git repo at $PWD" / "composer.json at $PWD" / "package.json at $PWD" / "Drupal docroot at $PWD"
+- Strategy 2: "sibling of memory folder at ~/workspace/<name>/"
+
+## Fallback — no detection
+
+If no strategy matches, show the cold prompt:
+
+```
+Where does the code for this project live?
+  [path] enter an absolute path
+  [d] mark this project docs-only
+  [s] skip for now — the first code-using feature will ask again
+```
+
+## Acceptance rules
+
+- Detected candidate must be an absolute path after `realpath -m` normalization.
+- Must still exist on disk at the moment of detection (if not, skip that strategy and try the next).
+- User's explicit path override is accepted even if the path does not currently exist (with a warning — see `/set-code-path` for the "future-path" handling).
+
+## Ordering is intentional
+
+`$PWD` > sibling. In doubt, prefer the cwd that the user explicitly launched Claude from. Keeps the detection predictable: "Claude suggests where I am, unless I'm clearly in a docs/knowledge location that has a sibling code repo."
+
+## Extension points
+
+New strategies can be added in future versions by:
+1. Adding a new numbered section to this file
+2. Updating the detection implementation (command-body instructions in `/new` and `/set-code-path`)
+3. Noting the addition in the release's CHANGELOG
+
+Schema-level changes (e.g., multiple candidate paths, monorepo sub-path guidance) require a design discussion — not bundled into minor-version adds.

--- a/drupal-dev-framework/references/code-path-detection.md
+++ b/drupal-dev-framework/references/code-path-detection.md
@@ -69,9 +69,35 @@ Where does the code for this project live?
 - Must still exist on disk at the moment of detection (if not, skip that strategy and try the next).
 - User's explicit path override is accepted even if the path does not currently exist (with a warning — see `/set-code-path` for the "future-path" handling).
 
+### Safety filter on detected + user-entered paths
+
+Regardless of source (detection, explicit arg, or interactive prompt), the following paths are **hard-rejected** before accept:
+
+- `/`, `/etc`, `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/boot`, `/sys`, `/proc`, `/dev`, `/var`, `/opt`, `/root`
+- Any ancestor of `$HOME` (e.g., `/home`, `/Users`)
+
+Paths outside `$HOME` but not in the hard-reject list (e.g., `/srv/myapp`, `/mnt/code`) are **warn-but-allow**: prompt for explicit confirmation (default no). See `/set-code-path` §"Acceptance / rejection rules" for the canonical rule set — all consumers of this reference MUST apply the same filter.
+
 ## Ordering is intentional
 
 `$PWD` > sibling. In doubt, prefer the cwd that the user explicitly launched Claude from. Keeps the detection predictable: "Claude suggests where I am, unless I'm clearly in a docs/knowledge location that has a sibling code repo."
+
+## Three distinct null-like states
+
+Consumers MUST distinguish these — they look similar at runtime but have different semantics:
+
+| State | `codePath` (runtime) | `project_state.md` line | `active_projects.json` | Warnings | Meaning | Action |
+|---|---|---|---|---|---|---|
+| **unknown** | `null` | line absent OR value blank | `codePath: null` | `code_path_unknown` | Never set. First-use flow must detect+confirm. | Run detect+confirm |
+| **docs-only** | `null` | `**Code path:** (docs-only)` | `codePath: null` | (none) | User intentionally declared no code. | Skip code-requiring features silently |
+| **set** | `/abs/path` | `**Code path:** /abs/path` | `codePath: "/abs/path"` | `code_path_missing` iff dir absent at read time | Normal case. | Use the path |
+
+Key distinction: both "unknown" and "docs-only" produce `codePath: null` at runtime, but **only "unknown" emits the `code_path_unknown` warning**. Consumers branch on the warning, not on the null value itself:
+
+- `warnings[] contains "code_path_unknown"` → trigger detect+confirm flow
+- `codePath: null` AND no `code_path_unknown` warning → docs-only; skip code read silently
+
+The `project-state-reader` skill's contract guarantees this. Do not guess from `codePath` alone.
 
 ## Extension points
 

--- a/drupal-dev-framework/scripts/project-state-read.sh
+++ b/drupal-dev-framework/scripts/project-state-read.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# project-state-read.sh — parse a project's project_state.md header block.
+#
+# Usage: project-state-read.sh <project_folder>
+#
+# Always emits a single-line JSON to stdout. Exit 0 regardless of input
+# (warnings surface via the warnings[] array). Mirrors the defensive posture
+# of task-frontmatter-reader.sh from v3.10.0.
+#
+# Output shape:
+#   {
+#     "project_name": "<name or folder basename>",
+#     "codePath": "<absolute path or null>",
+#     "folder": "<abs path to project folder>",
+#     "warnings": [{"code": "<code>", "detail": "..."}]
+#   }
+#
+# Warning codes:
+#   folder_missing            — project folder does not exist
+#   project_state_md_missing  — project_state.md not in folder
+#   code_path_unknown         — project_state.md has no Code path line (first-use case)
+#   code_path_missing         — Code path declares a directory that does not exist
+#   malformed_header          — metadata block could not be parsed
+#
+# codePath sentinels in project_state.md:
+#   **Code path:** /abs/path    → non-null string
+#   **Code path:** (docs-only)  → null (docs-only project)
+#   (absent)                    → null + warning code_path_unknown
+#
+# No writes. No side effects. This script only reads.
+
+set -uo pipefail
+
+PROJECT_DIR="${1:?path to project folder required}"
+FOLDER_NAME=$(basename "$PROJECT_DIR")
+PROJECT_STATE="$PROJECT_DIR/project_state.md"
+
+emit_json() {
+  # $1 = project_name, $2 = codePath (string "null" literal for null), $3 = folder, $4 = warnings JSON array
+  jq -nc --arg n "$1" --arg cp "$2" --arg d "$3" --argjson w "$4" '
+    {
+      project_name: $n,
+      codePath: (if $cp == "null" then null else $cp end),
+      folder: $d,
+      warnings: $w
+    }'
+}
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "folder_missing", "detail": "project folder does not exist"}]'
+  exit 0
+fi
+
+if [ ! -f "$PROJECT_STATE" ]; then
+  emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "project_state_md_missing", "detail": "project_state.md not found in folder"}]'
+  exit 0
+fi
+
+# Extract the H1 project name (first `# <name>` line)
+PROJECT_NAME=$(awk '/^# / {sub(/^# */,""); print; exit}' "$PROJECT_STATE")
+[ -z "$PROJECT_NAME" ] && PROJECT_NAME="$FOLDER_NAME"
+
+# Extract the code path line. Accepts any of:
+#   **Code path:** /abs/path
+#   **Code Path:** /abs/path
+#   **code path:** /abs/path
+# Plus the (docs-only) sentinel.
+CODE_PATH_RAW=$(awk '
+  BEGIN { IGNORECASE=1 }
+  /^\*\*Code path:\*\*/ {
+    sub(/^\*\*[Cc]ode [Pp]ath:\*\*[[:space:]]*/, "")
+    print
+    exit
+  }
+' "$PROJECT_STATE")
+
+WARNINGS='[]'
+
+if [ -z "$CODE_PATH_RAW" ]; then
+  WARNINGS='[{"code": "code_path_unknown", "detail": "project_state.md has no **Code path:** line"}]'
+  CODE_PATH_OUT="null"
+elif [ "$CODE_PATH_RAW" = "(docs-only)" ] || [ "$CODE_PATH_RAW" = "docs-only" ]; then
+  CODE_PATH_OUT="null"
+else
+  # Normalize: expand ~, realpath -m (doesn't require existence)
+  CODE_PATH_EXPANDED=$(eval echo "$CODE_PATH_RAW")
+  CODE_PATH_NORM=$(realpath -m "$CODE_PATH_EXPANDED" 2>/dev/null || echo "$CODE_PATH_EXPANDED")
+  if [ ! -d "$CODE_PATH_NORM" ]; then
+    WARNINGS=$(jq -c -n --arg p "$CODE_PATH_NORM" '[{code: "code_path_missing", detail: ("directory does not exist: " + $p)}]')
+  fi
+  CODE_PATH_OUT="$CODE_PATH_NORM"
+fi
+
+emit_json "$PROJECT_NAME" "$CODE_PATH_OUT" "$PROJECT_DIR" "$WARNINGS"

--- a/drupal-dev-framework/skills/project-initializer/SKILL.md
+++ b/drupal-dev-framework/skills/project-initializer/SKILL.md
@@ -4,6 +4,7 @@ description: Use when starting a new development project — creates memory fold
 version: 1.4.0
 model: sonnet
 user-invocable: false
+allowed-tools: Bash, Read, Write
 ---
 
 # Project Initializer

--- a/drupal-dev-framework/skills/project-initializer/SKILL.md
+++ b/drupal-dev-framework/skills/project-initializer/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: project-initializer
-description: Use when starting a new development project - creates memory folder structure with project_state.md, architecture scaffolding, and registers project
-version: 1.3.0
+description: Use when starting a new development project — creates memory folder structure with project_state.md (including codePath), architecture scaffolding, and registers project. Accepts optional code_path argument.
+version: 1.4.0
+model: sonnet
+user-invocable: false
 ---
 
 # Project Initializer
@@ -84,6 +86,7 @@ Use `Write` tool to create `{path}/{project_name}/project_state.md`:
 **Created:** {YYYY-MM-DD}
 **Status:** Initializing
 **Path:** {full_path_to_project_folder}
+**Code path:** {absolute_code_path OR (docs-only) OR omit-entirely-if-caller-did-not-provide}
 
 ## Overview
 {To be filled during requirements gathering}
@@ -147,6 +150,7 @@ Then read existing registry (or create new if doesn't exist) and add the project
     {
       "name": "{project_name}",
       "path": "{full_path_to_project}",
+      "codePath": "{absolute path to code OR null}",
       "created": "{YYYY-MM-DD}",
       "lastAccessed": "{YYYY-MM-DD}",
       "status": "active"
@@ -156,7 +160,8 @@ Then read existing registry (or create new if doesn't exist) and add the project
 ```
 
 - `projectsBase` — set once on first project creation, reused as default for all future projects
-- `path` — always the full absolute path to the specific project folder
+- `path` — always the full absolute path to the specific project folder (memory folder)
+- `codePath` — **(added v3.11.0)** absolute path to the code being worked on. `null` for docs-only projects. Optional; pre-v3.11.0 entries without it treated as "unknown" and trigger the first-use detect+confirm flow when a feature needs code. Source of truth is `project_state.md`; this is the cache.
 - No `phase` field — phase is tracked per-task in task files, not per-project
 
 Use `Read` to load existing registry, then `Write` to save updated version with new project appended.

--- a/drupal-dev-framework/skills/project-state-reader/SKILL.md
+++ b/drupal-dev-framework/skills/project-state-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-state-reader
-description: Use when a framework command needs project-level metadata (currently codePath, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input. Companion to task-frontmatter-reader (v3.10.0) — same design, different scope (project vs task).
+description: Use when a framework command needs project-level metadata (currently codePath, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
 version: 1.0.0
 user-invocable: false
 model: haiku

--- a/drupal-dev-framework/skills/project-state-reader/SKILL.md
+++ b/drupal-dev-framework/skills/project-state-reader/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: project-state-reader
+description: Use when a framework command needs project-level metadata (currently codePath, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input. Companion to task-frontmatter-reader (v3.10.0) — same design, different scope (project vs task).
+version: 1.0.0
+user-invocable: false
+model: haiku
+allowed-tools: Bash
+---
+
+# Project State Reader
+
+Thin wrapper around `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh`. The script parses the project's `project_state.md` header block and emits structured JSON. This skill exists to give it a Skill-tool-callable name and to document the contract.
+
+## Contract
+
+**Input:** one argument — absolute path to a project folder (the one containing `project_state.md`).
+
+**Output:** single JSON object to stdout. Exit code always 0.
+
+Fields:
+- `project_name` — from the H1 line in `project_state.md`, or folder basename fallback
+- `codePath` — absolute path (string) if declared and resolves, or `null` if docs-only / unknown
+- `folder` — the absolute path passed in
+- `warnings` — array of `{code, detail}` entries
+
+## Defensive posture (never throws)
+
+| Input state | Warning code |
+|---|---|
+| Project folder does not exist | `folder_missing` |
+| Folder exists, `project_state.md` missing | `project_state_md_missing` |
+| `project_state.md` has no `**Code path:**` line | `code_path_unknown` |
+| `**Code path:** /some/dir` but that directory doesn't exist | `code_path_missing` |
+| Declared `(docs-only)` sentinel | (none — legitimate docs-only state, codePath is null) |
+
+## Code path sentinels in `project_state.md`
+
+Accepted on the one-line `**Code path:**` metadata entry:
+- `**Code path:** /absolute/path` — non-null string; path normalized via `realpath -m`
+- `**Code path:** (docs-only)` — null; explicit docs-only declaration
+- (line absent) — null; first-use prompt should fire
+
+Case-insensitive match on the label.
+
+## Invocation
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh" "/abs/path/to/project/folder"
+```
+
+Parse with `jq`. Example:
+
+```bash
+OUTPUT=$("${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh" "$PROJECT_DIR")
+CODE_PATH=$(jq -r '.codePath // empty' <<<"$OUTPUT")
+UNKNOWN=$(jq -e '[.warnings[] | select(.code == "code_path_unknown")] | length > 0' <<<"$OUTPUT" >/dev/null && echo true || echo false)
+```
+
+## Consumers (v3.11.0+)
+
+- `/drupal-dev-framework:set-code-path` — read current value to show in confirm prompt
+- `/drupal-dev-framework:propose-epics` — get codePath before invoking analysis agent
+- `/drupal-dev-framework:research` — pre-analysis hook needs codePath for strong-signal check
+- `analysis-agent` — inputs `codePath` (resolved by caller; agent doesn't call this skill directly)
+
+Future consumers that need project-level metadata should call this skill rather than parsing `project_state.md` directly.
+
+## Do NOT
+
+- Do not write to `project_state.md` from this skill. Reading only. Writes go through `/set-code-path` command or the `/new` creation flow.
+- Do not treat non-empty `warnings[]` as a blocking error — warnings are observations.
+- Do not duplicate the parsing logic elsewhere. Call this skill or the script.
+
+## See also
+
+- `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh` — the script
+- `task-frontmatter-reader` skill (v2.0.0) — same design pattern, task-level metadata instead of project-level
+- Architecture decision Q5a in `dev_framework_project_code_path_and_analysis_agent/architecture.md`


### PR DESCRIPTION
## Summary

Ships sub-task 3.2 of the dev-framework improvements epic. Bumps `drupal-dev-framework` to **v3.11.0** and marketplace `metadata.version` to **1.14.7**.

### Two coupled capabilities

**1. Project `codePath` metadata** — projects can declare where their code lives (distinct from the memory folder). Three states: `unknown` / `docs-only` / `set`.

- New skill: `project-state-reader` v1.0.0 (haiku, user-invocable: false) + `scripts/project-state-read.sh`
- New command: `/set-code-path [<path>|--docs-only]` with interactive detect+confirm and safety filter (hard-rejects system roots, warns on paths outside `$HOME`)
- `/new` captures codePath at project creation (Step 3)
- `project-initializer` v1.4.0 (sonnet; now declares `allowed-tools`)
- Two new references: `analysis-agent-schema.md`, `code-path-detection.md` (source-of-truth for detection strategies, three-null-states table, safety filter)

**2. Analysis agent v1.0.0** (sonnet, read-only) — proposes epic decomposition for flat tasks. Tools: `Read`, `Grep`, `Glob`, `Bash` (with mutation-subcommand denylist: `rm`, `mv`, `cp`, `sed`, `tee`, `dd`, `chmod`, `chown`).

- Two input modes: folder (`task_folder`) + description (`task_description_text`, pre-folder-creation for `/research` pre-analysis hook)
- Step 0 validates exactly-one input; step 4 mode-gates signal evaluation (description mode skips folder-only signals)
- Emits JSON per `references/analysis-agent-schema.md` v1.0 (7 invariants, 7 signal codes, input-modes contract)

**Consumers:**
- New command: `/propose-epics` — bulk review, parallel subagent dispatch, per-task accept/edit/reject/skip, partial-failure reporting, schema_version type-check
- `/research` pre-analysis hook — fires on strong signals (>500 chars, ≥3 bullets, explicit conjunctions); user always keeps opt-out

## Validation

- `project-state-read.sh` smoke-tested across 6 fixtures (all three-null-states + folder-missing + set-valid + set-missing)
- Two paper-test passes with 11 findings applied (1 false alarm confirmed)
- 3-validator gate: metadata PASS, skill-quality BLOCKER+MAJOR fixed, structure-audit MAJOR fixed (README Agents/Skills tables were stale since v3.10.0 — now corrected to 6/20)

## Test plan

- [ ] Install updated plugin (pulls dev-guides-navigator automatically on CLI v2.1.110+)
- [ ] `/drupal-dev-framework:set-code-path` — try explicit path, `--docs-only`, interactive detect+confirm, `/etc` (must be rejected), path outside `$HOME` (must warn)
- [ ] `/drupal-dev-framework:propose-epics` — run against a project with flat in-progress tasks; verify per-task proposals surface correctly
- [ ] `/drupal-dev-framework:research <new-big-task>` with >500-char description + conjunctions — verify pre-analysis hook fires and offers epic/flat/standard choice
- [ ] Confirm flat tasks without signals proceed silently (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)