### PR TITLE
drupal-dev-framework v3.12.4 — alignment conversation UX patch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.11"
+    "version": "1.14.12"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.12.3",
+      "version": "3.12.4",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.4] - 2026-04-24
+
+### Fixed — alignment conversation UX (two gaps)
+
+Surfaced during live use of `/research granular_validation` in the camoa-skills repo: the scope-contract conversation was noisy on existing-content tasks and its sub-step prompts were framework-jargon rather than plain language. Both were pure UX defects in v3.12.0-3.12.3.
+
+**Gap 1 — `/scope` was interrogative, not conversational.** The task-level flow asked 5 rigid prompts ("What is the single-sentence Goal of `<task>`? Start with a verb.") even when `task.md` already had substantive Goal / Acceptance Criteria / Current State content. Users ended up restating what they'd already written.
+
+**Fix:** `/scope` now reads existing context first (task-frontmatter-reader + task.md body + current alignment.md), picks a conversation mode based on what's already there, and starts from reflection rather than interrogation:
+
+| task.md state | Conversation mode |
+|---|---|
+| Substantive Goal + ACs (≥40 words) | **Reflect-and-refine** — paraphrase what's there, ask if the paraphrase captures the real driver |
+| Partial content | **Draft-and-confirm** — propose a draft from available context, ask what's missing or wrong |
+| Stub / empty | **Open exploration** — ask openly; multi-sentence answers welcome |
+
+Phase-level (`--phase 1|2|3`) uses the same three modes, scoped to one phase. The 4 fields (Goal / Expected result / Success criteria / Non-goals) are still the output contract — but they surface from conversation, not from a rigid prompt script.
+
+**Gap 2 — phase-alignment sub-step prompts were framework-jargon.** `/research`, `/design`, `/implement` asked "Author the Phase N — <Phase> section of alignment.md now? [y]es / [n]o / [skip]" — which assumes the user reads framework docs and knows what "alignment.md" and "Phase N sections" mean.
+
+**Fix:** all phase-alignment prompts rewritten in plain language that explains what the choice means BEFORE asking:
+
+- `/research` pre-analysis scope nudge: now says "Before diving into research: this task looks scope-heavy (multiple deliverables or complex criteria). Want to pin down the scope first in a short conversation — goal, what success looks like, what's explicitly out of scope — so research doesn't drift?"
+- `/research` retrofit-check nudge: now says "This task doesn't have a declared scope yet, and I'm picking up signals that scope might drift during research..."
+- `/research` / `/design` / `/implement` phase sub-step prompts: "You've scoped the whole task. Want to also scope just this phase — what research/design/implementation does in this pass — or skip and start?"
+
+No schema, agent, skill, or script changes. Pure command-body rewrites. `commands/scope.md`, `commands/research.md`, `commands/design.md`, `commands/implement.md`. plugin.json 3.12.3 → 3.12.4; marketplace plugin entry synced; metadata 1.14.11 → 1.14.12.
+
 ## [3.12.3] - 2026-04-23
 
 ### Fixed — `scope_contract_recommended` signal coverage (two gaps)

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -33,11 +33,13 @@ Never block the command on this check — the user is in control. The nudge exis
 **Run after the Phase Transition Check, before any other Phase 2 work.** Same pattern as `/research`'s Phase 1 sub-step:
 
 1. Invoke `alignment-reader` skill against the task folder.
-2. Decide whether to offer the Phase 2 alignment section:
-   - If `sections.phase_2.present: true` → print: `"Phase 2 alignment already authored. Using existing section."` and proceed.
-   - Else if `sections.task_level.present: true` → ask: `"Author the Phase 2 — Architecture section of alignment.md now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
+2. Decide whether to offer an architecture-specific scope. Plain-language prompts:
+   - If `sections.phase_2.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
+   - Else if `sections.task_level.present: true` → ask:
+     > "You've scoped the whole task. Want to also scope just this architecture phase — what design decisions this phase commits to, what's deferred to implementation — or skip and start design now? [y]es / [n]o"
+     Default: `[n]`.
    - Otherwise → proceed silently (no nag; task never authored any alignment).
-3. If user says `[y]`, execute the `--phase 2` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 2 — Architecture` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with architecture work.
+3. If user says `[y]`, execute the `--phase 2` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 2 — Architecture` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with architecture work.
 4. If user says `[n]` / `[skip]`, proceed. Never block.
 
 **Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level alignment at task creation, that decision is considered final by the time they reach Phase 2 — the task is already underway.

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -39,11 +39,13 @@ Never block the command on this check — the user is in control. The nudge exis
 **Run after the Phase Transition Check, before loading implementation context.** Same pattern as `/research`'s Phase 1 sub-step:
 
 1. Invoke `alignment-reader` skill against the task folder.
-2. Decide whether to offer the Phase 3 alignment section:
-   - If `sections.phase_3.present: true` → print: `"Phase 3 alignment already authored. Using existing section."` and proceed.
-   - Else if `sections.task_level.present: true` → ask: `"Author the Phase 3 — Implementation section of alignment.md now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
+2. Decide whether to offer an implementation-specific scope. Plain-language prompts:
+   - If `sections.phase_3.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
+   - Else if `sections.task_level.present: true` → ask:
+     > "You've scoped the whole task. Want to also scope just this implementation phase — what exactly gets built in this pass, what's deferred to follow-up — or skip and start coding now? [y]es / [n]o"
+     Default: `[n]`.
    - Otherwise → proceed silently (no nag; task never authored any alignment).
-3. If user says `[y]`, execute the `--phase 3` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 3 — Implementation` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with implementation context loading.
+3. If user says `[y]`, execute the `--phase 3` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 3 — Implementation` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with implementation context loading.
 4. If user says `[n]` / `[skip]`, proceed. Never block.
 
 **Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level alignment at task creation, that decision is considered final — the task is already in Phase 3.

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -129,10 +129,10 @@ If a signal fires:
    - `keep_flat` → proceed silently with flat-task research.
    - `insufficient_info` → proceed with flat-task research; the task description alone wasn't sufficient for decomposition judgment (makes sense at creation time — usually the description IS minimal here).
 
-5. **(v3.12.0+)** After the `decision` branch completes (regardless of outcome unless the task became an epic), inspect `signals_used[]` for `scope_contract_recommended`. If present, print soft-nudge:
-   > "Analysis recommends authoring a scope contract before research. Start now? [y]es / [n]o / [later]"
+5. **(v3.12.0+)** After the `decision` branch completes (regardless of outcome unless the task became an epic), inspect `signals_used[]` for `scope_contract_recommended`. If present, print soft-nudge in plain language — explain WHY before asking:
+   > "Before diving into research: this task looks scope-heavy (multiple deliverables or complex criteria). Want to pin down the scope first in a short conversation — goal, what success looks like, what's explicitly out of scope — so research doesn't drift? [y]es / [n]o / [later]"
 
-   On `[y]` → execute the alignment conversation + write flow as documented in `commands/scope.md` (task-level prompt sequence + "Writing alignment.md") within this command's context. Do NOT try to shell out to a sibling slash command. After the write completes, continue with the standard research flow.
+   On `[y]` → execute the alignment conversation + write flow as documented in `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md") within this command's context. Do NOT try to shell out to a sibling slash command. After the write completes, continue with the standard research flow.
    On `[n]` → proceed without writing `alignment.md`. No nag.
    On `[later]` → same as `[n]` for this run; user can run `/scope <task>` anytime.
 
@@ -146,21 +146,27 @@ Conservative by design: pre-analysis only fires on strong signals, and even then
 
 2. **Task-level retrofit check (v3.12.2+)** — if the task folder ALREADY existed before this `/research` invocation (i.e., the user is running `/research` on a pre-existing flat task created outside the hook flow, NOT a fresh task just created by this command) AND `sections.task_level.present: false` AND the pre-analysis hook did NOT run this session → invoke `analysis-agent` in **folder mode** (`task_folder` set to the task directory, `codePath` resolved via `project-state-reader`, `schema_version: "1.0"`). Inspect the returned `signals_used[]` for `scope_contract_recommended`.
 
-   - If present → print soft-nudge: `"This task has no scope contract yet, and analysis suggests one would help. Author task-level alignment (Goal / Expected result / Success criteria / Non-goals) now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
-     - On `[y]` → execute the task-level flow from `commands/scope.md` (5-prompt task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so subsequent steps see the new section.
+   - If present → print soft-nudge in plain language:
+     > "This task doesn't have a declared scope yet, and I'm picking up signals that scope might drift during research (multiple distinct deliverables, or a description that could be interpreted several ways). Want to spend a minute nailing down the goal and success criteria before we dig in? [y]es / [n]o / [skip]"
+     Default: `[skip]`.
+     - On `[y]` → execute the task-level flow from `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so subsequent steps see the new section.
      - On `[n]` / `[skip]` → proceed; record "task-level retrofit declined" for this run.
    - If absent → proceed silently (no warrant — task is self-contained).
    - If analysis-agent fails or times out → proceed silently; do NOT nag the user.
 
    Skip this check entirely on fresh tasks where the pre-analysis hook fired (redundant) or where `task_level.present` is already `true` (already authored).
 
-3. Decide whether to offer the Phase 1 alignment section:
-   - If `sections.phase_1.present: true` → print: `"Phase 1 alignment already authored. Using existing section."` and proceed.
-   - Else if `sections.task_level.present: true` (including freshly authored in step 2) → ask: `"Author the Phase 1 — Research section of alignment.md now? [y]es / [n]o / [skip]"`. Default: `[skip]`.
-   - Else if pre-analysis hook emitted `scope_contract_recommended` and user declined task-level alignment earlier → re-offer as lighter-touch: `"Author a Phase 1 — Research alignment section (just this phase)? [y]es / [n]o"`. Default: `[n]`.
+3. Decide whether to offer a research-specific scope. All prompts use plain language that explains WHAT the choice means:
+   - If `sections.phase_1.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
+   - Else if `sections.task_level.present: true` (including freshly authored in step 2) → ask:
+     > "You've scoped the whole task. Want to also scope just this research phase specifically — what questions research needs to answer, what's out of scope for research — or skip and start research now? [y]es / [n]o"
+     Default: `[n]` (most tasks don't need a separate research sub-scope).
+   - Else if pre-analysis hook emitted `scope_contract_recommended` and user declined task-level scope earlier → re-offer lighter-touch:
+     > "You skipped the task-level scope earlier. Want to at least scope just this research phase (lighter — only what research is trying to answer)? [y]es / [n]o"
+     Default: `[n]`.
    - Otherwise → proceed silently (no nag).
 
-4. If user says `[y]`, execute the `--phase 1` flow from `commands/scope.md` (phase-level prompt sequence + "Writing alignment.md" for the `## Phase 1 — Research` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with research.
+4. If user says `[y]`, execute the `--phase 1` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 1 — Research` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with research.
 
 5. If user says `[n]` / `[skip]`, proceed with research. Never block.
 

--- a/drupal-dev-framework/commands/scope.md
+++ b/drupal-dev-framework/commands/scope.md
@@ -56,49 +56,68 @@ Default answer: `[c]` (cancel). Never overwrite without explicit confirmation.
 
 ## alignment conversation — Task-Level
 
-Follow brainstorming convention: **one question at a time**. The user's reply is the source of truth. You MAY draft a Goal or Non-goals suggestion after gathering context, but mark it as "Here's a draft — please edit or replace" — never silently accept your own suggestion.
+The conversation produces a 4-field contract (Goal / Expected result / Success criteria / Non-goals). It is author-driven — the user's words are the source of truth — but the agent starts from any existing content rather than asking from a blank slate.
 
-Prompts, in order:
+**Follow brainstorming convention:** one real question at a time. Never force the user to restate something they've already written. Never silently accept the agent's own draft.
 
-1. **Goal.** Ask:
-   > "What is the single-sentence Goal of `<task>`? (What problem does this solve? Start with a verb.)"
+### Step 1 — Read existing context first
 
-   Append reply verbatim to the `### Goal` field body.
+Before asking anything, read the task's current content:
 
-2. **Expected result.** Ask:
-   > "What Expected Result will be observable when this task ships? Describe the after-state in 1–3 sentences."
+1. Invoke `task-frontmatter-reader` on the task folder to get `kind`, `status`, description, dependencies.
+2. Read `task.md` body (Goal, Current State, Acceptance Criteria, Research Questions, Notes — whatever exists).
+3. Read `alignment.md` via `alignment-reader` (should be missing or have no Task-Level section, since this command path only runs when we intend to author).
 
-   Append reply to `### Expected result`.
+### Step 2 — Decide the conversation mode
 
-3. **Success criteria.** Ask:
-   > "List the Success Criteria — falsifiable statements, each one checkable. One per line. Hit enter on an empty line when done."
+Based on what Step 1 surfaced:
 
-   Collect lines until blank line. Format each as `- [ ] <text>`. Append under `### Success criteria`.
+| task.md state | Mode | Opening move |
+|---|---|---|
+| Substantive Goal + ACs (≥40 words of content) | **Reflect-and-refine** | Paraphrase what's there, ask if the paraphrase captures the real driver or if something else is the point |
+| Partial content (Goal only, or just a title) | **Draft-and-confirm** | Propose a draft Goal + expected result from available context, ask what's missing or wrong |
+| Stub / empty | **Open exploration** | Ask openly what the user wants to achieve; multi-sentence answers welcome; refine iteratively |
 
-4. **Non-goals.** Ask:
-   > "Any explicit Non-Goals? Things people might assume are in scope but aren't. One per line; empty line to finish."
+The mode determines tone, not script. The agent MUST NOT fall into "ask 5 rigid questions in order" regardless of mode.
 
-   Collect lines until blank line. Format each as `- <text>`. Append under `### Non-goals`.
+### Step 3 — Converse to surface the 4 fields
 
-5. **Confirm and write.** Show the assembled Task-Level section and ask:
-   > "Write this `## Task-Level` section to `alignment.md`? [y]es / [e]dit / [c]ancel"
+Operate conversationally. Over however many turns feel natural:
 
-   - `[y]` — write the file (see "Writing alignment.md" below)
-   - `[e]` — ask which field to edit (Goal / Expected result / Success criteria / Non-goals), re-run that prompt, re-assemble, re-confirm
-   - `[c]` — abort cleanly; no write
+- **Goal** — what problem this solves, why it matters. One to three sentences is fine.
+- **Expected result** — what's observable/different when the task ships.
+- **Success criteria** — the falsifiable checklist. Propose items as they surface in conversation; confirm at the end.
+- **Non-goals** — push proactively. Common drift sources: "Are we also doing X?" / "Is adjacent thing Y in scope?" / "Does this include migrating the existing data?". Non-goals prevent scope creep later — worth pulling a few out explicitly even if the user didn't mention them.
+
+The agent MAY propose drafts for any field after gathering enough context, but always marks them as drafts and asks for correction.
+
+### Step 4 — Assemble a draft and show it
+
+When the 4 fields feel substantively covered, assemble the full `## Task-Level` section and show it verbatim to the user. Not a summary — the actual markdown that would be written.
+
+### Step 5 — Confirm, edit, or cancel
+
+> "Here's the task-level scope as I understood it (shown above). Write it to `alignment.md` as-is, edit a specific field, or cancel? [y]es / [e]dit / [c]ancel"
+
+- `[y]` — write the file (see "Writing alignment.md" below).
+- `[e]` — ask which field needs revision (Goal / Expected result / Success criteria / Non-goals), loop back to Step 3 for just that field, reassemble, re-confirm.
+- `[c]` — abort; no write.
 
 ## alignment conversation — Phase-level (`--phase N`)
 
-Same 4 fields, scope-adjusted wording. Use "this phase's <research|architecture|implementation>" in place of "this task" throughout.
+Same 4 fields, scope-adjusted to one phase. Same conversation modes (reflect-and-refine / draft-and-confirm / open exploration) based on what's already in `task.md`, `research.md`, or `architecture.md` for that phase.
 
-Phase 1 example:
-1. "Goal of **this phase's research**: what question(s) must this research answer?"
-2. "Expected Result of research: what will `research.md` contain when done?"
-3. "Success Criteria for research — falsifiable statements. One per line; empty line to finish."
-4. "Non-Goals for research — investigations explicitly out of scope. One per line; empty line to finish."
-5. "Write this `## Phase 1 — Research` section to `alignment.md`? [y]es / [e]dit / [c]ancel"
+Scope-adjusted wording:
 
-Phase 2 and Phase 3 substitute "architecture"/"implementation" (and `## Phase 2 — Architecture` / `## Phase 3 — Implementation` in the H2 header and confirm prompt).
+- **Goal** — for research: what question(s) must research answer? For architecture: what design decisions does this phase commit to? For implementation: what will this phase actually build?
+- **Expected result** — what will `research.md` / `architecture.md` / `implementation.md` contain when the phase is done?
+- **Success criteria** — falsifiable per-phase criteria, not task-level ones
+- **Non-goals** — investigations / design decisions / implementation scope explicitly deferred to a later phase or task
+
+The phase-level agent MUST assume task-level scope already exists and NOT re-ask task-level questions. Phase-level is narrower: "given the task-level contract, what does THIS phase alone deliver?"
+
+Confirm prompt:
+> "Here's the Phase N scope (shown above). Write it to `alignment.md` as a `## Phase N — <Research|Architecture|Implementation>` section, edit a specific field, or cancel? [y]es / [e]dit / [c]ancel"
 
 ## Writing `alignment.md`
 


### PR DESCRIPTION
## Summary

Two UX gaps in the alignment feature, surfaced during live use of \`/research granular_validation\` in the camoa-skills repo itself. Both are pure UX defects in the commands shipped across v3.12.0–v3.12.3 — no schema, agent, skill, or script behavior changes.

Bumps drupal-dev-framework 3.12.3 → **3.12.4** and marketplace metadata 1.14.11 → **1.14.12**.

## Gap 1 — \`/scope\` was interrogative, not conversational

The task-level flow asked 5 rigid prompts (\"What is the single-sentence Goal of \<task\>? Start with a verb.\") even when \`task.md\` already had a substantive Goal + Current State + 10 Acceptance Criteria. Users ended up restating what they'd already written.

**Fix:** \`/scope\` now reads existing context first (task-frontmatter-reader + task.md body + current alignment.md), picks a conversation mode based on what's already there, and starts from reflection rather than interrogation:

| task.md state | Conversation mode |
|---|---|
| Substantive Goal + ACs (≥40 words) | **Reflect-and-refine** — paraphrase, ask if it captures the real driver |
| Partial content | **Draft-and-confirm** — propose a draft, ask what's missing |
| Stub / empty | **Open exploration** — multi-sentence answers welcome |

Phase-level (\`--phase 1|2|3\`) uses the same three modes, scoped to one phase. The 4 fields remain the output contract; they surface from conversation, not a rigid script.

## Gap 2 — phase-alignment prompts were framework jargon

\`/research\`, \`/design\`, \`/implement\` asked \"Author the Phase N — \<Phase\> section of alignment.md now? [y]es / [n]o / [skip]\" — which assumes the user has read framework docs and knows what \"alignment.md\" and \"Phase N sections\" mean.

**Fix:** every phase-alignment prompt rewritten in plain language that explains what the choice means before asking. Examples:

- Pre-analysis scope nudge: \"Before diving into research: this task looks scope-heavy (multiple deliverables or complex criteria). Want to pin down the scope first in a short conversation — goal, what success looks like, what's explicitly out of scope — so research doesn't drift?\"
- Retrofit-check nudge: \"This task doesn't have a declared scope yet, and I'm picking up signals that scope might drift during research...\"
- Phase sub-step prompts: \"You've scoped the whole task. Want to also scope just this phase — what research/design/implementation does in this pass — or skip and start?\"

## Scope of changes

- \`commands/scope.md\` — task-level and phase-level conversation rewritten context-aware
- \`commands/research.md\` — pre-analysis step 5 + Phase 1 sub-step prompts in plain language
- \`commands/design.md\` — Phase 2 sub-step prompts in plain language
- \`commands/implement.md\` — Phase 3 sub-step prompts in plain language

No schema bump. No new files. No behavior changes beyond conversation text + context-aware mode selection.

## Test plan

- [ ] Install v3.12.4
- [ ] Run \`/scope existing_task_with_goals_and_acs\` — verify reflect-and-refine mode kicks in, paraphrasing existing content rather than asking to restate
- [ ] Run \`/scope stub_task\` — verify open-exploration mode kicks in
- [ ] Run \`/research\` on task with no scope, strong signals — verify the pre-analysis nudge reads as plain-language explanation, not \"Author the Phase 1 — Research section\"
- [ ] Run \`/design\` / \`/implement\` after task-level scope — verify phase prompts explain the choice in plain language

🤖 Generated with [Claude Code](https://claude.com/claude-code)