### PR TITLE
feat(drupal-dev-framework): /validate:team — isolated validation via agent teams (v3.14.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.18"
+    "version": "1.14.19"
   },
   "plugins": [
     {
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator (declared via Plugin Dependencies).",
-      "version": "3.13.5",
+      "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator, code-quality-tools (declared via Plugin Dependencies).",
+      "version": "3.14.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.13.5",
+  "version": "3.14.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,83 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] - 2026-04-24
+
+### Added — `/validate:team` command for isolated validation
+
+New `/drupal-dev-framework:validate-team` command runs the 7 v3.13.0 `/validate:*` gates in **independent Claude Code agent-team sessions** so each gate is assessed by a fresh context free of the main session's prior reasoning. Primary driver: **honest validation** — the validator cannot be anchored on what the main session just built. Secondary benefits: context-window economy, parallel throughput for code gates.
+
+**Sibling to `/validate:all`, not a replacement.** Users on machines without `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` keep using `/validate:all` with no downgrade path. `/validate:team` automatically falls back to `/validate:all` when the experimental flag is unset, when `TeamCreate` fails, or when a team is already resident in the session (cleanup required in that last case — command refuses rather than auto-cleans).
+
+**4-teammate roster:**
+
+| Teammate | Gates | Model | Isolation |
+|---|---|---|---|
+| `validator-code-1` | `tdd`, `solid` | sonnet | worktree |
+| `validator-code-2` | `dry`, `security` | sonnet | worktree |
+| `validator-docs` | `guides` | haiku | worktree |
+| `validator-visual` | `visual-regression` (fanned out) | sonnet | none |
+
+`validate-visual-parity` is NOT in the roster — inherits `/validate:all`'s limitation requiring an explicit `<reference>` arg. Users who need parity run `/drupal-dev-framework:validate-visual-parity` manually.
+
+### Added — `team-manifest-schema.md` v1.0
+
+Canonical schema for `team-manifest.json` — the minimum-context package the lead writes before spawn. Lives at `<task>/validations/tmp/team-manifest.json`, written once, read by teammates, deleted by lead at cleanup.
+
+Key invariants:
+- All paths absolute (teammates in worktrees can't resolve relatives back to main)
+- `visual_fanout[]` present only on visual-regression gate entries (omitted, not empty, for code gates)
+- `gates[]` non-empty
+- `assigned_to` is a suggestion — file-lock task claiming (agent-teams runtime) decides actual ownership
+- Write-once; teammates treat it read-only; mid-run state flows through envelopes + mailbox
+
+### Fallback behavior
+
+Automatic and silent-of-failure:
+- Env var unset → print fallback message + auto-run `/validate:all`
+- `TeamCreate` fails → same fallback
+- `--no-fallback` flag → refuse rather than fall back (for CI users who want team-or-nothing)
+
+User never has to re-invoke manually.
+
+### Files changed
+
+**New files:**
+- `commands/validate-team.md` — lead-side orchestration (Steps 1-9: resolve task, detect availability, read context, write manifest, spawn 4 teammates, stream progress, aggregate, cleanup, persist)
+- `references/team-manifest-schema.md` — canonical `team-manifest.json` v1.0 spec (13 sections covering shape, field contracts, invariants, absolute-path rationale, lifecycle, versioning)
+
+**Updated files:**
+- `.claude-plugin/plugin.json` — `3.13.5` → `3.14.0`
+- `README.md` — commands table gains `/validate:team` row; Technical Contract References 5 → 6; CLI-version note acknowledges agent-teams v2.1.32+
+- `CLAUDE.md` — new `## Validation Team Mode (v3.14.0+)` sub-section in Validation Gates block
+- root `.claude-plugin/marketplace.json` — plugin entry version `3.13.5` → `3.14.0` + `metadata.version` patch `1.14.18` → `1.14.19`
+
+### Not changed
+
+- Validation envelope schema (`references/validation-gate-result.md` v1.0) — teammates write the same shape v3.13.0 gates produce; aggregate adds only a `source: "validate:team"` marker
+- Screenshot store schema (`references/screenshot-store-schema.md` v1.0)
+- Skills: `alignment-reader`, `screenshot-store-reader`, `project-state-reader`, `task-frontmatter-reader` — all consumed unchanged
+- `/validate:*` per-gate commands — siblings; `/validate:team` invokes them by running their flows in spawned teammate sessions
+- `/validate:all` — strictly unchanged; `/validate:team` is a sibling orchestrator
+
+### Deferred to v2
+
+- Set B1 — parallel visual gate execution (blocked on A2 deferred visual approvals)
+- Set B2 — `TaskCompleted` hook for streaming per-gate results
+- Set B3 — `--json` output mode on `/validate:team` itself
+- Set B4 — `/validate:team --cleanup` subcommand for crash recovery
+- Set B5 — `validate-visual-parity` in team mode (inherits `/validate:all`'s `<reference>`-arg limitation)
+
+All five tracked at epic level in `dev_framework_improvements_epic/shared/v2-candidates.md` Set B.
+
+### Dependency note
+
+Hard dependencies unchanged: `dev-guides-navigator`, `code-quality-tools` (both present since v3.13.0). Runtime dependency on Claude Code CLI v2.1.32+ (agent-teams minimum) is a soft requirement — gracefully degrades to `/validate:all` when teams are unavailable.
+
+### Philosophy
+
+Ship the honest-validation primitive with a narrow, provable contract. Defer every optimization and every ergonomic until real pain surfaces. Dog-food on self before calling it done — v3.14.0 merges only after `/validate:team dev_framework_isolated_validators` returns `pass` on `/validate:guides` from a fresh session.
+
 ## [3.13.5] - 2026-04-24
 
 ### Added — Post-phase epic check in `/research`, `/design`, `/implement`

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -58,6 +58,29 @@ Individual `/validate:*` commands for on-demand quality gates. Replaces `/comple
 
 **NOT wrapped** (keep invoking directly via `/code-quality:*` namespace): `lint`, `coverage`, `review`, `audit`, `ultrareview`, `architecture-debate`, `security-debate`. `/validate:all` surfaces them as discoverability hint.
 
+### Validation Team Mode (v3.14.0+)
+
+`/validate:team` is a **sibling** to `/validate:all` — NOT a replacement. It runs the 7 v3.13.0 gates in **isolated Claude Code agent teams** (4 teammates) so each gate is assessed in a fresh context window free of the main session's prior reasoning. Primary driver: **honest validation** (no self-review bias). Secondary benefits: context-window economy, parallel code-gate throughput.
+
+**4-teammate roster:**
+- `validator-code-1` (sonnet, worktree) — owns `tdd`, `solid`
+- `validator-code-2` (sonnet, worktree) — owns `dry`, `security`
+- `validator-docs` (haiku, worktree) — owns `guides`
+- `validator-visual` (sonnet, none) — owns `visual-regression` (fanned out per `<component>/<viewport>`)
+
+`validate-visual-parity` is NOT in the roster (deferred to v2 Set B5 — inherits `/validate:all`'s `<reference>`-arg limitation).
+
+**Manifest contract** (per `references/team-manifest-schema.md` v1.0): lead writes `<task>/validations/tmp/team-manifest.json` before spawn. All paths absolute; `visual_fanout[]` present only on visual gates; write-once; teammates treat it read-only.
+
+**Fallback chain:**
+1. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS != "1"` → auto-run `/validate:all` (unless `--no-fallback`)
+2. `TeamCreate` fails → same fallback
+3. Team already resident in session → REFUSE with cleanup guidance (do NOT auto-cleanup)
+
+**Envelope compatibility:** per-gate envelopes stay at v3.13.0 v1.0 unchanged. Aggregate `_all.json` adds only a `source: "validate:team"` marker — same shape `/validate:all` produces.
+
+**When to use:** pre-PR / pre-merge / pre-release honest-validation moments, long conversations where context economy matters. Prefer `/validate:all` for routine use.
+
 ## Alignment Step (v3.12.0+)
 
 Optional scope contract authored before Phase 1 via `/scope <task>`. Produces `alignment.md` with H2 sections (`## Task-Level`, `## Phase 1 — Research`, `## Phase 2 — Architecture`, `## Phase 3 — Implementation`), each carrying the same 4-field shape: Goal / Expected result / Success criteria / Non-goals. See `references/alignment-contract.md` for grammar v1.0.

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -27,6 +27,8 @@ Phases apply per task, not per project. A project can have tasks at different ph
 
 **Requires Claude Code v2.1.110 or later** — the plugin declares `dev-guides-navigator` as a dependency in `plugin.json`, which is enforced at install time on CLI v2.1.110+. Earlier CLI versions will not resolve the dependency automatically; install `dev-guides-navigator` manually and upgrade the CLI.
 
+**For `/validate:team` (v3.14.0+) specifically:** Claude Code CLI v2.1.32+ is the agent-teams minimum, and `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set. When unavailable, `/validate:team` gracefully falls back to `/validate:all`.
+
 ```bash
 # Add marketplace
 /plugin marketplace add https://github.com/camoa/claude-skills
@@ -105,6 +107,7 @@ Both enforced via `plugin.json` `dependencies`. Missing-dependency failures surf
 | `/validate:visual-regression <component> <viewport>` | **(v3.13.0)** Capture + diff against stored baseline. On diff, user classifies regression / intentional / cancel; intentional rotates baseline inline |
 | `/validate:visual-parity <component> <viewport> <reference>` | **(v3.13.0)** Compare built output against design comp (PNG/JPG, Figma URL, HTML file). Shared infrastructure with visual-regression |
 | `/validate:all` | **(v3.13.0)** Run all 7 gates sequentially; aggregate summary; discoverability hint for unwrapped `/code-quality:*` capabilities |
+| `/validate:team` | **(v3.14.0)** Sibling to `/validate:all` — runs the 7 gates in **isolated Claude Code agent teams** (4 teammates) for honest validation free of main-session bias. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (agent-teams CLI v2.1.32+); gracefully falls back to `/validate:all` when unavailable. `--no-fallback` opts out of fallback for CI team-or-nothing runs. See `references/team-manifest-schema.md` v1.0 for the minimum-context contract. |
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
@@ -169,7 +172,7 @@ Built-in docs enforced at specific phases:
 | `quality-gates.md` | 5 quality gates | Task completion |
 | `purposeful-code.md` | Every line has a purpose | Task completion |
 
-### Technical Contract References (5)
+### Technical Contract References (6)
 
 Machine-readable contracts consumed by skills and commands. These pin schemas and invariants so consumers don't drift:
 
@@ -180,6 +183,7 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `alignment-contract.md` **(v3.12.0)** | `alignment-reader` | `alignment.md` grammar v1.0, 8 warning codes, JSON output contract, em-dash canonicalization rule, versioning policy |
 | `screenshot-store-schema.md` **(v3.13.0)** | `screenshot-store-reader` + `scripts/screenshot-store-{read,write}.sh` | 9-field `.meta.json` v1.0, directory layout with `.previous` rotation (1-deep), 6 warning codes, `role` enum (`baseline` / `parity_reference` / `previous`), `captured_by` + `source` provenance fields |
 | `validation-gate-result.md` **(v3.13.0)** | All `/validate:*` commands | Shared JSON envelope v1.0 emitted by every gate; 4-value verdict (`pass` / `warning` / `fail` / `skipped`); per-gate `details` shapes; aggregate envelope for `/validate:all` |
+| `team-manifest-schema.md` **(v3.14.0)** | `/validate:team` + 4 teammates | Minimum-context package v1.0 written by lead before team spawn; absolute-path invariant; `visual_fanout[]` presence rule; write-once contract; fallback behavior hints; gate enum excludes `visual-parity` (deferred to v2 Set B5) |
 
 ### Online Dev-Guides (60+ topics) — Required
 

--- a/drupal-dev-framework/commands/validate-team.md
+++ b/drupal-dev-framework/commands/validate-team.md
@@ -83,6 +83,8 @@ Write the manifest **before** spawn so every teammate can read it regardless of 
 
 ### Step 5 — Spawn 4 teammates
 
+The roster covers **6 of the 7 v3.13.0 gates** — `validate-visual-parity` is excluded from the v1 roster (deferred to v2 Set B5 — requires an explicit `<reference>` arg that `/validate:all` can't supply either).
+
 Spawn each teammate with `TeamCreate`. Spawn prompts are ≤40 lines each, reference the manifest by absolute path, and declare the teammate's role + gate assignments + isolation mode in a header block:
 
 ```

--- a/drupal-dev-framework/commands/validate-team.md
+++ b/drupal-dev-framework/commands/validate-team.md
@@ -1,0 +1,247 @@
+---
+description: "Run the v3.13.0 /validate:* gates in isolated Claude Code agent teams (4 teammates) so each gate is assessed in a fresh context free of the main session's prior reasoning. Sibling to /validate:all — not a replacement. Gracefully falls back to /validate:all when the experimental flag is unset or TeamCreate fails. Introduced v3.14.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: [<task-name>] [--no-fallback]
+---
+
+# Validate: Team
+
+Run the 7 `/validate:*` gates in **independent Claude Code agent-team sessions** so each gate is assessed by a fresh context window. Primary driver: **honest validation** — the validator cannot be anchored on what the main session just built. Secondary benefits: context-window economy, parallel throughput for code gates.
+
+Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Without it, this command prints a fallback message and auto-runs `/validate:all` instead. Add `--no-fallback` to disable the auto-fallback (CI users who want team-or-nothing).
+
+## Usage
+
+```
+/drupal-dev-framework:validate-team                         # run on current task, allow fallback
+/drupal-dev-framework:validate-team <task-name>             # run on a specific task
+/drupal-dev-framework:validate-team <task-name> --no-fallback   # refuse to run /validate:all if team spawn fails
+```
+
+## When to use
+
+- **Pre-PR / pre-merge / pre-release honest-validation moments** — when self-review bias is a concern
+- **Long main-session conversations** where context-window economy matters
+- **Routine validation** — prefer `/validate:all` (single-session, warm caches, no agent-teams setup)
+
+## What this does
+
+### Step 1 — Resolve task + project context
+
+- Accept `<task>` arg (falls back to session-context `task` if omitted).
+- Invoke `project-state-reader` → `codePath`, `codePathState`, memory project folder.
+- Resolve task folder. Refuse if the folder doesn't exist.
+
+### Step 2 — Detect agent-teams availability (fallback chain)
+
+```
+$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS == "1" ?
+    NO  → print fallback message → auto-run /validate:all (unless --no-fallback)
+    YES → attempt TeamCreate
+        failed   → print fallback message → auto-run /validate:all (unless --no-fallback)
+        succeeded → continue
+            team already resident in session?
+                YES → REFUSE with cleanup guidance (do NOT auto-cleanup)
+                NO  → continue
+```
+
+Fallback message format:
+
+> `/validate:team` cannot run agent teams (reason: `<env-unset | teamcreate-failed | team-resident>`). Falling back to `/validate:all`. Use `--no-fallback` to refuse this fallback.
+
+With `--no-fallback`: print the reason, exit 2, do NOT invoke `/validate:all`.
+
+"Team already resident" refusal message format:
+
+> `/validate:team` detected an existing agent team in this session. Agent teams are one-per-session. Clean up via the team's cleanup procedure (see agent-teams docs §"Clean up the team"), then re-invoke. `/validate:team` will not auto-cleanup — teams the user didn't explicitly end may have in-flight work.
+
+### Step 3 — Read context for manifest
+
+Invoke these skills/readers **in parallel** where possible:
+
+- `alignment-reader` → `sections.task_level` (used by teammates that need the goal/success-criteria)
+- `project-state-reader` → `codePath`, `codePathState` (already loaded in Step 1; re-use)
+- `screenshot-store-reader` → enumerate `<component>/<viewport>` pairs with `role: baseline` → used to populate `visual_fanout[]` for the visual gate entry
+
+If the screenshot store is empty OR `codePathState != "set"` for visual gates, the visual-regression entry in the manifest still ships but its `visual_fanout[]` is an empty array (teammate will emit `verdict: "skipped"` with reason).
+
+### Step 4 — Write manifest
+
+Compose the manifest per `references/team-manifest-schema.md` v1.0 and write to:
+
+```
+<task>/validations/tmp/team-manifest.json
+```
+
+Invariants (see schema §9):
+- All paths absolute
+- `visual_fanout[]` present only on `visual-regression` gate entries (omit the field for code/docs gates — do NOT write `visual_fanout: []`)
+- `gates[]` non-empty
+- Teammate spawn prompts reference the manifest by **absolute path**; they do NOT re-inline the envelope contract
+
+Write the manifest **before** spawn so every teammate can read it regardless of its `cwd` (worktree or main). The lead's PWD when writing is irrelevant to readability; absolute paths resolve from any `cwd`.
+
+### Step 5 — Spawn 4 teammates
+
+Spawn each teammate with `TeamCreate`. Spawn prompts are ≤40 lines each, reference the manifest by absolute path, and declare the teammate's role + gate assignments + isolation mode in a header block:
+
+```
+**Model:** sonnet
+**MaxTurns:** 20
+**Isolation:** worktree
+```
+
+Roster (from architecture §7):
+
+| Teammate | Gates owned | Model | MaxTurns | Isolation |
+|---|---|---|---|---|
+| `validator-code-1` | `tdd`, `solid` | sonnet | 20 | worktree |
+| `validator-code-2` | `dry`, `security` | sonnet | 20 | worktree |
+| `validator-docs` | `guides` | haiku | 10 | worktree |
+| `validator-visual` | `visual-regression` (fanned out) | sonnet | 15 | none |
+
+Each spawn prompt MUST include the absolute-path reminder (schema §10):
+
+> When you write `<gate>.json` or append to `history.jsonl`, use the absolute paths in `manifest.envelope.latest_dir` / `manifest.envelope.history_file`. Do NOT use relative paths — you are in a worktree and relative writes will not reach the lead.
+
+Each spawn prompt MUST include the progress-message contract:
+
+> When a gate completes, send a mailbox message to the lead in this exact format: `"<gate> complete, verdict: <verdict>"` where `<verdict>` is one of `pass | warning | fail | skipped`. Do not vary the format — the lead parses it.
+
+### Step 6 — Stream progress
+
+Receive mailbox messages from teammates. Print one CLI line per message:
+
+```
+  tdd complete, verdict: pass
+  solid complete, verdict: warning
+  dry complete, verdict: pass
+  security complete, verdict: pass
+  guides complete, verdict: pass
+  visual-regression complete, verdict: skipped
+```
+
+Do NOT wait on `TaskCompleted` hook events (deferred to v2 Set B2). The mailbox stream is the progress signal.
+
+### Step 7 — Aggregate
+
+When all expected gates have reported (or timeout reached — document as manual-recovery scenario):
+
+1. Read each `<task>/validations/latest/<gate>.json` envelope written by teammates.
+2. Assemble `_all.json` using the same aggregation shape `/validate:all` emits (per `references/validation-gate-result.md` §6), with one addition:
+   ```json
+   "discoverability_hint": "Run produced by /validate:team (source: \"validate:team\"). For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
+   ```
+3. Include an explicit `source: "validate:team"` marker inside the aggregate object so downstream consumers can distinguish team-mode runs from single-session runs:
+   ```json
+   { "source": "validate:team", "schema_version": "1.0", ... }
+   ```
+
+Write aggregate to:
+- `<task>/validations/latest/_all.json` (overwrite)
+- `<task>/validations/history.jsonl` (append — note: each teammate already appended its own per-gate line; the `_all.json` aggregate appends one additional summary line)
+
+Print the summary table in the same format as `/validate:all` Step 7.
+
+### Step 8 — Cleanup
+
+- Remove `<task>/validations/tmp/team-manifest.json`
+- Clean up the agent team per the agent-teams guide §"Clean up the team"
+- Leave the `tmp/` directory itself in place (may be empty)
+
+Do NOT remove per-gate envelopes in `validations/latest/` — they are persistent artifacts, same as `/validate:all` produces.
+
+### Step 9 — Persist run metadata
+
+Append one aggregate-summary line to `<task>/validations/history.jsonl` tagged with `run_id` matching the manifest. The run_id links the per-gate history lines to the aggregate line for any future analysis tooling.
+
+## CLI summary
+
+```
+Team validation for <task_name>:
+
+  Teammate              Gates              Verdict mix
+  validator-code-1      tdd, solid         pass, warning
+  validator-code-2      dry, security      pass, pass
+  validator-docs        guides             pass
+  validator-visual      visual-regression  skipped (no baselines)
+
+  Aggregate verdict: warning (1 warning, 5 pass, 1 skipped)
+
+  Saved:
+    summary → <task>/validations/latest/_all.json
+    history → <task>/validations/history.jsonl
+
+  Source: validate:team
+```
+
+## Honest-validation guarantee
+
+Teammates run in their own Claude Code sessions. They do NOT have access to:
+
+- The lead's conversation history
+- Uncommitted edits in the main working directory (if using `isolation: "worktree"`, they see only committed state)
+- Any guide loads, skill activations, or file reads the lead performed before spawn
+
+They DO have access to:
+
+- The manifest at the absolute path
+- The project's `CLAUDE.md` + any `.claude/rules/` files (inherited per agent-teams runtime)
+- MCP configs (e.g., Playwright for visual-regression)
+- The filesystem (read + write per their permission mode)
+- The mailbox primitive for talking to the lead
+
+This separation is what makes `/validate:team` honest where `/validate:all` is efficient.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No task context | Abort; exit 2 |
+| Task folder missing | Abort; exit 2 |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` unset | Fallback (§Step 2) unless `--no-fallback` |
+| `TeamCreate` fails | Fallback (§Step 2) unless `--no-fallback` |
+| Team already resident | Refuse with cleanup guidance; do NOT auto-cleanup |
+| Teammate dies mid-run | Manifest + any partial envelopes remain; manual recovery (see `--cleanup` in v2 Set B4) |
+| Teammate writes invalid envelope (schema mismatch) | Aggregate step logs the mismatch in the `_all.json` `messages[]` for that gate; overall verdict reflects fail |
+| `--no-fallback` with env unset | Print reason; exit 2; NO fallback |
+
+## What this does NOT do
+
+- Does NOT wrap or modify `/validate:all` — sibling command, independent lifecycle
+- Does NOT introduce a new envelope schema — per-gate envelopes stay at v3.13.0 v1.0; the aggregate adds only the `source` marker
+- Does NOT support `validate-visual-parity` in the team roster (deferred to v2 Set B5 — parity requires explicit `<reference>` arg)
+- Does NOT offer parallel visual gates (v1 serializes in one visual teammate; deferred to v2 Set B1)
+- Does NOT stream per-gate results via hooks (deferred to v2 Set B2 — mailbox messages cover it for now)
+- Does NOT offer a `--json` flag (deferred to v2 Set B3 — `_all.json` is already structured)
+- Does NOT offer a `--cleanup` subcommand for crash recovery (deferred to v2 Set B4 — manual recovery documented)
+- Does NOT auto-skip gates based on AI-inferred applicability (inherits `/validate:all`'s v1 posture)
+
+## Soft-nudge posture
+
+- Individual gate `fail` never blocks; `/validate:team` aggregates, surfaces, and lets the user decide
+- The team-mode fallback is automatic unless `--no-fallback` — users on machines without the experimental flag get validated output without re-invoking
+- The "team already resident" case REFUSES rather than auto-cleans — the user may have in-flight work; asking is safer than guessing
+
+## Manual recovery (teammate crash)
+
+If a teammate dies mid-run:
+
+1. The manifest at `<task>/validations/tmp/team-manifest.json` is still on disk
+2. Any envelopes already written to `<task>/validations/latest/<gate>.json` are valid
+3. The lead may aggregate from the available envelopes (print a message for missing gates) OR
+4. Clean up the team via agent-teams docs §"Clean up the team", remove the manifest manually, and re-invoke `/validate:team`
+
+v2 Set B4 will ship a `--cleanup` subcommand to automate this.
+
+## Session context
+
+This command does NOT update `session_context.json`. Validation runs are transient; the command body + the envelope already capture everything worth persisting (per architecture §2 Q7.7). Other `/validate:*` commands follow the same convention.
+
+## Related
+
+- `/drupal-dev-framework:validate-all` — sibling; single-session aggregator. Use this for routine validation
+- `/drupal-dev-framework:validate-tdd` / `:validate-solid` / `:validate-dry` / `:validate-security` / `:validate-guides` / `:validate-visual-regression` — individual gates invoked by teammates
+- `references/team-manifest-schema.md` — canonical `team-manifest.json` v1.0 spec
+- `references/validation-gate-result.md` — per-gate + aggregate envelope schema (v3.13.0 v1.0; unchanged)
+- `references/screenshot-store-schema.md` — screenshot store layout (unchanged)

--- a/drupal-dev-framework/references/team-manifest-schema.md
+++ b/drupal-dev-framework/references/team-manifest-schema.md
@@ -1,0 +1,204 @@
+# Team Manifest Schema v1.0
+
+**Introduced:** drupal-dev-framework v3.14.0
+**Owner:** `commands/validate-team.md`
+**Consumers (as of v3.14.0):** the 4 teammates spawned by `/validate:team` (`validator-code-1`, `validator-code-2`, `validator-docs`, `validator-visual`)
+
+`team-manifest.json` is the **minimum-context package** the `/validate:team` lead writes before spawning teammates. Each teammate reads it at an absolute path named in its spawn prompt and uses it to determine:
+
+- Which gate(s) it owns
+- Where to write its result envelope (absolute paths — teammates run in worktrees)
+- Where the screenshot store lives (visual teammate only)
+- How to behave under interactive vs CI conditions
+
+The manifest is write-once by the lead, read-only for teammates, and deleted by the lead during cleanup (Step 8 of the team spawn flow).
+
+## 1. Location
+
+```
+<task_folder>/validations/tmp/team-manifest.json
+```
+
+`validations/tmp/` is a sibling of the existing `validations/latest/` and `validations/history.jsonl` established by v3.13.0 envelope persistence. `tmp/` is ephemeral — the lead creates it per-run and removes `team-manifest.json` after the team completes or fails. The `tmp/` directory itself may be left in place between runs (empty).
+
+## 2. Shape
+
+```json
+{
+  "schema_version": "1.0",
+  "run_id": "2026-04-24T15:00:00Z-team-a1b2c3d4",
+  "task": {
+    "name": "dev_framework_isolated_validators",
+    "folder": "/abs/path/to/project/implementation_process/.../dev_framework_isolated_validators",
+    "project_folder": "/abs/path/to/project",
+    "code_path": "/abs/path/to/code",
+    "code_path_state": "set"
+  },
+  "gates": [
+    {
+      "gate": "tdd",
+      "assigned_to": "validator-code-1",
+      "isolation": "worktree"
+    },
+    {
+      "gate": "solid",
+      "assigned_to": "validator-code-1",
+      "isolation": "worktree"
+    },
+    {
+      "gate": "dry",
+      "assigned_to": "validator-code-2",
+      "isolation": "worktree"
+    },
+    {
+      "gate": "security",
+      "assigned_to": "validator-code-2",
+      "isolation": "worktree"
+    },
+    {
+      "gate": "guides",
+      "assigned_to": "validator-docs",
+      "isolation": "worktree"
+    },
+    {
+      "gate": "visual-regression",
+      "assigned_to": "validator-visual",
+      "isolation": "none",
+      "visual_fanout": [
+        { "component": "article_hero", "viewport": "desktop" },
+        { "component": "article_hero", "viewport": "mobile" }
+      ]
+    }
+  ],
+  "envelope": {
+    "schema_version": "1.0",
+    "latest_dir": "/abs/path/to/task/validations/latest",
+    "history_file": "/abs/path/to/task/validations/history.jsonl"
+  },
+  "screenshot_store": {
+    "root": "/abs/path/to/project/.screenshots",
+    "schema_version": "1.0"
+  },
+  "fallback": {
+    "interactive_visual_classification": true,
+    "ci_mode": false
+  }
+}
+```
+
+## 3. Field contracts (top-level)
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `schema_version` | string | `"1.0"` at v3.14.0. JSON string. Consumers match on major |
+| `run_id` | string | ISO-8601 UTC timestamp + `-team-` + 8-char short UUID, e.g. `2026-04-24T15:00:00Z-team-a1b2c3d4`. Matches the entry appended to `history.jsonl` at Step 9 |
+| `task` | object | See §4 |
+| `gates` | array | Ordered list of gate assignments. See §5. Non-empty — a manifest with zero gates is invalid |
+| `envelope` | object | Envelope persistence paths. See §6 |
+| `screenshot_store` | object | Screenshot store location + schema version. See §7 |
+| `fallback` | object | Teammate behavior hints. See §8 |
+
+## 4. `task` — task + code context
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `name` | string | Task folder name (e.g., `dev_framework_isolated_validators`). Matches the `task` field teammates will write into each envelope |
+| `folder` | string | Absolute path to the task folder. Teammates use this to read `alignment.md`, `research.md`, `architecture.md` if needed |
+| `project_folder` | string | Absolute path to the memory project folder (parent of `implementation_process/`). Used to locate `.screenshots/` and `project_state.md` |
+| `code_path` | string \| null | Absolute path to the user's code base, or `null` for `docs-only` / `unknown` projects. Code-validator teammates skip with `verdict: "skipped"` + reason when null |
+| `code_path_state` | enum | `"set"` \| `"docs-only"` \| `"unset"`. From `project-state-reader`. Consumers distinguish states explicitly rather than inferring from null |
+
+## 5. `gates[]` — gate assignments
+
+Each entry is one gate run. A teammate owning multiple gates appears in multiple entries (see `validator-code-1` in the §2 example — one entry for `tdd`, one for `solid`).
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `gate` | enum | `"tdd"` \| `"solid"` \| `"dry"` \| `"security"` \| `"guides"` \| `"visual-regression"`. Matches `/validate:<gate>` command names. **`visual-parity` is NOT allowed** — it requires an explicit `<reference>` arg and inherits `/validate:all`'s limitation (deferred to v2 Set B5) |
+| `assigned_to` | enum | `"validator-code-1"` \| `"validator-code-2"` \| `"validator-docs"` \| `"validator-visual"`. Suggestion only — file-lock task claiming (agent-teams runtime) decides actual ownership. The field exists so the lead can report "expected owner vs actual claimer" mismatches during debugging |
+| `isolation` | enum | `"worktree"` \| `"none"`. Per teammate role from architecture §7. Worktree isolation is git-state only — filesystem writes use `envelope.*` absolute paths regardless (§10) |
+| `visual_fanout` | array? | **Present only when `gate == "visual-regression"`.** Enumerates the components × viewports to capture. Each element is `{ component: string, viewport: string }`. Empty array means the task has no baselines in the store — teammate emits `verdict: "skipped"` with reason. Omit the field entirely for non-visual gates — do not write `visual_fanout: []` for a code gate |
+
+## 6. `envelope` — where teammates write results
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `schema_version` | string | `"1.0"` — the envelope schema version teammates MUST emit. Matches `references/validation-gate-result.md`. If the lead and teammates disagree on this, the aggregate step fails loudly |
+| `latest_dir` | string | Absolute path to `<task>/validations/latest/`. Teammates write `<gate>.json` into this directory. Absolute-path invariant (§10) applies |
+| `history_file` | string | Absolute path to `<task>/validations/history.jsonl`. Teammates append one JSON-line entry per gate run |
+
+## 7. `screenshot_store` — visual teammate only
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `root` | string | Absolute path to `<project>/.screenshots/` (per `references/screenshot-store-schema.md` §1). Visual teammate reads baselines and writes `.previous.*` rotation from here |
+| `schema_version` | string | `"1.0"` — the screenshot store schema version at manifest-write time. Visual teammate refuses if it reads a different version from a `<component>/<viewport>.meta.json` |
+
+Non-visual teammates MUST NOT read this block. It is populated unconditionally by the lead (even on docs-only tasks) to keep the manifest shape invariant across runs.
+
+## 8. `fallback` — teammate behavior hints
+
+| Field | Type | Values / constraints |
+|---|---|---|
+| `interactive_visual_classification` | boolean | `true` → visual teammate prompts user via mailbox-to-lead when a diff is detected (regression/intentional/cancel). `false` → skip-with-reason. Mirrors `/validate:all`'s CI-mode guard |
+| `ci_mode` | boolean | `true` → teammates suppress interactive prompts across all gates (visual classification, user confirmations). `false` → interactive prompts allowed where the corresponding per-gate command would prompt |
+
+Redundancy between `interactive_visual_classification` and `ci_mode` is intentional: `ci_mode` is the global posture, `interactive_visual_classification` is the per-concern override. A lead could set `ci_mode: false, interactive_visual_classification: false` to run interactive code gates while auto-skipping visual diffs that would block.
+
+## 9. Invariants
+
+The manifest is a contract. Breaking any of these invariants invalidates a run:
+
+- **All paths are absolute.** No relative paths, no `~`, no env var references. Teammates in worktrees cannot resolve relative paths back to the main working directory.
+- **`visual_fanout[]` only on visual gates.** Omit the field entirely on code/docs gates. Do NOT write `visual_fanout: []` for a non-visual gate.
+- **`gates[]` non-empty.** A manifest with zero gates is invalid — the lead refuses to spawn the team.
+- **`assigned_to` is a suggestion.** File-lock task claiming (agent-teams runtime) decides actual ownership. Teammates MUST NOT refuse a task because its `assigned_to` names a different teammate — they claim what they can and leave the rest.
+- **Schema versions match.** `schema_version` (manifest), `envelope.schema_version`, and `screenshot_store.schema_version` are each independent. If a teammate reads a mismatch against the version it expects, it emits `verdict: "fail"` with an explicit mismatch message rather than silently continuing.
+- **Write-once.** The lead writes the manifest before spawn and never updates it mid-run. Teammates treat the file as read-only. Any mid-run state (per-gate progress, mailbox messages) flows through the envelope + mailbox primitives, not the manifest.
+
+## 10. Absolute-path invariant — why it matters
+
+Teammates with `isolation: "worktree"` run with `cwd` inside a temporary worktree. Relative-path writes from that `cwd` land inside the worktree's copy of the task folder — NOT the main working directory the lead reads from at aggregation time (Step 7 of the team spawn flow).
+
+Every teammate spawn prompt includes the reminder:
+
+> When you write `<gate>.json` or append to `history.jsonl`, use the absolute paths in `manifest.envelope.*`. Do NOT use relative paths — you are in a worktree and relative writes will not reach the lead.
+
+This applies uniformly regardless of `isolation`, because even `isolation: "none"` teammates have their own `cwd` in the agent-teams runtime.
+
+## 11. Lifecycle
+
+```
+lead                                            teammates
+────                                            ─────────
+1. compose manifest in memory
+2. write <task>/validations/tmp/team-manifest.json
+3. TeamCreate + spawn 4 teammates
+                                                4. read manifest from absolute path
+                                                5. claim gate via file-lock
+                                                6. run gate logic
+                                                7. write <latest>/<gate>.json
+                                                8. append <history> line
+                                                9. mailbox: "<gate> complete, verdict: <v>"
+10. receive progress messages (§4 Step 6)
+11. wait for all gates (or timeout)
+12. aggregate → _all.json
+13. rm <tmp>/team-manifest.json                 (teammates already exited)
+14. clean up team
+```
+
+## 12. Versioning policy
+
+- **Major bumps** (`2.0`) are breaking: any change to field names, types, enums, or invariants. Consumers gate on major.
+- **Minor bumps** (`1.1`) are additive: new optional fields, new enum values, clarifications that don't break existing readers.
+- **Patch bumps** do not exist for schema versioning — if the change is editorial only, do not bump. If it's a contract change of any kind, use minor or major.
+
+v1.0 is the committed shape for v3.14.0. No pre-release iterations were needed — the design is a direct lift of research §6 decisions.
+
+## 13. Non-goals (what this schema deliberately omits)
+
+- **No credentials.** The manifest MUST NOT contain environment variables, API keys, or secrets. Teammates inherit credentials from the project CLAUDE.md + MCP configs (agent-teams §"Context and communication") — not from the manifest.
+- **No per-teammate model/turns config.** Model routing and MaxTurns are set in teammate spawn prompt headers (architecture §7), not the manifest. This keeps the manifest stable when a user overrides model choice for a specific run.
+- **No streaming output specification.** Mailbox messages use a fixed format string (`"<gate> complete, verdict: <verdict>"`) documented in architecture §4 Step 6. Changing that format is a spawn-prompt change, not a schema change.
+- **No `--json` flag output shape.** `/validate:team` does not emit JSON directly — `_all.json` already is JSON. (Deferred to v2 Set B3 if a direct JSON output mode ships.)
+- **No cleanup/resume subcommand shape.** Manual recovery steps live in the command body. (Deferred to v2 Set B4.)


### PR DESCRIPTION
## Summary

New `/drupal-dev-framework:validate-team` command — sibling to `/validate:all` — runs the 7 v3.13.0 validation gates in **independent Claude Code agent-team sessions** (4 teammates) so each gate is assessed in a fresh context free of the main session's prior reasoning.

- **Primary driver:** honest validation (no self-review bias)
- **Secondary:** context-window economy, parallel code-gate throughput
- **Fallback:** auto-runs `/validate:all` when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` unset, `TeamCreate` fails, or team already resident. `--no-fallback` opts out.

## 4-teammate roster

| Teammate | Gates | Model | Isolation |
|---|---|---|---|
| `validator-code-1` | `tdd`, `solid` | sonnet | worktree |
| `validator-code-2` | `dry`, `security` | sonnet | worktree |
| `validator-docs` | `guides` | haiku | worktree |
| `validator-visual` | `visual-regression` (fanned out) | sonnet | none |

Covers 6 of 7 gates. `validate-visual-parity` deferred to v2 Set B5 (requires explicit `<reference>` arg).

## Files changed

**New:**
- `drupal-dev-framework/commands/validate-team.md` — lead-side orchestration (Steps 1-9)
- `drupal-dev-framework/references/team-manifest-schema.md` — `team-manifest.json` v1.0 contract (13 sections)

**Updated:**
- `drupal-dev-framework/.claude-plugin/plugin.json` — `3.13.5` → `3.14.0`
- `drupal-dev-framework/CHANGELOG.md` — `[3.14.0]` entry
- `drupal-dev-framework/README.md` — commands table + Technical Contract References `5` → `6` + agent-teams CLI v2.1.32 note
- `drupal-dev-framework/CLAUDE.md` — new `### Validation Team Mode (v3.14.0+)` sub-section
- `.claude-plugin/marketplace.json` (root) — plugin entry version + `metadata.version` `1.14.18` → `1.14.19`

## Paper-test report (pre-audit)

Quick-traced 4 tight seams across `validate-team.md`, `team-manifest-schema.md`, and in-task `v2-candidates.md`:

| Seam | Verdict |
|---|---|
| Fallback detection order: env → TeamCreate → residence | ✅ matches architecture §6 |
| Manifest path absolute in spawn prompts | ✅ schema §10 reminder included |
| Teammate write path ↔ lead read path | ✅ absolute via `envelope.latest_dir` / `envelope.history_file` |
| Mailbox message format stability | ✅ literal `"<gate> complete, verdict: <verdict>"` in prompt + parser |

Zero BLOCKERs, zero MAJORs.

## Structure audit (plugin-structure-auditor)

**28/30.** No MAJORs. Optional clarification applied as a follow-up commit (Step 5 now explicitly notes 6 of 7 gates covered).

## What's NOT in scope

- Parallel visual gate execution (v2 Set B1)
- `TaskCompleted` hook streaming (v2 Set B2)
- `--json` on `/validate:team` itself (v2 Set B3)
- `--cleanup` subcommand (v2 Set B4)
- `validate-visual-parity` in team mode (v2 Set B5)
- Envelope schema changes (stays at v3.13.0 v1.0)
- New skills or scripts

All deferred items tracked in `dev_framework_improvements_epic/shared/v2-candidates.md` Set B.

## Test plan

- [ ] `/plugin install drupal-dev-framework@camoa-skills` resolves v3.14.0 with both hard deps (`dev-guides-navigator`, `code-quality-tools`)
- [ ] `/drupal-dev-framework:validate-team` appears in the command list
- [ ] **Fresh-session dog-food (no env var)** — `/drupal-dev-framework:validate-team dev_framework_isolated_validators` prints fallback message + auto-runs `/validate:all` + produces `_all.json`
- [ ] **Fresh-session dog-food (env var set)** — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 /drupal-dev-framework:validate-team dev_framework_isolated_validators` spawns 4 teammates, manifest written, each teammate writes its envelope, lead aggregates with `source: "validate:team"`, team cleans up
- [ ] Dog-food passes: `/validate:guides` returns `pass`; visual gates return `skipped-with-reason` (no stored baselines for a docs-only task)
- [ ] Honest-validation spot-check: at least one code-validator teammate's envelope contains no references to this session's reasoning (no "earlier we decided…" language, no awareness of uncommitted edits)

Dog-food steps run from fresh sessions per task's alignment — intentionally out of scope for this PR's author session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)