### PR TITLE
feat(drupal-dev-framework): plain-language alignment prompts (v3.13.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.15"
+    "version": "1.14.16"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.13.2",
+      "version": "3.13.3",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.3] - 2026-04-24
+
+### Changed — Alignment-related prompt wording in `/research`, `/design`, `/implement`
+
+v3.12.4 already rewrote alignment prompts in plain language, but live use kept surfacing them as too jargon-heavy: "scope the task," "phase-level scope contract," "what X phase commits to," "deferred to implementation" — all framework vocabulary that assumes the user already understands the alignment system. Users who didn't read the framework docs were unsure whether to say yes.
+
+**Fix:** rewrite all 8 alignment prompts across the three phase commands using a consistent **example-driven** pattern:
+
+- **Lead with the phase action** — "Before I dig into research," "Before I start designing," "Before I start coding"
+- **One-sentence question** in the user's vocabulary — no "scope contract," no "phase commits to," no "deferred"
+- **Concrete example block** showing the shape of the output (4 fields with placeholder hints), so the user can see what "yes" produces before deciding
+- **Option labels with low-friction tails** — `[n]` carries `(can always add this later)` instead of an implied nag
+
+**Prompts rewritten:**
+
+- `commands/research.md`:
+  - Pre-analysis task-level nudge (L133)
+  - Task-level retrofit prompt (v3.12.2 retrofit check, L150)
+  - Phase 1 phase-level offer (L162)
+  - Phase 1 lighter-touch re-offer after declined task-level (L165)
+- `commands/design.md`:
+  - Step 2a task-level retrofit (v3.13.1)
+  - Step 2b Phase 2 phase-level offer (v3.12.0)
+- `commands/implement.md`:
+  - Step 3a task-level retrofit (v3.13.1)
+  - Step 3b Phase 3 phase-level offer (v3.12.0)
+
+**No logic changes** — all decision branches, defaults, and option semantics (`[y]` / `[n]` / `[later]` / `[skip]`) are unchanged. Pure UX / plain-language pass.
+
+**No consumer-facing artifact changes** — `alignment.md` schema unchanged; reader output unchanged; `/scope` flow unchanged.
+
+**Why example-driven beats description-driven:** the user can see a 4-line concrete template of what's being offered, decide in seconds whether that's worth 2 minutes of Q&A, and skip it with no ambiguity. Removes the common failure mode where jargon-heavy prompts prompt a clarifying question before the user can even answer.
+
 ## [3.13.2] - 2026-04-24
 
 ### Fixed — `alignment-reader` reported stub H2 sections as `present: true`

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -36,7 +36,19 @@ Never block the command on this check — the user is in control. The nudge exis
 
 1. Invoke `alignment-reader` skill against the task folder.
 2. If `sections.task_level.present: false` → offer task-level retrofit with soft, phase-aware phrasing:
-   > "Heads up — this task doesn't have a task-level scope recorded yet (`alignment.md` is missing or has no `## Task-Level` section). A short scope contract (goal / expected result / success criteria / non-goals) helps design stay on-track. Want 2 minutes to pin it down now, or skip and continue? [y]es / [n]o"
+   > **Before I dive into design:** this task has no task-level scope recorded yet. Want to pin down what the whole task is trying to deliver first, so design doesn't wander?
+   >
+   > You'd answer 4 short questions, one at a time. Shape of the result:
+   >
+   > ```
+   > Goal: <what this task is really about>
+   > Expected result: <what exists when it's done>
+   > Done when: <observable checks>
+   > Won't do here: <related work we're skipping>
+   > ```
+   >
+   > **[y]es** — 4 questions now
+   > **[n]o** — start designing as-is (can always add this later)
 3. On `[y]` → execute the **task-level** flow from `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so Step 2b sees the new section.
 4. On `[n]` / `[skip]` → proceed. Decision is final for this command invocation — no re-nag. Do NOT offer task-level retrofit again in the same `/design` run.
 5. If `sections.task_level.present: true` → proceed silently to Step 2b (no prompt, no nag).
@@ -46,7 +58,20 @@ Never block the command on this check — the user is in control. The nudge exis
 1. Decide whether to offer an architecture-specific scope. Plain-language prompts:
    - If `sections.phase_2.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
    - Else if `sections.task_level.present: true` (either pre-existing, or just authored by Step 2a) → ask:
-     > "You've scoped the whole task. Want to also scope just this architecture phase — what design decisions this phase commits to, what's deferred to implementation — or skip and start design now? [y]es / [n]o"
+     > **Before I start designing:** you've already scoped the task. Want to also pin down what *just this design pass* is deciding (vs leaving for implementation)?
+     >
+     > Useful when architecture has many threads. Shape of the result:
+     >
+     > ```
+     > Phase 2 — Architecture
+     > Goal: <what this design pass is deciding>
+     > Expected result: <e.g., "a doc naming the pieces and how they fit">
+     > Done when: <observable signal, e.g., "someone else could hand this off to implementation">
+     > Won't decide here: <pushed to Phase 3, e.g., "actual code / prose">
+     > ```
+     >
+     > **[y]es** — 4 questions now
+     > **[n]o** — start designing (can always add this later)
      Default: `[n]`.
    - Otherwise (user declined task-level retrofit in Step 2a) → proceed silently. No phase-level offer when there's no task-level foundation.
 2. If user says `[y]`, execute the `--phase 2` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 2 — Architecture` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with architecture work.

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -42,7 +42,19 @@ Never block the command on this check — the user is in control. The nudge exis
 
 1. Invoke `alignment-reader` skill against the task folder.
 2. If `sections.task_level.present: false` → offer task-level retrofit with soft, phase-aware phrasing:
-   > "Heads up — this task doesn't have a task-level scope recorded yet (`alignment.md` is missing or has no `## Task-Level` section). A short scope contract (goal / expected result / success criteria / non-goals) helps implementation stay on-track. Want 2 minutes to pin it down now, or skip and continue? [y]es / [n]o"
+   > **Before I start coding:** this task has no task-level scope recorded yet. Want to pin down what the whole task is trying to deliver first, so implementation stays on-target?
+   >
+   > You'd answer 4 short questions, one at a time. Shape of the result:
+   >
+   > ```
+   > Goal: <what this task is really about>
+   > Expected result: <what exists when it's done>
+   > Done when: <observable checks>
+   > Won't do here: <related work we're skipping>
+   > ```
+   >
+   > **[y]es** — 4 questions now
+   > **[n]o** — start coding as-is (can always add this later)
 3. On `[y]` → execute the **task-level** flow from `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so Step 3b sees the new section.
 4. On `[n]` / `[skip]` → proceed. Decision is final for this command invocation — no re-nag. Do NOT offer task-level retrofit again in the same `/implement` run.
 5. If `sections.task_level.present: true` → proceed silently to Step 3b (no prompt, no nag).
@@ -52,7 +64,20 @@ Never block the command on this check — the user is in control. The nudge exis
 1. Decide whether to offer an implementation-specific scope. Plain-language prompts:
    - If `sections.phase_3.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
    - Else if `sections.task_level.present: true` (either pre-existing, or just authored by Step 3a) → ask:
-     > "You've scoped the whole task. Want to also scope just this implementation phase — what exactly gets built in this pass, what's deferred to follow-up — or skip and start coding now? [y]es / [n]o"
+     > **Before I start coding:** you've already scoped the task. Want to also pin down what *just this implementation pass* builds (vs deferring to follow-up work)?
+     >
+     > Useful for scope-heavy implementations or when several follow-ups are already implied. Shape of the result:
+     >
+     > ```
+     > Phase 3 — Implementation
+     > Goal: <what this build pass is delivering>
+     > Expected result: <concrete files / behavior live after this pass>
+     > Done when: <observable check, e.g., "tests pass + manual smoke path works">
+     > Won't build here: <explicitly pushed to a follow-up task>
+     > ```
+     >
+     > **[y]es** — 4 questions now
+     > **[n]o** — start coding (can always add this later)
      Default: `[n]`.
    - Otherwise (user declined task-level retrofit in Step 3a) → proceed silently. No phase-level offer when there's no task-level foundation.
 2. If user says `[y]`, execute the `--phase 3` flow from `commands/scope.md` (context-aware phase-level conversation + "Writing alignment.md" for the `## Phase 3 — Implementation` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, continue with implementation context loading.

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -130,7 +130,20 @@ If a signal fires:
    - `insufficient_info` → proceed with flat-task research; the task description alone wasn't sufficient for decomposition judgment (makes sense at creation time — usually the description IS minimal here).
 
 5. **(v3.12.0+)** After the `decision` branch completes (regardless of outcome unless the task became an epic), inspect `signals_used[]` for `scope_contract_recommended`. If present, print soft-nudge in plain language — explain WHY before asking:
-   > "Before diving into research: this task looks scope-heavy (multiple deliverables or complex criteria). Want to pin down the scope first in a short conversation — goal, what success looks like, what's explicitly out of scope — so research doesn't drift? [y]es / [n]o / [later]"
+   > **Before I dig into research:** this task looks scope-heavy (multiple deliverables, or details that can be read several ways). Want to pin down what it's really trying to deliver first?
+   >
+   > You'd answer 4 short questions, one at a time. Shape of the result:
+   >
+   > ```
+   > Goal: <what this task is really about>
+   > Expected result: <what exists when it's done>
+   > Done when: <observable checks>
+   > Won't do here: <related work we're skipping>
+   > ```
+   >
+   > **[y]es** — 4 questions now
+   > **[n]o** — research as-is (we can always add this later)
+   > **[later]** — skip for now; `/scope <task>` anytime
 
    On `[y]` → execute the alignment conversation + write flow as documented in `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md") within this command's context. Do NOT try to shell out to a sibling slash command. After the write completes, continue with the standard research flow.
    On `[n]` → proceed without writing `alignment.md`. No nag.
@@ -147,7 +160,20 @@ Conservative by design: pre-analysis only fires on strong signals, and even then
 2. **Task-level retrofit check (v3.12.2+)** — if the task folder ALREADY existed before this `/research` invocation (i.e., the user is running `/research` on a pre-existing flat task created outside the hook flow, NOT a fresh task just created by this command) AND `sections.task_level.present: false` AND the pre-analysis hook did NOT run this session → invoke `analysis-agent` in **folder mode** (`task_folder` set to the task directory, `codePath` resolved via `project-state-reader`, `schema_version: "1.0"`). Inspect the returned `signals_used[]` for `scope_contract_recommended`.
 
    - If present → print soft-nudge in plain language:
-     > "This task doesn't have a declared scope yet, and I'm picking up signals that scope might drift during research (multiple distinct deliverables, or a description that could be interpreted several ways). Want to spend a minute nailing down the goal and success criteria before we dig in? [y]es / [n]o / [skip]"
+     > **Before I dig into research:** this task has no task-level scope recorded yet, and I'm seeing signals that scope could drift (multiple distinct deliverables, or a description that reads several ways). Want to pin down what it's really trying to deliver first?
+     >
+     > You'd answer 4 short questions, one at a time. Shape of the result:
+     >
+     > ```
+     > Goal: <what this task is really about>
+     > Expected result: <what exists when it's done>
+     > Done when: <observable checks>
+     > Won't do here: <related work we're skipping>
+     > ```
+     >
+     > **[y]es** — 4 questions now
+     > **[n]o** — research as-is (we can always add this later)
+     > **[skip]** — same as no, but quieter about it
      Default: `[skip]`.
      - On `[y]` → execute the task-level flow from `commands/scope.md` (context-aware task-level conversation + "Writing alignment.md" for the `## Task-Level` section) within this command's context. Do NOT shell out to the sibling slash command. After the write, refresh `alignment-reader` output so subsequent steps see the new section.
      - On `[n]` / `[skip]` → proceed; record "task-level retrofit declined" for this run.
@@ -159,10 +185,36 @@ Conservative by design: pre-analysis only fires on strong signals, and even then
 3. Decide whether to offer a research-specific scope. All prompts use plain language that explains WHAT the choice means:
    - If `sections.phase_1.present: true` → print: `"You already scoped this phase earlier. Using that scope."` and proceed.
    - Else if `sections.task_level.present: true` (including freshly authored in step 2) → ask:
-     > "You've scoped the whole task. Want to also scope just this research phase specifically — what questions research needs to answer, what's out of scope for research — or skip and start research now? [y]es / [n]o"
+     > **Before I start research:** you've already scoped the task. Want to also scope *just this research pass* — what it's trying to answer vs what it's leaving for later?
+     >
+     > Useful when research has many threads; often not needed. Shape of the result:
+     >
+     > ```
+     > Phase 1 — Research
+     > Goal: <what this research pass is answering>
+     > Expected result: <e.g., "a research.md recommending one option with citations">
+     > Done when: <observable signal, e.g., "≥2 concrete code references">
+     > Won't decide here: <pushed to Phase 2, e.g., "which option to actually build">
+     > ```
+     >
+     > **[y]es** — 4 questions now
+     > **[n]o** — start research (can always add this later)
      Default: `[n]` (most tasks don't need a separate research sub-scope).
    - Else if pre-analysis hook emitted `scope_contract_recommended` and user declined task-level scope earlier → re-offer lighter-touch:
-     > "You skipped the task-level scope earlier. Want to at least scope just this research phase (lighter — only what research is trying to answer)? [y]es / [n]o"
+     > **Before I start research:** you skipped the full task-level scope earlier. Want to scope *just this research pass* instead? (Lighter — only what research is trying to answer.)
+     >
+     > Shape of the result:
+     >
+     > ```
+     > Phase 1 — Research
+     > Goal: <what this research pass is answering>
+     > Expected result: <e.g., "a research.md recommending one option with citations">
+     > Done when: <observable signal>
+     > Won't decide here: <pushed to Phase 2>
+     > ```
+     >
+     > **[y]es** — 4 questions now
+     > **[n]o** — start research as-is
      Default: `[n]`.
    - Otherwise → proceed silently (no nag).
 


### PR DESCRIPTION
## Summary

- v3.12.4 rewrote alignment prompts in "plain language," but live use kept surfacing them as too jargon-heavy: "scope contract," "phase-level scope," "what X phase commits to," "deferred to implementation" — all framework vocabulary that assumes prior knowledge. Users who didn't read the framework docs were unsure whether to say yes.
- This PR rewrites all 8 alignment prompts across the three phase commands with a consistent **example-driven** pattern: phase-action lead-in, one-sentence question in the user's vocabulary, concrete 4-field example block showing the shape of the output, and option labels with low-friction tails like `(can always add this later)` on `[n]` to remove implied nag.
- Discovered live during the \`dev_framework_isolated_validators\` alignment conversation — the v3.13.1 \`/design\` Phase 2 offer was confusing enough that the user stopped the flow and asked for better wording.

## Pattern applied

Every rewritten prompt now follows:

1. **Phase-action lead-in** — "Before I dig into research," "Before I start designing," "Before I start coding" — not "Phase 2 alignment."
2. **One-sentence question** using user vocabulary — no "scope contract," no "commits to," no "deferred."
3. **Concrete example block** (4 fields with \`<placeholder hints>\`) showing exactly what the user gets if they say yes.
4. **Option labels with tails** — \`[y]es\` — 4 questions now / \`[n]o\` — X as-is (can always add this later).

## Files changed

- \`commands/research.md\` — 4 prompts (pre-analysis nudge, task-level retrofit, Phase 1 offer, lighter-touch re-offer)
- \`commands/design.md\` — 2 prompts (Step 2a task-level retrofit, Step 2b Phase 2 offer)
- \`commands/implement.md\` — 2 prompts (Step 3a task-level retrofit, Step 3b Phase 3 offer)
- \`CHANGELOG.md\` — new [3.13.3] entry
- \`.claude-plugin/plugin.json\` — 3.13.2 → 3.13.3
- root \`.claude-plugin/marketplace.json\` — plugin entry version + \`metadata.version\` 1.14.15 → 1.14.16

## What's NOT changing

- Logic: all decision branches, defaults, and option semantics (\`[y]\` / \`[n]\` / \`[later]\` / \`[skip]\`) unchanged
- Schema: \`alignment.md\` grammar v1.0 unchanged; reader output unchanged
- \`/scope\` flow unchanged
- No new commands, no new references, no new dependencies

## Test plan

- [ ] \`/design\` on a task without task-level scope → verify Step 2a prompt renders with new wording + example block
- [ ] \`/design\` on a task with task-level but no Phase 2 → verify Step 2b prompt renders with new wording
- [ ] Same matrix against \`/research\` (Phase 1 + lighter-touch path) and \`/implement\` (Phase 3)
- [ ] Verify \`[y]\` still routes to \`/scope\` inline flow; \`[n]\` still proceeds silently; \`[later]\` / \`[skip]\` still supported where existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)