### PR TITLE
fix(drupal-dev-framework): alignment-reader stub-H2 false-positive (v3.13.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.14"
+    "version": "1.14.15"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.13.1",
+      "version": "3.13.2",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.2] - 2026-04-24
+
+### Fixed — `alignment-reader` reported stub H2 sections as `present: true`
+
+Discovered while running v3.13.1 `/design` against a task with a placeholder `alignment.md` (Task-Level populated; Phase 1/2/3 H2 headers present but only a "to be authored later" stub under each).
+
+**Bug:** `alignment-read.sh` computed `sections.<key>.present` purely from the presence of the H2 heading. A stub like:
+
+```markdown
+## Phase 2 — Architecture
+
+_To be authored inline when `/design` is invoked._
+```
+
+...parsed as `phase_2.present: true` even though no H3 fields carried content. Downstream, the v3.12.0 phase-alignment sub-step in `/design` (and `/implement`, and `/research`) interprets `present: true` as "scope exists, skip the offer" — so stubbed sections silently suppressed legitimate alignment offers. Exactly the `/design` false-positive path.
+
+**Fix:** tighten the `present` semantics in the reader to require **H2 exists AND at least one field carries non-empty content** (populated prose body, ≥1 task-list criterion, ≥1 non-goal bullet, or fallback prose body). Empty stubs now return `present: false` plus a new `section_empty_stub` warning — surfaced to consumers who want to know the H2 was seen but contained nothing.
+
+Spec updated: `references/alignment-contract.md` §2 (section-presence semantics paragraph) + §6 (warning code table).
+
+**Consumer impact:** `/research` / `/design` / `/implement` now correctly skip-or-offer based on real content. Stub sections no longer silently suppress the phase-level alignment offer. No command-file changes required — the commands already check `present`; they just now get an honest answer.
+
+**Verified against:**
+- `dev_framework_isolated_validators/alignment.md` (Task-Level populated, Phase 1/2/3 stubs) → `task_level.present: true`, phase_N `present: false`, 3 `section_empty_stub` warnings
+- `completed/dev_framework_granular_validation/alignment.md` (Task-Level only, no phase sections at all) → `task_level.present: true`, no phase warnings (true absence vs stub correctly distinguished)
+
+### Files changed
+
+- `scripts/alignment-read.sh` — `$present_keys` now derived from content-bearing records (`field`, `criterion`, `non_goal`, `criteria_prose`, `non_goals_prose`), not `section_start` alone. New `$empty_stub_keys` derives from the set difference. New `$w_empty_stub` warning stream
+- `references/alignment-contract.md` — section-presence semantics paragraph added to §2; new `section_empty_stub` row in §6 warning code table
+
+### Not changed
+
+- `alignment-reader` skill wrapper — unchanged (delegates to the script)
+- `commands/research.md`, `commands/design.md`, `commands/implement.md` — no changes needed; fix is isolated to the reader
+- Public JSON envelope shape — unchanged (only the semantics of `present` tightened)
+
 ## [3.13.1] - 2026-04-24
 
 ### Fixed — Task-level alignment retrofit in `/design` and `/implement`

--- a/drupal-dev-framework/references/alignment-contract.md
+++ b/drupal-dev-framework/references/alignment-contract.md
@@ -61,6 +61,8 @@ Sibling to `task.md`, `research.md`, `architecture.md`, `implementation.md` in t
 
 Phase sections are OPTIONAL — a brand-new task's `alignment.md` may contain only `## Task-Level`; phase sections are appended as the task enters each phase.
 
+**Section presence semantics (v3.13.2+):** a section is `present: true` in the parsed output **only when the H2 heading exists AND at least one of its four canonical fields carries non-empty content** (populated prose body, ≥1 task-list criterion, ≥1 non-goal bullet, or any fallback prose body). An H2 with no H3s, or with all H3s empty, is a **stub** — the parser emits `present: false` for that section and adds a `section_empty_stub` warning. This matches consumer intent: `/research`, `/design`, `/implement` use `present: true` to decide "scope exists, skip the offer" — a stub H2 shouldn't satisfy that check. Before v3.13.2 the reader reported `present: true` for stub H2s, causing phase commands to silently skip legitimate alignment offers.
+
 ## 3. Recognized H2 section headings
 
 | Canonical heading | Maps to JSON key | Notes |
@@ -125,6 +127,7 @@ Reader emits all applicable warnings in a single `warnings[]` array. Never abort
 | `missing_field` | Expected H3 not found inside a recognized H2 |
 | `unknown_field` | H3 present but not one of the 4 canonical field names |
 | `empty_field` | Recognized H3 present but body is blank |
+| `section_empty_stub` | **(v3.13.2+)** H2 section heading exists but no H3 fields carry any content — the section is a stub. `sections.<key>.present` is `false` in this case. |
 | `success_criteria_not_checklist` | `Success criteria` body is prose instead of `- [ ]` task-list |
 | `non_goals_not_bulleted` | `Non-goals` body is prose instead of `- …` bulleted list |
 | `error` | Unrecoverable read failure (permission denied, invalid UTF-8). Only case producing non-zero exit. |

--- a/drupal-dev-framework/scripts/alignment-read.sh
+++ b/drupal-dev-framework/scripts/alignment-read.sh
@@ -243,8 +243,21 @@ printf '%s\n' "$RECORDS" | jq -cs --arg fp "$ALIGNMENT_MD" '
   (map(select(.kind == "meta" and .task_name_alt)) | last // {}) as $meta_alt |
   (map(select(.kind == "meta" and .created)) | last // {}) as $meta_created |
 
-  # Start with all four sections as empty, then upgrade any that appeared
-  (map(select(.kind == "section_start") | .section) | unique) as $present_keys |
+  # H2 existence (raw) — any section with a section_start record
+  (map(select(.kind == "section_start") | .section) | unique) as $h2_keys |
+
+  # Content existence — a section has content only if it has at least one
+  # record that represents an actual populated field: field, criterion,
+  # non_goal, criteria_prose, non_goals_prose. NOT empty_field (blank H3),
+  # NOT section_start alone (H2 with no H3s or all H3s empty).
+  (map(select(
+    (.kind == "field" or .kind == "criterion" or .kind == "non_goal"
+      or .kind == "criteria_prose" or .kind == "non_goals_prose")
+    and (.section // "" | IN("task_level","phase_1","phase_2","phase_3"))
+  ) | .section) | unique) as $present_keys |
+
+  # Empty-stub detection: H2 exists but zero content records
+  ($h2_keys - $present_keys) as $empty_stub_keys |
 
   (reduce $present_keys[] as $k (
     {task_level: empty_section, phase_1: empty_section, phase_2: empty_section, phase_3: empty_section};
@@ -299,6 +312,9 @@ printf '%s\n' "$RECORDS" | jq -cs --arg fp "$ALIGNMENT_MD" '
   (map(select(.kind == "criteria_prose"))  | map({code: "success_criteria_not_checklist", section: .section})) as $w_crit_prose |
   (map(select(.kind == "non_goals_prose")) | map({code: "non_goals_not_bulleted", section: .section})) as $w_ngoal_prose |
 
+  # section_empty_stub warnings: H2 exists but zero content records
+  ($empty_stub_keys | map({code: "section_empty_stub", section: .})) as $w_empty_stub |
+
   # missing_field warnings from sections_final.fields_missing (truly absent H3s)
   ([$sections_final | to_entries[] | select(.value.present) | {sk: .key, fm: .value.fields_missing}]
     | map(.sk as $sk | .fm | map({code: "missing_field", section: $sk, field: .})) | add // []) as $w_missing |
@@ -310,6 +326,6 @@ printf '%s\n' "$RECORDS" | jq -cs --arg fp "$ALIGNMENT_MD" '
     created: ($meta_created.created // null),
     schema_version: "1.0",
     sections: $sections_final,
-    warnings: ($w_unk_sec + $w_unk_field + $w_empty + $w_crit_prose + $w_ngoal_prose + $w_missing)
+    warnings: ($w_unk_sec + $w_unk_field + $w_empty + $w_crit_prose + $w_ngoal_prose + $w_empty_stub + $w_missing)
   }
 '


### PR DESCRIPTION
## Summary

- Discovered while running v3.13.1 \`/design\` against a task whose \`alignment.md\` had populated Task-Level + stubbed phase sections (H2 header + "_To be authored inline when \`/design\` is invoked._" placeholder).
- \`scripts/alignment-read.sh\` reported \`sections.phase_2.present: true\` based on H2 existence alone. The phase-alignment sub-step in \`/design\` (and \`/implement\`, and \`/research\`) interprets \`present: true\` as "scope exists, skip the offer" → stub sections silently suppressed legitimate alignment offers.
- Fix: \`present: true\` now requires **H2 exists AND at least one field carries content**. Stubs return \`present: false\` + new \`section_empty_stub\` warning. No command file changes — consumers already check \`present\`; they just now get an honest answer.

## Files changed

- \`scripts/alignment-read.sh\` — \`\$present_keys\` derived from content-bearing records (\`field\`, \`criterion\`, \`non_goal\`, \`criteria_prose\`, \`non_goals_prose\`), not \`section_start\` alone. New \`\$empty_stub_keys\` set-difference. New \`\$w_empty_stub\` warning stream
- \`references/alignment-contract.md\` — §2 section-presence semantics paragraph; §6 warning-code table gains \`section_empty_stub\`
- \`CHANGELOG.md\` — new [3.13.2] entry
- \`.claude-plugin/plugin.json\` — 3.13.1 → 3.13.2
- root \`.claude-plugin/marketplace.json\` — plugin entry version + \`metadata.version\` 1.14.14 → 1.14.15

## Verification

- [x] Discovery case: \`dev_framework_isolated_validators/alignment.md\` (Task-Level populated, phase 1/2/3 stubs) → \`task_level.present: true\`, phase_N \`present: false\`, 3 \`section_empty_stub\` warnings
- [x] Known-good: \`completed/dev_framework_granular_validation/alignment.md\` (only Task-Level, no phase H2s at all) → \`task_level.present: true\`, no phase warnings — true absence correctly distinguished from stub

## Test plan

- [ ] Clean install pulls v3.13.2 script
- [ ] Run \`/design\` against a task with stub phase sections → retrofit + phase offer both fire (not silently skipped)
- [ ] Run \`/design\` against a task with real phase content → "already scoped" prints (no re-prompt)
- [ ] Run \`/research\` against a task with stub Phase 1 → retrofit + Phase 1 offer fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)