### PR TITLE
drupal-dev-framework v3.13.0 — granular validation commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.12"
+    "version": "1.14.13"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.12.4",
+      "version": "3.13.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.12.4",
+  "version": "3.13.0",
   "author": {
     "name": "camoa"
   },
@@ -9,6 +9,7 @@
   "repository": "https://github.com/camoa/claude-skills",
   "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams"],
   "dependencies": [
-    "dev-guides-navigator"
+    "dev-guides-navigator",
+    "code-quality-tools"
   ]
 }

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.0] - 2026-04-24
+
+### Added — Granular Validation Commands (sub-task granular_validation of dev-framework improvements epic)
+
+Individual quality-gate commands invokable on demand, plus two new visual gates and an orchestrator. Replaces the all-or-nothing `/complete`-only gating with a per-aspect, per-moment validation surface.
+
+**7 new gate commands + 1 orchestrator:**
+
+- `/drupal-dev-framework:validate-tdd` — wraps `/code-quality:tdd`
+- `/drupal-dev-framework:validate-solid` — wraps `/code-quality:solid`
+- `/drupal-dev-framework:validate-dry` — wraps `/code-quality:dry`
+- `/drupal-dev-framework:validate-security` — wraps `/code-quality:security`
+- `/drupal-dev-framework:validate-guides` — **new, framework-owned.** Verifies research.md + architecture.md cite `dev-guides-navigator` guides
+- `/drupal-dev-framework:validate-visual-regression` — **new, framework-owned.** Captures screenshot via Playwright MCP (fallback: claude-in-chrome), diffs against stored baseline via `odiff` (fallback: `pixelmatch`), prompts on diff: regression / intentional (baseline rotates inline) / cancel
+- `/drupal-dev-framework:validate-visual-parity` — **new, framework-owned.** Same infrastructure; reference is an external design comp (PNG/JPG passthrough, Figma URL via MCP, HTML file rendered headless). v1 explicitly defers React / PSD / Sketch / Adobe XD
+- `/drupal-dev-framework:validate-all` — sequential orchestrator. Runs 5 non-visual gates + visual-regression for every stored baseline (collapsing into one `gates[]` entry with worst verdict); visual-parity always skipped (requires explicit reference arg). Aggregate envelope with `summary` counts and discoverability hint pointing to unwrapped `code-quality-tools:*` capabilities (`lint`, `coverage`, `review`, `audit`, `ultrareview`). CI-mode (non-interactive TTY or `$CI` env var) skips visual gates entirely — explicit-skip rather than silent-defaults
+
+Each gate emits a shared JSON envelope (`references/validation-gate-result.md` v1.0, schema_version `"1.0"`) persisted to `<task>/validations/latest/<gate>.json` (overwrite) + `<task>/validations/history.jsonl` (append). Verdict vocabulary: `pass | warning | fail | skipped`.
+
+**Screenshot store — new project-scoped resource.** Located at `<memory_project>/.screenshots/<component>/<viewport>.{png,meta.json}`. Stores regression baselines AND parity references with 9-field `.meta.json` (schema_version, role, viewport, captured_at, sha256, originating_task, captured_by enum, prior_hash, source — populated for parity refs only with `{type, uri}`). 1-deep history via `.previous.png` + `.previous.meta.json` siblings; unconditional drop on next update. Hash integrity checks at every write.
+
+**New skill + scripts:**
+
+- `screenshot-store-reader` (v1.0.0, haiku, user-invocable: false) — defensive wrapper over `scripts/screenshot-store-read.sh`. Mirrors `alignment-reader` / `project-state-reader` / `task-frontmatter-reader` pattern
+- `scripts/screenshot-store-read.sh` — inspects store state; 6 warning codes (`store_missing`, `component_missing_meta`, `meta_schema_mismatch`, `hash_mismatch`, `orphan_meta`, `error`); never throws except on IO errors
+- `scripts/screenshot-store-write.sh` — `write-baseline` + `write-parity-reference` modes; 6-step atomic rotation with sha256 verification and rollback on failure; input-validation regexes on component names, viewports, enum values
+
+**New references:**
+
+- `references/screenshot-store-schema.md` — canonical `.meta.json` v1.0 + directory layout + rotation rules + 6 warning codes + 3 example metas + versioning policy
+- `references/validation-gate-result.md` — shared result envelope v1.0 for all `/validate:*` commands; per-gate `details` shapes (wrappers vs framework-owned vs visual); aggregate envelope spec; 4 full example envelopes
+
+**Plugin dependencies:** `code-quality-tools` added to `.claude-plugin/plugin.json` `dependencies[]`. Now two hard deps (alongside `dev-guides-navigator`). Minimum supported code-quality-tools version: 3.0.0 (runtime preflight in each wrapper).
+
+**`/validate` (existing, unchanged) vs `/validate-*` (new)** — documented disambiguation in `commands/validate.md`. Original `/validate` checks architecture-fit; new `/validate-*` family checks quality gates. Complementary, not conflicting.
+
+### v1 explicit non-goals (v2 candidates documented)
+
+Tracked in the task's `v2-candidates.md`:
+
+- AI-driven gate applicability judgment (auto-skip inapplicable gates)
+- Deferred visual-change approvals via `/complete` batch hook (`.candidate` staging)
+- Extended `.meta.json` fields (ignore regions, DPR, capture-engine version, etc.)
+- Parallel `/validate:all` execution
+- Per-component visual coverage manifest for `/validate:all`
+
+### Validated
+
+- Scripts smoke-tested on 7 fixtures (first baseline, rotation, 1-deep enforcement, parity with provenance, 3 input-validation errors). prior_hash chain integrity verified across 3 rotations
+- Quick-trace paper test on pattern-validating wrapper (`validate-tdd`) found 3 MAJOR pattern issues BEFORE replication (task-root ambiguity, sibling-command invocation pattern, exit-code semantics) — all fixed before replicating to solid/dry/security
+- Structured 3-phase paper test across the cross-artifact integration found 3 MAJOR + 5 MINOR + 3 NIT, no BLOCKERs: sed-replica drift in solid/dry/security (stale "tdd.md" refs), `/validate:all` per-component aggregation rule undefined, `/validate:all` CI-mode handling undefined. All 3 MAJORs + 3 of 5 MINORs applied
+- Plugin-structure auditor: 24/30. 2 MAJORs fixed (over-granted `Edit`/`Task` on wrappers tightened; `/validate` vs `/validate-*` disambiguation documented)
+
 ## [3.12.4] - 2026-04-24
 
 ### Fixed — alignment conversation UX (two gaps)

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -37,6 +37,27 @@ Consumers distinguish states via warnings, not the null value: `code_path_unknow
 
 **Signal orthogonality:** `signals_used[]` contains BOTH epic-decomposition signals (used for the `decision` branch) AND orthogonal signals like `scope_contract_recommended` (v3.12.0+). Consumers branch on `decision` for decomposition and separately inspect `signals_used[]` for scope-contract warrant. The two judgments are independent.
 
+## Validation Gates (v3.13.0+)
+
+Individual `/validate:*` commands for on-demand quality gates. Replaces `/complete`-only all-or-nothing gating with per-aspect, per-moment validation.
+
+**7 gates + 1 orchestrator:**
+- `validate-tdd` / `validate-solid` / `validate-dry` / `validate-security` — thin wrappers over `code-quality-tools` skills; add task context + persistence + shared envelope
+- `validate-guides` — framework-owned; verifies `research.md` + `architecture.md` cite `dev-guides-navigator` guides
+- `validate-visual-regression <component> <viewport>` — captures via Playwright MCP, diffs via `odiff`/`pixelmatch`, prompts regression/intentional/cancel on diff. Intentional approval rotates baseline inline (no deferred approval in v1)
+- `validate-visual-parity <component> <viewport> <reference>` — compares against design comp (PNG/JPG, Figma URL via MCP, HTML file headless-rendered). React/PSD/Sketch deferred to v2
+- `validate-all` — sequential orchestrator; non-interactive CI mode skips visual gates
+
+**Shared result envelope** (per `references/validation-gate-result.md` v1.0): every gate emits `{schema_version, gate, task, run_at, verdict, details, messages}`. Verdicts: `pass | warning | fail | skipped`. Persisted to `<task>/validations/latest/<gate>.json` (overwrite) + `<task>/validations/history.jsonl` (append).
+
+**Screenshot store** (per `references/screenshot-store-schema.md` v1.0) at `<memory_project>/.screenshots/<component>/<viewport>.{png,meta.json}`. 9-field `.meta.json` with `role`, `captured_by` enum, `prior_hash` chain, `source` for parity refs. 1-deep `.previous` history.
+
+**Soft-nudge posture:** `fail` signals but never blocks; visual diffs require explicit user classification; `/validate:all` CI mode explicitly skips prompts rather than silent-defaulting.
+
+**Hard dependency:** `code-quality-tools` (v3.0.0+) added to `plugin.json`. Second hard dep alongside `dev-guides-navigator`.
+
+**NOT wrapped** (keep invoking directly via `/code-quality:*` namespace): `lint`, `coverage`, `review`, `audit`, `ultrareview`, `architecture-debate`, `security-debate`. `/validate:all` surfaces them as discoverability hint.
+
 ## Alignment Step (v3.12.0+)
 
 Optional scope contract authored before Phase 1 via `/scope <task>`. Produces `alignment.md` with H2 sections (`## Task-Level`, `## Phase 1 — Research`, `## Phase 2 — Architecture`, `## Phase 3 — Implementation`), each carrying the same 4-field shape: Goal / Expected result / Success criteria / Non-goals. See `references/alignment-contract.md` for grammar v1.0.

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -35,8 +35,11 @@ Phases apply per task, not per project. A project can have tasks at different ph
 /plugin install drupal-dev-framework@camoa-skills
 ```
 
-**Declared dependency:**
-- `dev-guides-navigator` — online guide discovery with caching (60+ Drupal/CSS/design guides). Enforced via `plugin.json` `dependencies`. Missing-dependency failures surface at install time.
+**Declared dependencies (2 as of v3.13.0):**
+- `dev-guides-navigator` — online guide discovery with caching (60+ Drupal/CSS/design guides)
+- `code-quality-tools` (v3.13.0+) — powers the `/validate:tdd|solid|dry|security` wrappers (minimum version 3.0.0)
+
+Both enforced via `plugin.json` `dependencies`. Missing-dependency failures surface at install time (CLI v2.1.110+).
 
 **Recommended companion plugins:**
 - `superpowers` — TDD enforcement, brainstorming, verification workflows
@@ -96,7 +99,12 @@ Phases apply per task, not per project. A project can have tasks at different ph
 
 | Command | Description |
 |---------|-------------|
-| `/validate [file]` | Check implementation against architecture and standards |
+| `/validate [file]` | Check implementation against architecture decisions (architecture-fit validator) |
+| `/validate:tdd` / `:solid` / `:dry` / `:security` | **(v3.13.0)** Individual quality gates wrapping `code-quality-tools` skills with task context + persistence |
+| `/validate:guides` | **(v3.13.0)** Verify research.md + architecture.md cite `dev-guides-navigator` guides |
+| `/validate:visual-regression <component> <viewport>` | **(v3.13.0)** Capture + diff against stored baseline. On diff, user classifies regression / intentional / cancel; intentional rotates baseline inline |
+| `/validate:visual-parity <component> <viewport> <reference>` | **(v3.13.0)** Compare built output against design comp (PNG/JPG, Figma URL, HTML file). Shared infrastructure with visual-regression |
+| `/validate:all` | **(v3.13.0)** Run all 7 gates sequentially; aggregate summary; discoverability hint for unwrapped `/code-quality:*` capabilities |
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
@@ -136,9 +144,9 @@ Agents handle complex multi-step tasks with model routing and cost control (`max
 | `contrib-researcher` | haiku | 15 | Searches drupal.org and contrib code for existing solutions |
 | `analysis-agent` **(v3.11.0)** | sonnet | 10 | Read-only scope analyzer — proposes epic decomposition as JSON per schema v1.0 |
 
-### Skills (21)
+### Skills (22)
 
-Skills are invoked automatically by commands and agents — 10 are user-invocable, 11 are internal:
+Skills are invoked automatically by commands and agents — 10 are user-invocable, 12 are internal:
 
 | Category | Skills |
 |----------|--------|
@@ -146,7 +154,7 @@ Skills are invoked automatically by commands and agents — 10 are user-invocabl
 | **Architecture** | `component-designer`, `diagram-generator`, `guide-integrator`, `guide-loader` |
 | **Implementation** | `tdd-companion`, `code-pattern-checker`, `task-completer` |
 | **Utility** | `project-initializer`, `requirements-gatherer`, `session-resume`, `implementation-task-creator`, `task-folder-migrator` |
-| **Internal** | `phase-detector`, `memory-manager`, `task-context-loader`, `session-context-writer`, `task-frontmatter-reader` (v3.10.0), `epic-migrator` (v3.10.0), `project-state-reader` (v3.11.0), `alignment-reader` (v3.12.0) |
+| **Internal** | `phase-detector`, `memory-manager`, `task-context-loader`, `session-context-writer`, `task-frontmatter-reader` (v3.10.0), `epic-migrator` (v3.10.0), `project-state-reader` (v3.11.0), `alignment-reader` (v3.12.0), `screenshot-store-reader` (v3.13.0) |
 
 ### Methodology References (6)
 
@@ -161,7 +169,7 @@ Built-in docs enforced at specific phases:
 | `quality-gates.md` | 5 quality gates | Task completion |
 | `purposeful-code.md` | Every line has a purpose | Task completion |
 
-### Technical Contract References (3)
+### Technical Contract References (5)
 
 Machine-readable contracts consumed by skills and commands. These pin schemas and invariants so consumers don't drift:
 
@@ -170,6 +178,8 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `analysis-agent-schema.md` **(v3.11.0)** | `analysis-agent` | JSON output schema v1.0, 8 signal codes, 7 invariants, consumer guidance for `/research` + `/propose-epics` |
 | `code-path-detection.md` **(v3.11.0)** | `/set-code-path`, `/new` | Detection strategies in priority order, three-null-states table (`unknown` / `docs-only` / `set`), safety filter (hard-reject list for system roots) |
 | `alignment-contract.md` **(v3.12.0)** | `alignment-reader` | `alignment.md` grammar v1.0, 8 warning codes, JSON output contract, em-dash canonicalization rule, versioning policy |
+| `screenshot-store-schema.md` **(v3.13.0)** | `screenshot-store-reader` + `scripts/screenshot-store-{read,write}.sh` | 9-field `.meta.json` v1.0, directory layout with `.previous` rotation (1-deep), 6 warning codes, `role` enum (`baseline` / `parity_reference` / `previous`), `captured_by` + `source` provenance fields |
+| `validation-gate-result.md` **(v3.13.0)** | All `/validate:*` commands | Shared JSON envelope v1.0 emitted by every gate; 4-value verdict (`pass` / `warning` / `fail` / `skipped`); per-gate `details` shapes; aggregate envelope for `/validate:all` |
 
 ### Online Dev-Guides (60+ topics) — Required
 

--- a/drupal-dev-framework/commands/validate-all.md
+++ b/drupal-dev-framework/commands/validate-all.md
@@ -38,6 +38,13 @@ Run every validation gate sequentially against the current task. Aggregate the p
 
 4. **Run visual-regression for each stored baseline** (step 2 gate): if the store has components, iterate. For each `<component>/<viewport>` pair, invoke the visual-regression flow with the stored baseline. The user may get a diff-classification prompt per component if any diffs are found — that's expected. Sequence matters: let the user classify each before moving to the next (do NOT batch the prompts).
 
+   **Per-component result aggregation:** multiple per-baseline runs collapse into a SINGLE entry in the aggregate `gates[]` with `gate: "visual-regression"`. Verdict is the worst across all runs (`fail` if any failed > `warning` if any warned > `pass` if all passed; `skipped` only if ALL runs skipped). Per-component details go into `messages[]`:
+   > `["home-hero/1920x1080: pass", "article-card/375x812: fail (4.2% diff, classified regression)", "admin-toolbar/1920x1080: pass (intentional change accepted, baseline rotated)"]`
+
+   This keeps the aggregate envelope's `gates[]` closed to the 7 known IDs; per-component fan-out lives in `messages[]`.
+
+   **Non-interactive (CI) mode:** when `/validate:all` runs without a TTY or with an env flag indicating CI (detect via `[ -t 0 ] || [ -n "$CI" ]`), visual-regression is ENTIRELY SKIPPED with a single entry: `{"gate": "visual-regression", "verdict": "skipped", "messages": ["non-interactive mode: visual regression requires interactive classification; run /validate:visual-regression manually or in interactive session"]}`. Rationale: the classification prompt has no sensible non-interactive default — defaulting to `regression` would fail every diff (noisy); defaulting to `intentional` would silently rotate baselines (dangerous). Explicit skip is honest.
+
 5. **Aggregate into the `_all.json` envelope** (per `references/validation-gate-result.md` §6):
 
    ```json

--- a/drupal-dev-framework/commands/validate-all.md
+++ b/drupal-dev-framework/commands/validate-all.md
@@ -1,0 +1,138 @@
+---
+description: "Run all 7 validation gates (tdd, solid, dry, security, guides, visual-regression, visual-parity) sequentially against the current task. Aggregates results, prints summary table, and surfaces complementary code-quality-tools capabilities that aren't wrapped. Soft-nudge; never blocks. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>]
+---
+
+# Validate: All
+
+Run every validation gate sequentially against the current task. Aggregate the per-gate results into a single summary envelope; print a human-readable table; point at `code-quality-tools` capabilities not wrapped here (for users who want to go deeper).
+
+## Usage
+
+```
+/drupal-dev-framework:validate-all              # run all gates against current task
+/drupal-dev-framework:validate-all <task-name>  # run against a specific task
+```
+
+## What this does
+
+1. **Resolve task + project context** — same resolution as other `/validate:*` commands.
+
+2. **Determine which visual gates can run** — visual-regression and visual-parity require args (`<component>`, `<viewport>`, and for parity a `<reference>`) that this command doesn't take. So:
+   - `validate-visual-regression` → runs ONLY if the project's screenshot store already has at least one `<component>/<viewport>` with `role: baseline`. Invokes itself for EACH known component+viewport pair. If the store is empty → skipped with a helpful message.
+   - `validate-visual-parity` → v1 ALWAYS skips in the `/validate:all` flow (no way to know the user's intended reference per-invocation). User runs `/validate:visual-parity` manually with explicit args.
+
+   v2 candidate: per-task "visual coverage manifest" declaring which components and references to include in `/validate:all`. For now, user picks.
+
+3. **Run the 5 non-visual gates sequentially**:
+   - `/drupal-dev-framework:validate-tdd` → capture envelope
+   - `/drupal-dev-framework:validate-solid` → capture
+   - `/drupal-dev-framework:validate-dry` → capture
+   - `/drupal-dev-framework:validate-security` → capture
+   - `/drupal-dev-framework:validate-guides` → capture
+
+   Sequential. Cache locality benefits (each gate may re-use loaded dev-guides, git state, etc.). Parallel is a v2 candidate.
+
+   For each: execute the flow of the target command within this command's execution context (same pattern as `/scope` invocation from `/research` — do NOT shell out to sibling slash commands). Produce the result envelope per `references/validation-gate-result.md`.
+
+4. **Run visual-regression for each stored baseline** (step 2 gate): if the store has components, iterate. For each `<component>/<viewport>` pair, invoke the visual-regression flow with the stored baseline. The user may get a diff-classification prompt per component if any diffs are found — that's expected. Sequence matters: let the user classify each before moving to the next (do NOT batch the prompts).
+
+5. **Aggregate into the `_all.json` envelope** (per `references/validation-gate-result.md` §6):
+
+   ```json
+   {
+     "schema_version": "1.0",
+     "run_at": "<ISO-8601 UTC>",
+     "task": "<task_name>",
+     "gates": [
+       {"gate": "tdd", "verdict": "pass"},
+       {"gate": "solid", "verdict": "warning", "messages": ["..."]},
+       {"gate": "dry", "verdict": "pass"},
+       {"gate": "security", "verdict": "pass"},
+       {"gate": "guides", "verdict": "fail", "messages": ["..."]},
+       {"gate": "visual-regression", "verdict": "skipped", "messages": ["No baselines in store"]},
+       {"gate": "visual-parity", "verdict": "skipped", "messages": ["visual-parity requires explicit reference; run manually"]}
+     ],
+     "summary": {"pass": 3, "warning": 1, "fail": 1, "skipped": 2, "total": 7},
+     "discoverability_hint": "For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
+   }
+   ```
+
+6. **Persist** — write aggregate to:
+   - `<task_folder>/validations/latest/_all.json` (overwrite)
+   - `<task_folder>/validations/history.jsonl` (append)
+
+   Note: each individual gate that ran also already persisted its own `latest/<gate>.json`. The `_all.json` is an additional summary, not a replacement.
+
+7. **Print CLI summary** — tabular output:
+
+   ```
+   Validation summary for <task_name>:
+
+     Gate                  Verdict    Notes
+     tdd                   pass       all checks passed
+     solid                 warning    SettingsForm violates SRP
+     dry                   pass       no duplication found
+     security              pass       no findings
+     guides                fail       no guide citations in research.md
+     visual-regression     skipped    no baselines in store yet
+     visual-parity         skipped    run manually with <reference>
+
+     Totals: 3 pass · 1 warning · 1 fail · 2 skipped
+
+   For deeper coverage, see:
+     /code-quality:lint          (coding standards)
+     /code-quality:coverage      (test coverage)
+     /code-quality:review        (rubric-scored review)
+     /code-quality:audit         (full code-quality audit)
+     /code-quality:ultrareview   (cloud-hosted deep review)
+
+   Saved:
+     summary → <task>/validations/latest/_all.json
+     history → <task>/validations/history.jsonl
+   ```
+
+8. **Exit behavior** — In interactive mode, the printed summary is the signal. When chained non-interactively (CI), exit with a code reflecting the worst verdict: 0 if all pass/warning/skipped; 1 if any fail.
+
+## Sequential execution
+
+Gates run one at a time. Rationale: simpler error handling, cache locality (git state, guide loads), and the visual gates require user input mid-run which doesn't parallelize well. v2 candidate for non-interactive gates (tdd/solid/dry/security can parallelize; visual gates can't).
+
+## What this does NOT do
+
+- Does NOT wrap `/code-quality:lint`, `:coverage`, `:review`, `:audit`, `:ultrareview`, `:architecture-debate`, `:security-debate`. These stay invokable via their native `/code-quality:*` namespace. `/validate:all` surfaces them as available via the discoverability hint.
+- Does NOT auto-skip gates based on AI-inferred applicability. v1 runs every gate (respects each gate's own skip semantics — e.g., `/validate:guides` skips if no phase artifacts exist). AI-driven skipping is a v2 candidate.
+- Does NOT enforce `/validate:visual-parity` to run. It requires an explicit reference per invocation; user runs it manually when they have a comp in hand.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No task context | Abort; exit 2 |
+| Individual gate fails to execute (e.g., code-quality-tools missing) | That gate's envelope gets `verdict: skipped` with the failure in messages. Other gates continue. Summary reflects the mix |
+| All gates skip | Print summary with all-skipped; exit 0; user sees there's no signal to act on |
+| Write to `_all.json` fails | Print summary to stdout anyway; mention write failure in trailer |
+
+## Soft-nudge posture
+
+- Individual gate `fail` never blocks; `/validate:all` aggregates, surfaces, and lets the user decide
+- The discoverability hint is a nudge, not noise — shown once at the end, not per-gate
+- Visual-regression prompts happen inline per component (can't batch the classification prompts in v1)
+
+## v2 candidates
+
+- Per-task visual coverage manifest (declare which components/viewports/references go into `/validate:all`)
+- Parallel execution of non-visual gates
+- AI-driven gate skipping based on task context / applicability metadata
+- Deferred visual-change approvals via `/complete` batch hook
+
+See `implementation_process/in_progress/<this-task>/v2-candidates.md`.
+
+## Related
+
+- `/drupal-dev-framework:validate-tdd` / `:validate-solid` / `:validate-dry` / `:validate-security` — wrapped gates
+- `/drupal-dev-framework:validate-guides` — framework-owned gate
+- `/drupal-dev-framework:validate-visual-regression` / `:validate-visual-parity` — visual gates
+- `references/validation-gate-result.md` — shared envelope + aggregate envelope schema
+- `/code-quality:lint` / `:coverage` / `:review` / `:audit` / `:ultrareview` — complementary `code-quality-tools` capabilities not wrapped here

--- a/drupal-dev-framework/commands/validate-dry.md
+++ b/drupal-dev-framework/commands/validate-dry.md
@@ -1,0 +1,122 @@
+---
+description: "Run the DRY quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:dry — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>]
+---
+
+# Validate: DRY
+
+Run the DRY quality gate (DRY — code duplication detection) against the current task. Wraps `/code-quality:dry` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+
+## Usage
+
+```
+/drupal-dev-framework:validate-dry              # run against current task from session context
+/drupal-dev-framework:validate-dry <task-name>  # run against a specific task
+```
+
+## What this does
+
+1. **Resolve task context** — resolve the project folder in this order:
+   (a) read `session_context.json` if present — it carries the active project's absolute path
+   (b) walk up from `$PWD` until you find a directory containing `implementation_process/`
+   (c) abort with "no project context — run /drupal-dev-framework:next first, or cd to a project workspace" if neither resolves
+
+   Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
+
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+
+3. **Invoke the check** — execute the `/code-quality:dry` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+
+4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:dry` wrote a JSON report to `.reports/dry.json` (disk-read fallback), capture its path.
+
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+
+6. **Persist** — write the envelope to TWO locations:
+   - `<task_folder>/validations/latest/dry.json` — overwrite (most-recent-run lookup)
+   - `<task_folder>/validations/history.jsonl` — append (full run log)
+
+7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
+
+## Verdict interpretation
+
+`/code-quality:dry` output has to be mapped to our 4-value verdict enum. Heuristics (ordered; first match wins):
+
+| Signal in output | Our verdict |
+|---|---|
+| Explicit "PASS" / "✓" / "all checks passed" / "no violations" | `pass` |
+| Explicit "FAIL" / "✗" / "violations found" / "tests missing for <x>" | `fail` |
+| Warnings-but-not-fatal phrasing ("1 concern", "minor issue", "consider") | `warning` |
+| Skip indicators ("not applicable", "no code changes to check", "skipped — <reason>") | `skipped` |
+| Ambiguous or empty output | `warning` (conservative — surface for human review) |
+
+If `/code-quality:dry` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
+
+## Shared envelope shape (per `references/validation-gate-result.md`)
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "dry",
+  "task": "<task_name>",
+  "run_at": "<ISO-8601 UTC>",
+  "verdict": "pass",
+  "details": {
+    "source": "code-quality-tools:dry",
+    "raw_output_path": "<path to .reports/dry.json if produced, else null>",
+    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
+  },
+  "messages": ["<top findings>"]
+}
+```
+
+## Persistence
+
+Write order:
+1. `mkdir -p <task_folder>/validations/latest`
+2. Write envelope to `<task_folder>/validations/latest/dry.json` (overwrites prior run)
+3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+
+`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+
+## CLI output format
+
+```
+DRY gate on <task_name>: <verdict>
+
+  • <message 1>
+  • <message 2>
+  • <message 3>
+
+Saved:
+  latest  → <task>/validations/latest/dry.json
+  history → <task>/validations/history.jsonl
+```
+
+On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On `fail`: up to 5 top findings surfaced.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no `<task-name>` arg | Print "no task context; pass a task name or run /drupal-dev-framework:next first" + exit 2 |
+| `<task-name>` doesn't resolve to a folder | Print candidate suggestions + exit 2 |
+| `code-quality-tools` plugin missing | Print "code-quality-tools not installed; install via /plugin install code-quality-tools@camoa-skills" + exit 3 |
+| `/code-quality:dry` fails to execute | Emit envelope with `verdict: skipped`, messages describing the failure, exit 0 |
+| Persistence write fails | Still print CLI summary; mention the failure in messages; exit 1 |
+
+## Soft-nudge posture
+
+- Manual invocation always runs, regardless of task kind or applicability signals (no auto-skip in v1)
+- `fail` verdict signals but does not block — user can continue working or fix the issue
+- Non-zero exit codes surface the signal to CI / `/validate:all` chaining, but the local session keeps going
+
+## Related
+
+- `/drupal-dev-framework:validate-solid` / `:validate-dry` / `:validate-security` — sibling wrappers, same pattern
+- `/drupal-dev-framework:validate-guides` — framework-owned gate, not a wrapper
+- `/drupal-dev-framework:validate-visual-parity` / `:validate-visual-regression` — visual gates
+- `/drupal-dev-framework:validate-all` — sequential orchestrator that calls this + all other gates
+- `references/validation-gate-result.md` — the shared envelope contract
+- `/code-quality:dry` — the underlying check this command wraps
+- `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage

--- a/drupal-dev-framework/commands/validate-dry.md
+++ b/drupal-dev-framework/commands/validate-dry.md
@@ -1,6 +1,6 @@
 ---
 description: "Run the DRY quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:dry — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
-allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+allowed-tools: Read, Write, Bash, Glob, Skill
 argument-hint: [<task-name>]
 ---
 
@@ -24,13 +24,13 @@ Run the DRY quality gate (DRY — code duplication detection) against the curren
 
    Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
 
-2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. Minimum supported version: **3.0.0** (earlier versions may work but are untested against this wrapper). If missing, abort with install instructions.
 
-3. **Invoke the check** — execute the `/code-quality:dry` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+3. **Invoke the check** — execute the `/code-quality:dry` flow as documented in the `code-quality-tools` plugin's `commands/dry.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the dry check, surface findings), then capture the output for envelope construction in step 4.
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:dry` wrote a JSON report to `.reports/dry.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the dry gate.
 
 6. **Persist** — write the envelope to TWO locations:
    - `<task_folder>/validations/latest/dry.json` — overwrite (most-recent-run lookup)

--- a/drupal-dev-framework/commands/validate-guides.md
+++ b/drupal-dev-framework/commands/validate-guides.md
@@ -1,6 +1,6 @@
 ---
 description: "Verify that the task's phase artifacts cite dev-guides-navigator guides appropriate to the domain. Framework-owned gate — not a wrapper. Reads research.md + architecture.md for guide citations, surfaces gaps. Soft-nudge posture; never blocks. Introduced v3.13.0."
-allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+allowed-tools: Read, Write, Bash, Glob, Skill
 argument-hint: [<task-name>]
 ---
 

--- a/drupal-dev-framework/commands/validate-guides.md
+++ b/drupal-dev-framework/commands/validate-guides.md
@@ -1,0 +1,112 @@
+---
+description: "Verify that the task's phase artifacts cite dev-guides-navigator guides appropriate to the domain. Framework-owned gate — not a wrapper. Reads research.md + architecture.md for guide citations, surfaces gaps. Soft-nudge posture; never blocks. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>]
+---
+
+# Validate: Guides
+
+Verify that this task's phase artifacts reference Drupal development guides loaded via the `dev-guides-navigator` plugin. The premise: decisions made without consulting authoritative guides drift from community consensus. Catching "no guide citations in research.md or architecture.md" early prevents downstream architectural debt.
+
+This is a **framework-owned** gate — it does NOT wrap a `code-quality-tools` skill. Implementation lives here in drupal-dev-framework.
+
+## Usage
+
+```
+/drupal-dev-framework:validate-guides              # run against current task
+/drupal-dev-framework:validate-guides <task-name>  # run against a specific task
+```
+
+## What this does
+
+1. **Resolve task context** — same resolution as other `/validate:*` commands:
+   (a) read `session_context.json` if present
+   (b) walk up from `$PWD` until you find `implementation_process/`
+   (c) abort with "no project context" if neither resolves
+
+   Locate the task folder under `<project>/implementation_process/in_progress/**/<task-name>/`.
+
+2. **Inspect phase artifacts** — read any of these that exist in the task folder:
+   - `research.md` (Phase 1 artifact)
+   - `architecture.md` (Phase 2 artifact)
+   - `implementation.md` (Phase 3 artifact)
+
+3. **Extract guide citations** — scan for guide references in each artifact. Accept:
+   - URLs matching `camoa.github.io/dev-guides/[a-z0-9/-]+` (the published dev-guides site)
+   - Inline mentions of guide slugs in the form `drupal/<category>/<topic>`, `design-systems/<topic>`, `nextjs/<topic>`, or similar kebab-case paths
+   - Markdown reference links `[...](https://camoa.github.io/dev-guides/...)`
+   - Explicit "Loaded guide: <slug>" annotations if the `dev-guides-navigator` skill wrote them
+
+4. **Judge adequacy** — apply verdict rules:
+   - `pass` → ≥1 guide citation found in research.md AND ≥1 in architecture.md (if architecture.md exists)
+   - `warning` → ≥1 citation found overall but phase coverage uneven (e.g., research cites guides but architecture doesn't)
+   - `fail` → no guide citations found in any phase artifact AND at least one artifact exists with ≥200 lines of content (substantive work without guide consultation)
+   - `skipped` → no phase artifacts exist yet (task hasn't progressed past creation)
+
+   The 200-line substance threshold prevents false-positives on near-empty stub artifacts.
+
+5. **Emit the shared envelope** (per `references/validation-gate-result.md`) with gate-specific details:
+
+   ```json
+   "details": {
+     "source": "framework:guides",
+     "checked_artifacts": ["<abs path to each artifact examined>"],
+     "guides_cited": ["<slug>", "<slug>"],
+     "guides_expected_min": 1
+   }
+   ```
+
+   - `guides_cited` — unique slugs found across all artifacts, deduplicated
+   - `guides_expected_min` — v1 hard-coded to 1 per substantive artifact; v2 candidate for per-task configuration
+
+6. **Persist** — write envelope to:
+   - `<task_folder>/validations/latest/guides.json` (overwrite)
+   - `<task_folder>/validations/history.jsonl` (append)
+
+7. **Print CLI summary** — show verdict, citations found, and per-artifact gaps. On `fail`, suggest running `/dev-guides-navigator` with domain keywords. Non-zero exit (1) only when invoked non-interactively.
+
+## Verdict messages
+
+Examples of what `messages[]` contains:
+
+- `pass`: `["3 guide citations found across research.md and architecture.md"]`
+- `warning`: `["2 citations in research.md but 0 in architecture.md — architecture may be under-grounded"]`
+- `fail`: `["No guide citations found in any phase artifact", "Suggest: /dev-guides-navigator with keywords from task.md Goal"]`
+- `skipped`: `["No phase artifacts exist yet; run /research to begin"]`
+
+## Why this gate exists
+
+The `dev-guides-navigator` plugin exists precisely because AI-generated Drupal work drifts from community consensus when it doesn't load authoritative guides. This gate surfaces the "we didn't check" case and recommends action — it's NOT a block, just a visible signal during `/validate:all`.
+
+Applicability (in the informal sense): relevant whenever a task writes substantive `research.md` or `architecture.md`. Not relevant for trivial config changes, test-only tasks, or documentation-only work. v1 has no auto-skip; user decides when to invoke.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no `<task-name>` arg | Print "no task context" + exit 2 |
+| `<task-name>` doesn't resolve to a folder | Print candidate suggestions + exit 2 |
+| Task folder has no phase artifacts | Emit `verdict: skipped` with helpful message |
+| Persistence write fails | Print CLI summary; mention failure in messages; exit 1 |
+
+## Soft-nudge posture
+
+- Manual invocation always runs
+- `fail` verdict signals under-grounded work but never blocks downstream phases
+- The recommendation ("run `/dev-guides-navigator`") is a suggestion; user decides if it's worth the time
+
+## v2 candidates
+
+- Per-task configurable `guides_expected_min` (e.g., "this complex task should cite ≥3")
+- Detecting STALE citations (guide was updated since task cited it)
+- Detecting domain mismatch (task is about forms, cited guides are about entities)
+
+See `implementation_process/in_progress/<this-task>/v2-candidates.md` for the full deferred-features inventory.
+
+## Related
+
+- `/drupal-dev-framework:validate-tdd` / `:validate-solid` / `:validate-dry` / `:validate-security` — sibling gate commands; wrappers
+- `/drupal-dev-framework:validate-visual-parity` / `:validate-visual-regression` — visual gates
+- `/drupal-dev-framework:validate-all` — sequential orchestrator
+- `references/validation-gate-result.md` — the shared envelope contract
+- `dev-guides-navigator` plugin — the guide discovery tool whose usage this gate verifies

--- a/drupal-dev-framework/commands/validate-security.md
+++ b/drupal-dev-framework/commands/validate-security.md
@@ -1,0 +1,122 @@
+---
+description: "Run the Security quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:security — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>]
+---
+
+# Validate: Security
+
+Run the Security quality gate (Security — OWASP Top 10 style audit + Drupal-specific sinks) against the current task. Wraps `/code-quality:security` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+
+## Usage
+
+```
+/drupal-dev-framework:validate-security              # run against current task from session context
+/drupal-dev-framework:validate-security <task-name>  # run against a specific task
+```
+
+## What this does
+
+1. **Resolve task context** — resolve the project folder in this order:
+   (a) read `session_context.json` if present — it carries the active project's absolute path
+   (b) walk up from `$PWD` until you find a directory containing `implementation_process/`
+   (c) abort with "no project context — run /drupal-dev-framework:next first, or cd to a project workspace" if neither resolves
+
+   Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
+
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+
+3. **Invoke the check** — execute the `/code-quality:security` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+
+4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:security` wrote a JSON report to `.reports/security.json` (disk-read fallback), capture its path.
+
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+
+6. **Persist** — write the envelope to TWO locations:
+   - `<task_folder>/validations/latest/security.json` — overwrite (most-recent-run lookup)
+   - `<task_folder>/validations/history.jsonl` — append (full run log)
+
+7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
+
+## Verdict interpretation
+
+`/code-quality:security` output has to be mapped to our 4-value verdict enum. Heuristics (ordered; first match wins):
+
+| Signal in output | Our verdict |
+|---|---|
+| Explicit "PASS" / "✓" / "all checks passed" / "no violations" | `pass` |
+| Explicit "FAIL" / "✗" / "violations found" / "tests missing for <x>" | `fail` |
+| Warnings-but-not-fatal phrasing ("1 concern", "minor issue", "consider") | `warning` |
+| Skip indicators ("not applicable", "no code changes to check", "skipped — <reason>") | `skipped` |
+| Ambiguous or empty output | `warning` (conservative — surface for human review) |
+
+If `/code-quality:security` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
+
+## Shared envelope shape (per `references/validation-gate-result.md`)
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "security",
+  "task": "<task_name>",
+  "run_at": "<ISO-8601 UTC>",
+  "verdict": "pass",
+  "details": {
+    "source": "code-quality-tools:security",
+    "raw_output_path": "<path to .reports/security.json if produced, else null>",
+    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
+  },
+  "messages": ["<top findings>"]
+}
+```
+
+## Persistence
+
+Write order:
+1. `mkdir -p <task_folder>/validations/latest`
+2. Write envelope to `<task_folder>/validations/latest/security.json` (overwrites prior run)
+3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+
+`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+
+## CLI output format
+
+```
+Security gate on <task_name>: <verdict>
+
+  • <message 1>
+  • <message 2>
+  • <message 3>
+
+Saved:
+  latest  → <task>/validations/latest/security.json
+  history → <task>/validations/history.jsonl
+```
+
+On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On `fail`: up to 5 top findings surfaced.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no `<task-name>` arg | Print "no task context; pass a task name or run /drupal-dev-framework:next first" + exit 2 |
+| `<task-name>` doesn't resolve to a folder | Print candidate suggestions + exit 2 |
+| `code-quality-tools` plugin missing | Print "code-quality-tools not installed; install via /plugin install code-quality-tools@camoa-skills" + exit 3 |
+| `/code-quality:security` fails to execute | Emit envelope with `verdict: skipped`, messages describing the failure, exit 0 |
+| Persistence write fails | Still print CLI summary; mention the failure in messages; exit 1 |
+
+## Soft-nudge posture
+
+- Manual invocation always runs, regardless of task kind or applicability signals (no auto-skip in v1)
+- `fail` verdict signals but does not block — user can continue working or fix the issue
+- Non-zero exit codes surface the signal to CI / `/validate:all` chaining, but the local session keeps going
+
+## Related
+
+- `/drupal-dev-framework:validate-solid` / `:validate-dry` / `:validate-security` — sibling wrappers, same pattern
+- `/drupal-dev-framework:validate-guides` — framework-owned gate, not a wrapper
+- `/drupal-dev-framework:validate-visual-parity` / `:validate-visual-regression` — visual gates
+- `/drupal-dev-framework:validate-all` — sequential orchestrator that calls this + all other gates
+- `references/validation-gate-result.md` — the shared envelope contract
+- `/code-quality:security` — the underlying check this command wraps
+- `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage

--- a/drupal-dev-framework/commands/validate-security.md
+++ b/drupal-dev-framework/commands/validate-security.md
@@ -1,6 +1,6 @@
 ---
 description: "Run the Security quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:security — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
-allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+allowed-tools: Read, Write, Bash, Glob, Skill
 argument-hint: [<task-name>]
 ---
 
@@ -24,13 +24,13 @@ Run the Security quality gate (Security — OWASP Top 10 style audit + Drupal-sp
 
    Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
 
-2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. Minimum supported version: **3.0.0** (earlier versions may work but are untested against this wrapper). If missing, abort with install instructions.
 
-3. **Invoke the check** — execute the `/code-quality:security` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+3. **Invoke the check** — execute the `/code-quality:security` flow as documented in the `code-quality-tools` plugin's `commands/security.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the security check, surface findings), then capture the output for envelope construction in step 4.
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:security` wrote a JSON report to `.reports/security.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the security gate.
 
 6. **Persist** — write the envelope to TWO locations:
    - `<task_folder>/validations/latest/security.json` — overwrite (most-recent-run lookup)

--- a/drupal-dev-framework/commands/validate-solid.md
+++ b/drupal-dev-framework/commands/validate-solid.md
@@ -1,0 +1,122 @@
+---
+description: "Run the SOLID quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:solid — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>]
+---
+
+# Validate: SOLID
+
+Run the SOLID quality gate (SOLID principles compliance (single responsibility, open-closed, LSP, interface segregation, dependency inversion)) against the current task. Wraps `/code-quality:solid` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+
+## Usage
+
+```
+/drupal-dev-framework:validate-solid              # run against current task from session context
+/drupal-dev-framework:validate-solid <task-name>  # run against a specific task
+```
+
+## What this does
+
+1. **Resolve task context** — resolve the project folder in this order:
+   (a) read `session_context.json` if present — it carries the active project's absolute path
+   (b) walk up from `$PWD` until you find a directory containing `implementation_process/`
+   (c) abort with "no project context — run /drupal-dev-framework:next first, or cd to a project workspace" if neither resolves
+
+   Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
+
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+
+3. **Invoke the check** — execute the `/code-quality:solid` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+
+4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:solid` wrote a JSON report to `.reports/solid.json` (disk-read fallback), capture its path.
+
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+
+6. **Persist** — write the envelope to TWO locations:
+   - `<task_folder>/validations/latest/solid.json` — overwrite (most-recent-run lookup)
+   - `<task_folder>/validations/history.jsonl` — append (full run log)
+
+7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
+
+## Verdict interpretation
+
+`/code-quality:solid` output has to be mapped to our 4-value verdict enum. Heuristics (ordered; first match wins):
+
+| Signal in output | Our verdict |
+|---|---|
+| Explicit "PASS" / "✓" / "all checks passed" / "no violations" | `pass` |
+| Explicit "FAIL" / "✗" / "violations found" / "tests missing for <x>" | `fail` |
+| Warnings-but-not-fatal phrasing ("1 concern", "minor issue", "consider") | `warning` |
+| Skip indicators ("not applicable", "no code changes to check", "skipped — <reason>") | `skipped` |
+| Ambiguous or empty output | `warning` (conservative — surface for human review) |
+
+If `/code-quality:solid` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
+
+## Shared envelope shape (per `references/validation-gate-result.md`)
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "solid",
+  "task": "<task_name>",
+  "run_at": "<ISO-8601 UTC>",
+  "verdict": "pass",
+  "details": {
+    "source": "code-quality-tools:solid",
+    "raw_output_path": "<path to .reports/solid.json if produced, else null>",
+    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
+  },
+  "messages": ["<top findings>"]
+}
+```
+
+## Persistence
+
+Write order:
+1. `mkdir -p <task_folder>/validations/latest`
+2. Write envelope to `<task_folder>/validations/latest/solid.json` (overwrites prior run)
+3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+
+`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+
+## CLI output format
+
+```
+SOLID gate on <task_name>: <verdict>
+
+  • <message 1>
+  • <message 2>
+  • <message 3>
+
+Saved:
+  latest  → <task>/validations/latest/solid.json
+  history → <task>/validations/history.jsonl
+```
+
+On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On `fail`: up to 5 top findings surfaced.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no `<task-name>` arg | Print "no task context; pass a task name or run /drupal-dev-framework:next first" + exit 2 |
+| `<task-name>` doesn't resolve to a folder | Print candidate suggestions + exit 2 |
+| `code-quality-tools` plugin missing | Print "code-quality-tools not installed; install via /plugin install code-quality-tools@camoa-skills" + exit 3 |
+| `/code-quality:solid` fails to execute | Emit envelope with `verdict: skipped`, messages describing the failure, exit 0 |
+| Persistence write fails | Still print CLI summary; mention the failure in messages; exit 1 |
+
+## Soft-nudge posture
+
+- Manual invocation always runs, regardless of task kind or applicability signals (no auto-skip in v1)
+- `fail` verdict signals but does not block — user can continue working or fix the issue
+- Non-zero exit codes surface the signal to CI / `/validate:all` chaining, but the local session keeps going
+
+## Related
+
+- `/drupal-dev-framework:validate-solid` / `:validate-dry` / `:validate-security` — sibling wrappers, same pattern
+- `/drupal-dev-framework:validate-guides` — framework-owned gate, not a wrapper
+- `/drupal-dev-framework:validate-visual-parity` / `:validate-visual-regression` — visual gates
+- `/drupal-dev-framework:validate-all` — sequential orchestrator that calls this + all other gates
+- `references/validation-gate-result.md` — the shared envelope contract
+- `/code-quality:solid` — the underlying check this command wraps
+- `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage

--- a/drupal-dev-framework/commands/validate-solid.md
+++ b/drupal-dev-framework/commands/validate-solid.md
@@ -1,6 +1,6 @@
 ---
 description: "Run the SOLID quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:solid — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
-allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+allowed-tools: Read, Write, Bash, Glob, Skill
 argument-hint: [<task-name>]
 ---
 
@@ -24,13 +24,13 @@ Run the SOLID quality gate (SOLID principles compliance (single responsibility, 
 
    Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
 
-2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. Minimum supported version: **3.0.0** (earlier versions may work but are untested against this wrapper). If missing, abort with install instructions.
 
-3. **Invoke the check** — execute the `/code-quality:solid` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+3. **Invoke the check** — execute the `/code-quality:solid` flow as documented in the `code-quality-tools` plugin's `commands/solid.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the solid check, surface findings), then capture the output for envelope construction in step 4.
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:solid` wrote a JSON report to `.reports/solid.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the solid gate.
 
 6. **Persist** — write the envelope to TWO locations:
    - `<task_folder>/validations/latest/solid.json` — overwrite (most-recent-run lookup)

--- a/drupal-dev-framework/commands/validate-tdd.md
+++ b/drupal-dev-framework/commands/validate-tdd.md
@@ -1,0 +1,122 @@
+---
+description: "Run the TDD quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:tdd — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>]
+---
+
+# Validate: TDD
+
+Run the TDD (Red-Green-Refactor discipline) quality gate against the current task. Wraps `/code-quality:tdd` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+
+## Usage
+
+```
+/drupal-dev-framework:validate-tdd              # run against current task from session context
+/drupal-dev-framework:validate-tdd <task-name>  # run against a specific task
+```
+
+## What this does
+
+1. **Resolve task context** — resolve the project folder in this order:
+   (a) read `session_context.json` if present — it carries the active project's absolute path
+   (b) walk up from `$PWD` until you find a directory containing `implementation_process/`
+   (c) abort with "no project context — run /drupal-dev-framework:next first, or cd to a project workspace" if neither resolves
+
+   Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
+
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+
+3. **Invoke the check** — execute the `/code-quality:tdd` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
+
+4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per §"Verdict interpretation" below. Extract any actionable findings into `messages[]`. If `/code-quality:tdd` wrote a JSON report to `.reports/tdd.json` (disk-read fallback), capture its path.
+
+5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+
+6. **Persist** — write the envelope to TWO locations:
+   - `<task_folder>/validations/latest/tdd.json` — overwrite (most-recent-run lookup)
+   - `<task_folder>/validations/history.jsonl` — append (full run log)
+
+7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
+
+## Verdict interpretation
+
+`/code-quality:tdd` output has to be mapped to our 4-value verdict enum. Heuristics (ordered; first match wins):
+
+| Signal in output | Our verdict |
+|---|---|
+| Explicit "PASS" / "✓" / "all checks passed" / "no violations" | `pass` |
+| Explicit "FAIL" / "✗" / "violations found" / "tests missing for <x>" | `fail` |
+| Warnings-but-not-fatal phrasing ("1 concern", "minor issue", "consider") | `warning` |
+| Skip indicators ("not applicable", "no code changes to check", "skipped — <reason>") | `skipped` |
+| Ambiguous or empty output | `warning` (conservative — surface for human review) |
+
+If `/code-quality:tdd` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
+
+## Shared envelope shape (per `references/validation-gate-result.md`)
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "tdd",
+  "task": "<task_name>",
+  "run_at": "<ISO-8601 UTC>",
+  "verdict": "pass",
+  "details": {
+    "source": "code-quality-tools:tdd",
+    "raw_output_path": "<path to .reports/tdd.json if produced, else null>",
+    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
+  },
+  "messages": ["<top findings>"]
+}
+```
+
+## Persistence
+
+Write order:
+1. `mkdir -p <task_folder>/validations/latest`
+2. Write envelope to `<task_folder>/validations/latest/tdd.json` (overwrites prior run)
+3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+
+`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+
+## CLI output format
+
+```
+TDD gate on <task_name>: <verdict>
+
+  • <message 1>
+  • <message 2>
+  • <message 3>
+
+Saved:
+  latest  → <task>/validations/latest/tdd.json
+  history → <task>/validations/history.jsonl
+```
+
+On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On `fail`: up to 5 top findings surfaced.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no `<task-name>` arg | Print "no task context; pass a task name or run /drupal-dev-framework:next first" + exit 2 |
+| `<task-name>` doesn't resolve to a folder | Print candidate suggestions + exit 2 |
+| `code-quality-tools` plugin missing | Print "code-quality-tools not installed; install via /plugin install code-quality-tools@camoa-skills" + exit 3 |
+| `/code-quality:tdd` fails to execute | Emit envelope with `verdict: skipped`, messages describing the failure, exit 0 |
+| Persistence write fails | Still print CLI summary; mention the failure in messages; exit 1 |
+
+## Soft-nudge posture
+
+- Manual invocation always runs, regardless of task kind or applicability signals (no auto-skip in v1)
+- `fail` verdict signals but does not block — user can continue working or fix the issue
+- Non-zero exit codes surface the signal to CI / `/validate:all` chaining, but the local session keeps going
+
+## Related
+
+- `/drupal-dev-framework:validate-solid` / `:validate-dry` / `:validate-security` — sibling wrappers, same pattern
+- `/drupal-dev-framework:validate-guides` — framework-owned gate, not a wrapper
+- `/drupal-dev-framework:validate-visual-parity` / `:validate-visual-regression` — visual gates
+- `/drupal-dev-framework:validate-all` — sequential orchestrator that calls this + all other gates
+- `references/validation-gate-result.md` — the shared envelope contract
+- `/code-quality:tdd` — the underlying check this command wraps
+- `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage

--- a/drupal-dev-framework/commands/validate-tdd.md
+++ b/drupal-dev-framework/commands/validate-tdd.md
@@ -1,6 +1,6 @@
 ---
 description: "Run the TDD quality gate on demand and persist the result to the current task folder. Thin wrapper around /code-quality:tdd — adds task context, persistence, and the shared result envelope. Soft-nudge: reports fail verdict but never blocks. Introduced v3.13.0."
-allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+allowed-tools: Read, Write, Bash, Glob, Skill
 argument-hint: [<task-name>]
 ---
 
@@ -24,7 +24,7 @@ Run the TDD (Red-Green-Refactor discipline) quality gate against the current tas
 
    Then resolve the task folder: if `<task-name>` arg is given, locate it under `<project>/implementation_process/in_progress/**/<task-name>/` (glob handles both flat and sub-epic nesting). If no arg, use the task from `session_context.json`. If the task doesn't resolve, abort with candidate suggestions.
 
-2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. If missing, abort with install instructions.
+2. **Verify dependency** — confirm `code-quality-tools` plugin is installed. Check: `ls ~/.claude/plugins/cache/camoa-skills/code-quality-tools/` returns a non-empty directory. Minimum supported version: **3.0.0** (earlier versions may work but are untested against this wrapper). If missing, abort with install instructions.
 
 3. **Invoke the check** — execute the `/code-quality:tdd` flow as documented in the `code-quality-tools` plugin's `commands/tdd.md` within this command's own execution context. Do NOT attempt to shell out to the sibling slash command. Follow its instructions (auto-detect project type, run the TDD check, surface findings), then capture the output for envelope construction in step 4.
 

--- a/drupal-dev-framework/commands/validate-visual-parity.md
+++ b/drupal-dev-framework/commands/validate-visual-parity.md
@@ -1,0 +1,137 @@
+---
+description: "Compare current built output against a design comp reference (PNG/JPG, Figma URL via MCP, or HTML file rendered headless) to check visual parity. On diff, prompts user to classify as parity-miss (fix the build) or intentional deviation (update the reference). Framework-owned; shares capture + diff infrastructure with /validate:visual-regression. Soft-nudge. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: <component> <viewport> <reference> [<url>]
+---
+
+# Validate: Visual Parity
+
+Compare the current built output against a design-comp reference and surface any parity gap. Unlike `visual-regression` (which compares against the project's own prior baseline), this compares against an **externally supplied target** — typically a Figma export, an HTML/React reference template, or a static image of the intended design.
+
+Framework-owned. Shares capture + diff infrastructure with `/validate:visual-regression`.
+
+## Usage
+
+```
+/drupal-dev-framework:validate-visual-parity <component> <viewport> <reference> [<url>]
+```
+
+- `<component>` — kebab-case identifier (e.g., `home-hero`, `article-card`)
+- `<viewport>` — `WIDTHxHEIGHT` (e.g., `1920x1080`)
+- `<reference>` — the design comp reference. Accepted in v1:
+  - Path to a PNG/JPG file (passthrough)
+  - A Figma URL (normalized via Figma MCP if available)
+  - Path to an HTML file (rendered via headless browser)
+  - Deferred to v2: React component paths, PSD, Sketch, Adobe XD — export to PNG first
+- `<url>` — optional; target URL for the built output. Resolves from project state if absent
+
+Example:
+```
+/drupal-dev-framework:validate-visual-parity home-hero 1920x1080 ~/designs/home-hero.png https://mysite.ddev.site
+/drupal-dev-framework:validate-visual-parity article-card 375x812 "https://figma.com/file/abc123/redesign?node-id=12:45" https://mysite.ddev.site/article/sample
+```
+
+## What this does
+
+1. **Resolve task + project context** — same resolution as other `/validate:*` commands.
+
+2. **Validate args** — `<component>`, `<viewport>` regex checks. `<reference>` must be a PNG/JPG path, Figma URL matching `figma.com/file/`, or HTML file path. If format unsupported in v1, emit `verdict: skipped` with a message pointing to the v1 supported formats + the "export to PNG" workaround.
+
+3. **Read the store** — invoke `screenshot-store-reader` for the project. Look for an existing parity reference at `<store>/<component>/<viewport>.png` with `role: parity_reference`.
+
+4. **Normalize the reference to a PNG:**
+   - **Path to PNG/JPG** → passthrough; use directly
+   - **Figma URL** → invoke the Figma MCP server's export tool (e.g., `mcp__figma-mcp__get_image` or equivalent per the installed Figma MCP plugin). Save to `<task_folder>/validations/tmp/parity-reference-<component>-<viewport>.png`. Record `captured_by: "figma-export"`, `source: {type: "figma", uri: <url>}`
+   - **HTML file path** → render via Playwright MCP: `mcp__plugin_playwright_playwright__browser_navigate "file://<abs-path>"` → resize to viewport → screenshot. Record `captured_by: "html-render"`, `source: {type: "html", uri: <abs-path>}`
+   - If normalization fails (Figma MCP unavailable, etc.) → emit `verdict: skipped` with actionable message.
+
+5. **Branch on imported-reference presence:**
+
+   **5a. No parity reference exists OR the imported reference differs from the newly-normalized one:**
+   - Prompt user: `"Import this reference as the parity target for <component>/<viewport>? [y]es / [n]o"`
+   - On `[y]` → invoke `scripts/screenshot-store-write.sh write-parity-reference <project> <component> <viewport> <normalized.png> <captured_by> <task> <source_type> <source_uri>`. The writer handles rotation (same 6-step sequence as baselines; rotated meta keeps `role: parity_reference`). Proceed to step 6 using the NEW reference.
+   - On `[n]` → emit `verdict: skipped`, messages `["No parity reference; user declined to import one"]`. Persist + print.
+
+   **5b. Imported reference matches the normalized one (same sha256):**
+   - Skip re-import; proceed directly to step 6.
+
+6. **Capture current built output** — same as `visual-regression` step 4: Playwright MCP → `browser_navigate <url>` → resize → screenshot. Save to `<task_folder>/validations/tmp/<component>-<viewport>.png`.
+
+7. **Run the diff** — same logic as `visual-regression` step 6: `odiff` primary, `pixelmatch` fallback. Output to `<task_folder>/validations/tmp/<component>-<viewport>.parity-diff.png`.
+
+8. **Apply tolerance** — v1 hard-coded 0.1% (0.001). If within tolerance → emit `verdict: pass`, messages `["Built output matches design comp within 0.1% tolerance"]`.
+
+9. **Diff > tolerance — classify:**
+   Print diff image path. Prompt:
+   > "Parity gap detected: `<diff_percent>%` pixels differ from the design comp. Saved diff image: `<diff_path>`. Is this:
+   >   [g] Build gap (implementation doesn't match comp — fix the build)
+   >   [i] Intentional deviation from the comp (update reference to reflect what's actually wanted)
+   >   [c] Cancel"
+
+   - `[g]` → emit `verdict: fail`. Messages include diff %, diff path, recommendation to update implementation. Set `classification: "build-gap"`, `baseline_updated: false`.
+   - `[i]` → re-import the current capture as the new parity reference: `screenshots-store-write.sh write-parity-reference` with source set to the user's own built output (`source_type: "image"`, `source_uri: <capture-path>`). This is unusual — the user is saying "the comp is wrong; the build is correct." Rare but legitimate. Set `classification: "intentional"`, `baseline_updated: true`.
+   - `[c]` → emit `verdict: skipped`, `classification: "cancelled"`.
+
+10. **Emit the shared envelope** with visual-parity-specific details:
+
+    ```json
+    "details": {
+      "source": "framework:visual-parity",
+      "component": "<component>",
+      "viewport": "<viewport>",
+      "reference_path": "<abs path to imported parity reference>",
+      "reference_source": {"type": "figma|html|image|url", "uri": "..."},
+      "capture_path": "<abs path to fresh built-output capture>",
+      "diff_path": "<abs path to parity-diff image OR null>",
+      "diff_percent": 0.038,
+      "diff_tolerance": 0.001,
+      "classification": "build-gap",
+      "baseline_updated": false
+    }
+    ```
+
+11. **Persist + print** — same pattern as other gates.
+
+## Key difference vs visual-regression
+
+| Axis | `visual-regression` | `visual-parity` |
+|---|---|---|
+| Reference source | Own prior baseline (stored) | External design comp (imported) |
+| On diff | "regression vs intentional change" | "build gap vs intentional deviation from comp" |
+| Intentional approval writes | New baseline | New parity reference |
+| Meta role | `baseline` | `parity_reference` |
+| `.meta.json` `source` field | `null` | Populated with type + uri |
+
+Same capture tooling, same diff tooling, same `.previous` rotation semantics, same shared envelope shape. Only the reference lifecycle differs.
+
+## v1 format support
+
+Per alignment.md non-goals:
+- **v1 accepted:** PNG/JPG passthrough, Figma URL (via Figma MCP), HTML file (headless render)
+- **Deferred to v2:** React components, PSD, Sketch, Adobe XD. Workaround: export to PNG first, then pass the PNG path.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no task resolution | Abort; exit 2 |
+| `<reference>` format unsupported in v1 | Emit `verdict: skipped` with format list + workaround |
+| Figma URL but Figma MCP not installed | Emit `verdict: skipped`; suggest installing the Figma MCP |
+| HTML file path but Playwright MCP + claude-in-chrome both unavailable | Emit `verdict: skipped` |
+| Writer returns `rollback` on intentional-deviation approval | Emit `verdict: fail` with writer warnings |
+
+## Soft-nudge posture
+
+Same as `visual-regression`: 0.1% tolerance, classification prompt is explicit and never silent-advances, `[c]ancel` is always safe, `fail` signals but never blocks.
+
+## v2 candidates
+
+Inherited from `visual-regression` — per-viewport tolerance, ignore regions, multi-DPR capture, deferred approval via `/complete`.
+
+## Related
+
+- `/drupal-dev-framework:validate-visual-regression` — sibling; compares against stored baseline instead of external comp
+- `/drupal-dev-framework:validate-all` — orchestrator
+- `scripts/screenshot-store-write.sh` — writer (in both `write-baseline` and `write-parity-reference` modes)
+- `skills/screenshot-store-reader` — store reader
+- `references/screenshot-store-schema.md` — canonical schema including `role: parity_reference` semantics + `source` field

--- a/drupal-dev-framework/commands/validate-visual-parity.md
+++ b/drupal-dev-framework/commands/validate-visual-parity.md
@@ -69,7 +69,7 @@ Example:
    >   [c] Cancel"
 
    - `[g]` → emit `verdict: fail`. Messages include diff %, diff path, recommendation to update implementation. Set `classification: "build-gap"`, `baseline_updated: false`.
-   - `[i]` → re-import the current capture as the new parity reference: `screenshots-store-write.sh write-parity-reference` with source set to the user's own built output (`source_type: "image"`, `source_uri: <capture-path>`). This is unusual — the user is saying "the comp is wrong; the build is correct." Rare but legitimate. Set `classification: "intentional"`, `baseline_updated: true`.
+   - `[i]` → re-import the current capture as the new parity reference. The user is saying "the comp is wrong; the build is correct." Rare but legitimate. Use **a stable URL** for `source_uri` — either the `<url>` arg the user passed (if a live URL) OR — if that's not available — generate `source_type: "url"` with the site URL the capture came from. Do NOT record `source_uri` pointing at the ephemeral `<task_folder>/validations/tmp/` capture path; that path gets cleaned up and the meta would become dangling. Invocation: `screenshot-store-write.sh write-parity-reference <project> <component> <viewport> <capture-path> <captured_by> <task> url <stable-url>`. Set `classification: "intentional"`, `baseline_updated: true`.
    - `[c]` → emit `verdict: skipped`, `classification: "cancelled"`.
 
 10. **Emit the shared envelope** with visual-parity-specific details:

--- a/drupal-dev-framework/commands/validate-visual-regression.md
+++ b/drupal-dev-framework/commands/validate-visual-regression.md
@@ -1,0 +1,146 @@
+---
+description: "Capture a screenshot of a component/page and compare against the project's stored baseline to detect unintended visual changes. On diff, prompts user to classify as regression (bug) or intentional (update baseline) with inline approval. Framework-owned; uses Playwright MCP for capture, odiff/pixelmatch for diff. Soft-nudge posture. Introduced v3.13.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: <component> <viewport> [<url>]
+---
+
+# Validate: Visual Regression
+
+Capture the current visual state of a component or page, diff it against the stored baseline, and classify any detected difference as regression or intentional. When intentional, the baseline is rotated inline (previous baseline slides to `.previous`; the fresh capture becomes the new baseline) per the screenshot store rotation rules.
+
+Framework-owned — uses Playwright MCP (primary) or claude-in-chrome MCP (fallback) for capture; `odiff` (primary) or `pixelmatch` (fallback) for diff.
+
+## Usage
+
+```
+/drupal-dev-framework:validate-visual-regression <component> <viewport> [<url>]
+```
+
+- `<component>` — kebab-case component/page identifier (e.g., `home-hero`, `article-card`, `admin-toolbar`). Used as the store key
+- `<viewport>` — display size, `WIDTHxHEIGHT` format (e.g., `1920x1080`, `375x812`)
+- `<url>` — optional; target URL to capture. If absent, attempt to resolve from task context (e.g., project `project_state.md` or last-used URL)
+
+Example:
+```
+/drupal-dev-framework:validate-visual-regression home-hero 1920x1080 https://mysite.ddev.site
+/drupal-dev-framework:validate-visual-regression article-card 375x812
+```
+
+## What this does
+
+1. **Resolve task + project context** — same resolution as other `/validate:*` commands. Need the project path to locate the screenshot store.
+
+2. **Validate args** — `<component>` matches `^[a-z0-9][a-z0-9-]*$`; `<viewport>` matches `^[0-9]+x[0-9]+$`. If `<url>` absent, attempt to resolve from project state; abort if none found with "pass a URL arg or set codePath's live URL in project_state.md".
+
+3. **Read the store** — invoke `screenshot-store-reader` skill against the project folder. Look for an existing baseline at `<store>/<component>/<viewport>.png` with `role: baseline`.
+
+4. **Capture current state** — via Playwright MCP:
+   - Tool sequence: `mcp__plugin_playwright_playwright__browser_navigate <url>` → wait for page load → `mcp__plugin_playwright_playwright__browser_resize <width> <height>` → `mcp__plugin_playwright_playwright__browser_take_screenshot`
+   - If Playwright MCP unavailable, fall back to `mcp__claude-in-chrome__*` tooling
+   - Save capture to `<task_folder>/validations/tmp/<component>-<viewport>.png`
+   - Record `captured_by` = `playwright-mcp` or `claude-in-chrome` accordingly
+
+5. **Branch on baseline presence:**
+
+   **5a. No baseline exists (first run for this component+viewport):**
+   - Prompt user: `"No baseline exists for <component>/<viewport>. Accept the current capture as the first baseline? [y]es / [n]o"`
+   - On `[y]` → invoke `scripts/screenshot-store-write.sh write-baseline <project> <component> <viewport> <capture-path> <captured_by> <task>`. Emit envelope with `verdict: pass`, messages `["First baseline established"]`. Persist + print summary.
+   - On `[n]` → emit `verdict: skipped`, messages `["No baseline; user declined to establish one"]`. Persist + print.
+
+   **5b. Baseline exists:**
+   - Proceed to diff (step 6).
+
+6. **Run the diff:**
+   - If `command -v odiff` succeeds → `odiff <baseline.png> <capture.png> <task_folder>/validations/tmp/<component>-<viewport>.diff.png`. Parse diff percentage from output.
+   - Else fall back to `pixelmatch` via Node (invoke as `npx pixelmatch` if available, or abort if no Node runtime) with the same args.
+   - If both unavailable, emit `verdict: skipped`, messages `["No image diff tool installed; install odiff (brew install odiff-bin / port) or ensure npx pixelmatch is available"]`. Persist + exit.
+
+7. **Apply tolerance** — v1 hard-coded 0.1% (0.001) pixel-diff threshold. If `diff_percent <= 0.001`, emit `verdict: pass`, messages `["No visual change detected (diff <= 0.1%)"]`. Skip to step 10.
+
+8. **Diff > tolerance — classify:**
+   Print the diff image path. Prompt user:
+   > "Diff detected: `<diff_percent>%` pixels changed. Saved diff image: `<diff_path>`. Is this:
+   >   [r] Regression (bug to fix — leave baseline as-is)
+   >   [i] Intentional change (update baseline to reflect new design)
+   >   [c] Cancel (abort without classifying)"
+
+   Default: `[c]` if unclear. Never silent-advance.
+
+   - `[r]` → emit `verdict: fail`. Messages include the diff percentage, the diff image path, and a prompt to investigate. Set `classification: "regression"`, `baseline_updated: false`. Go to step 10.
+   - `[i]` → proceed to step 9 (inline approval + rotation).
+   - `[c]` → emit `verdict: skipped`. Messages note user cancelled. Set `classification: "cancelled"`, `baseline_updated: false`. Go to step 10.
+
+9. **Inline approval + baseline rotation** (only on `[i]`):
+   - Invoke `scripts/screenshot-store-write.sh write-baseline <project> <component> <viewport> <capture-path> <captured_by> <task>`. The writer handles the 6-step rotation (prior_hash capture, `.previous` drop-and-rename, new capture install, new meta with provenance, post-write sha256 verification).
+   - Parse writer's JSON output. On `status: "ok"` → emit `verdict: pass`, messages `["Intentional change accepted; baseline rotated. Previous baseline archived as .previous.png."]`, `classification: "intentional"`, `baseline_updated: true`.
+   - On `status: "rollback"` or `"error"` → emit `verdict: fail`, messages include the writer's warnings. `baseline_updated: false`.
+
+10. **Emit the shared envelope** (per `references/validation-gate-result.md`) with visual-specific details:
+
+    ```json
+    "details": {
+      "source": "framework:visual-regression",
+      "component": "<component>",
+      "viewport": "<viewport>",
+      "reference_path": "<abs path to baseline>",
+      "capture_path": "<abs path to fresh capture>",
+      "diff_path": "<abs path to diff image OR null>",
+      "diff_percent": 0.042,
+      "diff_tolerance": 0.001,
+      "classification": "intentional",
+      "baseline_updated": true
+    }
+    ```
+
+11. **Persist** — write envelope to:
+    - `<task_folder>/validations/latest/visual-regression.json` (overwrite — note: just `visual-regression.json`, not keyed by component, because `latest/` only holds most-recent-run-per-gate; per-component history is in `history.jsonl`)
+    - `<task_folder>/validations/history.jsonl` (append)
+
+12. **Print CLI summary** — verdict, component+viewport, diff percent, classification if any, persisted paths.
+
+## Baseline lifecycle summary
+
+| Scenario | Writer action | Store result |
+|---|---|---|
+| First capture, user approves | `write-baseline`, first-baseline special case | `<component>/<viewport>.png` + `.meta.json` created; no `.previous` |
+| Second+ capture, no diff | None | No change; existing baseline unchanged |
+| Diff detected, user classifies regression | None | No change; baseline unchanged |
+| Diff detected, user classifies intentional | `write-baseline` with rotation | Previous current → `.previous`; fresh capture → current; new meta with `prior_hash` |
+| Diff detected, user cancels | None | No change |
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No session context AND no task resolution | Abort; exit 2 |
+| `<component>` or `<viewport>` malformed | Abort; exit 2 |
+| `<url>` not provided AND not resolvable from project state | Abort; exit 2 |
+| Playwright MCP AND claude-in-chrome MCP both unavailable | Emit `verdict: skipped`; exit 0 |
+| `odiff` AND `pixelmatch` both unavailable | Emit `verdict: skipped`; exit 0 |
+| Writer returns `status: rollback` | Emit `verdict: fail` with writer's warnings in messages; exit 1 |
+| Store reader returns `hash_mismatch` on baseline | Surface warning; proceed with diff (baseline file corruption is still worth catching) |
+
+## Soft-nudge posture
+
+- The 0.1% tolerance is hard in v1 but liberal enough to absorb antialiasing + font-hinting noise
+- `fail` verdict on regression does NOT block; user investigates at their pace
+- Intentional-change approval happens INLINE — no deferred `/complete` batch step in v1 (v2 candidate)
+- User `[c]ancel` is always safe — no partial writes; nothing rotates
+
+## v2 candidates
+
+- Per-component / per-viewport diff tolerance configuration
+- Deferred-approval path via `/complete` batch hook (requires `.candidate` staging)
+- Ignore regions (mask animated content, timestamps, etc.)
+- Multi-DPR capture sets
+
+See `implementation_process/in_progress/<this-task>/v2-candidates.md`.
+
+## Related
+
+- `/drupal-dev-framework:validate-visual-parity` — sibling visual gate; compares against a design comp, not a baseline
+- `/drupal-dev-framework:validate-all` — orchestrator
+- `scripts/screenshot-store-write.sh` — the writer invoked on intentional-change approval
+- `skills/screenshot-store-reader` — the store reader
+- `references/screenshot-store-schema.md` — `.meta.json` v1.0 + directory layout
+- `references/validation-gate-result.md` — shared result envelope

--- a/drupal-dev-framework/commands/validate.md
+++ b/drupal-dev-framework/commands/validate.md
@@ -9,6 +9,8 @@ argument-hint: [component-or-file]
 
 Validate implementation against architecture and coding standards.
 
+> **Note (v3.13.0+):** this is the **architecture-fit** validator — it checks whether code matches the task's architecture.md decisions. For granular **quality gates** (TDD discipline, SOLID, DRY, security, visual regression, etc.), use the `/validate:*` family introduced in v3.13.0: `/validate:tdd`, `/validate:solid`, `/validate:dry`, `/validate:security`, `/validate:guides`, `/validate:visual-regression`, `/validate:visual-parity`, `/validate:all`. The two are complementary: `/validate` asks "does the code match the design?"; `/validate:*` asks "does the code meet quality bars?".
+
 ## Usage
 
 ```

--- a/drupal-dev-framework/references/screenshot-store-schema.md
+++ b/drupal-dev-framework/references/screenshot-store-schema.md
@@ -1,0 +1,242 @@
+# Screenshot Store Schema v1.0
+
+**Introduced:** drupal-dev-framework v3.13.0
+**Owner:** `skills/screenshot-store-reader/SKILL.md` + `scripts/screenshot-store-read.sh` + `scripts/screenshot-store-write.sh`
+**Consumers (as of v3.13.0):** `commands/validate-visual-regression.md`, `commands/validate-visual-parity.md`, `commands/validate-all.md`
+
+The screenshot store is a project-scoped filesystem tree that holds regression baselines and parity references for visual validation. Per-image metadata files carry provenance, integrity hashes, and source info so any task can read the store and understand what each image represents.
+
+## 1. Location
+
+```
+<claude_memory_projects_base>/<project_name>/.screenshots/
+```
+
+The store lives next to the memory project's other artifacts (`project_state.md`, `implementation_process/`, etc.). It is NOT under `codePath` — screenshots are framework metadata, not code. Users who want team-sharing can use git on the memory folder or copy individual references manually.
+
+## 2. Directory layout
+
+```
+.screenshots/
+└── <component>/
+    ├── <viewport>.png
+    ├── <viewport>.meta.json
+    ├── <viewport>.previous.png         # optional — 1-deep history
+    └── <viewport>.previous.meta.json   # optional — 1-deep history
+```
+
+Examples:
+
+```
+.screenshots/
+├── home-hero/
+│   ├── 1920x1080.png
+│   ├── 1920x1080.meta.json
+│   ├── 1920x1080.previous.png
+│   ├── 1920x1080.previous.meta.json
+│   └── 375x812.png
+│   └── 375x812.meta.json
+└── article-hero/
+    ├── 1920x1080.png
+    └── 1920x1080.meta.json
+```
+
+## 3. Naming rules
+
+| Element | Format | Regex |
+|---|---|---|
+| `<component>` | kebab-case, lowercase, no spaces | `^[a-z0-9][a-z0-9-]*$` |
+| `<viewport>` | `WIDTHxHEIGHT` in pixels | `^[0-9]+x[0-9]+$` |
+
+No nesting beyond `<component>/<viewport>`. Flat within each component keeps retrieval predictable at Drupal-theme scale (dozens to hundreds of components). Multi-viewport per component is the common case.
+
+Component names should describe what's captured (`home-hero`, `article-card`, `admin-toolbar`, `footer`), not where on the page (`top-left`). Callers are responsible for sanitizing user input to the kebab-case format before invoking the writer.
+
+## 4. `.meta.json` schema v1.0 (9 fields)
+
+Every `.png` in the store has a sibling `.meta.json` with exactly these 9 fields:
+
+```json
+{
+  "schema_version": "1.0",
+  "role": "baseline",
+  "viewport": "1920x1080",
+  "captured_at": "2026-04-24T14:30:00Z",
+  "sha256": "429368832b95441f1bbd64e711867207eba2cfeb679919e72bb380f8740762ca",
+  "originating_task": "dev_framework_granular_validation",
+  "captured_by": "playwright-mcp",
+  "prior_hash": null,
+  "source": null
+}
+```
+
+### Field contracts
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `schema_version` | string | `"1.0"` for v3.13.0. Follows semver. Consumers match on major. MUST be a JSON string, never a number |
+| `role` | enum | `"baseline"` (regression source of truth) \| `"parity_reference"` (imported design comp) \| `"previous"` (used ONLY if meta is explicitly rewritten to mark an archived state; normally `.previous.meta.json` keeps the prior `role` unchanged) |
+| `viewport` | string | Matches `^[0-9]+x[0-9]+$` — same as the filename stem |
+| `captured_at` | string | ISO-8601 UTC with `Z` suffix (e.g. `2026-04-24T14:30:00Z`). Serves as approval timestamp for baselines (they're written at approval time) |
+| `sha256` | string | Lowercase hex SHA-256 of the sibling PNG. 64 chars. Integrity + provenance |
+| `originating_task` | string | Task folder name that approved/wrote this baseline. For auditing — answers "who put this here?" |
+| `captured_by` | enum | `"playwright-mcp"` \| `"claude-in-chrome"` \| `"figma-export"` \| `"html-render"` \| `"user-upload"`. Identifies capture method — matters for understanding cross-run differences |
+| `prior_hash` | string \| null | SHA-256 of the file rotated to `.previous` when this baseline was written. `null` on the first baseline (no predecessor). Enables quick integrity checks without reading `.previous.meta.json` |
+| `source` | object \| null | REQUIRED when `role: "parity_reference"`, MUST be `null` otherwise. Shape: `{type: "figma" \| "html" \| "image" \| "url", uri: "<absolute url or path>"}`. Without this, a parity reference is unidentifiable after capture |
+
+## 5. Invariants (writer enforces; reader reports violations as warnings)
+
+1. `schema_version` is always `"1.0"` at v3.13.0
+2. `role: "parity_reference"` requires non-null `source`; other roles have `source: null`
+3. `sha256` MUST match the actual sibling PNG hash; reader emits `hash_mismatch` warning if not
+4. First baseline for any `<component>/<viewport>` has `prior_hash: null`; subsequent ones have `prior_hash` = sha256 of what was rotated to `.previous`
+5. `<component>` matches `^[a-z0-9][a-z0-9-]*$`
+6. `<viewport>` matches `^[0-9]+x[0-9]+$` and matches the filename stem exactly
+
+## 6. `.previous` rotation (1-deep history)
+
+On every write to an existing `<viewport>`:
+
+1. Compute SHA-256 of current `<viewport>.png` → becomes `prior_hash` in the new meta
+2. Delete existing `<viewport>.previous.png` + `.previous.meta.json` if present (unconditional drop — only 1 deep ever)
+3. Rename `<viewport>.png` → `<viewport>.previous.png`; rename meta similarly (rotated meta keeps its original `role`, unchanged)
+4. Copy new source to `<viewport>.png`
+5. Write new `<viewport>.meta.json` with the 9 fields
+6. Verify sha256(new `<viewport>.png`) matches new meta's `sha256`; on mismatch, rollback via reverse-rename + emit warning
+
+Atomic enough: `mv` on POSIX is atomic within the same filesystem; `cp` + `rm` is not, but any failure path triggers a rollback to the previous good state. No `.candidate` staging in v1 — approval + rotation happen together at the moment of user approval.
+
+## 7. Reader JSON output contract
+
+`scripts/screenshot-store-read.sh <project_folder>` emits:
+
+```json
+{
+  "schema_version": "1.0",
+  "project_path": "/abs/path/to/project",
+  "store_path": "/abs/path/to/project/.screenshots",
+  "store_exists": true,
+  "components": [
+    {
+      "name": "home-hero",
+      "viewports": [
+        {
+          "viewport": "1920x1080",
+          "has_current": true,
+          "has_previous": true,
+          "meta": { ... 9-field object ... },
+          "previous_meta": { ... 9-field object OR null ... },
+          "warnings": [ ... per-viewport warnings ... ]
+        }
+      ]
+    }
+  ],
+  "warnings": [ ... store-level warnings ... ]
+}
+```
+
+Exit code always 0 except on unrecoverable IO failures (permission denied, etc.), which also produce best-effort JSON with `code: "error"` in `warnings`.
+
+## 8. Warning codes
+
+| Code | Level | When |
+|---|---|---|
+| `store_missing` | store | `.screenshots/` does not exist (normal for projects that never ran visual tests) |
+| `component_missing_meta` | viewport | `<viewport>.png` exists but no `.meta.json` sibling |
+| `meta_schema_mismatch` | viewport | `.meta.json` is invalid JSON OR missing one or more required v1.0 fields |
+| `hash_mismatch` | viewport | `.meta.json`'s `sha256` does not match the actual PNG (data drift; file edited outside the writer) |
+| `orphan_meta` | store | `<viewport>.meta.json` exists but no PNG sibling (cleanup needed) |
+| `error` | store | Unrecoverable read failure |
+
+Warnings are additive — a single viewport can have multiple. Never blocks; consumers decide severity.
+
+## 9. Versioning policy
+
+- **Adding fields within v1.x** — consumers ignore unknown keys. No schema bump required
+- **Changing field semantics or removing a field** — major bump (v2.0) with migration note
+- **Adding new warning codes within v1.x** — consumers treat unknown codes as informational (display, don't error)
+- **Changing `role` enum values or `captured_by` enum values** — minor-or-major depending on whether old values remain valid
+
+## 10. Writer invocation reference
+
+```bash
+# Baseline (regression source-of-truth)
+screenshot-store-write.sh write-baseline \
+  <project> <component> <viewport> <source.png> <captured_by> <originating_task>
+
+# Parity reference (imported design comp)
+screenshot-store-write.sh write-parity-reference \
+  <project> <component> <viewport> <source.png> <captured_by> <originating_task> <source_type> <source_uri>
+```
+
+Both return JSON: `{status: "ok"|"rollback"|"error", warnings: [], summary: {...}}`. Exit codes: 0 ok; 1 rollback (warning in JSON); 2 arg validation; 3 IO error pre-rotation.
+
+## 11. Consumers
+
+- **`screenshot-store-reader` skill** (v1.0.0) — thin wrapper around the reader script
+- **`/validate:visual-regression`** — reads current baseline; on approved intentional change, invokes `write-baseline` to rotate
+- **`/validate:visual-parity`** — reads/writes parity references; diffs against current capture
+- **`/validate:all`** — reads store for summary; does NOT write
+
+Future consumers needing screenshot data should call the reader skill rather than parsing the store directly.
+
+## 12. Example meta files
+
+### Regression baseline (first capture, no predecessor)
+
+```json
+{
+  "schema_version": "1.0",
+  "role": "baseline",
+  "viewport": "1920x1080",
+  "captured_at": "2026-04-24T14:30:00Z",
+  "sha256": "429368832b95441f1bbd64e711867207eba2cfeb679919e72bb380f8740762ca",
+  "originating_task": "theme_redesign",
+  "captured_by": "playwright-mcp",
+  "prior_hash": null,
+  "source": null
+}
+```
+
+### Regression baseline (after rotation)
+
+```json
+{
+  "schema_version": "1.0",
+  "role": "baseline",
+  "viewport": "1920x1080",
+  "captured_at": "2026-05-15T09:12:44Z",
+  "sha256": "d91ed079d493278a89a72d1e8f70144bb95a09f4c206c3a391ac44b027e65ce6",
+  "originating_task": "hero_cta_update",
+  "captured_by": "playwright-mcp",
+  "prior_hash": "429368832b95441f1bbd64e711867207eba2cfeb679919e72bb380f8740762ca",
+  "source": null
+}
+```
+
+### Parity reference imported from Figma
+
+```json
+{
+  "schema_version": "1.0",
+  "role": "parity_reference",
+  "viewport": "375x812",
+  "captured_at": "2026-04-24T16:00:00Z",
+  "sha256": "ffef02c5368e578cede902d953e7a9f20ef671d37700aab313d7fb5fcb8ec86c",
+  "originating_task": "mobile_redesign",
+  "captured_by": "figma-export",
+  "prior_hash": null,
+  "source": {
+    "type": "figma",
+    "uri": "https://figma.com/file/abc123/mobile-redesign?node-id=12:45"
+  }
+}
+```
+
+## 13. See also
+
+- `scripts/screenshot-store-read.sh` — the reader
+- `scripts/screenshot-store-write.sh` — the writer
+- `skills/screenshot-store-reader/SKILL.md` — skill wrapper
+- `references/validation-gate-result.md` — the JSON envelope emitted by all `/validate:*` commands
+- Architecture §4 in `dev_framework_granular_validation/architecture.md`

--- a/drupal-dev-framework/references/validation-gate-result.md
+++ b/drupal-dev-framework/references/validation-gate-result.md
@@ -1,0 +1,266 @@
+# Validation Gate Result Envelope v1.0
+
+**Introduced:** drupal-dev-framework v3.13.0
+**Owner:** `commands/validate-*.md`
+**Consumers (as of v3.13.0):** `commands/validate-all.md`, `commands/complete.md` (future, when v2 batch-approval lands)
+
+Every `/validate:*` command emits and persists a JSON result object with this shape, regardless of whether it wraps a `code-quality-tools` skill or implements its own check (guides, visual-parity, visual-regression). A shared envelope keeps consumers (`/validate:all`, future reports, `/complete` hooks) simple.
+
+## 1. Shape
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "tdd",
+  "task": "dev_framework_granular_validation",
+  "run_at": "2026-04-24T15:00:00Z",
+  "verdict": "pass",
+  "details": {
+    "source": "code-quality-tools:tdd",
+    "raw_output_path": "/abs/path/.reports/tdd.json"
+  },
+  "messages": [
+    "Red-Green-Refactor cycle observed across 3 commits",
+    "All new logic has tests"
+  ]
+}
+```
+
+## 2. Field contracts
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `schema_version` | string | `"1.0"` at v3.13.0. JSON string. Consumers match on major |
+| `gate` | string | Gate identifier: `tdd` \| `solid` \| `dry` \| `security` \| `guides` \| `visual-parity` \| `visual-regression`. Matches the `/validate:<gate>` command name |
+| `task` | string | Task folder name the run was scoped to |
+| `run_at` | string | ISO-8601 UTC with `Z` suffix |
+| `verdict` | enum | `"pass"` \| `"warning"` \| `"fail"` \| `"skipped"` |
+| `details` | object | Gate-specific detail structure. See §4 |
+| `messages` | array of string | Human-readable findings. Shown in CLI output. Non-empty for warning/fail; usually present for pass too (e.g., "3 checks passed") |
+
+## 3. Verdict semantics
+
+| Verdict | Meaning | Exit behavior |
+|---|---|---|
+| `pass` | Gate's criteria met. Nothing to fix | Command prints summary + exits 0 |
+| `warning` | Gate passes but with observations worth surfacing (e.g., "TDD followed but 1 commit lacks a test"). Not blocking | Command prints summary + exits 0 |
+| `fail` | Gate's criteria NOT met. Action required | Command prints summary + exits 1 (signals failure; user/AI can see + fix) |
+| `skipped` | Gate was invoked but not run (e.g., user passed `--skip`, or the underlying tool is unavailable) | Command prints reason + exits 0 |
+
+All gates are advisory by default — `fail` does NOT block the user's workflow (soft-nudge posture). The exit code communicates the result to invokers that want to chain (e.g., CI, `/validate:all` orchestration).
+
+## 4. `details` — gate-specific structures
+
+The `details` object's shape depends on `gate`. Consumers reading it should guard on `gate` field first.
+
+### Wrapper gates (tdd, solid, dry, security)
+
+```json
+"details": {
+  "source": "code-quality-tools:tdd",
+  "raw_output_path": "/abs/path/.reports/tdd.json",
+  "code_quality_tools_version": "3.0.0"
+}
+```
+
+- `source` — the underlying skill invoked (always `code-quality-tools:<gate>`)
+- `raw_output_path` — absolute path to the unmodified output from the wrapped tool, for deep diagnosis
+- `code_quality_tools_version` — version of the dependency at run time
+
+### Guides gate (framework-owned)
+
+```json
+"details": {
+  "source": "framework:guides",
+  "checked_artifacts": [
+    "/abs/path/task/research.md",
+    "/abs/path/task/architecture.md"
+  ],
+  "guides_cited": ["drupal/forms/config-forms", "drupal/caching/cache-api"],
+  "guides_expected_min": 1
+}
+```
+
+- `source` — always `framework:guides`
+- `checked_artifacts` — files inspected for guide citations
+- `guides_cited` — guide slugs found in the artifacts (via dev-guides-navigator markers)
+- `guides_expected_min` — minimum guide count for the gate to pass (default 1; configurable)
+
+### Visual gates (visual-parity, visual-regression)
+
+```json
+"details": {
+  "source": "framework:visual-regression",
+  "component": "home-hero",
+  "viewport": "1920x1080",
+  "reference_path": "/abs/path/.screenshots/home-hero/1920x1080.png",
+  "capture_path": "/abs/path/.validations/tmp/home-hero-1920x1080.png",
+  "diff_path": "/abs/path/.validations/tmp/home-hero-1920x1080.diff.png",
+  "diff_percent": 0.03,
+  "diff_tolerance": 0.001,
+  "classification": "regression",
+  "baseline_updated": false
+}
+```
+
+- `component`, `viewport` — which baseline was compared
+- `reference_path` — baseline for regression; imported parity reference for parity
+- `capture_path` — the fresh screenshot captured this run
+- `diff_path` — diff image (present only when diff > 0)
+- `diff_percent` — fraction of pixels different (0.0 = identical; 1.0 = completely different)
+- `diff_tolerance` — hard-coded 0.1% (0.001) in v1; v2 candidate for per-image tuning
+- `classification` — `null` if no diff; otherwise `"regression"` (user said it's a bug) \| `"intentional"` (user approved update) \| `"cancelled"` (user aborted)
+- `baseline_updated` — true only when `classification: "intentional"` AND writer rotation succeeded
+
+## 5. Persistence
+
+Every `/validate:*` command writes the result to TWO locations in the task folder:
+
+```
+<task>/validations/
+├── latest/
+│   └── <gate>.json          # overwritten on each run — fast lookup of most recent
+└── history.jsonl            # appended on each run — one JSON object per line
+```
+
+- `latest/<gate>.json` — most recent result per gate. `/validate:all` reads these to aggregate. `/complete` (future) may check for pending updates
+- `history.jsonl` — full run log, newest at the bottom. JSONL (one object per line) makes append cheap and git-diff legible
+
+`/validate:all` ALSO writes an aggregate `<task>/validations/latest/_all.json` with a summary envelope (see §6).
+
+## 6. Aggregate envelope (`/validate:all`)
+
+```json
+{
+  "schema_version": "1.0",
+  "run_at": "2026-04-24T15:30:00Z",
+  "task": "dev_framework_granular_validation",
+  "gates": [
+    {"gate": "tdd", "verdict": "pass"},
+    {"gate": "solid", "verdict": "warning", "messages": ["1 class exceeds 200 lines"]},
+    {"gate": "visual-regression", "verdict": "pass"}
+  ],
+  "summary": {
+    "pass": 5,
+    "warning": 1,
+    "fail": 0,
+    "skipped": 1,
+    "total": 7
+  },
+  "discoverability_hint": "See also: /code-quality:lint, :coverage, :review, :audit, :ultrareview"
+}
+```
+
+## 7. Invariants
+
+1. `schema_version` is always present and always `"1.0"` at v3.13.0
+2. `gate` matches one of the 7 known IDs OR `_all` for aggregate
+3. `verdict` is one of the 4 enum values
+4. `details.source` prefix identifies provenance: `code-quality-tools:*` for wrappers, `framework:*` for owned gates
+5. `messages[]` is always an array (possibly empty); never absent
+
+## 8. Versioning policy
+
+- Adding fields at v1.x — consumers ignore unknowns. No bump
+- Adding new `gate` values — additive within v1.x
+- Adding new `verdict` values — requires major bump
+- Adding new `details.source` values — additive
+- Removing any field or changing semantics — major bump
+
+## 9. Examples by gate
+
+### tdd (wrapper), pass
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "tdd",
+  "task": "fix_login_redirect",
+  "run_at": "2026-04-24T15:00:00Z",
+  "verdict": "pass",
+  "details": {
+    "source": "code-quality-tools:tdd",
+    "raw_output_path": "/abs/path/.reports/tdd.json",
+    "code_quality_tools_version": "3.0.0"
+  },
+  "messages": ["Red-Green-Refactor cycle observed across 3 commits"]
+}
+```
+
+### solid (wrapper), warning
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "solid",
+  "task": "settings_form_refactor",
+  "run_at": "2026-04-24T15:01:00Z",
+  "verdict": "warning",
+  "details": {
+    "source": "code-quality-tools:solid",
+    "raw_output_path": "/abs/path/.reports/solid.json",
+    "code_quality_tools_version": "3.0.0"
+  },
+  "messages": [
+    "SettingsForm::submitForm violates SRP (mixes validation + persistence + notification)",
+    "Consider splitting into SettingsFormValidator + SettingsFormPersister"
+  ]
+}
+```
+
+### guides (framework-owned), fail
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "guides",
+  "task": "custom_entity",
+  "run_at": "2026-04-24T15:02:00Z",
+  "verdict": "fail",
+  "details": {
+    "source": "framework:guides",
+    "checked_artifacts": ["/abs/path/research.md", "/abs/path/architecture.md"],
+    "guides_cited": [],
+    "guides_expected_min": 1
+  },
+  "messages": [
+    "No dev-guides citations found in research.md or architecture.md",
+    "Custom entity work typically loads drupal/entities/* guides; consider /dev-guides-navigator"
+  ]
+}
+```
+
+### visual-regression, intentional change approved
+
+```json
+{
+  "schema_version": "1.0",
+  "gate": "visual-regression",
+  "task": "hero_cta_update",
+  "run_at": "2026-04-24T15:03:00Z",
+  "verdict": "pass",
+  "details": {
+    "source": "framework:visual-regression",
+    "component": "home-hero",
+    "viewport": "1920x1080",
+    "reference_path": "/abs/path/.screenshots/home-hero/1920x1080.png",
+    "capture_path": "/tmp/fresh.png",
+    "diff_path": "/tmp/diff.png",
+    "diff_percent": 0.042,
+    "diff_tolerance": 0.001,
+    "classification": "intentional",
+    "baseline_updated": true
+  },
+  "messages": [
+    "Diff detected (4.2%). User classified as intentional; baseline rotated",
+    "Previous baseline archived as .previous.png (prior_hash: 42936883...)"
+  ]
+}
+```
+
+## 10. See also
+
+- `references/screenshot-store-schema.md` — the `.meta.json` schema referenced by visual gate details
+- `commands/validate-all.md` — the orchestrator that consumes per-gate envelopes and emits the aggregate
+- `commands/validate-tdd.md` (et al) — the per-gate commands that produce envelopes
+- Architecture §5.1 in `dev_framework_granular_validation/architecture.md`

--- a/drupal-dev-framework/scripts/screenshot-store-read.sh
+++ b/drupal-dev-framework/scripts/screenshot-store-read.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# screenshot-store-read.sh — inspect the screenshot store for a project.
+#
+# Usage: screenshot-store-read.sh <project_folder>
+#
+# Always emits single-line JSON to stdout. Exit 0 regardless of input
+# (warnings surface via the warnings[] array). Mirrors the defensive posture
+# of alignment-read.sh and project-state-read.sh.
+#
+# Output shape (per references/screenshot-store-schema.md v1.0):
+#   {
+#     "schema_version": "1.0",
+#     "project_path": "<abs path>",
+#     "store_path": "<abs path to .screenshots/>",
+#     "store_exists": true|false,
+#     "components": [
+#       {
+#         "name": "<component>",
+#         "viewports": [
+#           {
+#             "viewport": "1920x1080",
+#             "has_current": true|false,
+#             "has_previous": true|false,
+#             "meta": { ... 9-field meta.json content ... },
+#             "previous_meta": { ... | null },
+#             "warnings": [ ... per-viewport warnings ... ]
+#           }
+#         ]
+#       }
+#     ],
+#     "warnings": [ ... store-level warnings ... ]
+#   }
+#
+# Warning codes (per architecture §4.5):
+#   store_missing            — .screenshots/ folder does not exist
+#   component_missing_meta   — <viewport>.png exists but no .meta.json sibling
+#   meta_schema_mismatch     — .meta.json doesn't have expected v1.0 fields
+#   hash_mismatch            — .meta.json sha256 does not match the actual PNG
+#   orphan_meta              — <viewport>.meta.json exists but no PNG sibling
+#   error                    — unrecoverable read failure (permissions, IO)
+#
+# No writes. No side effects. This script only reads.
+
+set -uo pipefail
+
+PROJECT_DIR="${1:?path to project folder required}"
+STORE_DIR="$PROJECT_DIR/.screenshots"
+
+emit_json() {
+  # $1 = store_exists (true/false literal), $2 = components JSON array, $3 = warnings JSON array
+  jq -nc --arg pp "$PROJECT_DIR" --arg sp "$STORE_DIR" \
+         --argjson se "$1" --argjson comps "$2" --argjson warns "$3" '
+    {
+      schema_version: "1.0",
+      project_path: $pp,
+      store_path: $sp,
+      store_exists: $se,
+      components: $comps,
+      warnings: $warns
+    }'
+}
+
+# Short-circuit: project folder missing (caller error, but stay defensive)
+if [ ! -d "$PROJECT_DIR" ]; then
+  emit_json false '[]' '[{"code":"error","detail":"project folder does not exist"}]'
+  exit 0
+fi
+
+# Short-circuit: store doesn't exist (normal for projects that never ran visual tests)
+if [ ! -d "$STORE_DIR" ]; then
+  emit_json false '[]' '[{"code":"store_missing","detail":".screenshots/ does not exist; no visual baselines yet"}]'
+  exit 0
+fi
+
+# Gather per-viewport data
+# For each component directory under .screenshots/:
+#   - iterate current .png files (non-.previous, non-.candidate)
+#   - check for sibling .meta.json, .previous.png, .previous.meta.json
+#   - read metas, verify hashes, emit per-viewport record
+
+STORE_WARNINGS='[]'
+COMPONENTS_JSON='[]'
+
+# Process component directories
+while IFS= read -r comp_dir; do
+  [ -z "$comp_dir" ] && continue
+  comp_name=$(basename "$comp_dir")
+  viewports_json='[]'
+
+  # Find all current PNGs (exclude .previous.png, .candidate.png)
+  while IFS= read -r png_file; do
+    [ -z "$png_file" ] && continue
+    png_base=$(basename "$png_file" .png)
+
+    # Skip siblings-of-current
+    case "$png_base" in
+      *.previous|*.candidate) continue ;;
+    esac
+
+    viewport="$png_base"
+    meta_file="$comp_dir/$viewport.meta.json"
+    prev_png="$comp_dir/$viewport.previous.png"
+    prev_meta="$comp_dir/$viewport.previous.meta.json"
+
+    vp_warnings='[]'
+    meta_obj='null'
+    prev_meta_obj='null'
+    has_current='true'
+    has_previous='false'
+
+    # Read meta
+    if [ ! -f "$meta_file" ]; then
+      vp_warnings=$(jq -c -n '[{code:"component_missing_meta",detail:"png present without .meta.json sibling"}]')
+    else
+      meta_raw=$(cat "$meta_file" 2>/dev/null)
+      if ! meta_obj=$(echo "$meta_raw" | jq -c . 2>/dev/null); then
+        vp_warnings=$(jq -c -n '[{code:"meta_schema_mismatch",detail:".meta.json is not valid JSON"}]')
+        meta_obj='null'
+      else
+        # Schema sanity check — required v1.0 fields
+        req_ok=$(echo "$meta_obj" | jq -r '
+          (has("schema_version") and has("role") and has("viewport")
+           and has("captured_at") and has("sha256") and has("originating_task")
+           and has("captured_by") and has("prior_hash") and has("source"))
+        ' 2>/dev/null)
+        if [ "$req_ok" != "true" ]; then
+          vp_warnings=$(jq -c -n --argjson prev "$vp_warnings" '$prev + [{code:"meta_schema_mismatch",detail:"missing one or more required v1.0 fields"}]')
+        fi
+
+        # Hash verification — compute actual, compare to meta
+        actual_hash=$(sha256sum "$png_file" 2>/dev/null | awk '{print $1}')
+        declared_hash=$(echo "$meta_obj" | jq -r '.sha256 // empty' 2>/dev/null)
+        if [ -n "$actual_hash" ] && [ -n "$declared_hash" ] && [ "$actual_hash" != "$declared_hash" ]; then
+          vp_warnings=$(jq -c -n --argjson prev "$vp_warnings" --arg a "$actual_hash" --arg d "$declared_hash" \
+            '$prev + [{code:"hash_mismatch",detail:("meta.sha256=\($d) does not match actual=\($a)")}]')
+        fi
+      fi
+    fi
+
+    # Previous sibling
+    if [ -f "$prev_png" ]; then
+      has_previous='true'
+      if [ -f "$prev_meta" ]; then
+        prev_meta_raw=$(cat "$prev_meta" 2>/dev/null)
+        prev_meta_obj=$(echo "$prev_meta_raw" | jq -c . 2>/dev/null || echo 'null')
+      fi
+    fi
+
+    # Append to viewports
+    viewports_json=$(jq -c -n --argjson cur "$viewports_json" \
+      --arg vp "$viewport" --argjson hc "$has_current" --argjson hp "$has_previous" \
+      --argjson meta "$meta_obj" --argjson pmeta "$prev_meta_obj" --argjson vw "$vp_warnings" '
+      $cur + [{
+        viewport: $vp,
+        has_current: $hc,
+        has_previous: $hp,
+        meta: $meta,
+        previous_meta: $pmeta,
+        warnings: $vw
+      }]')
+  done < <(find "$comp_dir" -maxdepth 1 -type f -name '*.png' 2>/dev/null | sort)
+
+  # Also check for orphan .meta.json files (meta without PNG)
+  while IFS= read -r meta_file; do
+    [ -z "$meta_file" ] && continue
+    meta_base=$(basename "$meta_file" .meta.json)
+    # Skip .previous + .candidate metas; only check current-tier orphans
+    case "$meta_base" in
+      *.previous|*.candidate) continue ;;
+    esac
+    if [ ! -f "$comp_dir/$meta_base.png" ]; then
+      STORE_WARNINGS=$(jq -c -n --argjson prev "$STORE_WARNINGS" --arg c "$comp_name" --arg v "$meta_base" \
+        '$prev + [{code:"orphan_meta",detail:("\($c)/\($v).meta.json exists without PNG sibling")}]')
+    fi
+  done < <(find "$comp_dir" -maxdepth 1 -type f -name '*.meta.json' 2>/dev/null | sort)
+
+  COMPONENTS_JSON=$(jq -c -n --argjson cur "$COMPONENTS_JSON" --arg n "$comp_name" --argjson vps "$viewports_json" \
+    '$cur + [{name:$n, viewports:$vps}]')
+
+done < <(find "$STORE_DIR" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
+
+emit_json true "$COMPONENTS_JSON" "$STORE_WARNINGS"

--- a/drupal-dev-framework/scripts/screenshot-store-write.sh
+++ b/drupal-dev-framework/scripts/screenshot-store-write.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# screenshot-store-write.sh — write baselines + parity references with rotation.
+#
+# Usage:
+#   screenshot-store-write.sh write-baseline <project> <component> <viewport> <source.png> <captured_by> <originating_task>
+#   screenshot-store-write.sh write-parity-reference <project> <component> <viewport> <source.png> <captured_by> <originating_task> <source_type> <source_uri>
+#
+# Performs the 6-step rotation from architecture §4.4:
+#   1. Compute sha256 of existing <viewport>.png (becomes prior_hash)
+#   2. Delete existing .previous.png + .previous.meta.json unconditionally
+#   3. Rename current .png → .previous.png; rename meta similarly
+#   4. Copy source.png to <viewport>.png
+#   5. Write new meta with sha256, prior_hash, captured_at, captured_by, originating_task, role, source
+#   6. Verify new sha256 matches meta; on mismatch, rollback via reverse-rename + emit warning
+#
+# First-baseline special case: no predecessor → skip steps 1-3; new meta has prior_hash: null.
+#
+# Emits single-line JSON to stdout describing the operation result. Exit codes:
+#   0 — success
+#   1 — rollback performed (warning in JSON)
+#   2 — arg validation failure
+#   3 — IO error pre-rotation (safe; no partial state)
+#
+# captured_by values (from architecture §4.3):
+#   playwright-mcp | claude-in-chrome | figma-export | html-render | user-upload
+#
+# source_type values (parity-reference only):
+#   figma | html | image | url
+
+set -uo pipefail
+
+MODE="${1:-}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  screenshot-store-write.sh write-baseline <project> <component> <viewport> <source.png> <captured_by> <originating_task>
+  screenshot-store-write.sh write-parity-reference <project> <component> <viewport> <source.png> <captured_by> <originating_task> <source_type> <source_uri>
+EOF
+}
+
+emit_result() {
+  # $1 = status ("ok"|"rollback"|"error"), $2 = warnings JSON array, $3 = summary object
+  jq -nc --arg st "$1" --argjson w "$2" --argjson s "$3" '{status:$st, warnings:$w, summary:$s}'
+}
+
+case "$MODE" in
+  write-baseline)
+    if [ $# -ne 7 ]; then usage; exit 2; fi
+    PROJECT="$2"; COMPONENT="$3"; VIEWPORT="$4"; SOURCE="$5"; CAPTURED_BY="$6"; ORIGIN_TASK="$7"
+    ROLE="baseline"
+    SOURCE_TYPE=""
+    SOURCE_URI=""
+    ;;
+  write-parity-reference)
+    if [ $# -ne 9 ]; then usage; exit 2; fi
+    PROJECT="$2"; COMPONENT="$3"; VIEWPORT="$4"; SOURCE="$5"; CAPTURED_BY="$6"; ORIGIN_TASK="$7"
+    SOURCE_TYPE="$8"; SOURCE_URI="$9"
+    ROLE="parity_reference"
+    ;;
+  *)
+    usage; exit 2 ;;
+esac
+
+# Validate inputs
+if [ ! -f "$SOURCE" ]; then
+  emit_result "error" '[{"code":"source_missing","detail":"source png does not exist"}]' '{}'
+  exit 3
+fi
+if [ ! -d "$PROJECT" ]; then
+  emit_result "error" '[{"code":"project_missing","detail":"project folder does not exist"}]' '{}'
+  exit 3
+fi
+
+# Component name sanity (kebab-case; caller should sanitize, but check)
+if ! echo "$COMPONENT" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+  emit_result "error" '[{"code":"invalid_component","detail":"component name must match ^[a-z0-9][a-z0-9-]*$"}]' '{}'
+  exit 2
+fi
+# Viewport format
+if ! echo "$VIEWPORT" | grep -qE '^[0-9]+x[0-9]+$'; then
+  emit_result "error" '[{"code":"invalid_viewport","detail":"viewport must match ^[0-9]+x[0-9]+$"}]' '{}'
+  exit 2
+fi
+# captured_by enum
+case "$CAPTURED_BY" in
+  playwright-mcp|claude-in-chrome|figma-export|html-render|user-upload) ;;
+  *)
+    emit_result "error" '[{"code":"invalid_captured_by","detail":"captured_by must be one of: playwright-mcp, claude-in-chrome, figma-export, html-render, user-upload"}]' '{}'
+    exit 2 ;;
+esac
+# source_type enum (parity-reference only)
+if [ "$ROLE" = "parity_reference" ]; then
+  case "$SOURCE_TYPE" in
+    figma|html|image|url) ;;
+    *)
+      emit_result "error" '[{"code":"invalid_source_type","detail":"source_type must be one of: figma, html, image, url"}]' '{}'
+      exit 2 ;;
+  esac
+fi
+
+STORE="$PROJECT/.screenshots"
+COMP_DIR="$STORE/$COMPONENT"
+CURRENT_PNG="$COMP_DIR/$VIEWPORT.png"
+CURRENT_META="$COMP_DIR/$VIEWPORT.meta.json"
+PREV_PNG="$COMP_DIR/$VIEWPORT.previous.png"
+PREV_META="$COMP_DIR/$VIEWPORT.previous.meta.json"
+
+mkdir -p "$COMP_DIR" || { emit_result "error" '[{"code":"mkdir_failed"}]' '{}'; exit 3; }
+
+IS_FIRST_BASELINE="true"
+PRIOR_HASH="null"
+
+# STEP 1 — compute prior_hash if predecessor exists
+if [ -f "$CURRENT_PNG" ]; then
+  IS_FIRST_BASELINE="false"
+  PRIOR_HASH=$(sha256sum "$CURRENT_PNG" | awk '{print $1}')
+fi
+
+# STEPS 2-3 — rotation (only if predecessor exists)
+if [ "$IS_FIRST_BASELINE" = "false" ]; then
+  # Step 2: delete existing .previous.* unconditionally
+  rm -f "$PREV_PNG" "$PREV_META"
+  # Step 3: rename current → previous
+  mv "$CURRENT_PNG" "$PREV_PNG" || { emit_result "error" '[{"code":"rotation_mv_failed","detail":"could not rename current png to previous"}]' '{}'; exit 3; }
+  if [ -f "$CURRENT_META" ]; then
+    mv "$CURRENT_META" "$PREV_META" || {
+      # Rollback: move .previous.png back
+      mv "$PREV_PNG" "$CURRENT_PNG"
+      emit_result "rollback" '[{"code":"rotation_meta_mv_failed"}]' '{}'
+      exit 1
+    }
+  fi
+fi
+
+# STEP 4 — copy source to current
+cp "$SOURCE" "$CURRENT_PNG" || {
+  # Rollback: restore previous as current if we rotated
+  if [ "$IS_FIRST_BASELINE" = "false" ]; then
+    mv "$PREV_PNG" "$CURRENT_PNG"
+    [ -f "$PREV_META" ] && mv "$PREV_META" "$CURRENT_META"
+  fi
+  emit_result "rollback" '[{"code":"copy_failed","detail":"source copy failed; rotation rolled back"}]' '{}'
+  exit 1
+}
+
+# STEP 5 — write new meta
+NEW_HASH=$(sha256sum "$CURRENT_PNG" | awk '{print $1}')
+NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+if [ "$ROLE" = "parity_reference" ]; then
+  SOURCE_JSON=$(jq -nc --arg t "$SOURCE_TYPE" --arg u "$SOURCE_URI" '{type:$t, uri:$u}')
+else
+  SOURCE_JSON='null'
+fi
+
+if [ "$PRIOR_HASH" = "null" ]; then
+  PRIOR_HASH_JSON='null'
+else
+  PRIOR_HASH_JSON=$(jq -nc --arg h "$PRIOR_HASH" '$h')
+fi
+
+META_JSON=$(jq -nc \
+  --arg role "$ROLE" --arg vp "$VIEWPORT" --arg ca "$NOW_ISO" \
+  --arg sha "$NEW_HASH" --arg ot "$ORIGIN_TASK" --arg cb "$CAPTURED_BY" \
+  --argjson ph "$PRIOR_HASH_JSON" --argjson src "$SOURCE_JSON" '
+  {
+    schema_version: "1.0",
+    role: $role,
+    viewport: $vp,
+    captured_at: $ca,
+    sha256: $sha,
+    originating_task: $ot,
+    captured_by: $cb,
+    prior_hash: $ph,
+    source: $src
+  }')
+
+echo "$META_JSON" > "$CURRENT_META" || {
+  # Rollback: remove the new current, restore previous
+  rm -f "$CURRENT_PNG"
+  if [ "$IS_FIRST_BASELINE" = "false" ]; then
+    mv "$PREV_PNG" "$CURRENT_PNG"
+    [ -f "$PREV_META" ] && mv "$PREV_META" "$CURRENT_META"
+  fi
+  emit_result "rollback" '[{"code":"meta_write_failed"}]' '{}'
+  exit 1
+}
+
+# STEP 6 — verify integrity
+VERIFY_HASH=$(sha256sum "$CURRENT_PNG" | awk '{print $1}')
+if [ "$VERIFY_HASH" != "$NEW_HASH" ]; then
+  # Extremely unlikely — would mean mid-write corruption. Rollback.
+  rm -f "$CURRENT_PNG" "$CURRENT_META"
+  if [ "$IS_FIRST_BASELINE" = "false" ]; then
+    mv "$PREV_PNG" "$CURRENT_PNG"
+    [ -f "$PREV_META" ] && mv "$PREV_META" "$CURRENT_META"
+  fi
+  emit_result "rollback" '[{"code":"hash_verification_failed","detail":"new PNG hash does not match meta after write; rotation rolled back"}]' '{}'
+  exit 1
+fi
+
+# Success
+SUMMARY=$(jq -nc --arg comp "$COMPONENT" --arg vp "$VIEWPORT" --arg role "$ROLE" \
+  --arg cur "$CURRENT_PNG" --arg prev "$PREV_PNG" --argjson first "$([ "$IS_FIRST_BASELINE" = "true" ] && echo true || echo false)" \
+  --arg sha "$NEW_HASH" '
+  {
+    component: $comp,
+    viewport: $vp,
+    role: $role,
+    current_path: $cur,
+    previous_path: (if $first then null else $prev end),
+    first_baseline: $first,
+    new_sha256: $sha
+  }')
+
+emit_result "ok" '[]' "$SUMMARY"
+exit 0

--- a/drupal-dev-framework/skills/screenshot-store-reader/SKILL.md
+++ b/drupal-dev-framework/skills/screenshot-store-reader/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: screenshot-store-reader
+description: Use when a framework command needs to inspect the project's screenshot store — baselines and parity references used by visual-regression and visual-parity validation. Reads the store defensively via scripts/screenshot-store-read.sh and returns structured JSON. Never blocks on malformed input.
+version: 1.0.0
+user-invocable: false
+model: haiku
+allowed-tools: Bash
+---
+
+# Screenshot Store Reader
+
+Thin wrapper around `${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-read.sh`. The script inspects `.screenshots/` under a memory project folder and emits structured JSON per `references/screenshot-store-schema.md` v1.0. This skill gives the reader a Skill-tool-callable name and documents the invocation contract.
+
+## Contract
+
+**Input:** one argument — absolute path to a memory project folder (the one that may contain `.screenshots/`).
+
+**Output:** single JSON object to stdout per `references/screenshot-store-schema.md` §7. Exit code always 0 except for unrecoverable read failures (permission denied, IO error).
+
+Fields:
+- `schema_version` — JSON string, currently `"1.0"`
+- `project_path` — absolute path passed in
+- `store_path` — absolute path to the store (`<project>/.screenshots`); present whether or not it exists
+- `store_exists` — boolean
+- `components[]` — per-component array of `{name, viewports[]}` where each viewport has `{viewport, has_current, has_previous, meta, previous_meta, warnings}`
+- `warnings[]` — store-level warnings
+
+## Defensive posture (never throws)
+
+| Input state | Warning code | Level |
+|---|---|---|
+| Project folder missing | `error` | store |
+| `.screenshots/` does not exist | `store_missing` | store |
+| `<viewport>.png` exists without `.meta.json` | `component_missing_meta` | viewport |
+| `.meta.json` invalid JSON or missing required v1.0 fields | `meta_schema_mismatch` | viewport |
+| `.meta.json.sha256` differs from actual PNG hash | `hash_mismatch` | viewport |
+| `<viewport>.meta.json` exists without PNG sibling | `orphan_meta` | store |
+| Unrecoverable read failure (permission, IO) | `error` | store |
+
+## Invocation
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-read.sh" "/abs/path/to/memory/project"
+```
+
+Parse with `jq`. Examples:
+
+```bash
+OUT=$("${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-read.sh" "$PROJECT_DIR")
+STORE_EXISTS=$(jq -r '.store_exists' <<<"$OUT")
+COMPONENT_COUNT=$(jq '.components | length' <<<"$OUT")
+# Has a specific baseline?
+HAS_HERO=$(jq -e '.components[] | select(.name == "home-hero") | .viewports[] | select(.viewport == "1920x1080" and .has_current)' <<<"$OUT" >/dev/null && echo true || echo false)
+# Any warnings at the store level?
+jq -e '.warnings | length > 0' <<<"$OUT" >/dev/null && echo "store warnings present"
+# Get a specific baseline's prior_hash (for integrity check)
+PRIOR=$(jq -r '.components[] | select(.name=="home-hero") | .viewports[] | select(.viewport=="1920x1080") | .meta.prior_hash // "none"' <<<"$OUT")
+```
+
+## `.previous` siblings
+
+Every baseline OR parity reference MAY have an optional `.previous.png` + `.previous.meta.json` sibling (1-deep history). The reader surfaces these:
+- `has_previous: true|false` per viewport
+- `previous_meta: { ... }` contains the rotated meta exactly as it was when current, OR `null` if no `.previous` exists
+
+Consumers wanting to verify the rotation chain can cross-reference `meta.prior_hash` against `previous_meta.sha256`.
+
+## Consumers (v3.13.0+)
+
+- `/drupal-dev-framework:validate-visual-regression` — reads current baseline; checks `has_current` before running; reads `meta.sha256` for integrity
+- `/drupal-dev-framework:validate-visual-parity` — reads imported parity references; checks `source` field for provenance
+- `/drupal-dev-framework:validate-all` — enumerates components for visual coverage summary
+- `/drupal-dev-framework:complete` — (future v2) reads for pending-update surfacing when batch approval lands
+
+Future consumers needing screenshot-store data should call this skill rather than parsing the store directly.
+
+## Do NOT
+
+- Do not write to the store from this skill. Reading only. Writes happen via `scripts/screenshot-store-write.sh` invoked directly from visual gate commands
+- Do not treat non-empty `warnings[]` as a blocking error — warnings are observations
+- Do not duplicate the parsing logic elsewhere. Call this skill or the script
+- Do not assume any component or viewport exists. Always guard on `store_exists`, then filter `components[]`
+
+## See also
+
+- `${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-read.sh` — the reader
+- `${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-write.sh` — the writer (invoked directly by visual gate commands, not wrapped as a skill in v1)
+- `references/screenshot-store-schema.md` — canonical directory + `.meta.json` v1.0 schema, warning codes
+- `references/validation-gate-result.md` — the result envelope visual gates emit
+- `alignment-reader` skill (v1.0.0) — same design pattern
+- `project-state-reader` skill (v1.0.0) — same design pattern
+- `task-frontmatter-reader` skill (v2.0.0) — same design pattern

--- a/drupal-dev-framework/skills/screenshot-store-reader/SKILL.md
+++ b/drupal-dev-framework/skills/screenshot-store-reader/SKILL.md
@@ -65,6 +65,8 @@ Every baseline OR parity reference MAY have an optional `.previous.png` + `.prev
 
 Consumers wanting to verify the rotation chain can cross-reference `meta.prior_hash` against `previous_meta.sha256`.
 
+**Validation asymmetry (v1):** the reader performs full schema validation + hash verification on the CURRENT meta but NOT on `.previous.meta.json`. Rationale: `.previous` is opportunistic historical state (may be edited or deleted by the user without concern; not a source of truth). If a consumer needs full integrity on the previous tier, it should re-invoke the reader's validation logic OR treat `previous_meta` as best-effort. v2 candidate: symmetric validation if real use-cases surface.
+
 ## Consumers (v3.13.0+)
 
 - `/drupal-dev-framework:validate-visual-regression` — reads current baseline; checks `has_current` before running; reads `meta.sha256` for integrity


### PR DESCRIPTION
## Summary

Ships sub-task `granular_validation` from the dev-framework improvements epic. Adds 7 on-demand quality gate commands + 1 orchestrator, a new screenshot store for visual testing, and a hard dependency on \`code-quality-tools\`.

Bumps drupal-dev-framework 3.12.4 → **3.13.0** and marketplace metadata 1.14.12 → **1.14.13**.

## What's new

**7 new gate commands + 1 orchestrator:**

| Command | Kind | What it does |
|---|---|---|
| \`/validate:tdd\` | Wrapper | \`/code-quality:tdd\` + task context + persistence |
| \`/validate:solid\` | Wrapper | \`/code-quality:solid\` + persistence |
| \`/validate:dry\` | Wrapper | \`/code-quality:dry\` + persistence |
| \`/validate:security\` | Wrapper | \`/code-quality:security\` + persistence |
| \`/validate:guides\` | Framework-owned | Verifies research.md + architecture.md cite \`dev-guides-navigator\` guides |
| \`/validate:visual-regression\` | Framework-owned | Capture (Playwright MCP) + diff (\`odiff\`) + classify (regression/intentional/cancel) + inline approval |
| \`/validate:visual-parity\` | Framework-owned | Same infra; reference is an external design comp (PNG/JPG, Figma URL via MCP, HTML file) |
| \`/validate:all\` | Orchestrator | Sequential run of 5 non-visual gates + visual-regression per stored baseline; CI mode skips visual; discoverability hint for unwrapped \`/code-quality:*\` |

**Screenshot store:** Project-scoped at \`<memory_project>/.screenshots/<component>/<viewport>.{png,meta.json}\`. 9-field \`.meta.json\` (role, viewport, captured_at, sha256, originating_task, captured_by, prior_hash, source, schema_version). 1-deep \`.previous\` history with unconditional drop + hash integrity checks.

**New skill + scripts + references:**
- \`screenshot-store-reader\` skill (haiku, user-invocable: false)
- \`scripts/screenshot-store-{read,write}.sh\` (smoke-tested on 7 fixtures)
- \`references/screenshot-store-schema.md\`, \`references/validation-gate-result.md\`

**Hard dep:** \`code-quality-tools\` added to \`plugin.json\` (minimum v3.0.0). Now 2 hard deps alongside \`dev-guides-navigator\`.

**\`/validate\` disambiguation:** existing \`/validate\` (architecture-fit) documented to distinguish it from new \`/validate-*\` (quality gates) family.

## What's explicitly deferred to v2

Tracked in the task's \`v2-candidates.md\`:

- AI-driven gate applicability judgment (auto-skip inapplicable gates)
- Deferred visual-change approvals via \`/complete\` batch hook
- Extended \`.meta.json\` fields (ignore regions, DPR, capture-engine version)
- Parallel \`/validate:all\` execution
- Per-component visual coverage manifest

Principle: ship primitives first; add intelligence/batching in v2 after real usage shows warrant.

## Validation chain

- Scripts smoke-tested on 7 fixtures (first baseline, rotation, 1-deep enforcement, parity with provenance, 3 input-validation errors)
- Quick-trace paper test on pattern-validating \`/validate:tdd\` found 3 pattern issues BEFORE replication (task-root ambiguity, sibling-command invocation, exit-code semantics) — fixed before replicating to solid/dry/security
- Structured 3-phase paper test on cross-artifact integration: 3 MAJOR + 5 MINOR + 3 NIT, no BLOCKERs. All MAJORs + 3 of 5 MINORs applied
- Plugin-structure auditor: 24/30 → 2 MAJORs fixed (\`allowed-tools\` tightened; \`/validate\` vs \`/validate-*\` disambiguation)

## Test plan

- [ ] Install v3.13.0 (pulls both \`dev-guides-navigator\` AND \`code-quality-tools\` automatically)
- [ ] Run \`/validate:tdd <task>\` — verify wrapper invokes \`/code-quality:tdd\` and persists envelope to \`<task>/validations/latest/tdd.json\`
- [ ] Run \`/validate:guides <task>\` on a task with research.md citing dev-guides — verify pass; run on task without citations — verify fail
- [ ] Run \`/validate:visual-regression home-hero 1920x1080 <url>\` — first run establishes baseline; second run with same page → pass; second run with changed page → classification prompt fires
- [ ] Run \`/validate:visual-parity home-hero 1920x1080 <png-path> <url>\` — verify parity diff + classification
- [ ] Run \`/validate:all\` — verify sequential flow; aggregate \`_all.json\` persisted
- [ ] Run \`/validate:all\` with \`CI=1\` env — verify visual gates skipped with explicit message
- [ ] Confirm old tasks without \`.screenshots/\` work unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)