### PR TITLE
drupal-dev-framework v3.12.2 — /research retrofit-aware scope offer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.9"
+    "version": "1.14.10"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.2] - 2026-04-23
+
+### Fixed — `/research` retrofit-aware scope offer
+
+**Bug:** `/research` silently skipped the task-level alignment nudge when invoked on a pre-existing task that never went through the pre-analysis hook (e.g., tasks created before v3.11.0, or tasks that existed when their scope contract was omitted). The feature effectively did nothing for retrofit flows.
+
+**Fix:** `/research` Phase 1 alignment sub-step now runs a task-level retrofit check when ALL of the following are true:
+- Task folder existed before this `/research` invocation (not a fresh creation)
+- No `## Task-Level` section in `alignment.md` (or file missing)
+- Pre-analysis hook did NOT run this session
+
+When those conditions hold, the command invokes `analysis-agent` in folder mode to check scope warrant and, if `scope_contract_recommended` fires, offers task-level authoring before continuing to Phase 1 alignment. Failure modes (agent timeout / error) proceed silently — never blocks.
+
+Fresh-task and already-authored flows are unchanged (skip the new check entirely). `/design` and `/implement` retain their existing "task-level decline is final post-creation" posture — only `/research` needs to handle retrofit.
+
+No schema change. No new artifacts. `analysis-agent`, `alignment-reader`, and `scope` command unchanged. Behavior change isolated to `commands/research.md`.
+
 ## [3.12.1] - 2026-04-23
 
 ### Fixed — Private reference scrub (no behavior change)

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -138,18 +138,31 @@ If a signal fires:
 
 Conservative by design: pre-analysis only fires on strong signals, and even then the default choice presented to the user is to proceed as a flat task. Never creates an epic without explicit confirmation. The alignment nudge is soft; `[n]` is always respected.
 
-## Phase 1 alignment sub-step (v3.12.0+)
+## Phase 1 alignment sub-step (v3.12.0+, retrofit-aware in v3.12.2+)
 
 **First action of Phase 1 proper** (after the task directory is created and the pre-analysis hook has settled):
 
 1. Invoke `alignment-reader` skill against the task folder.
-2. Decide whether to offer the Phase 1 alignment section:
+
+2. **Task-level retrofit check (v3.12.2+)** — if the task folder ALREADY existed before this `/research` invocation (i.e., the user is running `/research` on a pre-existing flat task created outside the hook flow, NOT a fresh task just created by this command) AND `sections.task_level.present: false` AND the pre-analysis hook did NOT run this session → invoke `analysis-agent` in **folder mode** (`task_folder` set to the task directory, `codePath` resolved via `project-state-reader`, `schema_version: "1.0"`). Inspect the returned `signals_used[]` for `scope_contract_recommended`.
+
+   - If present → print soft-nudge: `"This task has no scope contract yet, and analysis suggests one would help. Author task-level alignment (Goal / Expected result / Success criteria / Non-goals) now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
+     - On `[y]` → execute the task-level flow from `commands/scope.md` (5-prompt task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so subsequent steps see the new section.
+     - On `[n]` / `[skip]` → proceed; record "task-level retrofit declined" for this run.
+   - If absent → proceed silently (no warrant — task is self-contained).
+   - If analysis-agent fails or times out → proceed silently; do NOT nag the user.
+
+   Skip this check entirely on fresh tasks where the pre-analysis hook fired (redundant) or where `task_level.present` is already `true` (already authored).
+
+3. Decide whether to offer the Phase 1 alignment section:
    - If `sections.phase_1.present: true` → print: `"Phase 1 alignment already authored. Using existing section."` and proceed.
-   - Else if `sections.task_level.present: true` → ask: `"Author the Phase 1 — Research section of alignment.md now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
+   - Else if `sections.task_level.present: true` (including freshly authored in step 2) → ask: `"Author the Phase 1 — Research section of alignment.md now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
    - Else if pre-analysis hook emitted `scope_contract_recommended` and user declined task-level alignment earlier → re-offer as lighter-touch: `"Author a Phase 1 — Research alignment section (just this phase)? [y]es / [n]o"`. Default: `[n]`.
    - Otherwise → proceed silently (no nag).
-3. If user says `[y]`, execute the `--phase 1` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 1 — Research` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with research.
-4. If user says `[n]` / `[skip]`, proceed with research. Never block.
+
+4. If user says `[y]`, execute the `--phase 1` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 1 — Research` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with research.
+
+5. If user says `[n]` / `[skip]`, proceed with research. Never block.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Bug fix. `/research` now offers a task-level scope contract on pre-existing tasks when warranted — closing the gap where the alignment feature silently did nothing on retrofit flows.

Bumps drupal-dev-framework 3.12.1 → **3.12.2** and marketplace metadata 1.14.9 → **1.14.10**.

## The bug

`/research`'s pre-analysis hook only fires **before task creation**. For any task already on disk — either created before v3.11.0 shipped, or created with no strong signals at the time — the hook doesn't run. The Phase 1 alignment sub-step's decision tree then hits the "proceed silently (no nag)" branch because `task_level.present: false` AND there's no prior hook flag.

Net effect: users running `/research existing_task` got zero scope-contract nudge, even when analysis would clearly recommend one. The alignment feature silently did nothing for retrofit flows.

## The fix

New **task-level retrofit check** in `/research`'s Phase 1 alignment sub-step. Runs when ALL of:
- Task folder existed before this `/research` invocation (not a fresh creation)
- `task_level` absent from `alignment.md` (or file missing)
- Pre-analysis hook did NOT run this session

When those hold, `/research` invokes `analysis-agent` in folder mode. If `signals_used[]` contains `scope_contract_recommended`, it offers task-level authoring before continuing with Phase 1 alignment. Agent timeout / error proceeds silently — never blocks.

## What's unchanged

- Fresh-task flow (hook fires at creation) — unchanged
- Tasks already carrying a `## Task-Level` section — unchanged (skip the check)
- `/design` and `/implement` — retain existing "task-level decline is final post-creation" posture; only `/research` needs retrofit awareness

## Scope

One command body edited (`commands/research.md`). No schema, agent, skill, or script changes. `analysis-agent`, `alignment-reader`, and `/scope` are all byte-identical.

## Test plan

- [ ] Install v3.12.2
- [ ] Run `/research` on a task that existed before v3.12.0 — retrofit check fires, offers task-level scope if warranted
- [ ] Run `/research new_task_description...` — pre-analysis hook still fires at creation; retrofit check skipped (no redundant analysis)
- [ ] Run `/research` on a task that already has `## Task-Level` — retrofit check skipped; goes to Phase 1 offer
- [ ] Induce agent timeout — `/research` proceeds silently, no error surfaced to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)