### PR TITLE
feat(drupal-dev-framework): post-phase epic check in all 3 phase commands (v3.13.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.17"
+    "version": "1.14.18"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.13.4",
+      "version": "3.13.5",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.13.4",
+  "version": "3.13.5",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.5] - 2026-04-24
+
+### Added — Post-phase epic check in `/research`, `/design`, `/implement`
+
+Pre-analysis hook (v3.11.0+) decides epic-vs-flat **before** task creation based on very thin signals — just the task name + sometimes a short user description. In practice this fires a false-negative often: the real scope only emerges after `/scope` authors `alignment.md`, after research surfaces sub-problems, and after architecture commits to a component breakdown. By the time the task is obviously epic-shaped, the framework has no mechanism to surface the offer — v3.12.2's alignment retrofit in `/research` checks for `scope_contract_recommended` but explicitly ignores `epic_candidate`.
+
+Concrete live example: a 4-area Drupal homepage redesign (Video + Trending + Trust Bar + Footer) created via `/next` → "Create new task" → `/research` flow. Task name alone didn't fire pre-analysis signals. Alignment conversation revealed 4 clear deliverables. No epic offer ever surfaced. User had to invoke `/propose-epics` or `/migrate-to-epic` manually AFTER-the-fact.
+
+**Fix:** add a **post-phase epic check** step to each of the three phase commands. Runs at end-of-phase, before the traceability walkthrough. Invokes `analysis-agent` in **folder mode** with full-to-date task context:
+
+- `/research` — checks with `task.md` + `alignment.md` + `research.md`
+- `/design` — checks with everything above + `architecture.md`
+- `/implement` — checks with everything above + `implementation.md`, **BEFORE any code is written** (last safe migration moment)
+
+If `analysis-agent` returns `epic_candidate`, surface a 3-way offer: `[y]es` migrate via `/migrate-to-epic`, `[n]o` keep flat (default), `[d]iscuss` show rationale + `signals_used[]` and re-ask. If `keep_flat` or `insufficient_info`, proceed silently — agent has full context and its judgment is authoritative.
+
+**Design principle:** **research is when epic-vs-flat is actually decidable.** Pre-analysis stays as an early hint for very obvious cases, but the authoritative check moves to each phase boundary. Later checks have strictly more context than earlier ones — if `/design`'s post-check says `epic_candidate` and pre-analysis said `keep_flat`, trust the later call.
+
+**Per-phase framing differences:**
+
+- `/research` post-check — "pre-analysis couldn't see this shape — research is where it became clear"
+- `/design` post-check — "the architecture surfaced decomposition that pre-analysis + post-research checks hadn't caught"
+- `/implement` post-check — **stronger wording** acknowledging the cost-of-delay: "Once code starts, migrating to an epic is much harder. Worth pausing to decide now."
+
+### Files changed
+
+- `commands/research.md` — new "Post-phase epic check (v3.13.5+)" section after research writes, before traceability walkthrough. "What This Does" list updated (11 steps, new step 9)
+- `commands/design.md` — same pattern for Phase 2 context. "What This Does" list updated (10 steps, new step 8)
+- `commands/implement.md` — same pattern for Phase 3 context, with explicit BEFORE-CODE-STARTS positioning. "What This Does" list updated (13 steps, new step 11)
+
+### Not changed
+
+- `analysis-agent` — unchanged (already supports folder mode per v3.11.0 `references/analysis-agent-schema.md`; we just invoke it at new times)
+- Pre-analysis hook in `/research` — unchanged (still fires pre-task-creation; v3.13.5 adds a complementary post-phase check, doesn't replace pre-analysis)
+- `/migrate-to-epic` — unchanged (consumed as-is)
+- `/propose-epics` — unchanged (still useful for batch review of tasks that missed all three post-phase checks, e.g. pre-v3.13.5 tasks)
+
+### Philosophy
+
+When a fix has a narrow version (one command) vs a fuller version (all affected surfaces), the fuller version is the right default. The root cause — "epic check uses weak signals and ignores richer post-phase context" — was symmetric across all three phase commands. Shipping to just one would leave the same latent bug on the other two.
+
 ## [3.13.4] - 2026-04-24
 
 Two phase-command UX fixes discovered during live use of `/design` on a non-Drupal plugin-framework task. Both bundled here as a single quick-fix release.

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -126,8 +126,58 @@ Default: `[c]`.
 5. Creates/updates `architecture.md` with design
 6. Updates `task.md` to mark Phase 2 as in progress
 7. Optionally creates component file in `architecture/{component}.md`
-8. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see next section) mapping `architecture.md` sections to the task's acceptance criteria
-9. **Invokes `session-context-writer` skill with the resolved project and task**
+8. **(v3.13.5+)** Post-design epic check (see "Post-phase epic check" below) — re-runs `analysis-agent` in folder mode with `task.md` + `alignment.md` + `research.md` + `architecture.md` and surfaces `epic_candidate` if architecture-level decomposition revealed epic-shaped work
+9. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `architecture.md` sections to the task's acceptance criteria
+10. **Invokes `session-context-writer` skill with the resolved project and task**
+
+## Post-phase epic check (v3.13.5+)
+
+**Run after `architecture.md` has been authored (and optional component file written), before the traceability walkthrough.**
+
+Purpose: epic-shape sometimes only becomes obvious at architecture time when you see the component breakdown. Research might have missed it; architecture might reveal that what looked like one task is actually 3 loosely-coupled components that belong as separate sub-tasks. This step catches that case.
+
+### Step 1 — Re-invoke analysis-agent in folder mode
+
+Invoke `analysis-agent` via Task tool with:
+
+- `task_folder` = absolute path to the task folder (now contains `task.md` + `alignment.md` + `research.md` + `architecture.md` — strictly more context than at research time)
+- `codePath` = resolved via `project-state-reader`
+- `schema_version: "1.0"`
+
+### Step 2 — Branch on `decision`
+
+- `epic_candidate` → continue to Step 3
+- `keep_flat` → proceed silently to traceability walkthrough
+- `insufficient_info` → proceed silently
+
+### Step 3 — Surface epic offer (only if `epic_candidate`)
+
+Print:
+
+> **Before locking in architecture:** looking at the design you just authored, this task might be cleaner as an epic. The architecture surfaced decomposition that pre-analysis + post-research checks hadn't caught.
+>
+> Proposed children (from `analysis-agent.proposed_decomposition`):
+>   • `<child_1>` — <short rationale>
+>   • `<child_2>` — <short rationale>
+>   • …
+>
+> **[y]es** — convert to epic now via `/migrate-to-epic <task> --children "<list>"`. `research.md` + `architecture.md` stay on the parent epic; each child re-runs `/research` → `/design` on its slice.
+> **[n]o** — keep flat; proceed to traceability walkthrough (can always migrate later)
+> **[d]iscuss** — show agent's `rationale` + `signals_used[]` before deciding
+
+Default: `[n]`.
+
+### Step 4 — Act on the answer
+
+- `[y]` → invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<comma-separated proposed names>"`. Stop this `/design` invocation after migration.
+- `[n]` → proceed to traceability walkthrough.
+- `[d]` → print rationale + signals_used, re-ask Step 3.
+
+### Notes
+
+- **Never blocks.** `[n]` always proceeds.
+- **Cumulative authority.** Post-design check has the MOST context of any epic check in the framework (task+alignment+research+architecture). If it fires `epic_candidate`, that's the strongest signal the framework can emit.
+- **Mid-design migration is heavier than post-research migration** — architecture.md won't be automatically partitioned across children. User must rebuild design per child. Worth doing anyway if the signal is real.
 
 ## Traceability walkthrough sub-step (v3.13.4+)
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -134,8 +134,58 @@ Default: `[c]`.
 8. Updates `task.md` to mark Phase 3 as in progress
 9. Activates `tdd-companion` for TDD discipline
 10. Prepares for interactive development
-11. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `implementation.md` progress + planned work to the task's acceptance criteria
-12. **Invokes `session-context-writer` skill with the resolved project and task**
+11. **(v3.13.5+)** Post-plan epic check (see "Post-phase epic check" below) — re-runs `analysis-agent` in folder mode with full task context (`task.md` + `alignment.md` + `research.md` + `architecture.md` + `implementation.md`) and surfaces `epic_candidate` if the step-plan surfaced separable work. **Runs BEFORE any code is written** — mid-implementation epic migration is prohibitively expensive
+12. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `implementation.md` progress + planned work to the task's acceptance criteria
+13. **Invokes `session-context-writer` skill with the resolved project and task**
+
+## Post-phase epic check (v3.13.5+)
+
+**Run after `implementation.md` has been created with the step plan but BEFORE interactive development begins.** This is the last safe moment to migrate to an epic — once code starts, partitioning implementation across children becomes expensive.
+
+Purpose: the `implementation.md` step plan sometimes reveals that the task's work naturally partitions into 3+ independent tracks (e.g., "Step 1-4 build component A, Step 5-8 build component B, Step 9-12 build component C"). When that pattern surfaces at plan time, an epic is almost always the right shape. This step catches it before code lock-in.
+
+### Step 1 — Re-invoke analysis-agent in folder mode
+
+Invoke `analysis-agent` via Task tool with:
+
+- `task_folder` = absolute path to the task folder (maximum context: task+alignment+research+architecture+implementation all present)
+- `codePath` = resolved via `project-state-reader`
+- `schema_version: "1.0"`
+
+### Step 2 — Branch on `decision`
+
+- `epic_candidate` → continue to Step 3
+- `keep_flat` → proceed silently to traceability walkthrough
+- `insufficient_info` → proceed silently
+
+### Step 3 — Surface epic offer (only if `epic_candidate`)
+
+Print:
+
+> **Last epic check before coding starts:** the implementation step plan reveals this task partitions naturally. Once code starts, migrating to an epic is much harder. Worth pausing to decide now.
+>
+> Proposed children (from `analysis-agent.proposed_decomposition`):
+>   • `<child_1>` — <short rationale>
+>   • `<child_2>` — <short rationale>
+>   • …
+>
+> **[y]es** — convert to epic now via `/migrate-to-epic <task> --children "<list>"`. All Phase 1-2 artifacts stay on the parent epic; each child re-runs `/research` → `/design` → `/implement` on its slice. Step plan in `implementation.md` is discarded (children rebuild theirs).
+> **[n]o** — keep flat; proceed to traceability walkthrough and interactive dev. Migration after code starts is significantly more disruptive.
+> **[d]iscuss** — show agent's `rationale` + `signals_used[]` before deciding
+
+Default: `[n]`.
+
+### Step 4 — Act on the answer
+
+- `[y]` → invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<list>"`. Stop this `/implement` invocation. User re-enters lifecycle at `/research` for each child.
+- `[n]` → proceed to traceability walkthrough and interactive dev.
+- `[d]` → print rationale + signals_used, re-ask Step 3.
+
+### Notes
+
+- **Never blocks.** `[n]` always proceeds.
+- **Stronger "stop-and-migrate" framing than research/design.** Because mid-implementation migration is expensive, the prompt explicitly flags the cost-of-delay. User can still proceed flat — it's just more informed.
+- **Cumulative authority.** This is the final epic check in the lifecycle. Agent has complete phase context.
 
 ## Traceability walkthrough sub-step (v3.13.4+)
 

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -25,8 +25,62 @@ Research existing solutions for a specific task (Phase 1 of a task).
 7. Stores findings in `research.md` file
 8. Updates `task.md` to mark Phase 1 as in progress
 8. Updates `project_state.md` with current task
-9. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `research.md` sections to the task's research questions + acceptance criteria
-10. **Invokes `session-context-writer` skill with the resolved project and task**
+9. **(v3.13.5+)** Post-research epic check (see "Post-phase epic check" below) — re-runs `analysis-agent` in folder mode with the now-complete task context and surfaces `epic_candidate` if the research revealed epic-shaped work that pre-analysis couldn't see at task-creation time
+10. **(v3.13.4+)** Offers an opt-in traceability walkthrough (see "Traceability walkthrough sub-step" below) mapping `research.md` sections to the task's research questions + acceptance criteria
+11. **Invokes `session-context-writer` skill with the resolved project and task**
+
+## Post-phase epic check (v3.13.5+)
+
+**Run after `research.md` has been authored and `task.md` / `project_state.md` updated, before the traceability walkthrough.**
+
+Purpose: pre-analysis at task-creation time has very thin signal (just the task name, sometimes a short description). The real scope-shape only emerges during research — `alignment.md` pins down what the task is about, and `research.md` surfaces sub-problems, dependencies, and natural decomposition seams. **Research is the moment epic-vs-flat is actually decidable.**
+
+This step catches the "task started flat, research revealed it's actually an epic" case that the v3.11.0 pre-analysis hook + v3.12.2 alignment retrofit both miss.
+
+### Step 1 — Re-invoke analysis-agent in folder mode
+
+Invoke `analysis-agent` via Task tool with:
+
+- `task_folder` = absolute path to the task folder (the folder now contains `task.md` + `alignment.md` + `research.md` — maximum context the agent has ever had for this task)
+- `codePath` = resolved via `project-state-reader` on the active project
+- `schema_version: "1.0"`
+
+### Step 2 — Branch on `decision`
+
+- `epic_candidate` → continue to Step 3 (surface offer)
+- `keep_flat` → proceed silently to traceability walkthrough. Agent saw full context and decided this task is correctly flat. Trust it.
+- `insufficient_info` → proceed silently. Unusual at this stage (research.md exists) but possible if artifacts are very thin. No nag.
+
+### Step 3 — Surface epic offer (only if `epic_candidate`)
+
+Print:
+
+> **Before locking in research:** based on what research found, this task looks like it'd be cleaner as an epic with sub-tasks. Pre-analysis at task-creation couldn't see this shape — research is where it became clear.
+>
+> Proposed children (from `analysis-agent.proposed_decomposition`):
+>   • `<child_1>` — <short rationale>
+>   • `<child_2>` — <short rationale>
+>   • …
+>
+> **[y]es** — convert to epic now via `/migrate-to-epic <task> --children "<list>"`. `research.md` stays on the parent epic; children inherit no research yet and will each get their own `/research` pass.
+> **[n]o** — keep flat; proceed to traceability walkthrough (can always migrate later via `/propose-epics` or `/migrate-to-epic`)
+> **[d]iscuss** — show agent's full `rationale` + `signals_used[]` before deciding
+
+Default: `[n]`.
+
+### Step 4 — Act on the answer
+
+- `[y]` → invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<comma-separated proposed names>"`. After successful migration, **stop** — the flat-task lifecycle ends here. User re-invokes `/research <child_name>` on each child when ready.
+- `[n]` → proceed to traceability walkthrough.
+- `[d]` → print agent's rationale + signals_used. Re-ask Step 3.
+
+### Notes
+
+- **Never blocks.** `[n]` (default) always proceeds to traceability walkthrough.
+- **Authoritative over pre-analysis.** If pre-analysis said "keep flat" and end-of-research says "epic_candidate," trust the later call — it has strictly more context.
+- **Migration is transactional.** `/migrate-to-epic` is atomic with 24h rollback; safe to opt into.
+
+## Traceability walkthrough sub-step (v3.13.4+)
 
 ## Traceability walkthrough sub-step (v3.13.4+)
 


### PR DESCRIPTION
## Summary

Discovered live on \`finish_barkley_redesign\` (4-area Drupal homepage redesign): task created via \`/next\` → \`/research\`, short task name didn't fire pre-analysis signals, alignment conversation revealed 4 clear deliverables, **no epic offer ever surfaced**. User had to reach for \`/propose-epics\` / \`/migrate-to-epic\` manually after the fact.

Root cause: pre-analysis hook (v3.11.0+) fires pre-task-creation from thin signals (task name + optional short description). By the time the task is obviously epic-shaped — after alignment, research, or architecture reveal the sub-problems — the framework had no mechanism to surface the offer.

v3.12.2's alignment retrofit in \`/research\` already demonstrated the fix pattern, but it only checks \`scope_contract_recommended\` and explicitly ignores \`epic_candidate\`.

## Fix

Add a **post-phase epic check** to each of the three phase commands. Runs at end-of-phase, before the traceability walkthrough. Invokes \`analysis-agent\` in **folder mode** with full-to-date context:

| Command | Agent sees | Framing |
|---|---|---|
| \`/research\` | task + alignment + research | "pre-analysis couldn't see this shape — research is where it became clear" |
| \`/design\` | + architecture | "the architecture surfaced decomposition that pre-analysis + post-research checks hadn't caught" |
| \`/implement\` | + implementation (plan only, **before code**) | "Last epic check before coding starts. Once code starts, migrating is much harder." |

On \`epic_candidate\` → 3-way prompt: \`[y]es\` (migrate via \`/migrate-to-epic\`), \`[n]o\` (keep flat, default), \`[d]iscuss\` (show rationale + \`signals_used[]\`). On \`keep_flat\` / \`insufficient_info\` → silent, trust the agent.

**Design principle:** research is when epic-vs-flat is actually decidable. Later checks have strictly more context; if \`/design\`'s post-check says \`epic_candidate\` and pre-analysis said \`keep_flat\`, the later call is authoritative.

## Why all three phases

Root cause is symmetric across \`/research\`, \`/design\`, \`/implement\` — narrow fix on one command would leave the same latent bug on the other two. Same reasoning applied to v3.13.1 (task-level retrofit in \`/design\` + \`/implement\`) and v3.13.4 (traceability walkthrough in all three).

## Files changed

- \`commands/research.md\` — new \"Post-phase epic check\" section + \"What This Does\" updated
- \`commands/design.md\` — same
- \`commands/implement.md\` — same, with stronger \"last safe moment\" framing
- \`CHANGELOG.md\` — new [3.13.5] entry
- \`.claude-plugin/plugin.json\` — 3.13.4 → 3.13.5
- root \`.claude-plugin/marketplace.json\` — plugin entry version + \`metadata.version\` 1.14.17 → 1.14.18

## Not changed

- \`analysis-agent\` — unchanged (already supports folder mode per v3.11.0)
- Pre-analysis hook in \`/research\` — unchanged (complementary, not replacement)
- \`/migrate-to-epic\`, \`/propose-epics\` — unchanged (consumed as-is)

## Test plan

- [ ] \`/research <new_task>\` on a task whose alignment reveals ≥3 deliverables → post-research check fires \`epic_candidate\` → prompt surfaces
- [ ] Same task, user picks \`[y]\` → \`/migrate-to-epic\` invoked, epic folder created with children
- [ ] Task whose alignment is scope-bounded → post-research check fires \`keep_flat\` → silent proceed to traceability walkthrough
- [ ] \`/design\` on an alignment-scoped task whose architecture reveals separable components → post-design check fires → prompt
- [ ] \`/implement\` on a plan-heavy task → post-plan check fires BEFORE interactive dev starts (not after)
- [ ] \`[d]iscuss\` branch prints rationale + signals_used, re-asks cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)