### PR TITLE
fix(drupal-dev-framework): /validate:guides applicability auto-skip (v3.14.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.20"
+    "version": "1.14.21"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator, code-quality-tools (declared via Plugin Dependencies).",
-      "version": "3.14.1",
+      "version": "3.14.2",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.2] - 2026-04-24
+
+### Fixed — `/validate:guides` applicability auto-skip for non-Drupal tasks
+
+Surfaced by the v3.14.0 dog-food run on `dev_framework_isolated_validators`: `/validate:guides` returned `fail` because neither `research.md` nor `architecture.md` cited a dev-guides-navigator guide. But the task is non-Drupal plugin-framework work (agent-teams orchestration), so guide citations weren't expected — the dev-guides catalog covers Drupal/Next.js/frontend, not this domain. The verdict was technically correct against the rule but a false positive against intent.
+
+The v1 gate's "Why this gate exists" prose already acknowledged the limitation: *"Not relevant for trivial config changes, test-only tasks, or documentation-only work. v1 has no auto-skip; user decides when to invoke."* That worked when humans invoked the gate manually but breaks when `/validate:all` or `/validate:team` invokes it autonomously.
+
+**Fix:** new Step 2 "Applicability check" in `validate-guides.md`. Before inspecting phase artifacts:
+
+- If `codePathState` is `docs-only` or `unset` → emit `verdict: "skipped"` with reason
+- If `codePathState == "set"` → quick-scan codePath for domain markers:
+  - **Drupal:** `*.info.yml`, `*.module`, `composer.json` containing `"drupal/core"`, or `*.theme` directory
+  - **Next.js:** `package.json` with `"next"` dep, or `next.config.{js,ts,mjs}`
+  - **Frontend/CSS:** `*.scss`, `*.css`, `tailwind.config.*`, or `package.json` with `"react"`/`"vue"`/`"svelte"`
+- At least one marker → applicable; continue to citation check
+- No markers → emit `verdict: "skipped"` with reason
+
+Detection is shallow (top-level + 1-deep) and intentionally generous. False positives (running citation check on a marginally-Drupal task) are cheaper than false negatives.
+
+`details.applicability` field added to the envelope so consumers can see what fired:
+
+```json
+"applicability": {
+  "decision": "applicable | skipped",
+  "reason": "<one-line explanation>",
+  "markers_found": ["drupal", "frontend"]
+}
+```
+
+### Files changed
+
+- `commands/validate-guides.md` — new Step 2 (applicability check); Steps 3-8 renumbered; envelope details adds `applicability` field; verdict-messages section adds skipped-applicability example; "Why this gate exists" prose updated to describe the auto-skip
+- `.claude-plugin/plugin.json` — `3.14.1` → `3.14.2`
+- root `marketplace.json` — plugin version + `metadata.version` `1.14.20` → `1.14.21`
+
+### Not changed
+
+- Envelope schema v1.0 (just adds an optional `details.applicability` sub-field; existing consumers ignore it)
+- Citation-extraction logic (Step 4) and verdict rules (Step 5) — both unchanged
+- `/validate:team` command body — `/validate:guides` semantics shifted underneath, but the team-mode wrapper is agnostic to per-gate verdict logic
+
+### Why patch, not minor
+
+Bug fix for a false-positive verdict surfaced by the v3.14.0 dog-food. No new behavior the user explicitly opts into — the auto-skip kicks in transparently. Existing Drupal tasks see no change (markers match, citation check runs as before). Patch per versioning policy.
+
+### Re-dog-food on this fix
+
+`/validate:team dev_framework_isolated_validators` is expected to now return `skipped` for the `guides` gate (codePath is `/home/camoa/workspace/claude_memory/marketplaces/camoa-skills` — Claude Code plugin marketplace, no Drupal/Next.js/frontend markers).
+
 ## [3.14.1] - 2026-04-24
 
 ### Fixed — Two `/validate:team` doc gaps surfaced by post-merge goal review

--- a/drupal-dev-framework/commands/validate-guides.md
+++ b/drupal-dev-framework/commands/validate-guides.md
@@ -26,18 +26,34 @@ This is a **framework-owned** gate — it does NOT wrap a `code-quality-tools` s
 
    Locate the task folder under `<project>/implementation_process/in_progress/**/<task-name>/`.
 
-2. **Inspect phase artifacts** — read any of these that exist in the task folder:
+2. **Applicability check (v3.14.2+)** — before inspecting artifacts, determine whether dev-guides apply to this task at all. The dev-guides catalog covers Drupal, Next.js, design systems (Bootstrap/Radix/Tailwind/DaisyUI), CSS, and cross-cutting methodology. For tasks whose codePath contains none of those domain markers (e.g., a Claude Code plugin marketplace, a pure docs project, a shell-script tools repo), guide citations are not expected and `fail` would be a false positive.
+
+   Read `project_state.md` for `codePath` and `codePathState`. Then:
+
+   - If `codePathState == "docs-only"` OR `codePathState == "unset"` → emit `verdict: "skipped"` with reason `"task has no code path declared (state: <state>); guide citation rule does not apply"`. Skip Steps 3-5.
+   - If `codePathState == "set"` → quick-scan codePath for domain markers:
+     - **Drupal:** any `*.info.yml`, `*.module`, `composer.json` containing `"drupal/core"`, or directory ending in `.theme`
+     - **Next.js:** `package.json` containing `"next"` as a dep, or `next.config.{js,ts,mjs}`
+     - **Frontend/CSS:** `*.scss`, `*.css`, `tailwind.config.*`, or `package.json` containing `"react"`/`"vue"`/`"svelte"`
+   - If at least one marker matches → applicable; continue.
+   - If NO markers match → emit `verdict: "skipped"` with reason `"codePath at <path> contains no Drupal/Next.js/frontend code; guide citation rule does not apply to this task type"`. Skip Steps 3-5.
+
+   The applicability check is intentionally generous (any marker → applicable). False positives are cheaper than false negatives — if a task even smells Drupal-or-frontend, run the citation check.
+
+   Detection is shallow (top-level + 1-deep) to keep the check fast. Implement via `Glob` + `Bash` `grep`. Cache result on `details.applicability` so consumers can see what fired.
+
+3. **Inspect phase artifacts** — read any of these that exist in the task folder:
    - `research.md` (Phase 1 artifact)
    - `architecture.md` (Phase 2 artifact)
    - `implementation.md` (Phase 3 artifact)
 
-3. **Extract guide citations** — scan for guide references in each artifact. Accept:
+4. **Extract guide citations** — scan for guide references in each artifact. Accept:
    - URLs matching `camoa.github.io/dev-guides/[a-z0-9/-]+` (the published dev-guides site)
    - Inline mentions of guide slugs in the form `drupal/<category>/<topic>`, `design-systems/<topic>`, `nextjs/<topic>`, or similar kebab-case paths
    - Markdown reference links `[...](https://camoa.github.io/dev-guides/...)`
    - Explicit "Loaded guide: <slug>" annotations if the `dev-guides-navigator` skill wrote them
 
-4. **Judge adequacy** — apply verdict rules:
+5. **Judge adequacy** — apply verdict rules:
    - `pass` → ≥1 guide citation found in research.md AND ≥1 in architecture.md (if architecture.md exists)
    - `warning` → ≥1 citation found overall but phase coverage uneven (e.g., research cites guides but architecture doesn't)
    - `fail` → no guide citations found in any phase artifact AND at least one artifact exists with ≥200 lines of content (substantive work without guide consultation)
@@ -45,25 +61,31 @@ This is a **framework-owned** gate — it does NOT wrap a `code-quality-tools` s
 
    The 200-line substance threshold prevents false-positives on near-empty stub artifacts.
 
-5. **Emit the shared envelope** (per `references/validation-gate-result.md`) with gate-specific details:
+6. **Emit the shared envelope** (per `references/validation-gate-result.md`) with gate-specific details:
 
    ```json
    "details": {
      "source": "framework:guides",
+     "applicability": {
+       "decision": "applicable | skipped",
+       "reason": "<one-line explanation>",
+       "markers_found": ["drupal", "frontend"]
+     },
      "checked_artifacts": ["<abs path to each artifact examined>"],
      "guides_cited": ["<slug>", "<slug>"],
      "guides_expected_min": 1
    }
    ```
 
+   - `applicability` — populated by Step 2; for `skipped` runs, `checked_artifacts` and `guides_cited` may be omitted
    - `guides_cited` — unique slugs found across all artifacts, deduplicated
    - `guides_expected_min` — v1 hard-coded to 1 per substantive artifact; v2 candidate for per-task configuration
 
-6. **Persist** — write envelope to:
+7. **Persist** — write envelope to:
    - `<task_folder>/validations/latest/guides.json` (overwrite)
    - `<task_folder>/validations/history.jsonl` (append)
 
-7. **Print CLI summary** — show verdict, citations found, and per-artifact gaps. On `fail`, suggest running `/dev-guides-navigator` with domain keywords. Non-zero exit (1) only when invoked non-interactively.
+8. **Print CLI summary** — show verdict, citations found, and per-artifact gaps. On `fail`, suggest running `/dev-guides-navigator` with domain keywords. On `skipped` due to applicability, print the applicability reason. Non-zero exit (1) only when invoked non-interactively.
 
 ## Verdict messages
 
@@ -71,6 +93,7 @@ Examples of what `messages[]` contains:
 
 - `pass`: `["3 guide citations found across research.md and architecture.md"]`
 - `warning`: `["2 citations in research.md but 0 in architecture.md — architecture may be under-grounded"]`
+- `skipped (applicability)`: `["codePath at /abs/path contains no Drupal/Next.js/frontend code; guide citation rule does not apply to this task type"]` or `["task has no code path declared (state: docs-only); guide citation rule does not apply"]`
 - `fail`: `["No guide citations found in any phase artifact", "Suggest: /dev-guides-navigator with keywords from task.md Goal"]`
 - `skipped`: `["No phase artifacts exist yet; run /research to begin"]`
 
@@ -78,7 +101,7 @@ Examples of what `messages[]` contains:
 
 The `dev-guides-navigator` plugin exists precisely because AI-generated Drupal work drifts from community consensus when it doesn't load authoritative guides. This gate surfaces the "we didn't check" case and recommends action — it's NOT a block, just a visible signal during `/validate:all`.
 
-Applicability (in the informal sense): relevant whenever a task writes substantive `research.md` or `architecture.md`. Not relevant for trivial config changes, test-only tasks, or documentation-only work. v1 has no auto-skip; user decides when to invoke.
+**Applicability auto-skip (v3.14.2+):** the gate now skips with reason when codePath has no Drupal/Next.js/frontend markers, OR when codePathState is `docs-only` / `unset`. This makes the gate safe to include in `/validate:all` and `/validate:team` runs against non-Drupal tasks (Claude Code plugin work, shell-tool repos, pure-docs projects) without producing spurious `fail` verdicts. v1 had no auto-skip and relied on user judgment about when to invoke; v3.14.2 makes that judgment explicit and machine-checkable.
 
 ## Error cases
 


### PR DESCRIPTION
## Summary

Surfaced by the v3.14.0 dog-food on \`dev_framework_isolated_validators\`: \`/validate:guides\` returned \`fail\` because neither phase artifact cited a dev-guides-navigator guide. But the task is non-Drupal plugin-framework work — guide citations weren't expected. False positive against intent.

## Fix

New Step 2 \"Applicability check\" in \`validate-guides.md\`. Before running the citation check:

- \`codePathState == \"docs-only\"\` or \`\"unset\"\` → \`skipped\` with reason
- \`codePathState == \"set\"\` → quick-scan codePath for markers:
  - **Drupal:** \`*.info.yml\`, \`*.module\`, \`composer.json\` with \`\"drupal/core\"\`, or \`*.theme\` dir
  - **Next.js:** \`package.json\` with \`\"next\"\` dep or \`next.config.{js,ts,mjs}\`
  - **Frontend:** \`*.scss\`, \`*.css\`, \`tailwind.config.*\`, or \`package.json\` with \`\"react\"\`/\`\"vue\"\`/\`\"svelte\"\`
- At least one marker → applicable; continue
- No markers → \`skipped\` with reason

Detection shallow (top-level + 1-deep) and intentionally generous. False positives cheaper than false negatives.

New \`details.applicability\` sub-field on the envelope so consumers can see what fired.

## Files changed

- \`commands/validate-guides.md\` — new Step 2; Steps 3-8 renumbered; envelope details adds \`applicability\` field; verdict-messages section adds skipped-applicability example
- \`.claude-plugin/plugin.json\` — 3.14.1 → 3.14.2
- root \`marketplace.json\` — plugin version + metadata.version 1.14.20 → 1.14.21

## Not changed

- Envelope schema v1.0 (adds an optional sub-field; existing consumers ignore it)
- Citation-extraction logic and verdict rules (untouched)
- \`/validate:team\` command body (agnostic to per-gate verdict logic)
- Other \`/validate:*\` commands

## Why patch, not minor

Bug fix for a false-positive verdict. No new opt-in behavior. Existing Drupal tasks see no change (markers match, citation check runs as before).

## Test plan

- [ ] Dog-food re-run: \`/drupal-dev-framework:validate-team dev_framework_isolated_validators\` after merge → \`guides\` gate returns \`skipped\` with applicability reason (was \`fail\` in v3.14.1)
- [ ] Spot-check on a real Drupal task — \`guides\` still runs the citation check normally
- [ ] \`details.applicability.markers_found\` populated for applicable runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)