### PR TITLE
feat(drupal-dev-framework): traceability walkthrough + dev-guides pre-flight (v3.13.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.16"
+    "version": "1.14.17"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.13.3",
+      "version": "3.13.4",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.13.3",
+  "version": "3.13.4",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.4] - 2026-04-24
+
+Two phase-command UX fixes discovered during live use of `/design` on a non-Drupal plugin-framework task. Both bundled here as a single quick-fix release.
+
+### Added — Traceability walkthrough sub-step in `/research`, `/design`, `/implement`
+
+Users had no in-command way to see how the newly-authored `research.md` / `architecture.md` / `implementation.md` addresses the task's research questions + acceptance criteria — they had to read the whole artifact and cross-reference by hand.
+
+**Fix:** after each phase command authors its artifact, offer an opt-in walkthrough that maps acceptance criteria (pulled from `alignment.md` Success criteria, falling back to `task.md` Acceptance Criteria) to the artifact's sections. User picks `[c]ontinue` / `[r]evise` / `[d]iscuss` and can inline-edit or discuss any row.
+
+**Pattern:**
+- Step 1: single-line `[y]es / [n]o` opt-in prompt. Default `[n]`.
+- Step 2 (on `[y]`): map each criterion → artifact section reference (honest — unaddressed criteria marked `— NOT YET ADDRESSED —`, never invented).
+- Step 3: print the table.
+- Step 4: 3-way prompt (`[c]` / `[r]` / `[d]`) with inline revise + discuss paths.
+
+**Never blocks.** Opt-in twice (`[n]` in Step 1 or `[c]` in Step 4) always proceeds. No persistence except edits the user approves under `[r]`.
+
+**Per-phase adaptations:**
+- `/research` — maps research questions (from `task.md`) AND task-level ACs (from `alignment.md`) to `research.md` sections.
+- `/design` — maps task-level ACs to `architecture.md` sections (+ optional `architecture/{component}.md` files).
+- `/implement` — maps task-level ACs to `implementation.md` progress status (`[complete]` / `[in-progress]` / `(planned)` / `— NOT YET ADDRESSED —`). Particularly useful mid-flight as a sanity check.
+
+### Added — Dev-guides pre-flight sub-step in `/research`, `/design`, `/implement`
+
+Before v3.13.4, each phase command's "What This Does" list said *"Loads dev-guides via `guide-integrator` (unless already loaded this session)"* — but that was documentation-of-intent, not an explicit directive to Claude to invoke the skill. The skill fired only via proactive-skill-detection, which is unreliable on non-Drupal tasks (plugin framework, docs-only, Claude Code work). Result: live observation on `dev_framework_isolated_validators` showed dev-guides were never consulted, even though applicable methodology guides (TDD, SOLID, DRY, security, quality-gates) and cross-cutting guides (Next.js, design systems, CSS) existed.
+
+**Fix:** new explicit "Dev-guides pre-flight" sub-step runs after Phase Transition Check, BEFORE the alignment sub-step. Two-part structure:
+
+1. **Explicit invocation** of `guide-integrator` (no reliance on proactive detection).
+2. **Always-prompt** the user — NEVER silent-skip — with the current auto-loaded set displayed, then `[c]ontinue` / `[a]dd (scan dev-guides-navigator catalog)` / `[n]one (decline all)`.
+
+**Why "never silent-skip":** dev-guides cover material beyond Drupal (methodology, Next.js, design systems, CSS). Even when auto-detection finds N guides, the user may want to `[a]dd` more. When auto-detection finds zero (common on non-Drupal tasks), the user would have had no signal that guides exist. Silent-skip was hiding the catalog.
+
+**Discoverability > compliance.** `[n]` is a first-class choice — users who explicitly don't want guides can decline without guilt. The fix is about surfacing the option, not mandating use.
+
+### Files changed
+
+- `commands/research.md` — new "Dev-guides pre-flight" section (runs after pre-analysis hook, before Phase 1 alignment). New "Traceability walkthrough sub-step" section (runs after `research.md` authoring, before session-context-writer). Both referenced from updated "What This Does" list
+- `commands/design.md` — same pair of sections, adapted for Phase 2 context. Updated "What This Does" list
+- `commands/implement.md` — same pair of sections, adapted for Phase 3 context (including mid-flight re-invocation note for the walkthrough). Updated "What This Does" list
+
+### Not changed
+
+- `guide-integrator` skill — unchanged (auto-load rules preserved; v3.13.4 just invokes it explicitly and adds the user prompt layer above it)
+- `dev-guides-navigator` plugin — unchanged (consumed unchanged by `[a]dd` branch)
+- `alignment-reader` skill — unchanged
+- Phase-alignment sub-steps (v3.12.0/v3.12.2/v3.13.1 work) — unchanged in logic; dev-guides pre-flight runs just ahead of them
+
 ## [3.13.3] - 2026-04-24
 
 ### Changed — Alignment-related prompt wording in `/research`, `/design`, `/implement`

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -28,6 +28,43 @@ Before doing anything else for this command, verify the prior phase is marked co
 
 Never block the command on this check — the user is in control. The nudge exists so they notice out-of-order invocations without being fought by the tool.
 
+## Dev-guides pre-flight (v3.13.4+)
+
+**Run after the Phase Transition Check, before the alignment sub-step.** The goal: every phase command either loads dev-guides or has the user explicitly say "no guides" — never a silent skip. Dev-guides cover Drupal, Next.js, design systems (Bootstrap, Radix, Tailwind, DaisyUI), CSS, and cross-cutting methodology (TDD, SOLID, DRY, security, quality gates) — relevant across Drupal AND non-Drupal (plugin framework, docs-only, Claude Code) tasks.
+
+### Step 1 — Invoke guide-integrator explicitly
+
+Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
+
+### Step 2 — ALWAYS prompt the user (never silent-skip)
+
+Regardless of whether guide-integrator auto-loaded 0, 1, or N guides, print:
+
+> **Dev-guides pre-flight for `<task_name>` (Phase 2 — Architecture):**
+>
+> Auto-loaded based on task keywords:
+>   <bulleted list of loaded guides, OR "  — none auto-matched —">
+>
+> Dev-guides cover Drupal (forms, entities, plugins, services, caching, views, etc.), Next.js, design systems (Bootstrap, Radix, Tailwind, DaisyUI), CSS, and methodology (TDD, SOLID, DRY, security, quality gates). Loading relevant guides before design keeps patterns grounded in proven approaches.
+>
+> **[c]ontinue** — auto-loaded set is fine, start design
+> **[a]dd** — scan the `dev-guides-navigator` catalog for more topics before I design
+> **[n]one** — skip dev-guides entirely (override any auto-loaded); I'll rely on you
+
+Default: `[c]`.
+
+### Step 3 — Act on the answer
+
+- `[c]` → proceed to the alignment sub-step with the auto-loaded guides (possibly empty).
+- `[a]` → invoke `dev-guides-navigator` interactively with task keywords the user supplies. Let the user select 0 or more additional guides. Load them via `guide-integrator`. After the user says "done," proceed to alignment.
+- `[n]` → clear any auto-loaded guides from the session context (do NOT persist them to `loadedGuides[]`). Note "dev-guides declined" in session. Proceed to alignment.
+
+### Notes
+
+- **Never blocks.** `[c]` (default) always proceeds.
+- **Discoverability > compliance.** The point is to surface available guides to users who don't know they exist — NOT to force guide consumption. `[n]` is a first-class choice.
+- **Works for non-Drupal tasks.** Plugin-framework tasks, docs-only tasks, and Claude Code framework work can still find relevant methodology and design-system guides via `[a]`.
+
 ## Phase 2 alignment sub-step (v3.12.0+, task-level retrofit in v3.13.1+)
 
 **Run after the Phase Transition Check, before any other Phase 2 work.** Same pattern as `/research`'s Phase 1 sub-step.
@@ -83,13 +120,79 @@ Never block the command on this check — the user is in control. The nudge exis
 
 1. Loads task from `implementation_process/in_progress/{task_name}/`
 2. Reviews research findings in `research.md`
-3. **Loads dev-guides** for architecture decisions via `guide-integrator` (unless already loaded this session)
+3. **(v3.13.4+)** Dev-guides pre-flight — explicit `guide-integrator` invocation + always-prompt the user to continue / add / decline (see "Dev-guides pre-flight" section below)
 4. Invokes `architecture-drafter` agent
 5. Invokes `guide-integrator` for methodology refs
 5. Creates/updates `architecture.md` with design
 6. Updates `task.md` to mark Phase 2 as in progress
 7. Optionally creates component file in `architecture/{component}.md`
-8. **Invokes `session-context-writer` skill with the resolved project and task**
+8. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see next section) mapping `architecture.md` sections to the task's acceptance criteria
+9. **Invokes `session-context-writer` skill with the resolved project and task**
+
+## Traceability walkthrough sub-step (v3.13.4+)
+
+**Run after `architecture.md` has been authored (and optional component file written), before `session-context-writer` is invoked.**
+
+Purpose: let the user see, at a glance, how each acceptance criterion from the task is addressed by the freshly-authored design — without having to read the whole artifact and cross-reference by hand.
+
+### Step 1 — Ask (opt-in)
+
+Print the one-line prompt:
+
+> **Walk through how this design addresses the task's acceptance criteria?** [y]es / [n]o
+
+Default: `[n]` (user can always re-invoke via `/scope` or by re-reading the artifact).
+
+If `[n]` → skip the walkthrough; proceed to session-context-writer.
+
+### Step 2 — Build the mapping
+
+On `[y]`:
+
+1. **Pull acceptance criteria** using this priority:
+   - Primary: `alignment-reader` → `sections.task_level.success_criteria[]` (each carries `{text, checked}`)
+   - Fallback: `task.md` → Acceptance Criteria list (extract `- [ ] ...` bullets)
+   - Final fallback: explicit message — "This task has no declared acceptance criteria. Walkthrough can't map without criteria; consider `/scope <task>` to add them."
+2. **For each criterion**, scan `architecture.md` (+ any `architecture/{component}.md` files from step 7) and identify the section(s) that address it. Look for:
+   - Section headings that match the criterion's domain keywords
+   - Explicit callouts in the artifact (e.g., §13 "Acceptance criteria" row, §15 "Risks" mitigations)
+   - Cross-references to fallback flows, invariants, or open questions resolutions
+3. **Honest mapping.** If a criterion has no clear section in the artifact, mark it **"NOT YET ADDRESSED"** — do not invent a section reference. Flag it for the discussion step.
+
+### Step 3 — Print the table
+
+Format:
+
+```
+Design addresses these acceptance criteria:
+
+  AC #1 "<first 60 chars of text>…"  →  architecture.md §N <short-hint>
+  AC #2 "<first 60 chars of text>…"  →  architecture.md §M + §P <short-hint>
+  AC #3 "<first 60 chars of text>…"  →  — NOT YET ADDRESSED — raise in Phase 3?
+  …
+```
+
+Section references are lightweight (e.g., `§7 (validator-visual row)` or `§4 step 5 + §7`). The user doesn't need precise line numbers — just enough to jump to the right place.
+
+### Step 4 — Three-way prompt
+
+After the table, ask:
+
+> **[c]ontinue** — looks right, proceed to session-context-writer
+> **[r]evise** — something's wrong or missing; let's edit `architecture.md` before continuing
+> **[d]iscuss** — not sure, let's talk through one or more rows before deciding
+
+Default: `[c]`.
+
+- `[c]` → proceed.
+- `[r]` → ask the user which row(s) need revision. Make the edit to `architecture.md` inline. After the edit, re-print the table (Step 3) so the user can verify, then re-ask Step 4.
+- `[d]` → ask which row(s) to discuss. Talk through them one at a time; after discussion, re-ask Step 4.
+
+### Notes
+
+- **Never blocks.** User can always pick `[n]` in Step 1 or `[c]` in Step 4.
+- **No schema writes.** The walkthrough is a print-and-optionally-edit flow. Nothing persists except the edits to `architecture.md` that happen under `[r]`.
+- **Opt-in by design.** Not every run needs this — experienced users working on tight scopes will skip; it shines on complex tasks or when the author wants a sanity check before locking Phase 2.
 
 ## Task-Based Workflow
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -34,6 +34,43 @@ Before doing anything else for this command, verify the prior phases are marked 
 
 Never block the command on this check — the user is in control. The nudge exists so they notice out-of-order invocations without being fought by the tool.
 
+## Dev-guides pre-flight (v3.13.4+)
+
+**Run after the Phase Transition Check, before the alignment sub-step.** The goal: every phase command either loads dev-guides or has the user explicitly say "no guides" — never a silent skip. Dev-guides cover Drupal, Next.js, design systems (Bootstrap, Radix, Tailwind, DaisyUI), CSS, and cross-cutting methodology (TDD, SOLID, DRY, security, quality gates) — relevant across Drupal AND non-Drupal (plugin framework, docs-only, Claude Code) tasks.
+
+### Step 1 — Invoke guide-integrator explicitly
+
+Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
+
+### Step 2 — ALWAYS prompt the user (never silent-skip)
+
+Regardless of whether guide-integrator auto-loaded 0, 1, or N guides, print:
+
+> **Dev-guides pre-flight for `<task_name>` (Phase 3 — Implementation):**
+>
+> Auto-loaded based on task keywords:
+>   <bulleted list of loaded guides, OR "  — none auto-matched —">
+>
+> Dev-guides cover Drupal (forms, entities, plugins, services, security, testing, etc.), Next.js, design systems (Bootstrap, Radix, Tailwind, DaisyUI), CSS, and methodology (TDD, SOLID, DRY, security, quality gates). Implementation-phase guides are especially useful for security, SDC, JS, and testing patterns.
+>
+> **[c]ontinue** — auto-loaded set is fine, start coding
+> **[a]dd** — scan the `dev-guides-navigator` catalog for more topics before I implement
+> **[n]one** — skip dev-guides entirely (override any auto-loaded); I'll rely on you
+
+Default: `[c]`.
+
+### Step 3 — Act on the answer
+
+- `[c]` → proceed to the alignment sub-step with the auto-loaded guides (possibly empty).
+- `[a]` → invoke `dev-guides-navigator` interactively with task keywords the user supplies. Let the user select 0 or more additional guides. Load them via `guide-integrator`. After the user says "done," proceed to alignment.
+- `[n]` → clear any auto-loaded guides from the session context (do NOT persist them to `loadedGuides[]`). Note "dev-guides declined" in session. Proceed to alignment.
+
+### Notes
+
+- **Never blocks.** `[c]` (default) always proceeds.
+- **Discoverability > compliance.** `[n]` is a first-class choice.
+- **Works for non-Drupal tasks.** Plugin/framework tasks can still find applicable methodology guides via `[a]`.
+
 ## Phase 3 alignment sub-step (v3.12.0+, task-level retrofit in v3.13.1+)
 
 **Run after the Phase Transition Check, before loading implementation context.** Same pattern as `/research`'s Phase 1 sub-step.
@@ -91,13 +128,83 @@ Never block the command on this check — the user is in control. The nudge exis
 2. Loads architecture from `architecture.md`
 3. Loads research context from `research.md`
 4. Loads referenced patterns from core/contrib
-5. **Loads dev-guides** for security, SDC, JS patterns via `guide-integrator` (unless already loaded this session)
+5. **(v3.13.4+)** Dev-guides pre-flight — explicit `guide-integrator` invocation + always-prompt the user to continue / add / decline (see "Dev-guides pre-flight" section below)
 6. Loads methodology refs (via `guide-integrator`)
 7. Creates/updates `implementation.md` for progress tracking
 8. Updates `task.md` to mark Phase 3 as in progress
 9. Activates `tdd-companion` for TDD discipline
 10. Prepares for interactive development
-11. **Invokes `session-context-writer` skill with the resolved project and task**
+11. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `implementation.md` progress + planned work to the task's acceptance criteria
+12. **Invokes `session-context-writer` skill with the resolved project and task**
+
+## Traceability walkthrough sub-step (v3.13.4+)
+
+**Run after `implementation.md` has been created / updated and the interactive-development prep is complete, before `session-context-writer` is invoked.** Can also be re-invoked at any point during implementation as a mid-flight sanity check by prompting the user.
+
+Purpose: let the user see, at a glance, how each acceptance criterion from the task is addressed by the implementation plan (for an initial run) or by the implementation progress so far (for a mid-flight run) — without having to read the whole artifact and cross-reference by hand.
+
+### Step 1 — Ask (opt-in)
+
+Print the one-line prompt:
+
+> **Walk through how the implementation plan addresses the task's acceptance criteria?** [y]es / [n]o
+
+Default: `[n]`.
+
+If `[n]` → skip the walkthrough; proceed to session-context-writer (or resume interactive development on mid-flight re-invocation).
+
+### Step 2 — Build the mapping
+
+On `[y]`:
+
+1. **Pull acceptance criteria** using this priority:
+   - Primary: `alignment-reader` → `sections.task_level.success_criteria[]` (each carries `{text, checked}`)
+   - Fallback: `task.md` → Acceptance Criteria list (`- [ ] ...` bullets)
+   - Final fallback: "This task has no declared acceptance criteria. Walkthrough can't map without them; consider `/scope <task>` to add them."
+2. **For each criterion**, identify where it's addressed using this priority of sources:
+   - `implementation.md` → Progress section entries, Files Created/Modified list
+   - `architecture.md` → section references that dictate the implementation approach for this AC
+   - `research.md` → decision log references if the AC is driven by a research recommendation
+3. **Honest mapping.** If a criterion has no clear source, mark **"NOT YET ADDRESSED"** — do not invent a reference. Specifically flag:
+   - ACs that have **no implementation plan** (no `implementation.md` entry)
+   - ACs that are **in-progress** (partial implementation)
+   - ACs that are **complete** (all planned files written, tests passing)
+
+### Step 3 — Print the table
+
+Format:
+
+```
+Implementation addresses these acceptance criteria:
+
+  AC #1 "<first 60 chars>…"  →  implementation.md §Progress step 2 [complete]
+  AC #2 "<first 60 chars>…"  →  implementation.md §Progress step 5 [in-progress]
+  AC #3 "<first 60 chars>…"  →  architecture.md §6 (planned, not yet started)
+  AC #4 "<first 60 chars>…"  →  — NOT YET ADDRESSED — add to implementation.md?
+  …
+```
+
+Status annotation (`[complete]`, `[in-progress]`, `(planned)`, `— NOT YET ADDRESSED —`) is mandatory for mid-flight runs; optional for initial runs where everything is planned.
+
+### Step 4 — Three-way prompt
+
+After the table:
+
+> **[c]ontinue** — looks right, proceed to session-context-writer (or resume dev)
+> **[r]evise** — something's wrong or missing; let's edit `implementation.md` before continuing
+> **[d]iscuss** — not sure, let's talk through one or more rows before deciding
+
+Default: `[c]`.
+
+- `[c]` → proceed.
+- `[r]` → ask which row(s) need revision. Edit `implementation.md` inline. Re-print table, re-ask Step 4.
+- `[d]` → talk through selected rows one at a time; re-ask Step 4.
+
+### Notes
+
+- **Never blocks.** Opt-in twice (`[n]` in Step 1 or `[c]` in Step 4) always proceeds.
+- **No schema writes.** Print-and-optionally-edit. Only persists edits the user approves under `[r]`.
+- **Particularly useful mid-flight** — call this on a partial implementation to see what's done vs planned vs missing before committing a checkpoint or opening a PR.
 
 ## Task-Based Workflow
 

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -19,13 +19,81 @@ Research existing solutions for a specific task (Phase 1 of a task).
 1. **Pre-analysis hook** (v3.11.0+, before anything else) — if strong signals fire in the task name + description, invoke `analysis-agent` to assess whether this should be an epic. See "Pre-analysis hook" section below.
 2. Creates task directory: `implementation_process/in_progress/{task_name}/`
 3. Creates `task.md` (tracker with links and acceptance criteria)
-4. **Loads dev-guides** for the task's Drupal domain via `guide-integrator` (unless already loaded this session)
+4. **(v3.13.4+)** Dev-guides pre-flight — explicit `guide-integrator` invocation + always-prompt the user to continue / add / decline (see "Dev-guides pre-flight" section below)
 5. Invokes `contrib-researcher` agent for drupal.org/contrib search
 6. Invokes `core-pattern-finder` skill for core examples
 7. Stores findings in `research.md` file
 8. Updates `task.md` to mark Phase 1 as in progress
 8. Updates `project_state.md` with current task
-9. **Invokes `session-context-writer` skill with the resolved project and task**
+9. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `research.md` sections to the task's research questions + acceptance criteria
+10. **Invokes `session-context-writer` skill with the resolved project and task**
+
+## Traceability walkthrough sub-step (v3.13.4+)
+
+**Run after `research.md` has been authored and `task.md` / `project_state.md` updated, before `session-context-writer` is invoked.**
+
+Purpose: let the user see, at a glance, how each research question (and each task-level acceptance criterion, if one exists) is addressed by the freshly-authored research — without having to read the whole artifact and cross-reference by hand.
+
+### Step 1 — Ask (opt-in)
+
+Print the one-line prompt:
+
+> **Walk through how this research answers the task's questions and acceptance criteria?** [y]es / [n]o
+
+Default: `[n]`.
+
+If `[n]` → skip the walkthrough; proceed to session-context-writer.
+
+### Step 2 — Build the mapping
+
+On `[y]`:
+
+1. **Pull the traceability sources** using this priority:
+   - `task.md` → Research Questions list (extract `- ...` bullets under that heading, if present)
+   - `alignment-reader` → `sections.task_level.success_criteria[]` (each carries `{text, checked}`)
+   - If both sources are empty → "This task has no research questions or acceptance criteria declared. Walkthrough can't map without them; consider `/scope <task>` to add task-level criteria."
+2. **For each item (question or criterion)**, scan `research.md` and identify the section(s) that address it. Look for:
+   - Q-headings that match (e.g., `### Q1 — Playwright MCP concurrency` ↔ a Research Question about MCP concurrency)
+   - Decision-log entries
+   - Cross-cutting pattern numbers
+   - Evidence index references
+3. **Honest mapping.** If a question or criterion has no clear section in `research.md`, mark it **"NOT YET ADDRESSED"** — do not invent a reference. Flag it for the discussion step.
+
+### Step 3 — Print the table
+
+Format:
+
+```
+Research addresses these questions and criteria:
+
+  Q1 "<first 60 chars>…"  →  research.md §4 Q1 + decision log #1
+  Q2 "<first 60 chars>…"  →  research.md §4 Q2 + §5 pattern 1
+  AC #1 "<first 60 chars>…"  →  research.md §6 decision #7
+  AC #2 "<first 60 chars>…"  →  — NOT YET ADDRESSED — raise in Phase 2?
+  …
+```
+
+Separate Q-rows from AC-rows. Section references are lightweight — just enough to jump to the right place.
+
+### Step 4 — Three-way prompt
+
+After the table, ask:
+
+> **[c]ontinue** — looks right, proceed to session-context-writer
+> **[r]evise** — something's wrong or missing; let's edit `research.md` before continuing
+> **[d]iscuss** — not sure, let's talk through one or more rows before deciding
+
+Default: `[c]`.
+
+- `[c]` → proceed.
+- `[r]` → ask the user which row(s) need revision. Make the edit to `research.md` inline. Re-print the table, re-ask Step 4.
+- `[d]` → talk through selected rows one at a time; re-ask Step 4 after discussion.
+
+### Notes
+
+- **Never blocks.** `[n]` in Step 1 or `[c]` in Step 4 always proceeds.
+- **No schema writes.** Print-and-optionally-edit flow. Only persists edits the user approves under `[r]`.
+- **Opt-in by design.** Skip for routine work; use for complex tasks or sanity-checks before locking Phase 1.
 
 ## Task-Based Workflow
 
@@ -150,6 +218,43 @@ If a signal fires:
    On `[later]` → same as `[n]` for this run; user can run `/scope <task>` anytime.
 
 Conservative by design: pre-analysis only fires on strong signals, and even then the default choice presented to the user is to proceed as a flat task. Never creates an epic without explicit confirmation. The alignment nudge is soft; `[n]` is always respected.
+
+## Dev-guides pre-flight (v3.13.4+)
+
+**Run after the Pre-analysis hook, before the Phase 1 alignment sub-step.** The goal: every phase command either loads dev-guides or has the user explicitly say "no guides" — never a silent skip. Dev-guides cover Drupal, Next.js, design systems (Bootstrap, Radix, Tailwind, DaisyUI), CSS, and cross-cutting methodology (TDD, SOLID, DRY, security, quality gates) — relevant across Drupal AND non-Drupal (plugin framework, docs-only, Claude Code) tasks.
+
+### Step 1 — Invoke guide-integrator explicitly
+
+Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
+
+### Step 2 — ALWAYS prompt the user (never silent-skip)
+
+Regardless of whether guide-integrator auto-loaded 0, 1, or N guides, print:
+
+> **Dev-guides pre-flight for `<task_name>` (Phase 1 — Research):**
+>
+> Auto-loaded based on task keywords:
+>   <bulleted list of loaded guides, OR "  — none auto-matched —">
+>
+> Dev-guides cover Drupal (forms, entities, plugins, services, caching, views, JSON:API, etc.), Next.js, design systems (Bootstrap, Radix, Tailwind, DaisyUI), CSS, and methodology (TDD, SOLID, DRY, security, quality gates). Loading relevant guides before research keeps findings grounded in existing knowledge and prevents re-research of known patterns.
+>
+> **[c]ontinue** — auto-loaded set is fine, start research
+> **[a]dd** — scan the `dev-guides-navigator` catalog for more topics before I research
+> **[n]one** — skip dev-guides entirely (override any auto-loaded); I'll rely on you
+
+Default: `[c]`.
+
+### Step 3 — Act on the answer
+
+- `[c]` → proceed to the alignment sub-step with the auto-loaded guides (possibly empty).
+- `[a]` → invoke `dev-guides-navigator` interactively with task keywords the user supplies. Let the user select 0 or more additional guides. Load them via `guide-integrator`. After the user says "done," proceed to alignment.
+- `[n]` → clear any auto-loaded guides from the session context (do NOT persist them to `loadedGuides[]`). Note "dev-guides declined" in session. Proceed to alignment.
+
+### Notes
+
+- **Never blocks.** `[c]` (default) always proceeds.
+- **Discoverability > compliance.** `[n]` is a first-class choice.
+- **Works for non-Drupal tasks.** Plugin/framework/docs tasks can still find applicable methodology or design-system guides via `[a]`.
 
 ## Phase 1 alignment sub-step (v3.12.0+, retrofit-aware in v3.12.2+)
 


### PR DESCRIPTION
## Summary

Two phase-command UX fixes discovered live on \`/design dev_framework_isolated_validators\`, bundled as a single quick-fix release. Both apply to all three phase commands (\`/research\`, \`/design\`, \`/implement\`) symmetrically.

### 1. Traceability walkthrough

After each phase command authors its artifact (\`research.md\` / \`architecture.md\` / \`implementation.md\`), the user had no in-command way to see how it addresses the task's research questions + acceptance criteria. They had to read the whole artifact and cross-reference by hand.

**Fix:** new opt-in sub-step, right before \`session-context-writer\`:

- Step 1: one-line \`[y]es / [n]o\` prompt (default \`[n]\`)
- Step 2 (on \`[y]\`): pull ACs from \`alignment.md\` Success criteria (fallback: \`task.md\`); map each to artifact section(s); mark unaddressed ones \`— NOT YET ADDRESSED —\` (never invent)
- Step 3: print the table
- Step 4: 3-way prompt — \`[c]\`ontinue / \`[r]\`evise inline / \`[d]\`iscuss

Never blocks. No persistence except approved \`[r]\` edits.

\`/implement\` variant adds status annotations (\`[complete]\` / \`[in-progress]\` / \`(planned)\`) — particularly useful mid-flight.

### 2. Dev-guides pre-flight

Before v3.13.4, each command's "What This Does" list said "Loads dev-guides via \`guide-integrator\` (unless already loaded this session)" — but that was documentation-of-intent, not an explicit directive. The skill fired only via proactive-skill-detection, which is unreliable on non-Drupal tasks. Live observation on \`dev_framework_isolated_validators\` (a Claude Code plugin task) showed dev-guides were never consulted despite applicable methodology guides (TDD, SOLID, DRY, quality-gates) and cross-cutting material (Next.js, design systems, CSS).

**Fix:** new explicit sub-step runs after Phase Transition Check, BEFORE alignment sub-step:

- Step 1: explicit \`guide-integrator\` invocation (no proactive-detection dependency)
- Step 2: **always-prompt** — display auto-loaded set, ask \`[c]\`ontinue / \`[a]\`dd-via-navigator / \`[n]\`one
- Step 3: act on answer

**Why "never silent-skip"** (user directive): dev-guides cover material beyond Drupal. Even when auto-detection finds N guides, the user may want \`[a]\`dd. When auto-detection finds zero (common on non-Drupal tasks), the user previously had no signal that guides exist. Silent-skip was hiding the catalog.

\`[n]\` remains a first-class choice — discoverability > compliance.

## Files changed

- \`commands/research.md\` — new Dev-guides pre-flight section + Traceability walkthrough section + updated "What This Does" list
- \`commands/design.md\` — same
- \`commands/implement.md\` — same (walkthrough variant includes mid-flight guidance + status annotations)
- \`CHANGELOG.md\` — new [3.13.4] entry
- \`.claude-plugin/plugin.json\` — 3.13.3 → 3.13.4
- root \`.claude-plugin/marketplace.json\` — plugin entry version + \`metadata.version\` 1.14.16 → 1.14.17

## Not changed

- \`guide-integrator\` skill — unchanged (auto-load rules preserved; v3.13.4 just invokes it explicitly and layers the user prompt above it)
- \`dev-guides-navigator\` plugin — unchanged (consumed as-is by \`[a]\`dd branch)
- \`alignment-reader\` skill — unchanged
- Alignment sub-steps — unchanged in logic; dev-guides pre-flight runs just ahead of them

## Test plan

- [ ] \`/design\` on a non-Drupal task → Dev-guides pre-flight fires; auto-loaded set may be empty; \`[a]\`dd opens \`dev-guides-navigator\` catalog
- [ ] \`/design\` on a Drupal task with form/entity keywords → Dev-guides pre-flight fires; auto-loaded set shows matched guides; \`[c]\`ontinue proceeds with them
- [ ] \`/design\` \`[n]\` → auto-loaded set cleared; proceeds to alignment without guides
- [ ] After \`/design\` authors \`architecture.md\` → Traceability walkthrough prompt fires; \`[y]\` prints criteria-to-section table; \`[r]\` edits inline; \`[c]\` proceeds
- [ ] Same matrix against \`/research\` and \`/implement\`
- [ ] Both sub-steps can be \`[n]\`/\`[c]\`'d without blocking the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)