### PR TITLE
docs(drupal-dev-framework): close two /validate:team gaps (v3.14.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.19"
+    "version": "1.14.20"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator, code-quality-tools (declared via Plugin Dependencies).",
-      "version": "3.14.0",
+      "version": "3.14.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.1] - 2026-04-24
+
+### Fixed — Two `/validate:team` doc gaps surfaced by post-merge goal review
+
+Reviewing the v3.14.0 PR against the task's original pain points + alignment success criteria surfaced two documentation gaps the paper-test didn't catch. Both are documentation-level; no contract change.
+
+**1. Worktree-creation-failure fallback.** Architecture §15 Risk #4 specified that if a teammate's worktree creation fails, the lead should retry that teammate with `isolation: "none"` and print a warning. This behavior was in architecture but missing from the command body's error-cases table. Added to `validate-team.md` with explicit warning string format and a note that absolute-path writes reach the lead regardless of isolation mode.
+
+**2. Visual teammate mailbox fan-out contract.** v3.14.0's Step 6 specified one mailbox line per gate — but the visual teammate fans out over N × (`<component>`, `<viewport>`) pairs. The command didn't say whether it emits per-component lines, one aggregate line, or both. Clarified: the visual teammate emits **both** — per-component progress lines in format `"visual-regression:<component>/<viewport> complete, verdict: <verdict>"`, then one aggregate line `"visual-regression complete, verdict: <worst-verdict>"` matching the format other teammates use. Spawn prompt contract updated to specify this explicitly.
+
+### Files changed
+
+- `commands/validate-team.md` — Step 5 spawn prompt adds visual-specific fan-out mailbox contract; Step 6 adds "Visual teammate fan-out" paragraph; error-cases table adds worktree-creation-failure row
+- `.claude-plugin/plugin.json` — `3.14.0` → `3.14.1`
+- root `.claude-plugin/marketplace.json` — plugin entry `3.14.0` → `3.14.1` + `metadata.version` `1.14.19` → `1.14.20`
+
+### Not changed
+
+- `team-manifest-schema.md` — manifest contract is unchanged (both gaps are command-body / spawn-prompt concerns, not manifest fields)
+- Envelope schema
+- Roster, fallback chain, or any other v3.14.0 contract
+
+### Why patch, not minor
+
+Both changes are additive documentation clarifications of previously-undefined behavior. No consumer could have relied on the prior (silent) behavior for either case — v3.14.0 shipped less than 24 hours ago with zero recorded runs. Patch bump per the versioning policy.
+
 ## [3.14.0] - 2026-04-24
 
 ### Added — `/validate:team` command for isolated validation

--- a/drupal-dev-framework/commands/validate-team.md
+++ b/drupal-dev-framework/commands/validate-team.md
@@ -110,6 +110,10 @@ Each spawn prompt MUST include the progress-message contract:
 
 > When a gate completes, send a mailbox message to the lead in this exact format: `"<gate> complete, verdict: <verdict>"` where `<verdict>` is one of `pass | warning | fail | skipped`. Do not vary the format — the lead parses it.
 
+The visual teammate's spawn prompt additionally specifies the fan-out mailbox contract:
+
+> For each `<component>/<viewport>` in `manifest.gates[visual-regression].visual_fanout[]`, send a per-component progress line in this exact format: `"visual-regression:<component>/<viewport> complete, verdict: <verdict>"`. After all fan-out items complete, send ONE aggregate line: `"visual-regression complete, verdict: <worst-verdict>"` (the same format other teammates use). Both line shapes are required — the lead uses per-component lines for progress and the aggregate line for the "all gates done" signal.
+
 ### Step 6 — Stream progress
 
 Receive mailbox messages from teammates. Print one CLI line per message:
@@ -124,6 +128,8 @@ Receive mailbox messages from teammates. Print one CLI line per message:
 ```
 
 Do NOT wait on `TaskCompleted` hook events (deferred to v2 Set B2). The mailbox stream is the progress signal.
+
+**Visual teammate fan-out.** The visual teammate runs N × (`<component>`, `<viewport>`) pairs from `manifest.gates[visual-regression].visual_fanout[]`. It sends **one mailbox message per component** as each completes — format `"visual-regression:<component>/<viewport> complete, verdict: <verdict>"` — so the lead can stream progress during long visual runs. After all fan-out items complete, it sends **one aggregate line** — format `"visual-regression complete, verdict: <worst-verdict>"` — matching the format the other teammates use. The aggregate envelope at `<latest>/visual-regression.json` collapses all fan-out runs into a single entry with per-component detail in `messages[]` (same shape `/validate:all` emits; see `validate-all.md` Step 4 "Per-component result aggregation"). Lead parses both per-component and aggregate lines; per-component lines are for progress, the aggregate line is for the "all gates done" signal.
 
 ### Step 7 — Aggregate
 
@@ -204,6 +210,7 @@ This separation is what makes `/validate:team` honest where `/validate:all` is e
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` unset | Fallback (§Step 2) unless `--no-fallback` |
 | `TeamCreate` fails | Fallback (§Step 2) unless `--no-fallback` |
 | Team already resident | Refuse with cleanup guidance; do NOT auto-cleanup |
+| Teammate worktree creation fails (disk space, repo state, permissions) | Lead retries the spawn for that teammate with `isolation: "none"` and prints a warning: `"<teammate> worktree creation failed; spawning with isolation: none. Code-gate honest-validation is weaker for this teammate (can see uncommitted edits)."` The teammate still runs — absolute-path writes via `manifest.envelope.*` reach the lead regardless of isolation mode |
 | Teammate dies mid-run | Manifest + any partial envelopes remain; manual recovery (see `--cleanup` in v2 Set B4) |
 | Teammate writes invalid envelope (schema mismatch) | Aggregate step logs the mismatch in the `_all.json` `messages[]` for that gate; overall verdict reflects fail |
 | `--no-fallback` with env unset | Print reason; exit 2; NO fallback |


### PR DESCRIPTION
## Summary

Post-merge review of v3.14.0 against `dev_framework_isolated_validators` pain points + alignment success criteria surfaced two documentation gaps the paper-test missed. Both are additive clarifications — no contract change.

## Gap 1 — worktree-creation failure fallback

Architecture §15 Risk #4 specified: if a teammate's worktree creation fails, the lead retries with \`isolation: \"none\"\` and prints a warning. This was in architecture but never made it into the command body's error-cases table.

**Fix:** new row in \`validate-team.md\` error-cases table with the exact warning format and a note that absolute-path writes reach the lead regardless of isolation mode.

## Gap 2 — visual-teammate mailbox fan-out

v3.14.0 Step 6 specified one mailbox line per gate. But the visual teammate runs N × (\`<component>\`, \`<viewport>\`) pairs. Previously ambiguous: one line per component? One aggregate line? Both?

**Fix:** visual teammate emits **both** —

- Per-component progress: \`\"visual-regression:<component>/<viewport> complete, verdict: <verdict>\"\`
- Aggregate on completion: \`\"visual-regression complete, verdict: <worst-verdict>\"\` (same format other teammates use)

Spawn prompt contract updated to enforce both shapes; Step 6 parser description updated to consume both.

## Files changed

- \`commands/validate-team.md\` — +7 lines (error case row + Step 6 paragraph + spawn prompt contract)
- \`.claude-plugin/plugin.json\` — 3.14.0 → 3.14.1
- \`CHANGELOG.md\` — [3.14.1] entry
- root \`marketplace.json\` — plugin version + metadata.version 1.14.19 → 1.14.20

## Why patch, not minor

Both changes describe previously-undefined behavior (worktree-fallback not documented; visual mailbox format not specified). v3.14.0 shipped <24h ago with zero recorded runs. No consumer could have depended on the prior silent behavior. Patch per versioning policy.

## Not changed

- \`team-manifest-schema.md\` — manifest contract is unchanged (both gaps are command-body + spawn-prompt concerns)
- Envelope schema, roster, fallback chain — all v3.14.0 contracts stand

## Test plan

- [ ] Install resolves v3.14.1 cleanly
- [ ] \`/drupal-dev-framework:validate-team --help\` (or similar discovery) surfaces the updated command body
- [ ] Dog-food from v3.14.0 task still applies — once this PR merges, run dog-food against main; the two newly-documented behaviors (worktree failure, visual fan-out) do not change pass/fail criteria for the dog-food

🤖 Generated with [Claude Code](https://claude.com/claude-code)