### PR TITLE
feat(drupal-dev-framework): playbook system — opinionated Drupal best-practices (v3.15.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.21"
+    "version": "1.14.22"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator, code-quality-tools (declared via Plugin Dependencies).",
-      "version": "3.14.2",
+      "version": "3.15.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,15 +1,18 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.14.2",
+  "version": "3.15.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams"],
+  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams", "playbook"],
   "dependencies": [
     "dev-guides-navigator",
     "code-quality-tools"
-  ]
+  ],
+  "defaults": {
+    "playbookSets": ["drupal/best-practices/camoa"]
+  }
 }

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,87 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0] - 2026-04-24
+
+### Added — Playbook System
+
+Two-layer Drupal best-practices system: shipped playbook sets (namespaced dev-guides categories) + per-project local user playbook. **Opinionation by default** — `plugin.json` ships `defaults.playbookSets: ["drupal/best-practices/camoa"]`. Local playbook can OVERRIDE shipped opinions or EXTEND them with topics shipped doesn't cover; local always wins on conflict.
+
+The camoa playbook is **already published** at `https://camoa.github.io/dev-guides/drupal/best-practices/camoa/` (20 guides as of 2026-04-24). v3.15.0 ships the framework integration over the existing content.
+
+### New commands (5)
+
+- `/drupal-dev-framework:set-playbook-sets` — set/clear active sets; validates each via `dev-guides-navigator`. Accepts comma-list, literal `none`, or `default` (revert to plugin default).
+- `/drupal-dev-framework:set-user-playbook` — set/clear local playbook path; 3-state field (`unset` / `docs-only-no-playbook` / `set <path>`); explicit / `--docs-only` / interactive detect-and-confirm modes.
+- `/drupal-dev-framework:playbook-capture` — interactive draft + diff preview + append. User is the deterministic approval gate.
+- `/drupal-dev-framework:playbook-review` — per-play `[k]eep / [u]pdate / [r]emove / [q]uit` walk; immediate-write semantics; quit preserves committed work; `/loop`-able.
+- `/drupal-dev-framework:playbook-active` — read-only display of subscribed sets, local playbook, recent conflicts.
+
+### New references (2 + 1 schema bump)
+
+- `references/playbook-schema.md` v1.0 — recommended local playbook structure (H3-per-play with What/Rationale/When/Example), freeform fallback contract, defensive parser invariants
+- `references/playbook-conflict-schema.md` v1.0 — JSONL log line for `.claude/playbook-conflicts.log`; local-vs-shipped + multi-set-contradiction types
+- `references/analysis-agent-schema.md` v1.0 → v1.1 — adds `play_candidates` mode used by `/complete` candidate-play surface; existing `folder` and `description` modes unchanged (backward-compatible — additive only)
+
+### New scripts (2)
+
+- `scripts/playbook-read.sh` — defensive markdown parser; never throws; emits warnings on malformed plays; handles freeform fallback
+- `scripts/playbook-conflicts-write.sh` — atomic JSONL append with schema-version + required-field validation
+
+### `project_state.md` schema additions
+
+- `**Playbook Sets:** <comma-list>` OR `none` OR absent (defaults from plugin.json)
+- `**User Playbook:** <abs path>` paired with `**User Playbook State:** unset | docs-only-no-playbook | set`
+- `**Playbook Resolutions:**` — multi-line list recording per-topic multi-set contradiction choices
+
+### Updated artifacts
+
+- `skills/guide-integrator` v4.1.1 → 5.0.0 — loads playbook sets via `dev-guides-navigator` + local playbook via `playbook-read.sh`; cross-references plays-by-topic; emits `loaded_playbook_sets[]`, `loaded_local_playbook`, `conflicts[]`; surfaces conflicts once per session per topic with persistence.
+- `skills/project-state-reader` v1.0.0 → 1.1.0 — parses new fields; falls back to plugin.json `defaults.playbookSets` when `Playbook Sets` field absent; emits `playbookSetsSource: explicit | explicit-none | default`.
+- `scripts/project-state-read.sh` — extended with new field parsing + plugin.json default resolution.
+- `commands/research.md`, `design.md`, `implement.md` — dev-guides preflight Step 1 documents v3.15.0 guide-integrator behavior (loads playbook layers, surfaces conflicts).
+- `commands/complete.md` — new "Candidate-play surface" section between pre-completion checks and task move; invokes `analysis-agent` `play_candidates` mode; per-candidate `[y]/[n]/[d]` prompt; `--no-play-candidates` opt-out; skipped when `userPlaybookState != "set"`.
+- `hooks/context-reminder.sh` (UserPromptSubmit) — emits `Playbook: <sets> + <local>` line below Project line when at least one of `playbookSets` or `userPlaybook` is configured. Silent otherwise.
+- `.claude-plugin/plugin.json` — `3.14.2` → `3.15.0`; new top-level `defaults.playbookSets` field; new `playbook` keyword.
+- `README.md` — 5 new commands in commands table; Technical Contract References 6 → 8.
+- `CLAUDE.md` — new `## Playbook System (v3.15.0+)` section before Validation Team Mode block.
+
+### Precedence rule
+
+When the same topic is addressed by multiple layers:
+
+1. Project-local playbook (always wins when present)
+2. Active opinion-set(s) (winner determined by `**Playbook Resolutions:**` if multi-set; else `null` and prompt user)
+3. Generic dev-guides (lowest precedence)
+
+### Conflict handling
+
+- **Local-vs-shipped:** precedence rule applies silently; one-line surface once per session per topic; persisted to `.claude/playbook-conflicts.log`.
+- **Multi-set contradiction:** framework refuses silent pick; prompts user (`[1]/[2]/cancel`); persists choice in `**Playbook Resolutions:**` for future sessions.
+- **Local extending (no contradiction):** loads silently; no conflict event.
+
+### Why minor, not major
+
+Purely additive. No breaking changes:
+
+- Existing commands (`/research`, `/design`, `/implement`, `/complete`, `/validate:*`) work unchanged when no playbook is configured.
+- Existing skills (`alignment-reader`, `task-frontmatter-reader`, etc.) consumed unchanged.
+- `analysis-agent` v1.0 outputs unchanged for existing modes; new `play_candidates` mode is opt-in via explicit `mode` parameter.
+- `project_state.md` parsing is forward-compatible: projects without the new fields just get default behavior.
+- `dev-guides-navigator` plugin and `code-quality-tools` consumed unchanged.
+
+### Default voice (political note)
+
+`plugin.json` ships `defaults.playbookSets: ["drupal/best-practices/camoa"]`. Forks of the plugin (alternative opinion-curators) override this field to ship a different default. The choice is documented as a deliberate decision, not implicit.
+
+### Deferred to v2
+
+- `/validate:playbook` adherence gate — pattern adherence requires agentic judgment; needs machine-readable playbook format first
+- Global `~/.claude/rules/playbook.md` surface — not needed (dev-guides serves this via subscription); CC Issue #21858 (`globs:` ignored at user-level) is irrelevant to the design
+- Determinism measurement / before-after eval — anecdotal user judgment is the only signal in v3.15.0
+- Multi-set contradiction silent resolution beyond per-topic prompt
+- Migration tooling for existing patterns docs in non-standard locations
+
 ## [3.14.2] - 2026-04-24
 
 ### Fixed — `/validate:guides` applicability auto-skip for non-Drupal tasks

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -58,6 +58,35 @@ Individual `/validate:*` commands for on-demand quality gates. Replaces `/comple
 
 **NOT wrapped** (keep invoking directly via `/code-quality:*` namespace): `lint`, `coverage`, `review`, `audit`, `ultrareview`, `architecture-debate`, `security-debate`. `/validate:all` surfaces them as discoverability hint.
 
+## Playbook System (v3.15.0+)
+
+Two-layer Drupal best-practices system:
+
+- **Published playbook sets** — namespaced dev-guides categories like `drupal/best-practices/camoa/*`. Each guide is one concrete "do it this way, not that way" rule. Multiple authors can ship parallel sets (`drupal/best-practices/<author>/*`); users subscribe per project.
+- **Project-local user playbook** — single markdown file the user maintains. Can OVERRIDE shipped opinions (replace) or EXTEND them (cover topics shipped doesn't). Local always wins on conflict.
+
+**`project_state.md` fields** (v3.15.0+):
+- `**Playbook Sets:** drupal/best-practices/camoa, ...` (comma-list) OR `none` (explicit opt-out) OR absent (uses plugin.json `defaults.playbookSets`)
+- `**User Playbook:** /abs/path/to/playbook.md` paired with `**User Playbook State:** unset | docs-only-no-playbook | set`
+- `**Playbook Resolutions:**` — multi-line list recording per-topic multi-set contradiction choices
+
+**Default voice:** `plugin.json` ships `defaults.playbookSets: ["drupal/best-practices/camoa"]` — opinionation by default. Forks of the plugin override this field to ship a different default.
+
+**Precedence at decision time:** project-local > active opinion-set(s) > generic dev-guides.
+
+**Conflict surface:** `guide-integrator` v5.0.0+ cross-references plays-by-topic at load time. Local-vs-shipped contradictions emit one-line surfaces (precedence rule applies, no prompt) and persist to `.claude/playbook-conflicts.log`. Multi-set contradictions prompt the user once and persist the choice in `**Playbook Resolutions:**`.
+
+**Maintenance commands** (all user-initiated, framework-drafted, user-approved with diff preview):
+- `/playbook-capture` — append a new play; framework drafts entry, shows diff
+- `/playbook-review` — walk plays one-at-a-time with `[k/u/r/q]`; immediate-write semantics
+- `/playbook-active` — read-only display of subscribed sets, local playbook, recent conflicts
+- `/set-playbook-sets` — set/clear active sets; validates each via dev-guides-navigator
+- `/set-user-playbook` — set/clear local playbook path; 3-state semantics
+
+**`/complete` candidate-play surface:** at task completion, `analysis-agent` `play_candidates` mode (v1.1+) analyzes task artifacts + `git diff` for repeated decisions worth capturing. Per-candidate `[y]/[n]/[d]` prompt; `[y]` hands off to `/playbook-capture`. `--no-play-candidates` opt-out.
+
+**Schemas:** `references/playbook-schema.md` v1.0 (recommended local playbook structure), `references/playbook-conflict-schema.md` v1.0 (JSONL log line), `references/analysis-agent-schema.md` v1.1 (adds `play_candidates` mode, additive/backward-compatible).
+
 ### Validation Team Mode (v3.14.0+)
 
 `/validate:team` is a **sibling** to `/validate:all` — NOT a replacement. It runs the 7 v3.13.0 gates in **isolated Claude Code agent teams** (4 teammates) so each gate is assessed in a fresh context window free of the main session's prior reasoning. Primary driver: **honest validation** (no self-review bias). Secondary benefits: context-window economy, parallel code-gate throughput.

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -183,7 +183,7 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 
 | Reference | Owner | What it pins |
 |-----------|-------|--------------|
-| `analysis-agent-schema.md` **(v3.11.0)** | `analysis-agent` | JSON output schema v1.0, 8 signal codes, 7 invariants, consumer guidance for `/research` + `/propose-epics` |
+| `analysis-agent-schema.md` **(v3.11.0; v1.1 since v3.15.0)** | `analysis-agent` | JSON output schema (v1.0 base + v1.1 adds `play_candidates` mode for `/complete`); 8 signal codes, 7 invariants, three input modes (`folder`, `description`, `play_candidates`); backward-compatible — existing `folder` and `description` modes unchanged |
 | `code-path-detection.md` **(v3.11.0)** | `/set-code-path`, `/new` | Detection strategies in priority order, three-null-states table (`unknown` / `docs-only` / `set`), safety filter (hard-reject list for system roots) |
 | `alignment-contract.md` **(v3.12.0)** | `alignment-reader` | `alignment.md` grammar v1.0, 8 warning codes, JSON output contract, em-dash canonicalization rule, versioning policy |
 | `screenshot-store-schema.md` **(v3.13.0)** | `screenshot-store-reader` + `scripts/screenshot-store-{read,write}.sh` | 9-field `.meta.json` v1.0, directory layout with `.previous` rotation (1-deep), 6 warning codes, `role` enum (`baseline` / `parity_reference` / `previous`), `captured_by` + `source` provenance fields |

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -108,6 +108,11 @@ Both enforced via `plugin.json` `dependencies`. Missing-dependency failures surf
 | `/validate:visual-parity <component> <viewport> <reference>` | **(v3.13.0)** Compare built output against design comp (PNG/JPG, Figma URL, HTML file). Shared infrastructure with visual-regression |
 | `/validate:all` | **(v3.13.0)** Run all 7 gates sequentially; aggregate summary; discoverability hint for unwrapped `/code-quality:*` capabilities |
 | `/validate:team` | **(v3.14.0)** Sibling to `/validate:all` — runs the 7 gates in **isolated Claude Code agent teams** (4 teammates) for honest validation free of main-session bias. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (agent-teams CLI v2.1.32+); gracefully falls back to `/validate:all` when unavailable. `--no-fallback` opts out of fallback for CI team-or-nothing runs. See `references/team-manifest-schema.md` v1.0 for the minimum-context contract. |
+| `/playbook-active` | **(v3.15.0)** Display the project's active playbook configuration: subscribed sets, local playbook, recent conflicts. Read-only. |
+| `/playbook-capture` | **(v3.15.0)** Capture a new opinionated rule into the project's local user playbook. Framework drafts entry; user approves with diff preview. |
+| `/playbook-review` | **(v3.15.0)** Walk every play in the local user playbook with `[k]eep / [u]pdate / [r]emove / [q]uit`. Immediate-write semantics; `/loop`-able for periodic review. |
+| `/set-playbook-sets` | **(v3.15.0)** Set or clear active playbook sets (e.g., `drupal/best-practices/camoa`). Validates each via `dev-guides-navigator`. Default subscription comes from plugin.json `defaults.playbookSets`. |
+| `/set-user-playbook` | **(v3.15.0)** Set/clear the project-local user playbook file. Three modes: explicit path, `--docs-only`, or interactive detect-and-confirm. |
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
@@ -172,7 +177,7 @@ Built-in docs enforced at specific phases:
 | `quality-gates.md` | 5 quality gates | Task completion |
 | `purposeful-code.md` | Every line has a purpose | Task completion |
 
-### Technical Contract References (6)
+### Technical Contract References (8)
 
 Machine-readable contracts consumed by skills and commands. These pin schemas and invariants so consumers don't drift:
 
@@ -184,6 +189,8 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `screenshot-store-schema.md` **(v3.13.0)** | `screenshot-store-reader` + `scripts/screenshot-store-{read,write}.sh` | 9-field `.meta.json` v1.0, directory layout with `.previous` rotation (1-deep), 6 warning codes, `role` enum (`baseline` / `parity_reference` / `previous`), `captured_by` + `source` provenance fields |
 | `validation-gate-result.md` **(v3.13.0)** | All `/validate:*` commands | Shared JSON envelope v1.0 emitted by every gate; 4-value verdict (`pass` / `warning` / `fail` / `skipped`); per-gate `details` shapes; aggregate envelope for `/validate:all` |
 | `team-manifest-schema.md` **(v3.14.0)** | `/validate:team` + 4 teammates | Minimum-context package v1.0 written by lead before team spawn; absolute-path invariant; `visual_fanout[]` presence rule; write-once contract; fallback behavior hints; gate enum excludes `visual-parity` (deferred to v2 Set B5) |
+| `playbook-schema.md` **(v3.15.0)** | `/playbook-capture`, `/playbook-review`, `scripts/playbook-read.sh` | Recommended local playbook structure v1.0: H3-per-play with What / Rationale / When it applies / Example fields; freeform fallback; defensive parser contract |
+| `playbook-conflict-schema.md` **(v3.15.0)** | `scripts/playbook-conflicts-write.sh`, `/playbook-active` | JSONL log line v1.0 for `<project>/.claude/playbook-conflicts.log`; per-conflict citation shape (local-vs-shipped + multi-set-contradiction types); append-only contract |
 
 ### Online Dev-Guides (60+ topics) — Required
 

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -47,6 +47,58 @@ If checks fail:
 - Does NOT complete task
 - Offers to continue working
 
+## Candidate-play surface (v3.15.0+)
+
+After the 5 quality gates pass and before the task moves to `completed/`, surface 0-N candidate plays the framework detected during this task. Skipped if `--no-play-candidates` flag is passed OR if the project has `userPlaybookState != "set"` (no playbook to capture into).
+
+### Step 1 — Invoke analysis-agent in `play_candidates` mode
+
+Per `references/analysis-agent-schema.md` v1.1, invoke `analysis-agent` (Task tool) with:
+
+```json
+{
+  "mode": "play_candidates",
+  "task_folder": "<abs path>",
+  "code_path": "<abs path or null>",
+  "git_diff_since": "<commit SHA at task start>",
+  "active_playbook_sets": ["<from project-state-reader>"],
+  "user_playbook_path": "<from project-state-reader>",
+  "schema_version": "1.1"
+}
+```
+
+The agent emits `candidates[]` with each carrying file:line evidence (≥2 occurrences), confidence, rationale, suggested_section. Filter `confidence: low` by default unless user passes `--include-low-confidence`.
+
+### Step 2 — Per-candidate prompt
+
+For each remaining candidate, print:
+
+```
+Candidate play: "<title>"
+Section: <suggested_section>
+Confidence: <high|medium>
+Evidence:
+  - <file:line>: <snippet>
+  - <file:line>: <snippet>
+
+Capture? [y]es / [n]o / [d]etails — show full rationale
+```
+
+- `[y]` → hand off to `/playbook-capture` flow with the draft pre-filled (title + section + What suggested from rationale + Example pre-filled from evidence snippets).
+- `[n]` → skip silently, no record.
+- `[d]` → print full agent rationale + signals; re-ask y/n.
+
+### Step 3 — Continue to task move
+
+After all candidates handled, continue with the existing `/complete` flow (move task to `completed/`, update `project_state.md`, etc.).
+
+### Notes
+
+- **Never blocks.** All candidates can be declined; task completes regardless.
+- **Skip when `userPlaybookState != "set"`** — no destination for captured plays.
+- **Threshold ≥2 evidence** enforced agent-side per schema; consumers don't re-check.
+- **`--no-play-candidates`** opt-out for users who don't want this step.
+
 ## Example
 
 ```

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -36,6 +36,8 @@ Never block the command on this check — the user is in control. The nudge exis
 
 Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
 
+**(v3.15.0+)** `guide-integrator` v5.0.0+ ALSO loads the project's active playbook sets and local user playbook at this step. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log`. See `references/playbook-schema.md` and `references/playbook-conflict-schema.md`.
+
 ### Step 2 — ALWAYS prompt the user (never silent-skip)
 
 Regardless of whether guide-integrator auto-loaded 0, 1, or N guides, print:

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -42,6 +42,8 @@ Never block the command on this check — the user is in control. The nudge exis
 
 Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
 
+**(v3.15.0+)** `guide-integrator` v5.0.0+ ALSO loads the project's active playbook sets and local user playbook at this step. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log`. See `references/playbook-schema.md` and `references/playbook-conflict-schema.md`.
+
 ### Step 2 — ALWAYS prompt the user (never silent-skip)
 
 Regardless of whether guide-integrator auto-loaded 0, 1, or N guides, print:

--- a/drupal-dev-framework/commands/playbook-active.md
+++ b/drupal-dev-framework/commands/playbook-active.md
@@ -1,0 +1,82 @@
+---
+description: "Display the project's currently-active playbook configuration: subscribed sets, local playbook file, recent conflicts. Read-only — no writes. Introduced v3.15.0."
+allowed-tools: Read, Bash, Skill
+---
+
+# Playbook Active
+
+Read-only view of the project's playbook state. Shows subscribed sets, local playbook file, recent conflict log entries.
+
+## Usage
+
+```
+/drupal-dev-framework:playbook-active
+```
+
+## What this does
+
+### Step 1 — Resolve project state
+
+Invoke `project-state-reader` to get `playbookSets[]`, `playbookSetsSource`, `userPlaybook`, `userPlaybookState`, `playbookResolutions[]`.
+
+### Step 2 — Read local playbook (if set)
+
+If `userPlaybookState == "set"`, invoke `scripts/playbook-read.sh` to get play count + warning count. Otherwise skip.
+
+### Step 3 — Read conflict log (if exists)
+
+```bash
+LOG="<project>/.claude/playbook-conflicts.log"
+if [ -f "$LOG" ]; then
+  tail -n 10 "$LOG" | jq -r '"\(.detected_at) [\(.conflict_type)] \(.topic): winner=\(.winner)"'
+fi
+```
+
+### Step 4 — Print summary
+
+Format:
+
+```
+Playbook configuration for <project>:
+
+  Subscribed sets (<source>):
+    - drupal/best-practices/camoa
+    - drupal/best-practices/lullabot
+  
+  Local playbook:
+    Path:   /home/me/projects/idexx/docs/playbook.md
+    State:  set
+    Plays:  19 (warnings: 19)
+  
+  Multi-set resolutions:
+    - font-sizing → drupal/best-practices/camoa
+    - bem-methodology → drupal/best-practices/lullabot
+  
+  Recent conflicts (last 10):
+    2026-04-24T23:45:00Z [local-vs-shipped] font-sizing: winner=local
+    2026-04-23T12:00:00Z [multi-set-contradiction] bem-methodology: winner=lullabot
+```
+
+When fields are absent, render `none` or `(empty)`:
+
+```
+  Subscribed sets (default):
+    (empty — plugin defaults are also empty)
+  
+  Local playbook:
+    State:  unset
+    Tip:    Run /drupal-dev-framework:set-user-playbook to configure
+```
+
+## What this does NOT do
+
+- Does NOT write
+- Does NOT load guides into context
+- Does NOT trigger conflict surface (just reads what's already logged)
+
+## Related
+
+- `/drupal-dev-framework:set-playbook-sets` — change subscribed sets
+- `/drupal-dev-framework:set-user-playbook` — change local playbook path
+- `/drupal-dev-framework:playbook-capture` — add new plays
+- `/drupal-dev-framework:playbook-review` — walk existing plays

--- a/drupal-dev-framework/commands/playbook-capture.md
+++ b/drupal-dev-framework/commands/playbook-capture.md
@@ -1,0 +1,122 @@
+---
+description: "Capture a new play (opinionated rule) into the project's local user playbook. Drafts entry with What/Rationale/When/Example fields, shows diff, appends on user confirmation. Introduced v3.15.0."
+allowed-tools: Read, Write, Edit, Bash, Skill
+argument-hint: [<short description of the rule>]
+---
+
+# Playbook Capture
+
+Interactive flow that drafts a new play and appends it to the project's local user playbook file. The user is the deterministic approval gate — no write happens without explicit confirmation, with a diff preview.
+
+## Usage
+
+```
+/drupal-dev-framework:playbook-capture                                # ask user to describe
+/drupal-dev-framework:playbook-capture "Use BEM mod-* for utilities"  # short description hint
+```
+
+## What this does
+
+### Step 1 — Resolve project context + check userPlaybook
+
+Invoke `project-state-reader`. If `userPlaybookState != "set"`:
+> Refuse with: "No user playbook configured for this project. Run `/drupal-dev-framework:set-user-playbook` first."
+
+If `userPlaybookState == "set"`, continue.
+
+### Step 2 — Gather intent from user
+
+If a description was passed as arg, use it as the seed. Otherwise ask:
+> What play do you want to capture? Paste a sentence or short description of the rule.
+
+### Step 3 — Draft entry
+
+Compose a play entry per `references/playbook-schema.md` v1.0:
+
+```markdown
+### <Title — concrete rule statement>
+
+**What:** <one-line restatement>
+**Rationale:** <why this rule; what breaks without it>
+**When it applies:** <scope — file types, contexts, exceptions>
+**Example:**
+
+```<lang>
+// Wrong
+<bad>
+
+// Right
+<good>
+```
+```
+
+Use session context (recent files modified, recent decisions discussed) to populate the example block when possible. If no context fits, leave the example block empty with a `// (no example yet)` comment — user can fill in later.
+
+### Step 4 — Pick target section
+
+Read the existing playbook via `playbook-read.sh` to enumerate H2 section names.
+
+Ask:
+> Save under which section?
+> 1. <existing H2 1>
+> 2. <existing H2 2>
+> ...
+> N+1. New section (you'll name it)
+
+User picks. If new, ask for the section name.
+
+### Step 5 — Show diff preview
+
+Construct the proposed file content (existing + new play + section if needed). Use a unified diff format:
+
+```diff
+@@ Section: CSS / SCSS @@
+
++### Use BEM mod-* prefix for utility-only files
++
++**What:** Utility-only files use BEM with the mod-* prefix.
++**Rationale:** Standardizes utility class naming...
++**When it applies:** Files under themes/<sub>/scss/utilities/.
++**Example:**
++
++```scss
++// Right
++.btn.mod-large { ... }
++```
++
+```
+
+Print the diff.
+
+### Step 6 — Confirm
+
+Ask:
+> [y]es write / [n]o cancel / [e]dit draft
+
+- `[y]` → use `Edit` (or `Write` for full file rewrite if simpler) to apply the change. Confirm with: `✓ Saved to <userPlaybook>`. Print updated total play count.
+- `[n]` → discard. No write. Confirm with: `✗ Cancelled. No changes written.`
+- `[e]` → return to Step 3 with the user's revisions; re-show diff at Step 5.
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| `userPlaybookState != "set"` | Refuse; exit 2; suggest `/set-user-playbook` |
+| User cancels | Exit 0; no write |
+| Write failure | Print error; exit 1; original file unchanged |
+| Append produces malformed playbook (parser fails post-write) | Print warning; suggest manual review; do NOT roll back (write already happened — soft-nudge posture) |
+
+## Soft-nudge posture
+
+- Never writes without explicit user confirmation
+- Always shows diff before write
+- User can `[e]edit` the draft as many times as needed
+- Cancel is a first-class option
+
+## Related
+
+- `/drupal-dev-framework:playbook-review` — walk existing plays for keep/update/remove
+- `/drupal-dev-framework:playbook-active` — display current state
+- `/drupal-dev-framework:set-user-playbook` — configure the local playbook path
+- `references/playbook-schema.md` — entry structure
+- `/drupal-dev-framework:complete` — surfaces candidate plays at task completion (auto-detected from session); user can accept and route to this capture flow

--- a/drupal-dev-framework/commands/playbook-review.md
+++ b/drupal-dev-framework/commands/playbook-review.md
@@ -1,0 +1,112 @@
+---
+description: "Walk every play in the project's local user playbook, asking keep/update/remove per entry. Soft-nudge posture; quitting mid-review preserves committed edits. Designed to be /loop-able for periodic review. Introduced v3.15.0."
+allowed-tools: Read, Write, Edit, Bash, Skill
+---
+
+# Playbook Review
+
+Walk every play in the project-local user playbook one at a time. Per-play prompt: `[k]eep / [u]pdate / [r]emove / [q]uit`. Each edit writes immediately so quitting mid-review preserves committed work.
+
+## Usage
+
+```
+/drupal-dev-framework:playbook-review
+```
+
+## What this does
+
+### Step 1 — Resolve project context + load playbook
+
+Invoke `project-state-reader`. If `userPlaybookState != "set"`:
+> Refuse with: "No user playbook configured. Run `/drupal-dev-framework:set-user-playbook` first."
+
+Invoke `scripts/playbook-read.sh` against the path. Parse JSON output.
+
+If `plays.length == 0`:
+> Print: "No structured plays found in `<path>`. (Free-form content present: <line count> lines.)" Exit cleanly.
+
+### Step 2 — Print preamble
+
+```
+Reviewing <N> plays in <path>.
+Per-play prompt: [k]eep / [u]pdate / [r]emove / [q]uit
+Edits write immediately; quit mid-review preserves committed work.
+```
+
+### Step 3 — Per-play loop
+
+For each play in order:
+
+1. Print:
+   ```
+   <i>/<N>: "<title>"
+   Section: <section>  Lines: <start>-<end>
+   ───
+   What: <what>
+   Rationale: <rationale>
+   When it applies: <when>
+   <body excerpt, max 10 lines>
+   ───
+   ```
+
+2. Ask: `[k]eep / [u]pdate / [r]emove / [q]uit`
+
+3. Branch:
+   - **`k`** → continue to next play.
+   - **`u`** → enter draft-edit conversation:
+     - Ask: "What changes? Paste new content or describe."
+     - Compose updated play body.
+     - Show unified diff.
+     - Ask: `[y]es write / [n]o discard`
+     - On `y`: use `Edit` to surgically replace lines `start..end` of the play with the new content; track that source lines have shifted for subsequent plays (re-parse if shift > 0).
+     - On `n`: discard; treat as `keep`.
+     - Continue to next play.
+   - **`r`** → ask: `Confirm remove "<title>"? [y/n]`
+     - On `y`: use `Edit` to remove lines `start..end` (plus surrounding blank lines for cleanliness); re-parse for line shift; continue.
+     - On `n`: treat as `keep`.
+   - **`q`** → exit loop. Print summary.
+
+### Step 4 — Final summary
+
+```
+Reviewed <i>/<N> plays.
+  Kept: <K>
+  Updated: <U>
+  Removed: <R>
+  Skipped: <N - i> (quit mid-review)
+```
+
+### Step 5 — No automatic git commit
+
+The local playbook is in the user's repo; the user runs `git add` + `git commit` themselves if they want a checkpoint. The framework does NOT auto-commit.
+
+## Soft-nudge posture
+
+- Never blocks
+- Quit mid-review is first-class — committed edits stay; un-reviewed plays unchanged
+- Each edit writes immediately (atomic per play; no batch)
+- No "you should review more" nag
+
+## Loop-able
+
+Designed to fit `/loop` for periodic review:
+```
+/loop 30d /drupal-dev-framework:playbook-review
+```
+
+(or whatever cadence the user prefers — default cadence is zero; this is purely user-initiated)
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| `userPlaybookState != "set"` | Refuse; exit 2 |
+| Playbook file unreadable | Refuse; exit 2 |
+| Parser warns about freeform fallback | Print: "File has no structured plays; review can't iterate. View raw with `/playbook-active --raw`." Exit cleanly |
+| Edit/write fails mid-loop | Print error; commit what's been done; exit 1 |
+
+## Related
+
+- `/drupal-dev-framework:playbook-capture` — add a new play
+- `/drupal-dev-framework:playbook-active` — read-only view
+- `references/playbook-schema.md` — recommended structure

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -281,6 +281,8 @@ Conservative by design: pre-analysis only fires on strong signals, and even then
 
 Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
 
+**(v3.15.0+)** `guide-integrator` v5.0.0+ ALSO loads the project's active playbook sets (per `Playbook Sets` in `project_state.md`) and the local user playbook (per `User Playbook`) at this step. The skill emits `loaded_playbook_sets[]`, `loaded_local_playbook`, and `conflicts[]` in its return JSON. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log` via `scripts/playbook-conflicts-write.sh`. See `references/playbook-schema.md` and `references/playbook-conflict-schema.md`.
+
 ### Step 2 — ALWAYS prompt the user (never silent-skip)
 
 Regardless of whether guide-integrator auto-loaded 0, 1, or N guides, print:

--- a/drupal-dev-framework/commands/set-playbook-sets.md
+++ b/drupal-dev-framework/commands/set-playbook-sets.md
@@ -1,0 +1,86 @@
+---
+description: "Set or clear the active playbook sets for the current project. Validates each set ID via dev-guides-navigator before writing. Accepts comma-separated list, literal `none` (explicit opt-out), or no arg (interactive). Introduced v3.15.0."
+allowed-tools: Read, Write, Edit, Bash, Skill
+argument-hint: [<set-id-1,set-id-2,...> | none]
+---
+
+# Set Playbook Sets
+
+Set or update the project's `**Playbook Sets:**` field in `project_state.md`. The framework subscribes the project to the listed dev-guides categories, loading them at every phase entry alongside other dev-guides.
+
+## Usage
+
+```
+/drupal-dev-framework:set-playbook-sets                                       # interactive
+/drupal-dev-framework:set-playbook-sets drupal/best-practices/camoa           # single set
+/drupal-dev-framework:set-playbook-sets drupal/best-practices/camoa,drupal/best-practices/lullabot  # multiple
+/drupal-dev-framework:set-playbook-sets none                                  # explicit opt-out
+```
+
+## What this does
+
+### Step 1 — Resolve project context
+
+Invoke `project-state-reader` to get current `playbookSets[]`, `playbookSetsSource`, and `folder`. Refuse with helpful message if no project resolved.
+
+### Step 2 — Parse arg
+
+Three cases:
+
+- **No arg** → interactive: print current state, ask user to enter new value (comma-separated, or `none`, or `default` to clear).
+- **Arg `none`** → set to literal `none` (explicit opt-out).
+- **Arg `default`** → remove the line from `project_state.md` (revert to plugin.json default).
+- **Arg with comma-separated IDs** → split on commas, trim whitespace, validate each.
+
+### Step 3 — Validate set IDs (if not `none`/`default`)
+
+For each set ID, invoke `dev-guides-navigator` to confirm the set exists:
+
+```bash
+curl -s https://camoa.github.io/dev-guides/llms.txt | grep -F "/<set-id>/"
+```
+
+If a set ID doesn't resolve, refuse with a suggestion list (the closest matches by Levenshtein on `llms.txt` topic names) and exit without writing.
+
+### Step 4 — Write to `project_state.md`
+
+Use `Edit` to update the `**Playbook Sets:**` line. If the line doesn't exist, append it after the last metadata line (typically after `**Code path:**` or `**Code Path State:**`).
+
+Format:
+```markdown
+**Playbook Sets:** drupal/best-practices/camoa, drupal/best-practices/lullabot
+```
+
+Or, for opt-out:
+```markdown
+**Playbook Sets:** none
+```
+
+For `default`, remove the line entirely.
+
+### Step 5 — Confirm
+
+Print:
+```
+✓ Playbook Sets updated for <project>:
+  Active sets: <list>
+  Source: <explicit|explicit-none|default>
+
+Next phase command (research/design/implement/complete) will load these sets via dev-guides-navigator.
+```
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No project context | Abort; exit 2; suggest `/next` to select a project |
+| Invalid set ID (doesn't resolve via navigator) | Print suggestion list; refuse; exit 2; do NOT write |
+| `project_state.md` missing | Abort; exit 2; suggest `/new` to initialize project |
+| Write failure | Print error; exit 1 |
+
+## Related
+
+- `/drupal-dev-framework:set-user-playbook` — set the project-local playbook file
+- `/drupal-dev-framework:playbook-active` — display current active sets + local playbook + last conflicts
+- `references/playbook-schema.md` — local playbook structure (not relevant to sets)
+- `dev-guides-navigator` — set ID resolution and loading

--- a/drupal-dev-framework/commands/set-user-playbook.md
+++ b/drupal-dev-framework/commands/set-user-playbook.md
@@ -1,0 +1,110 @@
+---
+description: "Set, update, or clear the project-local user playbook file path. Three modes: explicit path, --docs-only sentinel, or interactive detect-and-confirm. Mirrors /set-code-path precedent. Introduced v3.15.0."
+allowed-tools: Read, Write, Edit, Bash, Skill, Glob
+argument-hint: [<path> | --docs-only]
+---
+
+# Set User Playbook
+
+Set or update the project's `**User Playbook:**` and `**User Playbook State:**` fields in `project_state.md`. Declares the project-local playbook file the framework loads alongside subscribed playbook sets.
+
+## Usage
+
+```
+/drupal-dev-framework:set-user-playbook /abs/path/to/playbook.md   # explicit
+/drupal-dev-framework:set-user-playbook --docs-only                # explicit opt-out
+/drupal-dev-framework:set-user-playbook                             # interactive detect-and-confirm
+```
+
+## What this does
+
+### Step 1 — Resolve project context
+
+Invoke `project-state-reader`. Refuse with helpful message if no project resolved.
+
+### Step 2 — Mode dispatch
+
+#### Explicit path
+
+Validate the path:
+- Absolute path required
+- File must exist (not a directory)
+- File must be readable
+- Path-safety filter (reject system roots `/`, `/etc`, `/usr`, etc., per `references/code-path-detection.md` precedent)
+
+If validation passes, write:
+```markdown
+**User Playbook:** <abs path>
+**User Playbook State:** set
+```
+
+#### `--docs-only` sentinel
+
+Write:
+```markdown
+**User Playbook State:** docs-only-no-playbook
+```
+
+(no `**User Playbook:**` value line)
+
+Confirms the project explicitly has no local playbook. Framework skips loading; never re-prompts.
+
+#### Interactive (no arg)
+
+Run detect-and-confirm scan:
+
+1. Look in known locations (in order):
+   - `<codePath>/docs/technical/guides/development-patterns.md`
+   - `<codePath>/docs/conventions.md`
+   - `<codePath>/docs/playbook.md`
+   - `<codePath>/CONTRIBUTING.md`
+   - `<codePath>/.claude/rules/playbook.md`
+2. Glob: `<codePath>/docs/**/*playbook*.md`, `<codePath>/docs/**/*conventions*.md`, `<codePath>/docs/**/*patterns*.md`
+
+For each found path, ask:
+> Found `<path>`. Use as User Playbook? [y]es / [n]o / [s]how me what's in it / [next]
+
+If user accepts → write `set` state with that path.
+If no candidates found → ask:
+> No playbook detected. Options:
+> - Provide an absolute path
+> - Run with `--docs-only` to declare none
+> - Skip for now (state stays `unset`; framework asks again on next relevant command)
+
+### Step 3 — Smoke-test load
+
+After writing, run:
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/playbook-read.sh" "<new path>"
+```
+
+Print play count + warning count. If parser warns, surface (informational).
+
+### Step 4 — Confirm
+
+Print:
+```
+✓ User Playbook configured:
+  Path: <path or none>
+  State: <set | docs-only-no-playbook>
+  Plays detected: <N>
+  Warnings: <N>
+```
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No project context | Abort; exit 2 |
+| Path doesn't exist | Refuse; exit 2; do NOT write |
+| Path-safety violation (system root) | Refuse; exit 2; do NOT write |
+| Path is a directory | Refuse; exit 2 |
+| Write failure | Print error; exit 1 |
+
+## Related
+
+- `/drupal-dev-framework:set-playbook-sets` — set subscribed playbook sets
+- `/drupal-dev-framework:playbook-active` — display current state
+- `/drupal-dev-framework:playbook-capture` — append new entries to the file
+- `/drupal-dev-framework:playbook-review` — walk existing entries for keep/update/remove
+- `references/playbook-schema.md` — recommended file structure

--- a/drupal-dev-framework/hooks/context-reminder.sh
+++ b/drupal-dev-framework/hooks/context-reminder.sh
@@ -22,10 +22,11 @@ SESSION_TSV=$(jq -r '[
     .task        // "",
     .taskPath    // "",
     .project     // "",
+    .projectPath // "",
     ((.loadedGuides // []) | join(","))
   ] | @tsv' "$SESS" 2>/dev/null) || exit 0
 
-IFS=$'\t' read -r TASK TASK_PATH PROJECT GUIDES_CSV <<<"$SESSION_TSV"
+IFS=$'\t' read -r TASK TASK_PATH PROJECT PROJECT_PATH GUIDES_CSV <<<"$SESSION_TSV"
 
 # Fast gate — no active task.
 [ -n "$TASK" ] && [ -n "$TASK_PATH" ] && [ -d "$TASK_PATH" ] || exit 0
@@ -80,6 +81,26 @@ esac
 arrow() { [ "$CUR" = "$1" ] && printf '◀ current' || printf '' ; }
 
 # Truncate loaded-guides list to 20 entries to keep payload bounded.
+# (v3.15.0+) Compute Playbook line from project_state.md if project resolved.
+# Silent when neither field is set; one line otherwise.
+PLAYBOOK_LINE=""
+if [ -n "$PROJECT_PATH" ] && [ -f "$PROJECT_PATH/project_state.md" ]; then
+  PB_SETS_RAW=$(awk 'BEGIN{IGNORECASE=1} /^\*\*Playbook Sets:\*\*/ {sub(/^\*\*Playbook Sets:\*\*[[:space:]]*/,""); print; exit}' "$PROJECT_PATH/project_state.md")
+  UP_RAW=$(awk 'BEGIN{IGNORECASE=1} /^\*\*User Playbook:\*\*/ {sub(/^\*\*User Playbook:\*\*[[:space:]]*/,""); print; exit}' "$PROJECT_PATH/project_state.md")
+  UPS_RAW=$(awk 'BEGIN{IGNORECASE=1} /^\*\*User Playbook State:\*\*/ {sub(/^\*\*User Playbook State:\*\*[[:space:]]*/,""); print; exit}' "$PROJECT_PATH/project_state.md")
+  PB_SETS_DISPLAY=""
+  UP_DISPLAY=""
+  if [ -n "$PB_SETS_RAW" ] && [ "$PB_SETS_RAW" != "none" ]; then
+    PB_SETS_DISPLAY="$PB_SETS_RAW"
+  fi
+  if [ "$UPS_RAW" = "set" ] && [ -n "$UP_RAW" ]; then
+    UP_DISPLAY="$UP_RAW"
+  fi
+  if [ -n "$PB_SETS_DISPLAY" ] || [ -n "$UP_DISPLAY" ]; then
+    PLAYBOOK_LINE="Playbook: ${PB_SETS_DISPLAY:-(no sets)} + ${UP_DISPLAY:-(no local)}"
+  fi
+fi
+
 if [ -z "$GUIDES_CSV" ]; then
   GUIDES_LINE="(none loaded this session)"
 else
@@ -102,7 +123,8 @@ Task folder: \`$TASK_PATH/\`
   - \`implementation.md\` $P3 Phase 3 $(arrow 3)
 
 Project: \`$PROJECT\`
-Loaded guides: $GUIDES_LINE
+${PLAYBOOK_LINE:+$PLAYBOOK_LINE
+}Loaded guides: $GUIDES_LINE
 Next: \`$NEXT_CMD\`
 
 Write each phase's content to its own \`.md\` file. Do not merge phases into a monolithic document.

--- a/drupal-dev-framework/references/analysis-agent-schema.md
+++ b/drupal-dev-framework/references/analysis-agent-schema.md
@@ -8,14 +8,17 @@ The analysis agent emits a single JSON object per analyzed task. Schema is versi
 
 ## Input modes
 
-The agent accepts one of two mutually exclusive input modes (caller picks):
+The agent accepts one of three mutually exclusive input modes (caller picks):
 
 | Mode | Input | When used |
 |---|---|---|
-| **folder mode** | `task_folder` (absolute path to an existing task directory) | `/propose-epics` — task folders exist on disk |
+| **folder mode** | `task_folder` (absolute path to an existing task directory) | `/propose-epics`, `/research` post-phase epic check, `/design` post-phase epic check, `/implement` post-phase epic check — task folders exist on disk |
 | **description mode** | `task_description_text` (raw text: task name + description, no folder) | `/research` pre-analysis hook — task folder has not been created yet |
+| **play_candidates mode** *(v1.1+)* | `task_folder` + `code_path` + `git_diff_since` (commit SHA) + `active_playbook_sets[]` + `user_playbook_path` (or null) | `/complete` candidate-play surface — analyzes task work for repeated decisions worth capturing as plays in the local playbook |
 
-Both modes also accept `codePath` (abs path or null) and `schema_version` (expected version). In description mode: `task_folder` in the output is set to the string `"(pre-creation)"`, and `task_id` to `local:(pre-creation)`. The agent cannot read `task.md` / `research.md` / `architecture.md` / `implementation.md` in description mode — it only evaluates signals from the description text + optional code read.
+Folder + description modes also accept `codePath` (abs path or null) and `schema_version` (expected version). In description mode: `task_folder` in the output is set to the string `"(pre-creation)"`, and `task_id` to `local:(pre-creation)`. The agent cannot read `task.md` / `research.md` / `architecture.md` / `implementation.md` in description mode — it only evaluates signals from the description text + optional code read.
+
+`play_candidates` mode is documented separately in §"play_candidates mode (v1.1+)" below — it has a different output schema (`candidates[]` instead of `decision` + `proposed_children[]`).
 
 Signals evaluated in description mode: `description_length_and_conjunction`, `bullet_count_clustering`, `multiple_code_areas` (if code_read). Signals that require on-disk phase artifacts (`many_heterogeneous_criteria` from task.md's AC section, `long_in_progress`, `research_architecture_fragmented`, `explicit_user_signal`) are skipped in description mode — the agent notes `"description mode: phase-artifact signals unavailable"` in `notes[]`.
 
@@ -189,8 +192,101 @@ Consumers MUST perform both steps. A task can be `keep_flat` + `scope_contract_r
 }
 ```
 
+## play_candidates mode (v1.1+)
+
+**Introduced:** drupal-dev-framework v3.15.0 (alongside the Playbook System).
+**Consumer:** `commands/complete.md` candidate-play surface step.
+
+A different output shape than the epic-decomposition modes — emits `candidates[]` instead of `decision` + `proposed_children[]`. Used by `/complete` to surface repeated decisions made during a task that might be worth capturing as plays in the user's local playbook.
+
+### Input
+
+```json
+{
+  "mode": "play_candidates",
+  "task_folder": "/abs/path/to/task",
+  "code_path": "/abs/path/to/code",
+  "git_diff_since": "<commit-sha>",
+  "active_playbook_sets": ["drupal/best-practices/camoa"],
+  "user_playbook_path": "/abs/path/to/local/playbook.md",
+  "schema_version": "1.1"
+}
+```
+
+| Field | Type | Required? |
+|---|---|---|
+| `mode` | string | Required. Literal `"play_candidates"` |
+| `task_folder` | string | Required. Absolute path |
+| `code_path` | string \| null | Required. Null when codePath is `docs-only` or `unset` — agent skips code-derived candidates |
+| `git_diff_since` | string | Required. SHA of the commit at task-start, or `"HEAD~1"` as a fallback |
+| `active_playbook_sets` | array of string | Required. Set IDs the agent should NOT re-suggest (already shipped) |
+| `user_playbook_path` | string \| null | Required. Null when userPlaybook unset; agent doesn't read it but uses path-presence to decide whether candidate suggestions are worth surfacing at all |
+| `schema_version` | string | Required. `"1.1"` |
+
+### Output
+
+```json
+{
+  "schema_version": "1.1",
+  "mode": "play_candidates",
+  "analyzed_at": "2026-04-24T23:45:00Z",
+  "task_folder": "/abs/path/to/task",
+  "candidates": [
+    {
+      "title": "Use BEM with mod-* prefix for utility-only files",
+      "evidence": [
+        { "file": "themes/.../navbar.scss", "line": 42, "snippet": ".navbar.mod-sticky { ... }" },
+        { "file": "themes/.../footer.scss", "line": 18, "snippet": ".footer.mod-condensed { ... }" }
+      ],
+      "confidence": "high",
+      "rationale": "Pattern appears 2+ times in modified files; not in active playbook sets",
+      "suggested_section": "CSS / SCSS"
+    }
+  ],
+  "warnings": [],
+  "notes": []
+}
+```
+
+### Field contracts (output)
+
+| Field | Type | Constraints |
+|---|---|---|
+| `schema_version` | string | `"1.1"` for play_candidates mode outputs |
+| `mode` | string | Literal `"play_candidates"` (echoed from input) |
+| `analyzed_at` | string | ISO-8601 UTC |
+| `task_folder` | string | Echo of input |
+| `candidates` | array of object | 0 or more candidates. May be empty when nothing meets threshold |
+| `warnings` | array of string | Informational; never fatal |
+| `notes` | array of string | Optional explanatory notes |
+
+### Candidate sub-object
+
+| Field | Type | Required? |
+|---|---|---|
+| `title` | string | Required. Short rule statement |
+| `evidence` | array of object | Required. **Minimum 2 entries** (single occurrence isn't a pattern; threshold enforced by agent) |
+| `evidence[].file` | string | Absolute or codePath-relative file path |
+| `evidence[].line` | integer | Line number |
+| `evidence[].snippet` | string | Short code excerpt (≤200 chars) |
+| `confidence` | enum | `"high"` \| `"medium"` \| `"low"` |
+| `rationale` | string | One-line explanation |
+| `suggested_section` | string | Suggested H2 section in the local playbook |
+
+### Backward compatibility
+
+The v1.0 → v1.1 bump is **purely additive**:
+
+- Existing modes (`folder`, `description`) continue to emit v1.0-shape outputs unchanged. The `schema_version` they emit stays `"1.0"`.
+- Existing consumers (`/research` pre-analysis hook, `/propose-epics`, post-phase epic checks) call the agent without `mode: "play_candidates"` and parse v1.0 output exactly as before — no code change required.
+- The new mode is a separate code path: callers who explicitly set `mode: "play_candidates"` get v1.1 output with `candidates[]`. They never see v1.0 fields.
+- Any consumer that hard-codes `schema_version === "1.0"` keeps working — their invocations don't trigger the new mode.
+
+The bump is at the schema-doc level, not the per-output level. Different modes emit different versions, both documented under one schema reference.
+
 ## Versioning policy
 
 - **Adding fields at v1.x** — consumers that don't know about them ignore them. No schema bump needed if field is optional.
-- **Changing field semantics** — schema bump to v1.1 with a migration note. Consumers version-check.
+- **Adding new MODES at v1.x** — schema bump to v1.x with separate documentation for the new mode. Existing modes' shape unchanged. (v1.1 follows this — `play_candidates` is new mode, folder/description unchanged.)
+- **Changing field semantics** — schema bump to v1.x with a migration note. Consumers version-check.
 - **Removing fields** — major bump to v2.0. Old consumers fail fast on missing expected fields.

--- a/drupal-dev-framework/references/playbook-conflict-schema.md
+++ b/drupal-dev-framework/references/playbook-conflict-schema.md
@@ -1,0 +1,121 @@
+# Playbook Conflict Schema v1.0
+
+**Introduced:** drupal-dev-framework v3.15.0
+**Owner:** `scripts/playbook-conflicts-write.sh`
+**Consumers:** `commands/playbook-active.md`, `skills/guide-integrator` (writer side)
+
+`<project>/.claude/playbook-conflicts.log` is an append-only JSONL file that records every detected conflict between the active playbook layers. One line per detection. Used for diagnostic review by the user and by `/playbook-active`. No consumer reads it programmatically for decision-making in v1 — it's a receipt, not a state file.
+
+## 1. Location
+
+```
+<project>/.claude/playbook-conflicts.log
+```
+
+The `.claude/` directory is per-project (different from `~/.claude/` which is per-user). Created on first conflict detection if absent.
+
+## 2. Format
+
+JSONL — one valid JSON object per line. Append-only. No header, no footer, no in-line comments.
+
+## 3. Line shape
+
+```json
+{
+  "schema_version": "1.0",
+  "detected_at": "2026-04-24T23:45:00Z",
+  "session_id": "<session-id-or-null>",
+  "topic": "font-sizing",
+  "conflict_type": "local-vs-shipped | multi-set-contradiction",
+  "playbook_set_citation": {
+    "set": "drupal/best-practices/camoa",
+    "guide": "font-sizing-rfs",
+    "summary": "Use @include font-size(); never raw font-size:"
+  },
+  "local_citation": {
+    "path": "/abs/path/to/playbook.md",
+    "section": "CSS / SCSS",
+    "title": "Permits raw font-size: for non-text utility classes",
+    "line": 18,
+    "summary": "Permits raw font-size: for non-text utility classes"
+  },
+  "second_set_citation": null,
+  "winner": "local",
+  "resolution_source": "precedence-rule | per-topic-resolution | user-prompt"
+}
+```
+
+## 4. Field contracts
+
+| Field | Type | Values |
+|---|---|---|
+| `schema_version` | string | `"1.0"` at v3.15.0 |
+| `detected_at` | string | ISO-8601 UTC with `Z` suffix |
+| `session_id` | string \| null | Whatever session identifier the framework has access to; `null` when unknown |
+| `topic` | string | A short topic key (e.g., `"font-sizing"`, `"bem-methodology"`). Free-form; should match across runs so dedup tooling can group by topic |
+| `conflict_type` | enum | `"local-vs-shipped"` (covered by precedence rule) \| `"multi-set-contradiction"` (resolved by user prompt or stored resolution) |
+| `playbook_set_citation` | object | Citation for the shipped opinion. Always present for both conflict types |
+| `local_citation` | object \| null | Citation for the local opinion. Present when `conflict_type == "local-vs-shipped"`; `null` when `conflict_type == "multi-set-contradiction"` |
+| `second_set_citation` | object \| null | Citation for the second shipped opinion. Present when `conflict_type == "multi-set-contradiction"`; `null` when `conflict_type == "local-vs-shipped"` |
+| `winner` | enum | `"local"` (local-vs-shipped) \| `"<set-id>"` (the set ID that won the multi-set contradiction) |
+| `resolution_source` | enum | `"precedence-rule"` (local-vs-shipped — local always wins) \| `"per-topic-resolution"` (multi-set, user chose previously, value applied from `project_state.md`) \| `"user-prompt"` (multi-set, user prompted this session) |
+
+### 4.1 `playbook_set_citation` sub-object
+
+| Field | Type | Description |
+|---|---|---|
+| `set` | string | The dev-guides path slug (e.g., `drupal/best-practices/camoa`) |
+| `guide` | string | The specific guide ID within the set (e.g., `font-sizing-rfs`) |
+| `summary` | string | One-line restatement of the play, for quick reading |
+
+### 4.2 `local_citation` sub-object
+
+| Field | Type | Description |
+|---|---|---|
+| `path` | string | Absolute path to the local playbook file |
+| `section` | string | The H2 section under which the play lives |
+| `title` | string | The H3 title of the play |
+| `line` | integer | Source line number where the play starts |
+| `summary` | string | One-line restatement |
+
+## 5. Append semantics
+
+`scripts/playbook-conflicts-write.sh`:
+
+1. Validates the input JSON line is well-formed and has `schema_version: "1.0"` (refuses with stderr if not — never silently skips).
+2. Creates `<project>/.claude/` if absent.
+3. Appends the line + `\n` to `playbook-conflicts.log` using `>>` (atomic append on POSIX systems).
+4. Does NOT dedupe. Caller is responsible for deciding whether to write (e.g., once per session per topic — caller-side state, not file-state).
+5. Does NOT lock. Concurrent writes from multiple Claude Code sessions could interleave on slow filesystems; v1 accepts this risk (rare in practice).
+
+## 6. Reading
+
+`/playbook-active` reads with:
+
+```bash
+tail -n 50 <project>/.claude/playbook-conflicts.log | jq -r '...'
+```
+
+Default display: last 50 entries, formatted as a human-readable list. No paging in v1.
+
+## 7. Invariants
+
+- **Append-only.** No tool truncates, edits, or reorders. Users wanting to clear it run `rm` themselves.
+- **One line per detection.** No multi-line entries. Newline-terminated.
+- **UTF-8.** Citations may contain em-dashes, smart quotes, etc. — preserved verbatim.
+- **Schema version on every line.** Even if v1.1 ships later, old lines stay v1.0; readers branch on `schema_version`.
+
+## 8. Versioning policy
+
+- **Major bumps** are breaking: changes to required field names, types, or enums.
+- **Minor bumps** are additive: new optional fields. Existing readers ignore them.
+- **Patch bumps** do not exist.
+
+v1.0 is committed for v3.15.0.
+
+## 9. Non-goals
+
+- **No conflict resolution from the log.** The log records what happened; it does NOT influence future decisions. Future decisions re-detect, re-cite, and re-prompt as needed.
+- **No automatic rotation/compaction.** Log grows monotonically. Real-world projects accumulate dozens, not thousands, of conflicts. v2 candidate if files grow large.
+- **No schema validation tooling shipped.** v3.15.0 documents the shape; v2 could ship a `.schema.json` if hand-editing the log becomes a real pain.
+- **No cross-project aggregation.** Each project has its own log. Cross-project rollups are user concern.

--- a/drupal-dev-framework/references/playbook-schema.md
+++ b/drupal-dev-framework/references/playbook-schema.md
@@ -1,0 +1,158 @@
+# Playbook Schema v1.0
+
+**Introduced:** drupal-dev-framework v3.15.0
+**Owner:** `commands/playbook-capture.md`, `commands/playbook-review.md`, `scripts/playbook-read.sh`
+**Consumers:** `skills/guide-integrator`, `commands/research.md`, `commands/design.md`, `commands/implement.md`, `commands/complete.md`
+
+A "playbook" is a curated collection of opinionated rules ("plays") that govern Drupal development decisions. Playbooks come in two layers:
+
+- **Published playbook sets** — namespaced dev-guides categories (e.g., `drupal/best-practices/camoa/*`). Multiple authors coexist; users subscribe per project via `Playbook Sets` in `project_state.md`.
+- **Local project playbook** — a single markdown file the user maintains, declared via `User Playbook` in `project_state.md`. Can override published opinions or extend them with topics published sets don't cover. **Local always wins on conflict.**
+
+This schema specifies the **recommended structure** for a local playbook file. Convention but not required — plays without the recommended structure load as raw text and Claude can still read them; they just don't surface in structured tooling like `/playbook-review` or future `/validate:playbook`.
+
+## 1. File location
+
+The user declares the absolute path via `**User Playbook:**` in `project_state.md`. Common conventions in the wild:
+
+- `<project>/docs/technical/guides/development-patterns.md`
+- `<project>/docs/conventions.md`
+- `<project>/docs/playbook.md`
+- `<project>/CONTRIBUTING.md` (if it doubles as opinion record)
+
+The framework respects whatever path the user declares. No filename enforcement.
+
+## 2. Recommended structure
+
+```markdown
+# Playbook: <project name>
+
+Brief description of what this playbook covers.
+
+## <Domain — e.g., CSS / SCSS>
+
+### <Title — concrete rule statement>
+
+**What:** <one-line restatement of the rule>
+**Rationale:** <why this rule; what breaks without it>
+**When it applies:** <scope — file types, contexts, exceptions>
+**Example:**
+
+```scss
+// Wrong
+font-size: 2.125rem;
+
+// Right
+@include font-size($h2-font-size);
+```
+
+### <Next play title>
+
+**What:** ...
+**Rationale:** ...
+**When it applies:** ...
+**Example:** ...
+
+## <Next domain section>
+
+### <Play>
+...
+```
+
+## 3. Field contracts
+
+Each play (an `### H3` block under an `## H2` domain section) carries four optional-but-recommended bold-prefixed fields:
+
+| Field | Type | Required? | Purpose |
+|---|---|---|---|
+| `**What:**` | one-line statement | Recommended | Restate the rule clearly. Used as the citation summary in conflict logs and `/playbook-active` |
+| `**Rationale:**` | prose | Recommended | Why the rule exists; what breaks without it. Surfaces when Claude is asked to explain a decision |
+| `**When it applies:**` | prose | Recommended | Scope: file types, contexts, exceptions. Helps the agent know when to apply vs not |
+| `**Example:**` | code block(s) | Recommended | Wrong/right pairs. Most useful for code-style rules |
+
+Plays may include other content (additional prose, additional code blocks, links). The four fields above are what `playbook-read.sh` extracts; everything else is preserved as raw text in the play's `body` field.
+
+## 4. Play structure rules (for parser)
+
+`scripts/playbook-read.sh` parses the file with these rules:
+
+- **`# H1`** — single, optional, file-level title. Ignored by parser (decorative).
+- **`## H2`** — domain section. Each play inherits the most-recent H2 as its `section` field.
+- **`### H3`** — one play. The H3 text becomes the play's `title`.
+- **Body** — everything between this `### H3` and the next H3 or H2. Parser scans for the four bold-prefixed fields and extracts them; everything else stays in `body_raw`.
+- **No frontmatter** at the file level. Plays are self-contained markdown.
+
+Plays at the top of the file (before any `## H2`) inherit `section: "<root>"`.
+
+## 5. Free-form fallback
+
+A playbook file without `### H3` plays loads as a single synthetic play:
+
+```json
+{
+  "title": "<file-name>",
+  "section": "<root>",
+  "applicability": "free-form",
+  "body_raw": "<entire file contents>"
+}
+```
+
+Claude has the content available; it just won't surface in structured tooling. Users with existing playbooks in non-standard formats can opt in to structure incrementally — convert one section at a time.
+
+## 6. Parsed output (JSON)
+
+`scripts/playbook-read.sh` emits:
+
+```json
+{
+  "schema_version": "1.0",
+  "path": "/abs/path/to/playbook.md",
+  "plays": [
+    {
+      "title": "Use @include font-size() not raw font-size:",
+      "section": "CSS / SCSS",
+      "what": "Never set font-size: directly...",
+      "rationale": "Bootstrap's @include font-size() handles RFS scaling automatically.",
+      "when_it_applies": "All headings, body text, and any element where typography responds to viewport.",
+      "example_blocks": ["// Wrong\nfont-size: 2.125rem;\n\n// Right\n@include font-size($h2-font-size);"],
+      "body_raw": "**What:** Never set...\n**Rationale:** ...",
+      "source_lines": { "start": 18, "end": 41 },
+      "applicability": "structured"
+    },
+    {
+      "title": "<freeform-play-title>",
+      "section": "<root>",
+      "applicability": "free-form",
+      "body_raw": "...",
+      "source_lines": { "start": 1, "end": 1410 }
+    }
+  ],
+  "warnings": [
+    "Play 'Foo' (line 132): missing **Rationale:** field"
+  ]
+}
+```
+
+Empty `plays[]` allowed when file is empty. `warnings[]` is informational; never fatal.
+
+## 7. Invariants
+
+- **Read-only by parser.** `playbook-read.sh` never modifies the file. Writes happen only via `/playbook-capture` + `/playbook-review` (which use `Edit`/`Write` tools, not the parser).
+- **Defensive parsing.** Malformed plays produce warnings, never throws. Empty/missing file produces empty `plays[]` + warning.
+- **Source-line preservation.** Every parsed play carries its source line range, so `/playbook-review` can surgically edit individual plays without re-rendering the whole file.
+- **Encoding:** UTF-8. Em-dashes, smart quotes, code blocks all preserved verbatim.
+
+## 8. Versioning policy
+
+- **Major bumps** (`2.0`) are breaking: changes to the `### H3 = play` rule, the four field names, or the parser output JSON shape.
+- **Minor bumps** (`1.1`) are additive: new optional fields, additional metadata in output JSON, clarifications.
+- **Patch bumps** do not exist for schema versioning.
+
+v1.0 is the committed shape for v3.15.0.
+
+## 9. Non-goals
+
+- **No machine-readable enforcement.** This schema describes structure for parsing, not a JSON-Schema validator. `/validate:playbook` (deferred to v2) would be the layer that enforces structure if it ever ships.
+- **No play-level frontmatter.** Plays are markdown, not YAML+markdown. Keeps authoring frictionless.
+- **No play IDs / cross-references.** Plays are addressed by `title + section`; collisions on duplicate titles produce a warning + suffix (`title (2)`) but not enforcement.
+- **No conditional/parameterized plays.** A play applies or it doesn't; no "this rule only when project uses Bootstrap 5+" logic. Authors split into multiple plays if they need conditional scope.

--- a/drupal-dev-framework/scripts/playbook-conflicts-write.sh
+++ b/drupal-dev-framework/scripts/playbook-conflicts-write.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# playbook-conflicts-write.sh — append a single conflict line to a project's
+# playbook conflict log.
+#
+# Usage: playbook-conflicts-write.sh <project_dir> <json_string>
+#
+#   <project_dir>: absolute path to the project memory folder
+#                  (the .claude/ directory will be created here if missing)
+#   <json_string>: a single JSON object conforming to
+#                  references/playbook-conflict-schema.md v1.0
+#
+# Behavior:
+# - Validates the JSON parses and has schema_version "1.0"; refuses on stderr if not
+# - Creates <project_dir>/.claude/ if missing
+# - Appends one line + \n to <project_dir>/.claude/playbook-conflicts.log
+# - No deduplication; caller is responsible for once-per-session-per-topic logic
+# - No locking; v1 accepts interleave risk on slow filesystems (rare)
+#
+# Exit codes:
+#   0 — appended successfully (or input was a no-op invalid line caught by validation)
+#   1 — bash-level write failure (permissions, disk full)
+#   2 — invalid JSON / schema_version mismatch / missing required fields
+
+set -uo pipefail
+
+PROJECT_DIR="${1:?project directory required}"
+LINE_JSON="${2:?conflict JSON object required as second arg}"
+
+if ! echo "$LINE_JSON" | jq empty >/dev/null 2>&1; then
+  echo "playbook-conflicts-write: invalid JSON" >&2
+  exit 2
+fi
+
+# Validate required fields
+SCHEMA_VERSION=$(echo "$LINE_JSON" | jq -r '.schema_version // empty')
+if [[ "$SCHEMA_VERSION" != "1.0" ]]; then
+  echo "playbook-conflicts-write: schema_version must be \"1.0\" (got \"$SCHEMA_VERSION\")" >&2
+  exit 2
+fi
+
+CONFLICT_TYPE=$(echo "$LINE_JSON" | jq -r '.conflict_type // empty')
+if [[ "$CONFLICT_TYPE" != "local-vs-shipped" && "$CONFLICT_TYPE" != "multi-set-contradiction" ]]; then
+  echo "playbook-conflicts-write: conflict_type must be 'local-vs-shipped' or 'multi-set-contradiction'" >&2
+  exit 2
+fi
+
+TOPIC=$(echo "$LINE_JSON" | jq -r '.topic // empty')
+if [[ -z "$TOPIC" ]]; then
+  echo "playbook-conflicts-write: topic field required" >&2
+  exit 2
+fi
+
+# Ensure .claude/ exists
+CLAUDE_DIR="$PROJECT_DIR/.claude"
+if ! mkdir -p "$CLAUDE_DIR"; then
+  echo "playbook-conflicts-write: cannot create $CLAUDE_DIR" >&2
+  exit 1
+fi
+
+LOG_FILE="$CLAUDE_DIR/playbook-conflicts.log"
+
+# Compact the JSON to one line, append + newline
+COMPACT=$(echo "$LINE_JSON" | jq -c .)
+if ! echo "$COMPACT" >> "$LOG_FILE"; then
+  echo "playbook-conflicts-write: failed to write $LOG_FILE" >&2
+  exit 1
+fi
+
+exit 0

--- a/drupal-dev-framework/scripts/playbook-read.sh
+++ b/drupal-dev-framework/scripts/playbook-read.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# playbook-read.sh — parse a project's local playbook markdown into structured JSON.
+#
+# Usage: playbook-read.sh <playbook_path>
+#
+# Always emits single JSON object to stdout. Exit 0 for all recoverable states
+# (missing file, malformed plays). Non-zero ONLY for bash-level read failures.
+#
+# Mirrors defensive posture of alignment-read.sh and project-state-read.sh.
+#
+# Output contract: see references/playbook-schema.md §6.
+
+set -uo pipefail
+
+PLAYBOOK_PATH="${1:?path to playbook file required}"
+
+emit_missing_file() {
+  jq -nc --arg p "$PLAYBOOK_PATH" '
+    {
+      schema_version: "1.0",
+      path: $p,
+      file_exists: false,
+      plays: [],
+      warnings: [{code: "file_missing", detail: ("playbook not found at " + $p)}]
+    }'
+  exit 0
+}
+
+if [[ ! -f "$PLAYBOOK_PATH" ]]; then
+  emit_missing_file
+fi
+
+if [[ ! -r "$PLAYBOOK_PATH" ]]; then
+  jq -nc --arg p "$PLAYBOOK_PATH" '
+    {
+      schema_version: "1.0",
+      path: $p,
+      file_exists: true,
+      plays: [],
+      warnings: [{code: "file_unreadable", detail: ("playbook exists but is not readable: " + $p)}]
+    }'
+  exit 0
+fi
+
+# Parse the markdown into plays. Algorithm:
+#   - H2 (`## ...`) sets the current section
+#   - H3 (`### ...`) starts a new play; previous play (if any) closes
+#   - Within a play body, scan for `**What:**`, `**Rationale:**`, `**When it applies:**`, `**Example:**`
+#   - Code blocks (``` ... ```) are extracted into example_blocks[] when they appear under **Example:** OR after one
+#   - Source line range tracked per play
+#
+# If the file has no H3 plays, emit a single freeform synthetic play with the entire file as body_raw.
+
+awk -v file_path="$PLAYBOOK_PATH" '
+BEGIN {
+  current_section = "<root>"
+  in_play = 0
+  in_code = 0
+  in_example = 0
+  play_count = 0
+  total_h3 = 0
+  delete plays_title
+  delete plays_section
+  delete plays_what
+  delete plays_rationale
+  delete plays_when
+  delete plays_examples
+  delete plays_body
+  delete plays_start
+  delete plays_end
+}
+
+# Track code blocks (toggle on triple-backtick lines)
+/^```/ {
+  if (in_play) {
+    if (in_code == 0) {
+      in_code = 1
+      code_buffer = ""
+      next
+    } else {
+      in_code = 0
+      if (in_example) {
+        plays_examples[play_count] = plays_examples[play_count] code_buffer "\n---SEPARATOR---\n"
+      }
+      plays_body[play_count] = plays_body[play_count] $0 "\n"
+      next
+    }
+  }
+}
+
+in_code {
+  if (in_play) {
+    plays_body[play_count] = plays_body[play_count] $0 "\n"
+    if (in_example) {
+      code_buffer = code_buffer (code_buffer == "" ? "" : "\n") $0
+    }
+  }
+  next
+}
+
+# H2 section header
+/^## / {
+  if (in_play) {
+    plays_end[play_count] = NR - 1
+  }
+  current_section = $0
+  sub(/^## +/, "", current_section)
+  in_play = 0
+  in_example = 0
+  next
+}
+
+# H3 play header
+/^### / {
+  if (in_play) {
+    plays_end[play_count] = NR - 1
+  }
+  total_h3++
+  play_count++
+  title = $0
+  sub(/^### +/, "", title)
+  plays_title[play_count] = title
+  plays_section[play_count] = current_section
+  plays_what[play_count] = ""
+  plays_rationale[play_count] = ""
+  plays_when[play_count] = ""
+  plays_examples[play_count] = ""
+  plays_body[play_count] = ""
+  plays_start[play_count] = NR
+  in_play = 1
+  in_example = 0
+  next
+}
+
+# Field extraction (within a play)
+in_play && /^\*\*What:\*\*/ {
+  v = $0
+  sub(/^\*\*What:\*\* */, "", v)
+  plays_what[play_count] = v
+  plays_body[play_count] = plays_body[play_count] $0 "\n"
+  in_example = 0
+  next
+}
+
+in_play && /^\*\*Rationale:\*\*/ {
+  v = $0
+  sub(/^\*\*Rationale:\*\* */, "", v)
+  plays_rationale[play_count] = v
+  plays_body[play_count] = plays_body[play_count] $0 "\n"
+  in_example = 0
+  next
+}
+
+in_play && /^\*\*When it applies:\*\*/ {
+  v = $0
+  sub(/^\*\*When it applies:\*\* */, "", v)
+  plays_when[play_count] = v
+  plays_body[play_count] = plays_body[play_count] $0 "\n"
+  in_example = 0
+  next
+}
+
+in_play && /^\*\*Example:\*\*/ {
+  plays_body[play_count] = plays_body[play_count] $0 "\n"
+  in_example = 1
+  next
+}
+
+# Generic body line
+in_play {
+  plays_body[play_count] = plays_body[play_count] $0 "\n"
+}
+
+END {
+  if (in_play) {
+    plays_end[play_count] = NR
+  }
+
+  if (total_h3 == 0) {
+    # Freeform fallback — entire file as one synthetic play
+    printf("{\"freeform\": true, \"plays\": [{\"title\": \"%s\", \"section\": \"<root>\", \"applicability\": \"free-form\"}]}\n", file_path)
+  } else {
+    # Structured emit — one play per H3
+    printf("{\"freeform\": false, \"plays\": [")
+    for (i = 1; i <= play_count; i++) {
+      if (i > 1) printf(",")
+      title = plays_title[i]
+      gsub(/\\/, "\\\\", title); gsub(/"/, "\\\"", title)
+      section = plays_section[i]
+      gsub(/\\/, "\\\\", section); gsub(/"/, "\\\"", section)
+      what = plays_what[i]; gsub(/\\/, "\\\\", what); gsub(/"/, "\\\"", what)
+      rat = plays_rationale[i]; gsub(/\\/, "\\\\", rat); gsub(/"/, "\\\"", rat)
+      whn = plays_when[i]; gsub(/\\/, "\\\\", whn); gsub(/"/, "\\\"", whn)
+      printf("{\"title\":\"%s\",\"section\":\"%s\",\"what\":\"%s\",\"rationale\":\"%s\",\"when_it_applies\":\"%s\",\"start\":%d,\"end\":%d,\"applicability\":\"structured\"}",
+             title, section, what, rat, whn, plays_start[i], plays_end[i])
+    }
+    printf("]}\n")
+  }
+}
+' "$PLAYBOOK_PATH" > /tmp/playbook-read-$$.json
+
+# Wrap awk output with file metadata + warnings
+RAW_BODY=$(cat /tmp/playbook-read-$$.json)
+rm -f /tmp/playbook-read-$$.json
+
+# Compute warnings: detect plays missing fields
+WARNINGS=$(echo "$RAW_BODY" | jq -c '
+  if .freeform == true then
+    [{code: "free-form-fallback", detail: "no ### H3 plays found; entire file loaded as raw text"}]
+  else
+    [.plays[] | select(.applicability == "structured") |
+     select(.what == "" or .rationale == "" or .when_it_applies == "") |
+     {code: "missing_field", detail: ("Play \"" + .title + "\" (line " + (.start | tostring) + "): missing one or more recommended fields (What/Rationale/When)")}]
+  end
+')
+
+# Read raw body content for freeform case
+BODY_RAW=""
+if echo "$RAW_BODY" | jq -e '.freeform == true' > /dev/null; then
+  BODY_RAW=$(jq -Rs . < "$PLAYBOOK_PATH")
+fi
+
+# Final output
+jq -n \
+  --arg p "$PLAYBOOK_PATH" \
+  --argjson plays "$(echo "$RAW_BODY" | jq '.plays')" \
+  --argjson warnings "$WARNINGS" \
+  --arg body_raw "$(cat "$PLAYBOOK_PATH")" \
+  '{
+    schema_version: "1.0",
+    path: $p,
+    file_exists: true,
+    plays: $plays,
+    body_raw_available: ($body_raw != ""),
+    warnings: $warnings
+  }'

--- a/drupal-dev-framework/scripts/playbook-read.sh
+++ b/drupal-dev-framework/scripts/playbook-read.sh
@@ -178,9 +178,9 @@ END {
 
   if (total_h3 == 0) {
     # Freeform fallback — entire file as one synthetic play
-    printf("{\"freeform\": true, \"plays\": [{\"title\": \"%s\", \"section\": \"<root>\", \"applicability\": \"free-form\"}]}\n", file_path)
+    printf("{\"freeform\": true, \"plays\": [{\"title\": \"%s\", \"section\": \"<root>\", \"applicability\": \"free-form\", \"source_lines\": {\"start\": 1, \"end\": NR}, \"example_blocks\": []}]}\n", file_path)
   } else {
-    # Structured emit — one play per H3
+    # Structured emit — one play per H3, schema per references/playbook-schema.md §6
     printf("{\"freeform\": false, \"plays\": [")
     for (i = 1; i <= play_count; i++) {
       if (i > 1) printf(",")
@@ -191,8 +191,27 @@ END {
       what = plays_what[i]; gsub(/\\/, "\\\\", what); gsub(/"/, "\\\"", what)
       rat = plays_rationale[i]; gsub(/\\/, "\\\\", rat); gsub(/"/, "\\\"", rat)
       whn = plays_when[i]; gsub(/\\/, "\\\\", whn); gsub(/"/, "\\\"", whn)
-      printf("{\"title\":\"%s\",\"section\":\"%s\",\"what\":\"%s\",\"rationale\":\"%s\",\"when_it_applies\":\"%s\",\"start\":%d,\"end\":%d,\"applicability\":\"structured\"}",
+
+      # Build example_blocks[] JSON array from plays_examples buffer (split on ---SEPARATOR---)
+      printf("{\"title\":\"%s\",\"section\":\"%s\",\"what\":\"%s\",\"rationale\":\"%s\",\"when_it_applies\":\"%s\",\"source_lines\":{\"start\":%d,\"end\":%d},\"example_blocks\":[",
              title, section, what, rat, whn, plays_start[i], plays_end[i])
+
+      ex_buffer = plays_examples[i]
+      if (ex_buffer != "") {
+        # Split on the separator and emit each non-empty chunk as a JSON string
+        block_count = split(ex_buffer, ex_blocks, /\n---SEPARATOR---\n/)
+        emitted = 0
+        for (b = 1; b <= block_count; b++) {
+          if (ex_blocks[b] != "") {
+            blk = ex_blocks[b]
+            gsub(/\\/, "\\\\", blk); gsub(/"/, "\\\"", blk); gsub(/\n/, "\\n", blk); gsub(/\r/, "", blk); gsub(/\t/, "\\t", blk)
+            if (emitted > 0) printf(",")
+            printf("\"%s\"", blk)
+            emitted++
+          }
+        }
+      }
+      printf("],\"applicability\":\"structured\"}")
     }
     printf("]}\n")
   }

--- a/drupal-dev-framework/scripts/project-state-read.sh
+++ b/drupal-dev-framework/scripts/project-state-read.sh
@@ -12,6 +12,11 @@
 #     "project_name": "<name or folder basename>",
 #     "codePath": "<absolute path or null>",
 #     "folder": "<abs path to project folder>",
+#     "playbookSets": ["<set-id>", ...],
+#     "playbookSetsSource": "explicit" | "explicit-none" | "default",
+#     "userPlaybook": "<absolute path or null>",
+#     "userPlaybookState": "unset" | "docs-only-no-playbook" | "set",
+#     "playbookResolutions": [{"topic": "<t>", "set": "<set-id>"}, ...],
 #     "warnings": [{"code": "<code>", "detail": "..."}]
 #   }
 #
@@ -37,22 +42,49 @@ PROJECT_STATE="$PROJECT_DIR/project_state.md"
 
 emit_json() {
   # $1 = project_name, $2 = codePath (string "null" literal for null), $3 = folder, $4 = warnings JSON array
-  jq -nc --arg n "$1" --arg cp "$2" --arg d "$3" --argjson w "$4" '
+  # $5 = playbookSets JSON array, $6 = playbookSetsSource string,
+  # $7 = userPlaybook (string "null" literal for null), $8 = userPlaybookState string,
+  # $9 = playbookResolutions JSON array
+  jq -nc \
+    --arg n "$1" --arg cp "$2" --arg d "$3" \
+    --argjson w "$4" \
+    --argjson ps "${5:-[]}" --arg pss "${6:-default}" \
+    --arg up "${7:-null}" --arg ups "${8:-unset}" \
+    --argjson pr "${9:-[]}" '
     {
       project_name: $n,
       codePath: (if $cp == "null" then null else $cp end),
       folder: $d,
+      playbookSets: $ps,
+      playbookSetsSource: $pss,
+      userPlaybook: (if $up == "null" then null else $up end),
+      userPlaybookState: $ups,
+      playbookResolutions: $pr,
       warnings: $w
     }'
 }
 
+# Resolve framework default playbook sets from plugin.json
+PLUGIN_JSON_PATH="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")/.claude-plugin/plugin.json"
+get_default_playbook_sets() {
+  if [ -f "$PLUGIN_JSON_PATH" ]; then
+    jq -c '.defaults.playbookSets // []' "$PLUGIN_JSON_PATH" 2>/dev/null || echo "[]"
+  else
+    echo "[]"
+  fi
+}
+
+DEFAULT_PB_SETS=$(get_default_playbook_sets)
+
 if [ ! -d "$PROJECT_DIR" ]; then
-  emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "folder_missing", "detail": "project folder does not exist"}]'
+  emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "folder_missing", "detail": "project folder does not exist"}]' \
+    "$DEFAULT_PB_SETS" "default" "null" "unset" "[]"
   exit 0
 fi
 
 if [ ! -f "$PROJECT_STATE" ]; then
-  emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "project_state_md_missing", "detail": "project_state.md not found in folder"}]'
+  emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "project_state_md_missing", "detail": "project_state.md not found in folder"}]' \
+    "$DEFAULT_PB_SETS" "default" "null" "unset" "[]"
   exit 0
 fi
 
@@ -91,4 +123,86 @@ else
   CODE_PATH_OUT="$CODE_PATH_NORM"
 fi
 
-emit_json "$PROJECT_NAME" "$CODE_PATH_OUT" "$PROJECT_DIR" "$WARNINGS"
+# === Playbook Sets parsing ===
+PB_SETS_RAW=$(awk '
+  BEGIN { IGNORECASE=1 }
+  /^\*\*Playbook Sets:\*\*/ {
+    sub(/^\*\*Playbook Sets:\*\*[[:space:]]*/, "")
+    print
+    exit
+  }
+' "$PROJECT_STATE")
+
+if [ -z "$PB_SETS_RAW" ]; then
+  PB_SETS_OUT="$DEFAULT_PB_SETS"
+  PB_SETS_SOURCE="default"
+elif [ "$PB_SETS_RAW" = "none" ]; then
+  PB_SETS_OUT="[]"
+  PB_SETS_SOURCE="explicit-none"
+else
+  # Comma-split, trim, JSON-encode
+  PB_SETS_OUT=$(echo "$PB_SETS_RAW" | jq -R -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+  PB_SETS_SOURCE="explicit"
+fi
+
+# === User Playbook + State parsing ===
+UP_RAW=$(awk '
+  BEGIN { IGNORECASE=1 }
+  /^\*\*User Playbook:\*\*/ {
+    sub(/^\*\*User Playbook:\*\*[[:space:]]*/, "")
+    print
+    exit
+  }
+' "$PROJECT_STATE")
+
+UPS_RAW=$(awk '
+  BEGIN { IGNORECASE=1 }
+  /^\*\*User Playbook State:\*\*/ {
+    sub(/^\*\*User Playbook State:\*\*[[:space:]]*/, "")
+    print
+    exit
+  }
+' "$PROJECT_STATE")
+
+if [ -n "$UPS_RAW" ]; then
+  UP_STATE="$UPS_RAW"
+elif [ -z "$UP_RAW" ]; then
+  UP_STATE="unset"
+elif [ "$UP_RAW" = "(docs-only-no-playbook)" ] || [ "$UP_RAW" = "docs-only-no-playbook" ]; then
+  UP_STATE="docs-only-no-playbook"
+else
+  UP_STATE="set"
+fi
+
+if [ "$UP_STATE" = "set" ] && [ -n "$UP_RAW" ]; then
+  UP_OUT="$UP_RAW"
+else
+  UP_OUT="null"
+fi
+
+# === Playbook Resolutions parsing ===
+# Format: multi-line list under **Playbook Resolutions:** heading
+#   - topic1 → set-id-1
+#   - topic2 → set-id-2
+PB_RESOLUTIONS=$(awk '
+  BEGIN { in_block = 0 }
+  /^\*\*Playbook Resolutions:\*\*/ { in_block = 1; next }
+  in_block && /^\*\*[A-Z]/ { in_block = 0 }
+  in_block && /^- / {
+    line = $0
+    sub(/^- */, "", line)
+    # Split on → or ->
+    if (match(line, / *(→|->|=) */)) {
+      topic = substr(line, 1, RSTART-1)
+      set = substr(line, RSTART+RLENGTH)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", topic)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", set)
+      printf("{\"topic\":\"%s\",\"set\":\"%s\"}\n", topic, set)
+    }
+  }
+' "$PROJECT_STATE" | jq -s -c .)
+
+[ -z "$PB_RESOLUTIONS" ] && PB_RESOLUTIONS="[]"
+
+emit_json "$PROJECT_NAME" "$CODE_PATH_OUT" "$PROJECT_DIR" "$WARNINGS" \
+  "$PB_SETS_OUT" "$PB_SETS_SOURCE" "$UP_OUT" "$UP_STATE" "$PB_RESOLUTIONS"

--- a/drupal-dev-framework/skills/guide-integrator/SKILL.md
+++ b/drupal-dev-framework/skills/guide-integrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guide-integrator
-description: "Use when designing or researching features — loads plugin methodology refs (SOLID, DRY, TDD, Library-First, Quality Gates, Purposeful Code) and delegates to dev-guides-navigator for online Drupal domain knowledge. Records each loaded guide into session_context.json loadedGuides[] so re-loads are skipped and the context-reminder hook can surface them."
-version: 4.1.1
+description: "Use when designing or researching features — loads plugin methodology refs (SOLID, DRY, TDD, Library-First, Quality Gates, Purposeful Code), delegates to dev-guides-navigator for online Drupal domain knowledge, AND loads active playbook sets + project-local user playbook (v3.15.0+). Cross-references plays-by-topic and emits conflicts[]. Records each loaded guide into session_context.json loadedGuides[] so re-loads are skipped."
+version: 5.0.0
 user-invocable: false
 model: sonnet
 ---
@@ -138,6 +138,79 @@ Use `Edit` to add references section to architecture file:
 ### 5. Summarize
 
 Tell user what was integrated from each source: plugin methodology and dev-guides topics.
+
+### 6. Load Playbook (v3.15.0+)
+
+After loading methodology refs and dev-guides topics, load the project's playbook layers:
+
+#### 6a. Read project state
+
+Invoke `project-state-reader` skill to get `playbookSets[]`, `userPlaybook`, `userPlaybookState`, and `playbookResolutions[]`.
+
+#### 6b. Load shipped playbook sets
+
+For each set ID in `playbookSets[]` (e.g., `drupal/best-practices/camoa`):
+
+- Delegate to `dev-guides-navigator` to fetch the set's index.md and individual guide pages relevant to the current task domain.
+- Record each loaded guide ID via the snippet in §2b.
+- Track loaded guide titles + summaries for cross-reference.
+
+When `playbookSets` is empty (`playbookSetsSource: "explicit-none"` or `"default"` with empty default), skip this step silently.
+
+#### 6c. Load local playbook
+
+If `userPlaybookState == "set"`, invoke:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/playbook-read.sh" "<userPlaybook absolute path>"
+```
+
+Parse the JSON. Each play is `{title, section, what, rationale, when_it_applies, applicability, ...}`. Track titles + sections + topics for cross-reference.
+
+If `userPlaybookState != "set"`, skip silently.
+
+#### 6d. Detect conflicts
+
+Cross-reference local plays vs shipped guides AND multi-set vs multi-set:
+
+- **Local-vs-shipped:** when a local play's `title` or `section` topic matches a shipped guide's topic AND their normative content differs → emit a conflict (winner: `local`).
+- **Multi-set contradiction:** when 2+ shipped sets address the same topic with different normative content → emit a conflict (winner determined by `playbookResolutions[]` if present, else `null` and surface to user).
+
+Emit `conflicts[]` in the return JSON:
+
+```json
+{
+  "loaded_guides": ["plugin:solid-drupal", "drupal/forms/config-forms"],
+  "loaded_playbook_sets": ["drupal/best-practices/camoa"],
+  "loaded_local_playbook": { "path": "/abs/path", "play_count": 19 },
+  "conflicts": [
+    {
+      "topic": "font-sizing",
+      "type": "local-vs-shipped",
+      "playbook_set_citation": {...},
+      "local_citation": {...},
+      "winner": "local"
+    }
+  ]
+}
+```
+
+#### 6e. Surface conflicts once per session per topic
+
+For each conflict in `conflicts[]`:
+
+1. Check session-context state (a per-session "surfaced topics" set) to see if this topic was already surfaced.
+2. If not surfaced: print one-line surface to the user (e.g. `"Playbook conflict on `font-sizing`: shipped says X, local says Y. Local wins."`).
+3. Record to `<project>/.claude/playbook-conflicts.log` via `playbook-conflicts-write.sh`.
+4. Mark topic surfaced for this session.
+
+For multi-set contradictions WITHOUT a stored resolution: prompt the user to pick (1/2/cancel); on choice, persist to `project_state.md` `**Playbook Resolutions:**` map.
+
+For local-vs-shipped: no prompt; precedence rule applies; just announce.
+
+#### 6f. Record loaded playbook IDs
+
+Record each loaded shipped-set guide and the local playbook into `loadedGuides[]` per §2b. Local playbook ID convention: `local:userPlaybook:<basename>`.
 
 ## Reference Locations
 

--- a/drupal-dev-framework/skills/project-state-reader/SKILL.md
+++ b/drupal-dev-framework/skills/project-state-reader/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-state-reader
-description: Use when a framework command needs project-level metadata (currently codePath, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
-version: 1.0.0
+description: Use when a framework command needs project-level metadata (codePath, playbookSets, userPlaybook, playbookResolutions, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
+version: 1.1.0
 user-invocable: false
 model: haiku
 allowed-tools: Bash
@@ -21,6 +21,11 @@ Fields:
 - `project_name` — from the H1 line in `project_state.md`, or folder basename fallback
 - `codePath` — absolute path (string) if declared and resolves, or `null` if docs-only / unknown
 - `folder` — the absolute path passed in
+- `playbookSets` — *(v1.1+)* array of dev-guides path slugs the project subscribes to (e.g., `["drupal/best-practices/camoa"]`). Falls back to plugin.json `defaults.playbookSets` when field absent. Empty array when explicit `none`.
+- `playbookSetsSource` — *(v1.1+)* `"explicit"` (field present with values) \| `"explicit-none"` (field is literal `none`) \| `"default"` (field absent, defaults applied)
+- `userPlaybook` — *(v1.1+)* absolute path to project-local playbook file, or `null` when state is `unset` or `docs-only-no-playbook`
+- `userPlaybookState` — *(v1.1+)* `"unset"` \| `"docs-only-no-playbook"` \| `"set"`
+- `playbookResolutions` — *(v1.1+)* array of `{topic, set}` entries recording per-topic multi-set contradiction resolutions
 - `warnings` — array of `{code, detail}` entries
 
 ## Defensive posture (never throws)
@@ -41,6 +46,27 @@ Accepted on the one-line `**Code path:**` metadata entry:
 - (line absent) — null; first-use prompt should fire
 
 Case-insensitive match on the label.
+
+## Playbook fields in `project_state.md` (v1.1+)
+
+```markdown
+**Playbook Sets:** drupal/best-practices/camoa, drupal/best-practices/lullabot
+**User Playbook:** /home/me/projects/idexx/docs/playbook.md
+**User Playbook State:** set
+
+**Playbook Resolutions:**
+- font-sizing → drupal/best-practices/camoa
+- bem-methodology → drupal/best-practices/lullabot
+```
+
+| Line | Semantics |
+|---|---|
+| `**Playbook Sets:** <ids,...>` | Comma-separated set IDs |
+| `**Playbook Sets:** none` | Explicit opt-out — empty list, source `explicit-none` |
+| (line absent) | Use plugin.json `defaults.playbookSets`; source `default` |
+| `**User Playbook:** <abs path>` | Project-local playbook file |
+| `**User Playbook State:** unset \| docs-only-no-playbook \| set` | 3-state field; mirrors `Code Path State` precedent |
+| `**Playbook Resolutions:**` (multi-line list) | Per-topic multi-set choices |
 
 ## Invocation
 


### PR DESCRIPTION
## Summary

v3.15.0 ships the **Playbook System** — a two-layer Drupal best-practices framework integrated over the already-published `drupal/best-practices/camoa/*` 20-guide playbook on dev-guides.

**Two layers, both first-class:**
- **Published playbook sets** — namespaced dev-guides categories. Multiple authors coexist; users subscribe per project.
- **Project-local user playbook** — single markdown file. OVERRIDE shipped opinions or EXTEND with topics shipped doesn't cover. Local always wins on conflict.

**Opinionation by default** — \`plugin.json\` ships \`defaults.playbookSets: ["drupal/best-practices/camoa"]\`. New projects automatically subscribe; users opt out via \`Playbook Sets: none\`.

## What ships

### 5 new commands

- \`/playbook-active\` — read-only display
- \`/playbook-capture\` — interactive draft + diff + append
- \`/playbook-review\` — per-play \`[k]eep/[u]pdate/[r]emove/[q]uit\` walk; \`/loop\`-able
- \`/set-playbook-sets\` — set/clear active sets; validates each via dev-guides-navigator
- \`/set-user-playbook\` — set/clear local playbook; explicit / \`--docs-only\` / interactive modes

### 2 new references + 1 schema bump

- \`references/playbook-schema.md\` v1.0 — recommended local playbook structure (H3-per-play with What/Rationale/When/Example), defensive parser invariants
- \`references/playbook-conflict-schema.md\` v1.0 — JSONL log line for \`.claude/playbook-conflicts.log\`
- \`references/analysis-agent-schema.md\` v1.0 → v1.1 — adds \`play_candidates\` mode (additive; backward-compatible)

### 2 new scripts

- \`scripts/playbook-read.sh\` — defensive markdown parser; smoke-tested against idexx development-patterns.md (parses 19 plays)
- \`scripts/playbook-conflicts-write.sh\` — atomic JSONL append with schema-version validation

### Updated

- \`skills/guide-integrator\` 4.1.1 → 5.0.0 — loads playbook layers + emits conflicts[]; surfaces once per session per topic
- \`skills/project-state-reader\` 1.0.0 → 1.1.0 — parses new fields with plugin.json defaults fallback
- \`commands/research.md\`, \`design.md\`, \`implement.md\` — preflight Step 1 documents v5.0.0 guide-integrator behavior
- \`commands/complete.md\` — new "Candidate-play surface" section between gates and task move
- \`hooks/context-reminder.sh\` — emits Playbook line when relevant
- \`plugin.json\` 3.14.2 → 3.15.0; \`marketplace.json\` metadata.version 1.14.21 → 1.14.22

## Paper-test report

4 contract seams verified live:

| Seam | Verdict |
|---|---|
| Default fallback (field absent → plugin.json defaults) | ✓ \`playbookSets: ["drupal/best-practices/camoa"]\`, source: \"default\" |
| Explicit \`none\` opt-out | ✓ \`playbookSets: []\`, source: \"explicit-none\" |
| Explicit list + Playbook Resolutions parsing | ✓ Comma-split + → separator handled correctly |
| playbook-read.sh on real file | ✓ 19 plays parsed; 19 warnings (flat structure → recommended fields missing); source_lines + example_blocks present per schema §6 |

## Audit

plugin-structure-auditor: **25/30 → expected 27+/30 after fixes**. Two MAJORs caught:
1. \`playbook-read.sh\` output drift (flat \`start\`/\`end\` instead of \`source_lines: {start, end}\`; missing \`example_blocks[]\`) — **fixed**
2. README stale schema version on \`analysis-agent-schema.md\` — **fixed**

## Why minor, not major

Purely additive. Existing \`/research\`, \`/design\`, \`/implement\`, \`/complete\`, \`/validate:*\` work unchanged when no playbook is configured. \`analysis-agent\` v1.0 outputs unchanged for existing modes. \`project_state.md\` parsing forward-compatible.

## Test plan

- [ ] Install resolves v3.15.0 cleanly with both hard deps
- [ ] Existing projects (no Playbook Sets field) get the default \`drupal/best-practices/camoa\` automatically
- [ ] \`/set-user-playbook\` interactive detect-and-confirm finds idexx's \`docs/technical/guides/development-patterns.md\`
- [ ] \`/research\`, \`/design\`, \`/implement\` on idexx surface the Playbook line in context-reminder
- [ ] \`guide-integrator\` v5.0.0 loads camoa playbook guides via dev-guides-navigator (the 20 guides already published)
- [ ] On a manufactured local-vs-shipped conflict, framework surfaces once with citations + winner; persists to \`.claude/playbook-conflicts.log\`
- [ ] Multi-set contradiction prompts user; per-topic choice persists in \`Playbook Resolutions:\`
- [ ] \`/playbook-capture\` writes a new entry with diff preview; smoke-tested via interactive draft on idexx
- [ ] \`/complete\` candidate-play surface (analysis-agent play_candidates mode) emits ≥1 candidate from a real idexx task with repeated decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)