### PR TITLE
drupal-dev-framework v3.12.1 — scrub private references (docs-only)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.8"
+    "version": "1.14.9"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.1] - 2026-04-23
+
+### Fixed — Private reference scrub (no behavior change)
+
+Documentation-only patch removing internal/private references that leaked into the shipped plugin during v3.10.0–v3.12.0 development.
+
+- **"P7" terminology removed** — 18 references across 7 files. "P7" was private pain-point numbering from internal epic planning; it was undefined in plugin docs and confusing to marketplace users. Replaced with clear terms: "scope contract", "alignment step", "alignment conversation". No user-visible behavior change.
+- **Stale sub-task numbering removed** — `/migrate-to-epic`, `/next`, `/complete`, `/propose-epics` command bodies contained "sub-task 3.1", "sub-task 3.2" references to internal roadmap items. Some (like `/propose-epics`) were documented as "future" despite having shipped in v3.11.0. Replaced with concrete version numbers or removed.
+- **Private project-file paths removed** — `alignment-reader`, `project-state-reader`, `analysis-agent`, `alignment-contract.md` each pointed at files like `dev_framework_task_contract/architecture.md` in the maintainer's private memory directory that marketplace users will never have. Dropped.
+- **Example JSON using private names replaced** — `session-context-writer` SKILL had `"currentEpic": "dev_framework_improvements_epic"` as the example value; `alignment-contract.md` used `"task_name": "dev_framework_task_contract"` in the reader-output example. Both replaced with generic placeholders.
+- **CHANGELOG future-task name redacted** — v3.10.0 entry named a specific-future-task (`dev_framework_next_orchestrator_dedup`) that was private roadmap. Generalized to "tracked for a future release".
+- **Minor grammar fixes** — article/spacing artifacts from automated replacement cleaned up.
+
+No command, skill, agent, or script behavior changes. Schema stays v1.0; no migrations needed.
+
 ## [3.12.0] - 2026-04-23
 
 ### Added — Task Contract / P7 Alignment Step (sub-task 3.3 of dev-framework improvements epic)
@@ -152,7 +167,7 @@ The `plugin-structure-auditor` gate (newly required by the epic AC) surfaced fiv
 
 ### Still tracked for follow-up (not in this patch)
 
-- **WARN-1: `/next` command and `project-orchestrator` agent duplicate routing logic.** Fix requires a design decision (which is source of truth) plus an integration test — `/next` is the primary entry point and regression is high-impact. Separate sub-task: `dev_framework_next_orchestrator_dedup`.
+- **WARN-1: `/next` command and `project-orchestrator` agent duplicate routing logic.** Fix requires a design decision (which is source of truth) plus an integration test — `/next` is the primary entry point and regression is high-impact. Tracked for a separate future release.
 
 ### Dismissed (auditor false positive)
 

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -17,7 +17,7 @@ The plugin supports **opt-in epic/sub-task hierarchy** on top of flat tasks (whi
 
 **When to promote a task to epic:** many heterogeneous acceptance criteria, long-in-progress without phase progression, or user signals "this is too big." Most tasks should stay flat — epic-ification is additive, not aspirational.
 
-**Automated epic proposal (`/propose-epics`) landed in v3.11.0** — bulk-review of flat in-progress tasks via `analysis-agent` (read-only, sonnet), per-task accept/edit/reject/skip, accepted proposals invoke `/migrate-to-epic`. Plus `/research` pre-analysis hook that fires on strong signals (description > 500 chars, ≥3 bullets, explicit conjunctions) at new-task creation time. Goal-alignment step (P7) lands in sub-task 3.3.
+**Automated epic proposal (`/propose-epics`) landed in v3.11.0** — bulk-review of flat in-progress tasks via `analysis-agent` (read-only, sonnet), per-task accept/edit/reject/skip, accepted proposals invoke `/migrate-to-epic`. Plus `/research` pre-analysis hook that fires on strong signals (description > 500 chars, ≥3 bullets, explicit conjunctions) at new-task creation time. The scope-contract alignment step landed in v3.12.0 — see `## Alignment Step` below.
 
 ## Project codePath Metadata (v3.11.0+)
 
@@ -37,7 +37,7 @@ Consumers distinguish states via warnings, not the null value: `code_path_unknow
 
 **Signal orthogonality:** `signals_used[]` contains BOTH epic-decomposition signals (used for the `decision` branch) AND orthogonal signals like `scope_contract_recommended` (v3.12.0+). Consumers branch on `decision` for decomposition and separately inspect `signals_used[]` for scope-contract warrant. The two judgments are independent.
 
-## P7 Alignment Step (v3.12.0+)
+## Alignment Step (v3.12.0+)
 
 Optional scope contract authored before Phase 1 via `/scope <task>`. Produces `alignment.md` with H2 sections (`## Task-Level`, `## Phase 1 — Research`, `## Phase 2 — Architecture`, `## Phase 3 — Implementation`), each carrying the same 4-field shape: Goal / Expected result / Success criteria / Non-goals. See `references/alignment-contract.md` for grammar v1.0.
 

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -12,7 +12,7 @@ You create a **project** (a Drupal module, theme, or set of related work), then 
 
 | Phase | Command | What Happens |
 |-------|---------|--------------|
-| **0. Alignment** *(optional, v3.12.0+)* | `/scope <task>` | P7 scope contract — Goal / Expected result / Success criteria / Non-goals. Offered automatically when the analysis-agent detects warrant; soft-nudge, never blocks |
+| **0. Alignment** *(optional, v3.12.0+)* | `/scope <task>` | scope contract — Goal / Expected result / Success criteria / Non-goals. Offered automatically when the analysis-agent detects warrant; soft-nudge, never blocks |
 | **1. Research** | `/research <task>` | Search contrib, find core patterns, study existing solutions |
 | **2. Architecture** | `/design <task>` | Design approach, choose patterns, set acceptance criteria |
 | **3. Implementation** | `/implement <task>` | Build with TDD, user approval at each step |
@@ -102,7 +102,7 @@ Phases apply per task, not per project. A project can have tasks at different ph
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
 | `/set-code-path [<path>|--docs-only]` | **(v3.11.0)** Set/update the active project's `codePath` — where its code actually lives (distinct from the memory folder). Supports explicit path, `--docs-only` sentinel, or interactive detect+confirm. Path-safety filter rejects system roots and prompts for paths outside `$HOME`. Writes `project_state.md` + syncs `active_projects.json`. |
 | `/propose-epics` | **(v3.11.0)** Bulk-review flat in-progress tasks — analysis-agent (read-only, sonnet) scans each candidate and proposes epic decompositions with 3-5 children. Per-task accept / edit / reject / skip. Accepted proposals invoke `/migrate-to-epic` under the hood. Counterpart to `/research`'s pre-analysis hook. |
-| `/scope <task> [--phase 1\|2\|3]` | **(v3.12.0)** Author or retrofit a task's P7 scope contract (`alignment.md`) — 4-field structure (Goal / Expected result / Success criteria / Non-goals). Without `--phase`, authors Task-Level. With `--phase N`, authors the corresponding phase section (also invoked inline as the first sub-step of `/research`, `/design`, `/implement` when warranted). One-question-at-a-time conversation, author-owned, never auto-generated. Soft-nudge posture; never blocks the lifecycle. |
+| `/scope <task> [--phase 1\|2\|3]` | **(v3.12.0)** Author or retrofit a task's scope contract (`alignment.md`) — 4-field structure (Goal / Expected result / Success criteria / Non-goals). Without `--phase`, authors Task-Level. With `--phase N`, authors the corresponding phase section (also invoked inline as the first sub-step of `/research`, `/design`, `/implement` when warranted). One-question-at-a-time conversation, author-owned, never auto-generated. Soft-nudge posture; never blocks the lifecycle. |
 
 All commands are prefixed with `drupal-dev-framework:` (e.g., `/drupal-dev-framework:next`).
 

--- a/drupal-dev-framework/agents/analysis-agent.md
+++ b/drupal-dev-framework/agents/analysis-agent.md
@@ -113,13 +113,13 @@ For each signal code that is ✓ in the current mode, determine whether it fires
 - `multiple_code_areas` (requires `code_read: true`) — task's concerns touch ≥2 distinct module/package boundaries per code read
 - `description_length_and_conjunction` — task description > 500 chars AND contains explicit "and also" / "plus" / "as well as" conjunctions
 - `bullet_count_clustering` — description has ≥3 bullets that group into distinct topics
-- `scope_contract_recommended` **(v3.12.0+)** — task would benefit from an up-front P7 scope contract. Fires when ANY of:
+- `scope_contract_recommended` **(v3.12.0+)** — task would benefit from an up-front scope contract. Fires when ANY of:
   - Description describes ≥2 distinct outcome dimensions (e.g., "faster AND more secure", separable deliverables)
   - Description contains conjunctive phrasing: `and also`, `plus`, `as well as`, `in addition to`
   - ≥3 acceptance criteria already listed in task.md (folder mode only)
   - AND not trivially small: word count > 60 in description OR > 3 distinct action verbs in goal statement
   
-  Orthogonal to `epic_candidate` — evaluate independently. A task MAY fire both, one, or neither. Consumers use this signal to offer/suggest the `/scope` P7 step; never forces.
+  Orthogonal to `epic_candidate` — evaluate independently. A task MAY fire both, one, or neither. Consumers use this signal to offer/suggest the `/scope` alignment step; never forces.
 
 Record all fired signals in `signals_used[]`.
 
@@ -190,4 +190,3 @@ If any invariant would be violated, adjust the decision/output rather than emitt
 - `project-state-reader` skill v1.0.0 — read project metadata (caller provides codePath; agent doesn't call this itself)
 - `/drupal-dev-framework:propose-epics` command — primary consumer
 - `/drupal-dev-framework:research` command — pre-analysis hook consumer
-- Architecture decisions Q7, Q8, Q9, Q10 in `dev_framework_project_code_path_and_analysis_agent/architecture.md`

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -31,9 +31,7 @@ Mark a task as complete and move it to the completed folder.
 - **`kind: flat`** — unchanged v3.0.0 behavior. Target: project-level `completed/<name>/`.
 - **`kind: subtask`** — completion moves the folder from `<epic>/in_progress/<subtask>/` to `<epic>/completed/<subtask>/`. **The child stays inside the epic.** The epic's `children[]` list still references the subtask by id. Spatial association with the parent epic is preserved — you can always browse the epic folder to see its full history.
 - **`kind: epic`** or **`kind: sub_epic`** — pre-completion gate enforces that `<epic>/in_progress/` is empty (all children have already moved to `<epic>/completed/`). If any child is still in progress, abort listing them. When the gate passes, the whole epic folder (including its internal `in_progress/`=empty and `completed/`=full) moves to project-level `completed/<epic>/`. History stays intact in one move.
-- **Dog-food note for v3.10.0 release:** the first epic completed under these rules will be sub-task 3.1's dog-food test. Verify the flow end-to-end before declaring 3.1 shipped.
-
-Do NOT touch dependency graphs (`blocks`/`blocked_by`) here — those are a 3.2 `/next` concern.
+Do NOT touch dependency graphs (`blocks`/`blocked_by`) here — dependency-aware routing is the concern of `/next`, not completion.
 8. **Invokes `session-context-writer` skill with project and task set to `null` (task is now completed)**
 
 ## Pre-Completion Checks

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -40,7 +40,7 @@ Never block the command on this check — the user is in control. The nudge exis
 3. If user says `[y]`, execute the `--phase 2` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 2 — Architecture` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with architecture work.
 4. If user says `[n]` / `[skip]`, proceed. Never block.
 
-**Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level P7 at task creation, that decision is considered final by the time they reach Phase 2 — the task is already underway.
+**Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level alignment at task creation, that decision is considered final by the time they reach Phase 2 — the task is already underway.
 
 ## What This Does (v3.0.0)
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -46,7 +46,7 @@ Never block the command on this check — the user is in control. The nudge exis
 3. If user says `[y]`, execute the `--phase 3` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 3 — Implementation` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with implementation context loading.
 4. If user says `[n]` / `[skip]`, proceed. Never block.
 
-**Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level P7 at task creation, that decision is considered final — the task is already in Phase 3.
+**Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level alignment at task creation, that decision is considered final — the task is already in Phase 3.
 
 ## What This Does (v3.0.0)
 

--- a/drupal-dev-framework/commands/migrate-to-epic.md
+++ b/drupal-dev-framework/commands/migrate-to-epic.md
@@ -6,7 +6,7 @@ argument-hint: <task-name> [--children "name1,name2,..."] [--dry-run]
 
 # Migrate To Epic
 
-Convert a single flat task into an epic folder containing child sub-tasks. Manual and explicit — this command is the atomic primitive for the hierarchy feature. Automated epic detection (`/propose-epics`) lands in sub-task 3.2 and will call this command under the hood; today, the user invokes it directly.
+Convert a single flat task into an epic folder containing child sub-tasks. Manual and explicit — this command is the atomic primitive for the hierarchy feature. For automated epic detection across many tasks, see `/propose-epics` (v3.11.0+), which calls this command under the hood when the user accepts a proposal.
 
 ## Usage
 
@@ -165,8 +165,8 @@ Next: work on the epic's own phases, or add children when ready.
 
 ## What this command does NOT do
 
-- **Does not propose which tasks should be epics.** That's `/drupal-dev-framework:propose-epics` (sub-task 3.2, not yet shipped).
-- **Does not migrate multiple tasks at once.** One invocation = one task. Bulk migration is a 3.2 concern.
+- **Does not propose which tasks should be epics.** That's `/drupal-dev-framework:propose-epics` (v3.11.0+).
+- **Does not migrate multiple tasks at once.** One invocation = one task. Bulk review is a `/propose-epics` concern.
 - **Does not migrate completed tasks.** Preflight refuses.
 - **Does not promote a subtask to a sub_epic.** That's a different flow (candidate for a later command). Today, sub-epics are created by running this command on a task whose parent is already an epic — which the preflight currently refuses. If you need nested decomposition, contact the framework maintainers (mechanism pending).
 - **Does not cross project boundaries.** A task in project A cannot have children in project B.
@@ -187,4 +187,4 @@ Next: work on the epic's own phases, or add children when ready.
 - `/drupal-dev-framework:status` — shows the new tree view after migration
 - `/drupal-dev-framework:next` — honors the new parent/child relationship when suggesting next action
 - `/drupal-dev-framework:complete` — epic completion awareness
-- `/drupal-dev-framework:propose-epics` — **future (sub-task 3.2)** — calls this command under the hood when the user accepts an agent's proposal
+- `/drupal-dev-framework:propose-epics` (v3.11.0+) — calls this command under the hood when the user accepts an agent's proposal

--- a/drupal-dev-framework/commands/next.md
+++ b/drupal-dev-framework/commands/next.md
@@ -32,9 +32,9 @@ When choosing what to recommend next, apply these preferences in order:
 3. **If the current task is an epic** with children — suggest starting/continuing the first child whose prerequisites are met. If children don't yet exist, suggest `/drupal-dev-framework:migrate-to-epic <epic> --children "..."` to expand.
 4. **Otherwise** — existing flat-task behavior applies unchanged.
 
-**Surfacing `/migrate-to-epic`:** if the current task OR any active task looks epic-sized (signals: many heterogeneous acceptance criteria, long-in-progress without phase progression, user-mentioned "this is getting too big"), mention `/drupal-dev-framework:migrate-to-epic <task>` as an option in the output. Conservative — only suggest when signals are clear. A richer detection agent lands in sub-task 3.2.
+**Surfacing `/migrate-to-epic`:** if the current task OR any active task looks epic-sized (signals: many heterogeneous acceptance criteria, long-in-progress without phase progression, user-mentioned "this is getting too big"), mention `/drupal-dev-framework:migrate-to-epic <task>` as an option in the output. Conservative — only suggest when signals are clear. For bulk review, see `/propose-epics` (v3.11.0+).
 
-Do NOT walk `blocks`/`blocked_by` graph transitively here — direct relationships only (v3.10.0 scope per sub-task 3.1 research). A full dependency-aware `/next` lands in 3.2.
+Do NOT walk `blocks`/`blocked_by` graph transitively here — direct relationships only. A full dependency-aware `/next` is tracked for a future release.
 
 ## Output Format
 

--- a/drupal-dev-framework/commands/propose-epics.md
+++ b/drupal-dev-framework/commands/propose-epics.md
@@ -6,7 +6,7 @@ argument-hint: [--only-in-progress]
 
 # Propose Epics
 
-Run the analysis agent over all candidate flat tasks in the active project and present per-task proposals for epic-ification. User accepts or rejects each; accepted proposals invoke `/migrate-to-epic` (from 3.1) to do the file surgery.
+Run the analysis agent over all candidate flat tasks in the active project and present per-task proposals for epic-ification. User accepts or rejects each; accepted proposals invoke `/migrate-to-epic` to do the file surgery.
 
 This is the bulk-review counterpart to the inline pre-analysis hook in `/research` (which runs at new-task creation). Both consume the same `analysis-agent` with the same JSON Schema v1.0.
 

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -130,13 +130,13 @@ If a signal fires:
    - `insufficient_info` → proceed with flat-task research; the task description alone wasn't sufficient for decomposition judgment (makes sense at creation time — usually the description IS minimal here).
 
 5. **(v3.12.0+)** After the `decision` branch completes (regardless of outcome unless the task became an epic), inspect `signals_used[]` for `scope_contract_recommended`. If present, print soft-nudge:
-   > "Analysis recommends authoring a scope contract before research (P7). Start now? [y]es / [n]o / [later]"
+   > "Analysis recommends authoring a scope contract before research. Start now? [y]es / [n]o / [later]"
 
-   On `[y]` → execute the P7 conversation + write flow as documented in `commands/scope.md` (task-level prompt sequence + "Writing alignment.md") within this command's context. Do NOT try to shell out to a sibling slash command. After the write completes, continue with the standard research flow.
+   On `[y]` → execute the alignment conversation + write flow as documented in `commands/scope.md` (task-level prompt sequence + "Writing alignment.md") within this command's context. Do NOT try to shell out to a sibling slash command. After the write completes, continue with the standard research flow.
    On `[n]` → proceed without writing `alignment.md`. No nag.
    On `[later]` → same as `[n]` for this run; user can run `/scope <task>` anytime.
 
-Conservative by design: pre-analysis only fires on strong signals, and even then the default choice presented to the user is to proceed as a flat task. Never creates an epic without explicit confirmation. The P7 nudge is soft; `[n]` is always respected.
+Conservative by design: pre-analysis only fires on strong signals, and even then the default choice presented to the user is to proceed as a flat task. Never creates an epic without explicit confirmation. The alignment nudge is soft; `[n]` is always respected.
 
 ## Phase 1 alignment sub-step (v3.12.0+)
 
@@ -146,7 +146,7 @@ Conservative by design: pre-analysis only fires on strong signals, and even then
 2. Decide whether to offer the Phase 1 alignment section:
    - If `sections.phase_1.present: true` → print: `"Phase 1 alignment already authored. Using existing section."` and proceed.
    - Else if `sections.task_level.present: true` → ask: `"Author the Phase 1 — Research section of alignment.md now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
-   - Else if pre-analysis hook emitted `scope_contract_recommended` and user declined task-level P7 earlier → re-offer as lighter-touch: `"Author a Phase 1 — Research alignment section (just this phase)? [y]es / [n]o"`. Default: `[n]`.
+   - Else if pre-analysis hook emitted `scope_contract_recommended` and user declined task-level alignment earlier → re-offer as lighter-touch: `"Author a Phase 1 — Research alignment section (just this phase)? [y]es / [n]o"`. Default: `[n]`.
    - Otherwise → proceed silently (no nag).
 3. If user says `[y]`, execute the `--phase 1` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 1 — Research` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with research.
 4. If user says `[n]` / `[skip]`, proceed with research. Never block.

--- a/drupal-dev-framework/commands/scope.md
+++ b/drupal-dev-framework/commands/scope.md
@@ -1,12 +1,12 @@
 ---
-description: "Author or retrofit a task's P7 scope contract (alignment.md) through a structured 4-field conversation — Goal / Expected result / Success criteria / Non-goals. Runs before /research for new tasks, or on-demand for retrofitting existing tasks. Soft-nudge posture: never blocks the task lifecycle. Introduced v3.12.0."
+description: "Author or retrofit a task's scope contract (alignment.md) through a structured 4-field conversation — Goal / Expected result / Success criteria / Non-goals. Runs before /research for new tasks, or on-demand for retrofitting existing tasks. Soft-nudge posture: never blocks the task lifecycle. Introduced v3.12.0."
 allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
 argument-hint: <task-name> [--phase 1|2|3]
 ---
 
 # Scope
 
-Author the P7 alignment contract for a task. Produces `alignment.md` in the task folder per `references/alignment-contract.md` v1.0.
+Author the alignment contract for a task. Produces `alignment.md` in the task folder per `references/alignment-contract.md` v1.0.
 
 ## Usage
 
@@ -24,7 +24,7 @@ Without `--phase`, authors the `## Task-Level` section. With `--phase N`, author
 1. Resolves `<task-name>` to a task folder using the usual resolver (in-progress folder, epic subfolder, etc.).
 2. Invokes `alignment-reader` skill to read the current state of `alignment.md` (if any).
 3. **Overwrite guard** — if the target section already exists, asks before overwriting.
-4. Runs the P7 conversation — **one question at a time**, author-authored, never auto-generated.
+4. Runs the alignment conversation — **one question at a time**, author-authored, never auto-generated.
 5. Writes the section to `alignment.md` (creates the file with H1 + metadata if absent).
 6. Invokes `session-context-writer` skill with resolved project + task.
 7. Prints next-step hint.
@@ -48,13 +48,13 @@ Invoke `alignment-reader` at start. Behavior:
 | File exists, target section `present: false` | any section | Proceed to conversation; write appends the section |
 | File exists, target section `present: true` | any section | **Prompt:** "`alignment.md` already has a `<Section>` section. [o]verwrite / [e]dit / [c]ancel?" |
 
-- `[o]` — discard existing section, run full P7 conversation, overwrite
+- `[o]` — discard existing section, run full alignment conversation, overwrite
 - `[e]` — show the existing section; loop user into per-field prompts; write back only the fields they touched
 - `[c]` — exit without changes; report "No change."
 
 Default answer: `[c]` (cancel). Never overwrite without explicit confirmation.
 
-## P7 conversation — Task-Level
+## alignment conversation — Task-Level
 
 Follow brainstorming convention: **one question at a time**. The user's reply is the source of truth. You MAY draft a Goal or Non-goals suggestion after gathering context, but mark it as "Here's a draft — please edit or replace" — never silently accept your own suggestion.
 
@@ -87,7 +87,7 @@ Prompts, in order:
    - `[e]` — ask which field to edit (Goal / Expected result / Success criteria / Non-goals), re-run that prompt, re-assemble, re-confirm
    - `[c]` — abort cleanly; no write
 
-## P7 conversation — Phase-level (`--phase N`)
+## alignment conversation — Phase-level (`--phase N`)
 
 Same 4 fields, scope-adjusted wording. Use "this phase's <research|architecture|implementation>" in place of "this task" throughout.
 
@@ -183,7 +183,7 @@ After a successful write, print:
 - README Commands table
 - Command frontmatter `description` (this file)
 - `/drupal-dev-framework:next` mentions `/scope` as a retrofit option when the selected task has no `alignment.md`
-- CLAUDE.md P7 section
+- CLAUDE.md alignment section
 
 ## Do NOT
 

--- a/drupal-dev-framework/references/alignment-contract.md
+++ b/drupal-dev-framework/references/alignment-contract.md
@@ -4,7 +4,7 @@
 **Owner:** `skills/alignment-reader/SKILL.md` + `scripts/alignment-read.sh`
 **Consumers (as of v3.12.0):** `commands/scope.md`, `commands/research.md`, `commands/design.md`, `commands/implement.md`, `agents/analysis-agent.md` (via `scope_contract_recommended` signal evaluation)
 
-The P7 alignment step produces a single per-task artifact at `implementation_process/in_progress/<task>/alignment.md` (or the equivalent inside an epic's `in_progress/`). The file has a strict grammar so it can be parsed defensively by `alignment-read.sh` into structured JSON, while remaining hand-authorable in conversation and diff-friendly.
+The alignment step produces a single per-task artifact at `implementation_process/in_progress/<task>/alignment.md` (or the equivalent inside an epic's `in_progress/`). The file has a strict grammar so it can be parsed defensively by `alignment-read.sh` into structured JSON, while remaining hand-authorable in conversation and diff-friendly.
 
 ## 1. File location
 
@@ -135,20 +135,20 @@ Reader emits all applicable warnings in a single `warnings[]` array. Never abort
 {
   "file_exists": true,
   "file_path": "/abs/path/to/alignment.md",
-  "task_name": "dev_framework_task_contract",
+  "task_name": "my_task",
   "created": "2026-04-23",
   "schema_version": "1.0",
   "sections": {
     "task_level": {
       "present": true,
-      "goal": "Add an explicit P7 alignment step…",
-      "expected_result": "After 3.3 ships, every new task…",
+      "goal": "Implement the feature …",
+      "expected_result": "After this ships, users can …",
       "success_criteria": [
-        { "text": "P7 alignment command/hook produces…", "checked": false }
+        { "text": "Primary deliverable is live", "checked": false }
       ],
       "non_goals": [
-        "Not changing /design or /implement contracts",
-        "Not auto-generating alignment from description"
+        "Not refactoring adjacent components",
+        "Not changing the public API shape"
       ],
       "extras": [],
       "fields_missing": []
@@ -228,4 +228,3 @@ Research note citing 2–3 core examples and one contrib pattern if relevant.
 - `scripts/alignment-read.sh` — parser
 - `references/analysis-agent-schema.md` §Signal codes — `scope_contract_recommended` signal fires when an `alignment.md` is recommended
 - `commands/scope.md` — primary authoring command
-- Architecture decisions §3.2 / §4 in `dev_framework_task_contract/architecture.md`

--- a/drupal-dev-framework/references/analysis-agent-schema.md
+++ b/drupal-dev-framework/references/analysis-agent-schema.md
@@ -49,7 +49,7 @@ Signals evaluated in description mode: `description_length_and_conjunction`, `bu
 |---|---|---|
 | `schema_version` | string | Follows semver. `"1.0"` for v3.11.0. Consumers match on major version for compat. **MUST be a JSON string** (quoted `"1.0"`), never a number — `1.0` (unquoted) becomes `1` in JSON and breaks semver parsing. |
 | `analyzed_at` | string | ISO-8601 UTC timestamp of analysis completion. |
-| `task_id` | string | URI-style `local:<folder_name>`. Matches 3.1's task-frontmatter-reader `id` field. |
+| `task_id` | string | URI-style `local:<folder_name>`. Matches the `task-frontmatter-reader` skill's `id` field. |
 | `task_folder` | string | Absolute path to the task folder at analysis time. |
 | `decision` | enum | One of `"epic_candidate"`, `"keep_flat"`, `"insufficient_info"`. |
 | `confidence` | enum | One of `"high"`, `"medium"`, `"low"`. |
@@ -82,7 +82,7 @@ Signals the agent cites in `signals_used` when it reaches `epic_candidate`:
 | `multiple_code_areas` | (requires `code_read: true`) Task touches multiple distinct module/package boundaries in the codebase |
 | `description_length_and_conjunction` | Task description has both length > threshold AND explicit conjunction phrasing ("and also", "plus", "as well as") — typical trigger for the `/research` pre-analysis hook |
 | `bullet_count_clustering` | Task description's bullet list has ≥3 bullets that group into distinct topics |
-| `scope_contract_recommended` | **(v3.12.0+)** Task's scope is non-trivial enough to warrant a P7 alignment contract (`alignment.md`). Fires when ANY of: (a) task description has ≥2 distinct outcome dimensions; (b) description contains conjunctive phrasing (`and also`, `plus`, `as well as`, `in addition to`); (c) **(folder mode only — requires task.md on disk)** ≥3 acceptance criteria listed in `task.md` AND description word count > 60. Orthogonal to `epic_candidate` — a task can be both, either, or neither. Description-mode compatible via triggers (a) and (b) only; trigger (c) is skipped in description mode. Consumed by `/research` pre-analysis hook and `/scope` to suggest the P7 step. |
+| `scope_contract_recommended` | **(v3.12.0+)** Task's scope is non-trivial enough to warrant an alignment contract (`alignment.md`). Fires when ANY of: (a) task description has ≥2 distinct outcome dimensions; (b) description contains conjunctive phrasing (`and also`, `plus`, `as well as`, `in addition to`); (c) **(folder mode only — requires task.md on disk)** ≥3 acceptance criteria listed in `task.md` AND description word count > 60. Orthogonal to `epic_candidate` — a task can be both, either, or neither. Description-mode compatible via triggers (a) and (b) only; trigger (c) is skipped in description mode. Consumed by `/research` pre-analysis hook and `/scope` to suggest the alignment step. |
 
 **Signal extensibility:** new codes can be added at v1.x without breaking consumers. Consumers should treat unknown codes as informational (display them; don't error).
 
@@ -118,10 +118,10 @@ At new-task creation time, consumers branch in two orthogonal steps:
 - `decision: insufficient_info` → proceed with flat task research; agent didn't have enough to decide.
 
 **Step B — inspect `signals_used[]` for `scope_contract_recommended` (v3.12.0+, orthogonal to decision):**
-- If the array contains `scope_contract_recommended` → soft-nudge the user to author a P7 scope contract (`alignment.md`) before research begins. The signal can fire with ANY decision (including `keep_flat`) because it's an orthogonal judgment about scope contract warrant, not decomposition.
+- If the array contains `scope_contract_recommended` → soft-nudge the user to author a scope contract (`alignment.md`) before research begins. The signal can fire with ANY decision (including `keep_flat`) because it's an orthogonal judgment about scope contract warrant, not decomposition.
 - If absent → no nudge; proceed.
 
-Consumers MUST perform both steps. A task can be `keep_flat` + `scope_contract_recommended` (most common P7 case) or `epic_candidate` + `scope_contract_recommended` (both needed) or neither. See §"Signal independence" above.
+Consumers MUST perform both steps. A task can be `keep_flat` + `scope_contract_recommended` (most common alignment case) or `epic_candidate` + `scope_contract_recommended` (both needed) or neither. See §"Signal independence" above.
 
 ## Example outputs
 

--- a/drupal-dev-framework/skills/alignment-reader/SKILL.md
+++ b/drupal-dev-framework/skills/alignment-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alignment-reader
-description: Use when a framework command needs to parse a task's alignment.md (the P7 scope contract — Goal / Expected result / Success criteria / Non-goals per section). Reads defensively via scripts/alignment-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
+description: Use when a framework command needs to parse a task's alignment.md (the scope contract — Goal / Expected result / Success criteria / Non-goals per section). Reads defensively via scripts/alignment-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
 version: 1.0.0
 user-invocable: false
 model: haiku
@@ -86,4 +86,3 @@ Future consumers needing scope-contract data should call this skill rather than 
 - `references/alignment-contract.md` — canonical grammar, warning codes, JSON output contract
 - `project-state-reader` skill (v1.0.0) — same design pattern, project-level metadata
 - `task-frontmatter-reader` skill (v2.0.0) — same design pattern, task frontmatter
-- Architecture decisions §3.2 / §3.3 in `dev_framework_task_contract/architecture.md`

--- a/drupal-dev-framework/skills/project-state-reader/SKILL.md
+++ b/drupal-dev-framework/skills/project-state-reader/SKILL.md
@@ -75,4 +75,3 @@ Future consumers that need project-level metadata should call this skill rather 
 
 - `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh` — the script
 - `task-frontmatter-reader` skill (v2.0.0) — same design pattern, task-level metadata instead of project-level
-- Architecture decision Q5a in `dev_framework_project_code_path_and_analysis_agent/architecture.md`

--- a/drupal-dev-framework/skills/session-context-writer/SKILL.md
+++ b/drupal-dev-framework/skills/session-context-writer/SKILL.md
@@ -27,7 +27,7 @@ You receive the resolved project and task values from the calling command. Write
   "updatedAt": "2026-04-22",
   "loadedGuides": ["drupal/forms/form-validation"],
   "lastPhase": "research",
-  "currentEpic": "dev_framework_improvements_epic"
+  "currentEpic": "my_epic_name"
 }
 ```
 


### PR DESCRIPTION
## Summary

Docs-only patch. Removes internal/private references that leaked into the shipped plugin during v3.10.0–v3.12.0 development. **No command, skill, agent, script, or schema behavior changes.**

Bumps drupal-dev-framework 3.12.0 → **3.12.1** and marketplace metadata 1.14.8 → **1.14.9**.

## What was leaking

| # | Class | Count | Example |
|---|---|---:|---|
| 1 | Undefined private jargon | 18 | "P7 scope contract", "P7 conversation", "P7 nudge" — "P7" was private pain-point numbering from internal epic planning, undefined in plugin docs |
| 2 | Stale sub-task numbering | 5 | "sub-task 3.2 (not yet shipped)" in /migrate-to-epic — /propose-epics actually shipped in v3.11.0 |
| 3 | Private project-file paths | 3 | "Architecture decisions §3.2 / §3.3 in `dev_framework_task_contract/architecture.md`" — path exists only in maintainer's private memory directory |
| 4 | Private project names in JSON examples | 2 | `"currentEpic": "dev_framework_improvements_epic"` in session-context-writer example |
| 5 | CHANGELOG future-task name | 1 | Named a specific private-roadmap task in a "follow-up" note |

## What changed

- **"P7" replaced** with clear terms: "scope contract", "alignment step", "alignment conversation"
- **Stale sub-task numbers** replaced with concrete version numbers ("v3.11.0+") or removed
- **Private architecture.md references** dropped from `alignment-reader`, `project-state-reader`, `analysis-agent`, `alignment-contract.md` "See also" sections
- **Example JSON values** genericized (`my_task`, `my_epic_name`)
- **CHANGELOG v3.10.0 follow-up note** generalized to "tracked for a future release"
- Minor grammar cleanup from automated replacement

## Validation

- Byte-diff audit: all changes are string substitutions. No logic paths, `if` branches, schema fields, script calls, signal definitions, or invariants touched.
- `scope_contract_recommended` signal trigger conditions (a/b/c) byte-identical to v3.12.0.
- plugin-structure-auditor verdict: **READY — no behavior drift detected.**

## Test plan

- [ ] `grep -rn '\bP7\b' drupal-dev-framework/ | grep -v CHANGELOG` returns empty
- [ ] `grep -rn 'dev_framework_' drupal-dev-framework/ | grep -v CHANGELOG` returns empty
- [ ] Install v3.12.1 over v3.12.0 — no regressions in `/scope`, `/research`, `/design`, `/implement`
- [ ] Fresh install from marketplace — new users see no "P7" or private-project references in any SKILL/command/agent doc they'd read

🤖 Generated with [Claude Code](https://claude.com/claude-code)