### PR TITLE
fix(drupal-dev-framework): task-level alignment retrofit in /design + /implement (v3.13.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.13"
+    "version": "1.14.14"
   },
   "plugins": [
     {
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.13.0",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
+      "version": "3.13.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.1] - 2026-04-24
+
+### Fixed — Task-level alignment retrofit in `/design` and `/implement`
+
+Before v3.13.1, only `/research` offered task-level alignment retrofit (v3.12.2+). `/design` and `/implement` had an explicit `**Note:**` stating "that decision is considered final by the time they reach Phase 2/3 — the task is already underway." In practice that justification didn't hold for two real scenarios:
+
+1. **Phase executed outside the plugin command** — `research.md` authored manually (plan-mode handoff, staged-file rewrite, pre-v3.12.0 tasks). The user never had a chance to be offered task-level alignment because `/research` never ran.
+2. **Tasks jumping directly to Phase 2/3** — pre-existing flat tasks where the user reaches `/design` without ever running `/research`.
+
+In both cases, users who don't know the alignment feature exists had no path to discover it at Phase 2 or Phase 3 entry.
+
+**Fix:** `/design` and `/implement` now run the same task-level retrofit branch that `/research` ships — adapted for phase-aware phrasing:
+
+- New **Step 2a** (design) / **Step 3a** (implement) runs BEFORE the existing phase-level scope offer
+- Invokes `alignment-reader`. If `sections.task_level.present: false`, soft-prompts the user to author a task-level contract in 2 minutes
+- `[y]` → executes the task-level flow from `scope.md` inline, then refreshes `alignment-reader` so the phase-level step sees the new section
+- `[n]` / `[skip]` → final for this command invocation, no re-nag
+- `sections.task_level.present: true` → skip silently
+
+Deliberately simpler than `/research`'s Phase 1 retrofit: **skips the `analysis-agent` folder-mode warrant check**. By Phase 2/3 the task has concrete `research.md`/`architecture.md` content; re-running the analysis-agent for a warrant signal would be redundant. Offer unconditionally on missing task-level, soft phrasing, skippable — never blocks.
+
+**Phase-level offer flow unchanged** except for one conditional: when the user declines task-level retrofit in Step 2a/3a (i.e., task_level still not present), the phase-level offer is also skipped (no phase-level foundation without task-level, matching existing "otherwise proceed silently" branch).
+
+**Rationale:** discoverability. Task-level alignment is a first-class feature; users who don't know it exists should be **offered** it at every phase entry, not required to already-know-and-invoke `/scope`. Single-shot per command invocation, fully skippable, never blocking. Matches v3.12.0's soft-nudge posture.
+
+### Files changed
+
+- `commands/design.md` — replaced single-step Phase 2 alignment sub-step with Step 2a (task-level retrofit, new) + Step 2b (phase-level offer, existing). Removed `**Note:**` justifying asymmetric behavior
+- `commands/implement.md` — same pattern: Step 3a (retrofit) + Step 3b (phase-level). Same `**Note:**` removal
+
+### Not changed
+
+- `commands/research.md` — already had task-level retrofit (v3.12.2+). No change
+- `alignment-reader` skill — no change
+- `commands/scope.md` — no change (retrofit flows call it inline the same way)
+- No version bump to any hard dependency
+
 ## [3.13.0] - 2026-04-24
 
 ### Added — Granular Validation Commands (sub-task granular_validation of dev-framework improvements epic)

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -66,6 +66,8 @@ Optional scope contract authored before Phase 1 via `/scope <task>`. Produces `a
 
 **Conversation convention:** one question at a time, author-authored, never auto-generated. Claude MAY propose a draft, but the user's reply is the final text. Follows superpowers `brainstorming` precedent.
 
+**Task-level retrofit (v3.12.2 in `/research`, v3.13.1 in `/design` + `/implement`):** at every phase entry, commands invoke `alignment-reader` first; if `sections.task_level.present: false`, soft-prompt the user to author task-level scope inline (2-minute conversation) before the phase-level offer. Skippable, single-shot per command invocation, never blocking. Discoverability for users who didn't know `/scope` exists.
+
 **Reader:** `alignment-reader` skill (haiku, user-invocable: false) parses `alignment.md` into structured JSON via `scripts/alignment-read.sh`. Defensive — never throws; emits `warnings[]` on malformed sections. Mirrors `project-state-reader` (v3.11.0) and `task-frontmatter-reader` (v3.10.0).
 
 ## Agents

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -28,21 +28,31 @@ Before doing anything else for this command, verify the prior phase is marked co
 
 Never block the command on this check — the user is in control. The nudge exists so they notice out-of-order invocations without being fought by the tool.
 
-## Phase 2 alignment sub-step (v3.12.0+)
+## Phase 2 alignment sub-step (v3.12.0+, task-level retrofit in v3.13.1+)
 
-**Run after the Phase Transition Check, before any other Phase 2 work.** Same pattern as `/research`'s Phase 1 sub-step:
+**Run after the Phase Transition Check, before any other Phase 2 work.** Same pattern as `/research`'s Phase 1 sub-step.
+
+### Step 2a — Task-level retrofit (v3.13.1+)
 
 1. Invoke `alignment-reader` skill against the task folder.
-2. Decide whether to offer an architecture-specific scope. Plain-language prompts:
+2. If `sections.task_level.present: false` → offer task-level retrofit with soft, phase-aware phrasing:
+   > "Heads up — this task doesn't have a task-level scope recorded yet (`alignment.md` is missing or has no `## Task-Level` section). A short scope contract (goal / expected result / success criteria / non-goals) helps design stay on-track. Want 2 minutes to pin it down now, or skip and continue? [y]es / [n]o"
+3. On `[y]` → execute the **task-level** flow from `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so Step 2b sees the new section.
+4. On `[n]` / `[skip]` → proceed. Decision is final for this command invocation — no re-nag. Do NOT offer task-level retrofit again in the same `/design` run.
+5. If `sections.task_level.present: true` → proceed silently to Step 2b (no prompt, no nag).
+
+### Step 2b — Phase-level scope offer
+
+1. Decide whether to offer an architecture-specific scope. Plain-language prompts:
    - If `sections.phase_2.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
-   - Else if `sections.task_level.present: true` → ask:
+   - Else if `sections.task_level.present: true` (either pre-existing, or just authored by Step 2a) → ask:
      > "You've scoped the whole task. Want to also scope just this architecture phase — what design decisions this phase commits to, what's deferred to implementation — or skip and start design now? [y]es / [n]o"
      Default: `[n]`.
-   - Otherwise → proceed silently (no nag; task never authored any alignment).
-3. If user says `[y]`, execute the `--phase 2` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 2 — Architecture` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with architecture work.
-4. If user says `[n]` / `[skip]`, proceed. Never block.
+   - Otherwise (user declined task-level retrofit in Step 2a) → proceed silently. No phase-level offer when there's no task-level foundation.
+2. If user says `[y]`, execute the `--phase 2` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 2 — Architecture` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with architecture work.
+3. If user says `[n]` / `[skip]`, proceed. Never block.
 
-**Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level alignment at task creation, that decision is considered final by the time they reach Phase 2 — the task is already underway.
+**Why task-level retrofit lives here (v3.13.1 rationale):** Before v3.13.1, only `/research` offered task-level retrofit. Tasks that completed Phase 1 outside the `/research` command (plan-mode handoffs, manually-authored `research.md`, pre-v3.12.0 tasks) reached `/design` with no task-level scope and no chance to opt in. The v3.13.1 retrofit makes task-level alignment **discoverable** at every phase entry for users who don't know the feature exists — soft prompt, single-shot per invocation, fully skippable.
 
 ## What This Does (v3.0.0)
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -34,21 +34,31 @@ Before doing anything else for this command, verify the prior phases are marked 
 
 Never block the command on this check — the user is in control. The nudge exists so they notice out-of-order invocations without being fought by the tool.
 
-## Phase 3 alignment sub-step (v3.12.0+)
+## Phase 3 alignment sub-step (v3.12.0+, task-level retrofit in v3.13.1+)
 
-**Run after the Phase Transition Check, before loading implementation context.** Same pattern as `/research`'s Phase 1 sub-step:
+**Run after the Phase Transition Check, before loading implementation context.** Same pattern as `/research`'s Phase 1 sub-step.
+
+### Step 3a — Task-level retrofit (v3.13.1+)
 
 1. Invoke `alignment-reader` skill against the task folder.
-2. Decide whether to offer an implementation-specific scope. Plain-language prompts:
+2. If `sections.task_level.present: false` → offer task-level retrofit with soft, phase-aware phrasing:
+   > "Heads up — this task doesn't have a task-level scope recorded yet (`alignment.md` is missing or has no `## Task-Level` section). A short scope contract (goal / expected result / success criteria / non-goals) helps implementation stay on-track. Want 2 minutes to pin it down now, or skip and continue? [y]es / [n]o"
+3. On `[y]` → execute the **task-level** flow from `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so Step 3b sees the new section.
+4. On `[n]` / `[skip]` → proceed. Decision is final for this command invocation — no re-nag. Do NOT offer task-level retrofit again in the same `/implement` run.
+5. If `sections.task_level.present: true` → proceed silently to Step 3b (no prompt, no nag).
+
+### Step 3b — Phase-level scope offer
+
+1. Decide whether to offer an implementation-specific scope. Plain-language prompts:
    - If `sections.phase_3.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
-   - Else if `sections.task_level.present: true` → ask:
+   - Else if `sections.task_level.present: true` (either pre-existing, or just authored by Step 3a) → ask:
      > "You've scoped the whole task. Want to also scope just this implementation phase — what exactly gets built in this pass, what's deferred to follow-up — or skip and start coding now? [y]es / [n]o"
      Default: `[n]`.
-   - Otherwise → proceed silently (no nag; task never authored any alignment).
-3. If user says `[y]`, execute the `--phase 3` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 3 — Implementation` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with implementation context loading.
-4. If user says `[n]` / `[skip]`, proceed. Never block.
+   - Otherwise (user declined task-level retrofit in Step 3a) → proceed silently. No phase-level offer when there's no task-level foundation.
+2. If user says `[y]`, execute the `--phase 3` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 3 — Implementation` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with implementation context loading.
+3. If user says `[n]` / `[skip]`, proceed. Never block.
 
-**Note:** There is no "re-offer for lighter-touch" branch here (unlike `/research`'s Phase 1 sub-step). If the user declined task-level alignment at task creation, that decision is considered final — the task is already in Phase 3.
+**Why task-level retrofit lives here (v3.13.1 rationale):** Before v3.13.1, only `/research` offered task-level retrofit. Tasks that completed Phases 1-2 outside the plugin commands (plan-mode handoffs, manually-authored `research.md`/`architecture.md`, pre-v3.12.0 tasks) reached `/implement` with no task-level scope and no chance to opt in. The v3.13.1 retrofit makes task-level alignment **discoverable** at every phase entry for users who don't know the feature exists — soft prompt, single-shot per invocation, fully skippable.
 
 ## What This Does (v3.0.0)
 


### PR DESCRIPTION
## Summary

- Before v3.13.1, only `/research` offered task-level alignment retrofit (v3.12.2+). `/design` and `/implement` silently assumed "user declined at task creation" and never re-offered. That assumption breaks for two real scenarios:
  1. **Phase executed outside the plugin command** — `research.md` authored manually (plan-mode handoff, staged-file rewrite, pre-v3.12.0 tasks). The user never had a chance to be offered alignment because `/research` never ran.
  2. **Tasks jumping directly to Phase 2/3** — pre-existing flat tasks where the user reaches `/design` without ever running `/research`.
- v3.13.1 mirrors `/research`'s retrofit branch into `/design` and `/implement`, adapted for phase-aware phrasing and deliberately simpler (no `analysis-agent` warrant check — by Phase 2/3 the task has concrete artifacts, so unconditional-offer-on-missing-task-level is more honest than re-judging warrant).
- Soft prompt, single-shot per invocation, fully skippable, never blocking. Matches v3.12.0's soft-nudge posture. Discoverability fix for users who don't know `/scope` exists.

## Files changed

- `commands/design.md` — new Step 2a (task-level retrofit) + Step 2b (existing phase-level offer)
- `commands/implement.md` — new Step 3a (task-level retrofit) + Step 3b (existing phase-level offer)
- Both files: removed the `**Note:**` justifying asymmetric behavior
- `CHANGELOG.md` — new [3.13.1] entry
- `CLAUDE.md` — short note on retrofit coverage
- `.claude-plugin/plugin.json` — 3.13.0 → 3.13.1
- root `.claude-plugin/marketplace.json` — plugin entry version + `metadata.version` 1.14.13 → 1.14.14

## Test plan

- [ ] Fresh task with no `alignment.md` → run `/design <task>` → verify task-level retrofit prompt appears BEFORE phase-level offer
- [ ] Same task, answer `[n]` → verify no re-prompt in same invocation
- [ ] Task with `alignment.md` containing only `## Task-Level` → run `/design <task>` → verify Step 2a silent-skips, Step 2b offers phase-level
- [ ] Task with full alignment (task-level + phase 2) → run `/design <task>` → verify both Steps silent-skip
- [ ] Same matrix against `/implement`
- [ ] Verify `/research` unchanged (existing v3.12.2+ retrofit logic untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)