### PR TITLE
feat(drupal-dev-framework): worktree awareness — parallel task execution (v3.16.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.22"
+    "version": "1.14.23"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator, code-quality-tools (declared via Plugin Dependencies).",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "author": {
         "name": "camoa"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,7 +72,9 @@
         "solid",
         "dry",
         "security",
-        "agent-teams"
+        "agent-teams",
+        "playbook",
+        "worktree"
       ]
     },
     {

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams", "playbook"],
+  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams", "playbook", "worktree"],
   "dependencies": [
     "dev-guides-navigator",
     "code-quality-tools"

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,77 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.0] - 2026-04-24
+
+### Added — Worktree Awareness
+
+Make git worktrees the standard mechanism for running parallel tasks on the same drupal-dev-framework project. Two Claude Code sessions on the same workspace collide on `~/.claude/drupal-dev-framework/sessions/<md5($PWD)>.json` and on the git working tree itself; a worktree at `.worktrees/<task_name>/` solves both — distinct `$PWD` → distinct hash → independent session. **No changes to `session-context-writer`.**
+
+### New commands (2)
+
+- `/drupal-dev-framework:worktree <task>` — 10-step creation: resolve task, refuse-if-in-worktree, directory priority (`.worktrees/` > `worktrees/` > CLAUDE.md > ask), gitignore verify + commit if missing, DDEV `name:` warning (Drupal-specific), `git worktree add` with `feature/<task>` branch, auto-detect setup (`composer install` / `npm install`), optional `--with-baseline`, pre-seed session-context, summary
+- `/drupal-dev-framework:worktree-prune` — per-worktree `[y]/[n]/[q]` cleanup; lists state (branch merged? task completed?); honors git's refusal on uncommitted changes; force-remove requires explicit per-worktree confirmation
+
+### New reference (1)
+
+- `references/worktree-conventions.md` v1.0 — directory priority, branch naming, gitignore requirement, detection signal taxonomy (HIGH/MEDIUM-HIGH), 3-path lifecycle at `/complete`, DDEV compatibility, refusal cases, versioning policy
+
+### New scripts (2)
+
+- `scripts/worktree-detect.sh` — defensive in-worktree state check (uses `git rev-parse --git-dir` vs `--git-common-dir` difference); emits `{schema_version, in_git_repo, in_worktree, worktree_path, main_path, branch, warnings}`
+- `scripts/worktree-signals.sh` — computes detection signals for `/implement`: `another_task_active` (commits to other tasks' files within 2 hours), `dirty_tree` (uncommitted changes), `multi_session` (2+ session-context files for same project), `project_opt_in` (`Worktree By Default: true`); resolves codePath via `project-state-read.sh`; HIGH threshold: at least one HIGH signal or EXPLICIT user/project flag
+
+### `project_state.md` schema addition
+
+- `**Worktree By Default:** true` — opts project into worktree-always for `/implement` (otherwise signal-driven)
+
+### Updated artifacts
+
+- `commands/implement.md` — new "Worktree recommendation" pre-step BEFORE Phase Transition Check; soft-nudge with `[c]reate / [m]ain tree / [a]bort`; `--worktree` flag chains into `/worktree`; `--in-main-tree` flag suppresses
+- `commands/complete.md` — new "Worktree merge prompt" sub-step BETWEEN quality gates and candidate-play surface; 3-path (merge-back / push+PR / skip); default skip; merge-conflict path 1 aborts merge + leaves worktree for manual resolution
+- `scripts/project-state-read.sh` — parse new `Worktree By Default` field; emit `worktreeByDefault: bool`
+- `skills/project-state-reader` v1.1.0 → 1.2.0 — documents new field
+- `.claude-plugin/plugin.json` — `3.15.0` → `3.16.0`; new `worktree` keyword
+- `CLAUDE.md` — new `## Worktree Workflow (v3.16.0+)` section before Playbook System block
+- `README.md` — 2 new commands; Technical Contract References 8 → 9
+
+### Detection signals (HIGH-strength)
+
+| Signal | Evidence |
+|---|---|
+| `another_task_active` | Another task folder has `implementation.md` AND `git log --since="2 hours" --name-only` shows commits to its tracked files |
+| `dirty_tree` | `git status --porcelain` shows modified files matching another task's tracked files |
+| `multi_session` | (MEDIUM-HIGH) 2+ session-context files in `~/.claude/drupal-dev-framework/sessions/` reference the same project |
+| `--worktree` user flag | EXPLICIT |
+| `Worktree By Default: true` in `project_state.md` | EXPLICIT |
+
+Recommendation fires only on HIGH or EXPLICIT signals; suppressed when already in a worktree; printed only on `/implement` (not `/research` or `/design` — read-mostly phases).
+
+### DDEV compatibility
+
+DDEV explicitly supports worktrees ([DDEV Contributor Training, March 2026](https://ddev.com/blog/git-worktree-contributor-training/)) but requires the `name:` key removed from `.ddev/config.yaml`. Framework detects + warns; **never auto-edits** the config. User picks `[c]ontinue / [a]bort / [s]how-instructions`.
+
+### Why minor, not major
+
+Purely additive. Existing `/implement` works unchanged when no signals fire. Existing `/complete` works unchanged outside worktrees. `session-context-writer` and all `/validate:*` commands consumed unchanged. v3.15.0 Playbook System orthogonal — no integration needed.
+
+### Reused vs extended
+
+Reused: `superpowers:using-git-worktrees` core patterns (directory priority, gitignore verify, auto-detect setup). Replicated in command body — not a hard dependency.
+
+Extended with: task-aware lifecycle (`/implement` recommendation, `/complete` merge prompt), Drupal/DDEV awareness, session-context pre-seed, conservative HIGH-only signal threshold (false positives are worse than false negatives).
+
+### Deferred to v2
+
+- Configurable detection-window beyond 2 hours
+- Detection signals on `/research` and `/design`
+- `/migrate-to-worktree` for in-flight tasks
+- Refined heuristics from real-world false-positive reports
+- Multi-task worktree reuse (single worktree, multiple tasks)
+- Auto-edit `.ddev/config.yaml` (with backup + commit)
+- Test-baseline runs default-on for Drupal projects
+- Distributed / cross-machine worktree-equivalent
+
 ## [3.15.0] - 2026-04-24
 
 ### Added — Playbook System

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -58,6 +58,29 @@ Individual `/validate:*` commands for on-demand quality gates. Replaces `/comple
 
 **NOT wrapped** (keep invoking directly via `/code-quality:*` namespace): `lint`, `coverage`, `review`, `audit`, `ultrareview`, `architecture-debate`, `security-debate`. `/validate:all` surfaces them as discoverability hint.
 
+## Worktree Workflow (v3.16.0+)
+
+Two Claude Code sessions on the same project workspace collide on `~/.claude/drupal-dev-framework/sessions/<md5($PWD)>.json` (last-writer-wins) and on the git working tree itself. Solution: the second session runs in a worktree at `.worktrees/<task_name>/`. Distinct `$PWD` → distinct hash → independent session-context. **No changes to `session-context-writer` — the existing hash naturally separates worktree sessions.**
+
+**Commands:**
+- `/worktree <task>` — create a worktree on `feature/<task>` from current HEAD; runs auto-detect setup; pre-seeds session-context. Refuses to double-wrap (refuses when already in a worktree). Drupal/DDEV-aware: warns about `.ddev/config.yaml` `name:` key conflict.
+- `/worktree-prune` — list and selectively remove worktrees; per-worktree confirm; honors git's refusal on uncommitted changes; force-remove requires explicit per-worktree confirmation.
+
+**Detection:** `/implement <task>` invokes `worktree-signals.sh` BEFORE Phase Transition Check. Signals (HIGH-strength only trigger): `another_task_active` (recent commits to another task's tracked files within 2 hours), `dirty_tree` (uncommitted changes matching another task), `multi_session` (medium-high; informational), `--worktree` flag, `worktreeByDefault: true` in `project_state.md`. Suppressed when already in a worktree. Soft-nudge — never blocks.
+
+**Lifecycle at `/complete`:** when current task is on a worktree, prompts 3 paths (default 3 — skip):
+1. Merge back to main + remove worktree
+2. Push branch + open PR (worktree stays)
+3. Skip — leave as-is
+
+Merge-conflict path 1 aborts merge, prints conflict files, leaves worktree intact for manual resolution.
+
+**`project_state.md` field:** `**Worktree By Default:** true` opts the project into worktree-always for `/implement`. Absent → false.
+
+**Conventions:** `references/worktree-conventions.md` v1.0 documents directory priority (`.worktrees/` > `worktrees/` > CLAUDE.md > ask), branch naming (`feature/<task>`), gitignore requirement, signal taxonomy, lifecycle paths, DDEV concerns, refusal cases.
+
+**Reuses:** `superpowers:using-git-worktrees` skill's core patterns (directory priority, gitignore verify, auto-detect setup); extends with task-aware lifecycle + Drupal/DDEV awareness. Not a hard dependency; replicated in command body.
+
 ## Playbook System (v3.15.0+)
 
 Two-layer Drupal best-practices system:

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -113,6 +113,8 @@ Both enforced via `plugin.json` `dependencies`. Missing-dependency failures surf
 | `/playbook-review` | **(v3.15.0)** Walk every play in the local user playbook with `[k]eep / [u]pdate / [r]emove / [q]uit`. Immediate-write semantics; `/loop`-able for periodic review. |
 | `/set-playbook-sets` | **(v3.15.0)** Set or clear active playbook sets (e.g., `drupal/best-practices/camoa`). Validates each via `dev-guides-navigator`. Default subscription comes from plugin.json `defaults.playbookSets`. |
 | `/set-user-playbook` | **(v3.15.0)** Set/clear the project-local user playbook file. Three modes: explicit path, `--docs-only`, or interactive detect-and-confirm. |
+| `/worktree <task>` | **(v3.16.0)** Create a git worktree at `.worktrees/<task>/` on `feature/<task>` for parallel task execution. Auto-detects composer/npm setup; pre-seeds session-context. Drupal/DDEV-aware (warns about `.ddev/config.yaml` `name:` conflict). |
+| `/worktree-prune` | **(v3.16.0)** List and selectively remove worktrees with per-item `[y]/[n]/[q]` confirm; honors git's refusal on uncommitted changes; force-remove requires explicit confirmation. |
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
@@ -177,7 +179,7 @@ Built-in docs enforced at specific phases:
 | `quality-gates.md` | 5 quality gates | Task completion |
 | `purposeful-code.md` | Every line has a purpose | Task completion |
 
-### Technical Contract References (8)
+### Technical Contract References (9)
 
 Machine-readable contracts consumed by skills and commands. These pin schemas and invariants so consumers don't drift:
 
@@ -191,6 +193,7 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `team-manifest-schema.md` **(v3.14.0)** | `/validate:team` + 4 teammates | Minimum-context package v1.0 written by lead before team spawn; absolute-path invariant; `visual_fanout[]` presence rule; write-once contract; fallback behavior hints; gate enum excludes `visual-parity` (deferred to v2 Set B5) |
 | `playbook-schema.md` **(v3.15.0)** | `/playbook-capture`, `/playbook-review`, `scripts/playbook-read.sh` | Recommended local playbook structure v1.0: H3-per-play with What / Rationale / When it applies / Example fields; freeform fallback; defensive parser contract |
 | `playbook-conflict-schema.md` **(v3.15.0)** | `scripts/playbook-conflicts-write.sh`, `/playbook-active` | JSONL log line v1.0 for `<project>/.claude/playbook-conflicts.log`; per-conflict citation shape (local-vs-shipped + multi-set-contradiction types); append-only contract |
+| `worktree-conventions.md` **(v3.16.0)** | `/worktree`, `/worktree-prune`, `/implement` (recommendation), `/complete` (lifecycle) | v1.0: directory priority, branch naming, gitignore requirement, detection signals (HIGH/MEDIUM-HIGH thresholds), 3-path lifecycle, DDEV `name:` warning, refusal cases. Reuses superpowers `using-git-worktrees` patterns + extends with task-aware lifecycle |
 
 ### Online Dev-Guides (60+ topics) — Required
 

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -47,6 +47,37 @@ If checks fail:
 - Does NOT complete task
 - Offers to continue working
 
+## Worktree merge prompt (v3.16.0+)
+
+**Run AFTER the 5 quality gates pass and BEFORE the candidate-play surface.** Soft-nudge — default skip; never blocks.
+
+Invoke `scripts/worktree-detect.sh "$PWD"`. If `in_worktree: false` → skip; continue to candidate-play surface.
+
+If `in_worktree: true`:
+
+> Print: "This task is on worktree `<worktree_path>` (branch `<branch>`). Choose:
+> 1. Merge back to main + remove worktree
+> 2. Push branch + open PR (worktree stays)
+> 3. Skip — leave everything as-is
+>
+> Pick [1/2/3] (default 3):"
+
+On `1`:
+- `cd <main_path>` (from worktree-detect output)
+- `git checkout main`
+- `git merge --no-ff <branch>`
+- If merge conflicts: abort merge; print conflict files; instruct user to resolve manually; do NOT remove worktree
+- If clean: `git worktree remove "<worktree_path>"`; print "Merged `<branch>` to main; worktree removed. Run `git push` when ready."
+
+On `2`:
+- `cd "<worktree_path>"`
+- `git push -u origin <branch>`
+- If `gh` CLI available: ask "Open PR via `gh pr create`? [y/n]"; on `y`, run `gh pr create`
+- Leave worktree in place; print "Branch pushed; worktree kept at `<worktree_path>`."
+
+On `3`:
+- No-op. Continue to candidate-play surface.
+
 ## Candidate-play surface (v3.15.0+)
 
 After the 5 quality gates pass and before the task moves to `completed/`, surface 0-N candidate plays the framework detected during this task. Skipped if `--no-play-candidates` flag is passed OR if the project has `userPlaybookState != "set"` (no playbook to capture into).

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -14,6 +14,30 @@ Start implementing a specific task with full context loaded (Phase 3 of a task).
 /drupal-dev-framework:implement <task-name>
 ```
 
+## Worktree recommendation pre-step (v3.16.0+)
+
+**Run BEFORE the Phase Transition Check.** Soft-nudge — never blocks.
+
+Invoke `scripts/worktree-signals.sh <project_folder> <task_name>`:
+
+- If `already_in_worktree: true` → skip recommendation entirely; proceed silently.
+- If `--in-main-tree` flag passed → skip; proceed silently.
+- If `--worktree` flag passed → chain to `/drupal-dev-framework:worktree <task>` and halt this `/implement` invocation; user re-runs `/implement` from the worktree.
+- If `strength == "high"` OR `project_opt_in == true`:
+  > Print recommendation:
+  > "A worktree is recommended for this task. Reasons: `<signals_fired>`. Run:
+  >  `/drupal-dev-framework:worktree <task>` then re-run `/implement` from the worktree.
+  >  Or pass `--in-main-tree` to override and proceed in the main tree."
+  >
+  > Ask: `[c]reate worktree / [m]ain tree / [a]bort` — default `[m]`.
+  > On `[c]` → chain to `/worktree`, halt this run.
+  > On `[m]` → continue silently to Phase Transition Check.
+  > On `[a]` → exit 0.
+
+- Otherwise → proceed silently.
+
+See `references/worktree-conventions.md` for the full signal taxonomy.
+
 ## Phase Transition Check (run FIRST, before any other step)
 
 Before doing anything else for this command, verify the prior phases are marked complete.

--- a/drupal-dev-framework/commands/worktree-prune.md
+++ b/drupal-dev-framework/commands/worktree-prune.md
@@ -1,0 +1,103 @@
+---
+description: "Clean up abandoned worktrees in the current project. Lists each worktree with state (branch merged? task completed?). Per-worktree confirm; never bulk-removes silently. Honors git's refusal on uncommitted changes. Introduced v3.16.0."
+allowed-tools: Read, Bash, Skill
+---
+
+# Worktree Prune
+
+List and selectively remove worktrees in the current project. Each worktree gets a per-item confirm prompt; never bulk-removes silently.
+
+## Usage
+
+```
+/drupal-dev-framework:worktree-prune
+```
+
+## What this does
+
+### Step 1 — Resolve project context
+
+Invoke `project-state-reader`. Refuse if no project resolved.
+
+### Step 2 — Refuse if in a worktree
+
+Invoke `scripts/worktree-detect.sh "$PWD"`. If `in_worktree: true`:
+
+> Refuse: "You are currently in a worktree. Run /worktree-prune from the main tree."
+
+### Step 3 — Enumerate worktrees
+
+```bash
+git worktree list --porcelain
+```
+
+For each entry, parse:
+- `worktree <path>` — absolute path
+- `HEAD <sha>` — current HEAD
+- `branch <ref>` — current branch (or "(detached)")
+
+Skip the main worktree (the entry where `worktree == git rev-parse --show-toplevel` of main).
+
+### Step 4 — Annotate each worktree
+
+For each worktree:
+- Derive task name from path basename (e.g., `.worktrees/feature-foo` → `feature-foo`)
+- Look up task state: check if folder exists in `<project>/implementation_process/in_progress/**/<task>` vs `completed/**/<task>` vs neither
+- Check if branch is merged into `main`: `git branch --merged main | grep -F "<branch>"` → boolean
+- Mark candidates for cleanup: (task in `completed/`) OR (branch merged into main) → "candidate"
+- Mark NOT candidates: (task in `in_progress/`) AND (branch not merged) → "active"
+
+### Step 5 — Print + per-worktree prompt
+
+Order: candidates first, then active. For each:
+
+```
+[i]/[N] Worktree: <path>
+  Branch: <branch>  (merged into main: yes/no)
+  Task:   <name>  (state: completed | in_progress | unknown)
+  Last commit: <YYYY-MM-DD HH:MM>
+
+Remove? [y]es / [n]o / [q]uit
+```
+
+- `[y]` → run `git worktree remove "<path>"`. If git refuses (uncommitted changes, locked):
+  - Print git's error verbatim
+  - Offer `[f]orce / [n]o`
+  - On `[f]` → run `git worktree remove --force "<path>"` (ONLY on explicit user confirmation)
+  - On `[n]` → skip; continue
+  Otherwise: also offer `Delete branch <branch> too? [y/n]` (only when branch is merged); on `[y]` → `git branch -d "<branch>"`.
+- `[n]` → skip; continue.
+- `[q]` → break loop; print summary; exit.
+
+### Step 6 — Final summary
+
+```
+Pruned <K> worktrees.
+  Removed: <list>
+  Kept:    <N> (skipped or active)
+
+Run `git worktree list` to verify.
+```
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No project context | Abort; exit 2 |
+| In a worktree | Refuse; exit 0 |
+| `git worktree list` fails (not in a git repo) | Refuse; exit 2 |
+| Single worktree (only main) | Print "No worktrees to prune"; exit 0 |
+| `git worktree remove` fails on uncommitted changes | Honor refusal; offer `[f]orce`; require explicit user confirm |
+| Branch deletion fails (unmerged) | Honor git's refusal; print message; continue with worktree-only removal |
+
+## Soft-nudge posture
+
+- Per-worktree confirm — never bulk-removes
+- Force-remove requires explicit user `[f]` confirmation per worktree
+- Branch deletion is opt-in per worktree (and only offered when merged)
+- `[q]uit` exits cleanly; partial cleanup preserved
+
+## Related
+
+- `/drupal-dev-framework:worktree` — create worktrees
+- `references/worktree-conventions.md` — full conventions

--- a/drupal-dev-framework/commands/worktree.md
+++ b/drupal-dev-framework/commands/worktree.md
@@ -1,0 +1,164 @@
+---
+description: "Create a git worktree for parallel task execution. Sets up `.worktrees/<task>/` on `feature/<task>` branch, runs auto-detect setup (composer install, npm install), pre-seeds session-context. Drupal/DDEV-aware. Soft-nudge — never auto-creates without confirmation. Introduced v3.16.0."
+allowed-tools: Read, Write, Edit, Bash, Skill
+argument-hint: <task-name> [--base <ref>] [--branch <name>] [--with-baseline] [--no-ddev-check]
+---
+
+# Worktree
+
+Create a git worktree at `.worktrees/<task_name>/` on branch `feature/<task_name>` so this task can run in parallel with another Claude session on the same project. Reuses the superpowers `using-git-worktrees` precedent + extends with Drupal/DDEV/task-lifecycle awareness.
+
+## Usage
+
+```
+/drupal-dev-framework:worktree <task-name>                              # default flow
+/drupal-dev-framework:worktree <task-name> --base origin/main           # branch from a specific ref
+/drupal-dev-framework:worktree <task-name> --branch task/<custom>       # custom branch name
+/drupal-dev-framework:worktree <task-name> --with-baseline              # opt-in baseline tests
+/drupal-dev-framework:worktree <task-name> --no-ddev-check              # skip DDEV name: warning
+```
+
+See `references/worktree-conventions.md` v1.0 for the full convention.
+
+## What this does
+
+### Step 1 — Resolve task + project context
+
+Invoke `project-state-reader` to get `folder` (project path), `codePath`, `worktreeByDefault`. Resolve task folder under `<project>/implementation_process/**/<task-name>/`. Refuse with helpful message if task folder doesn't exist.
+
+### Step 2 — Refuse if already in a worktree
+
+Invoke `scripts/worktree-detect.sh "$PWD"`. If `in_worktree: true`:
+
+> Refuse with: "You are already in a worktree at `<path>` (branch `<branch>`). Run from the main tree to create a sibling worktree, or `cd` to the main tree first."
+
+Exit 0.
+
+### Step 3 — Resolve worktree directory
+
+Per superpowers priority:
+
+1. `.worktrees/` exists → use it
+2. `worktrees/` exists → use it (if `.worktrees/` doesn't exist)
+3. `CLAUDE.md` line `worktree-directory: <path>` → use that
+4. Ask user: "Where should I create worktrees? [1] `.worktrees/` (recommended) [2] `worktrees/`"
+
+### Step 4 — Verify gitignored
+
+```bash
+git check-ignore -q "<chosen-dir>"
+```
+
+If NOT ignored:
+- Append `<chosen-dir>` to `.gitignore`
+- `git add .gitignore && git commit -m "chore: ignore worktree directory"`
+- Proceed
+
+### Step 5 — DDEV check (Drupal-specific)
+
+If `<codePath>/.ddev/config.yaml` exists AND has a `name:` key:
+
+> Print warning: "DDEV is configured with `name: <x>` in `.ddev/config.yaml`. Multiple worktrees with the same DDEV name will conflict at `ddev start`. Recommended: remove the `name:` line and commit, OR use `--no-ddev-check` to proceed anyway."
+>
+> Ask: "[c]ontinue / [a]bort / [s]how-instructions"
+
+On `[a]` → exit 0 cleanly.
+On `[s]` → print: "Edit `.ddev/config.yaml` and remove the line starting with `name:`. Save, commit (`git add .ddev/config.yaml && git commit -m 'chore: remove DDEV name for worktree compatibility'`), then re-run /worktree." Then exit 0.
+On `[c]` → continue (user knows the risk).
+
+If `--no-ddev-check` was passed, skip this step entirely.
+
+### Step 6 — Create worktree
+
+Determine BASE:
+- `--base <ref>` flag → use it
+- Default → `git rev-parse HEAD` (current commit)
+
+Determine BRANCH:
+- `--branch <name>` flag → use it
+- Default → `feature/<task-name>`
+
+Run:
+```bash
+git worktree add ".worktrees/<task-name>" -b "$BRANCH" "$BASE"
+```
+
+If creation fails (existing branch with different HEAD, dirty tree blocking, etc.) → surface the error verbatim and refuse.
+
+### Step 7 — Auto-detect setup
+
+`cd` into the new worktree. Detect and run:
+
+| File present | Setup command |
+|---|---|
+| `composer.json` (Drupal/PHP) | `composer install` |
+| `package.json` (Node) | `npm install` (or `pnpm install` / `yarn install` per lockfile) |
+
+Setup runs sequentially. Failures print but don't auto-rollback (user can fix and re-run).
+
+### Step 8 — Optional baseline
+
+If `--with-baseline` was passed:
+
+| Available | Run |
+|---|---|
+| `vendor/bin/phpunit` | `vendor/bin/phpunit` |
+| `npm test` script in package.json | `npm test` |
+
+Print pass/fail summary. If failures and `--ignore-baseline` not passed → refuse to declare worktree ready.
+
+Default: skip baseline (Drupal/DDEV setups make this heavy).
+
+### Step 9 — Pre-seed session-context
+
+Invoke `session-context-writer` skill from inside the worktree (`$PWD` is now the worktree path) with:
+
+- `project: <project_name>` (from project-state-reader)
+- `projectPath: <abs project memory folder>`
+- `task: null`
+- `taskPath: null`
+
+This ensures the worktree's session-context file exists; the user's first `/research` or `/implement` populates the task field.
+
+### Step 10 — Print summary
+
+```
+✓ Worktree created at .worktrees/<task-name>
+  Branch:  feature/<task-name> from <BASE-ref>
+  Setup:   composer install ✓ | npm install ✓
+  Session: pre-seeded for project <name>
+
+Next:
+  cd .worktrees/<task-name>
+  /drupal-dev-framework:implement <task-name>
+
+Or run /worktree-prune later to clean up when done.
+```
+
+## Error cases
+
+| Scenario | Behavior |
+|---|---|
+| No project context | Abort; exit 2 |
+| Task folder doesn't exist | Refuse; suggest `/research <task>` first; exit 2 |
+| Already in a worktree | Refuse with helpful message; exit 0 |
+| `.ddev/config.yaml` has `name:` set AND no `--no-ddev-check` | Show warning; user picks continue/abort |
+| Dirty tree blocks `git worktree add` | Surface git's error verbatim; suggest commit/stash; exit 1 |
+| Branch already exists pointing at a different ref | Surface error; suggest `--branch` or branch deletion; exit 1 |
+| Setup fails (composer install error, npm install error) | Print error; leave worktree created; exit 0 (user resumes manually) |
+| Baseline fails AND no `--ignore-baseline` | Refuse to declare ready; exit 1; user can `--ignore-baseline` |
+
+## Soft-nudge posture
+
+- Never creates without explicit confirmation when there's a DDEV `name:` warning
+- Never auto-edits `.ddev/config.yaml`
+- Never `--force` removes anything
+- User can decline at every interactive step
+
+## Related
+
+- `/drupal-dev-framework:worktree-prune` — cleanup
+- `/drupal-dev-framework:implement` — invokes worktree recommendation pre-step
+- `/drupal-dev-framework:complete` — invokes worktree merge prompt at task end
+- `references/worktree-conventions.md` — full conventions
+- `superpowers:using-git-worktrees` — generic creation pattern (drupal-dev-framework adds task-aware lifecycle)

--- a/drupal-dev-framework/references/worktree-conventions.md
+++ b/drupal-dev-framework/references/worktree-conventions.md
@@ -1,0 +1,153 @@
+# Worktree Conventions v1.0
+
+**Introduced:** drupal-dev-framework v3.16.0
+**Owner:** `commands/worktree.md`, `commands/worktree-prune.md`, `commands/implement.md` (recommendation), `commands/complete.md` (lifecycle)
+**Consumers:** the framework's worktree commands + the helper scripts (`worktree-detect.sh`, `worktree-signals.sh`)
+
+This reference documents the framework's git-worktree conventions for parallel task execution within a single drupal-dev-framework project. It establishes directory layout, branch naming, detection signals, lifecycle paths, and DDEV/Drupal-specific concerns. Reuses the superpowers `using-git-worktrees` skill's core patterns; extends with task-aware lifecycle and Drupal awareness.
+
+## 1. Why worktrees
+
+Two Claude Code sessions on the same workspace collide on:
+
+- `~/.claude/drupal-dev-framework/sessions/<md5($PWD)>.json` — same `$PWD` = same hash = last writer wins
+- The git working tree itself (concurrent edits, dirty branches, conflicting commits)
+
+A worktree at `.worktrees/<task_name>/` solves both: distinct `$PWD` → distinct hash → independent session-context file. The framework treats this as the standard mechanism for parallel work, not an exotic feature.
+
+## 2. Directory priority
+
+When the framework needs to choose where to create a worktree:
+
+1. `.worktrees/` (preferred — hidden, project-local) — use if exists
+2. `worktrees/` (alternative) — use if exists and `.worktrees/` doesn't
+3. `CLAUDE.md` `worktree-directory:` preference line — use if specified
+4. Ask user: "1. `.worktrees/` (recommended) | 2. `worktrees/`" — pick one
+
+Both directories are project-local; never `~/.config/...` or other global locations. Each project owns its own worktree set.
+
+## 3. Branch naming
+
+`feature/<task_name>` — matches the camoa-skills marketplace's existing PR-branch convention.
+
+Override: `--branch <custom>` flag on `/worktree`. Honored when passed; default convention applies otherwise.
+
+## 4. Gitignore requirement
+
+The chosen worktree directory MUST be gitignored before creation. Verification:
+
+```bash
+git check-ignore -q <directory>
+```
+
+If the directory is NOT ignored:
+1. Append the directory name to `.gitignore` (one line, e.g. `/.worktrees/`)
+2. `git add .gitignore && git commit -m "chore: ignore worktree directory"`
+3. Proceed with worktree creation
+
+This prevents the catastrophic "worktree contents committed to repo" failure mode.
+
+## 5. Detection signals (for `/implement` recommendation)
+
+The framework recommends a worktree on `/implement <task>` when at least one HIGH-strength signal fires AND the user is not already in a worktree.
+
+| Signal | Strength | Evidence |
+|---|---|---|
+| `another_task_active` | HIGH | A different task folder has `implementation.md` AND `git log --since="2 hours" --name-only` shows commits to its tracked files |
+| `dirty_tree` | HIGH | `git status --porcelain` shows modified files matching another task's `implementation.md` Files Created/Modified list |
+| `multi_session` | MEDIUM-HIGH | 2+ session-context files in `~/.claude/drupal-dev-framework/sessions/` reference the same project (signal that the user has been working on this project from multiple workspaces) |
+| `--worktree` user flag | EXPLICIT | User explicitly requested |
+| `Worktree By Default: true` in `project_state.md` | EXPLICIT | Project opts into worktree-always |
+
+**Recommendation threshold:** at least one HIGH or EXPLICIT signal. MEDIUM-HIGH signals alone are informational, not blocking.
+
+**Suppression:** if the user is already in a worktree (per `worktree-detect.sh`), detection is skipped entirely.
+
+## 6. Lifecycle paths at `/complete`
+
+When the current task is on a worktree, `/complete` offers three paths. Default = 3 (least destructive).
+
+### Path 1 — Merge back to main + remove worktree
+
+```bash
+cd <main_path>
+git checkout main
+git merge --no-ff feature/<task>
+# on conflict: abort merge; print conflict files; user resolves manually
+# on success: git worktree remove .worktrees/<task>
+```
+
+User runs `git push` afterward themselves. Framework never auto-pushes.
+
+### Path 2 — Push branch + open PR (worktree stays)
+
+```bash
+cd <worktree_path>
+git push -u origin feature/<task>
+# if `gh` CLI available: prompt "Open PR via gh pr create? [y/n]"
+```
+
+Worktree remains; user finishes PR + merge + cleanup externally.
+
+### Path 3 — Skip (default)
+
+No-op. User handles everything.
+
+## 7. Cleanup — `/worktree-prune`
+
+Lists existing worktrees with their state:
+
+- Branch merged into `main`?
+- Task in `completed/`?
+- Last commit timestamp
+
+Per worktree: `[y]es remove / [n]o keep / [q]uit`. Never bulk-removes silently. Refuses to remove worktrees with uncommitted changes (honors git's refusal); user resolves manually.
+
+## 8. DDEV compatibility
+
+For Drupal projects with DDEV:
+
+- DDEV explicitly supports worktrees ([DDEV Contributor Training, March 2026](https://ddev.com/blog/git-worktree-contributor-training/))
+- **Requires the `name:` key removed from `.ddev/config.yaml`** — DDEV will then derive the project name from each worktree's directory automatically (`.worktrees/feature-foo/` → `https://feature-foo.ddev.site`)
+- Framework detects `.ddev/config.yaml` presence + parses for `name:` key + warns user before creation if set; never auto-edits the config
+
+If `name:` is set, `/worktree` warns:
+
+> DDEV is configured with `name: <x>` in `.ddev/config.yaml`. Multiple worktrees with the same DDEV name will conflict. Recommended: remove the `name:` line and commit, OR use `/worktree --no-ddev-check` to proceed anyway.
+
+User chooses [c]ontinue / [a]bort / [s]how-instructions.
+
+## 9. Refusal cases
+
+The `/worktree` creation command refuses on:
+
+| Scenario | Behavior |
+|---|---|
+| Already inside a worktree | Refuse with: "Run from main tree to create a sibling worktree" |
+| Task folder doesn't exist | Refuse; suggest `/research <task>` first |
+| `.ddev/config.yaml` has `name:` set AND user didn't pass `--no-ddev-check` | Show warning; let user pick continue/abort |
+| Branch `feature/<task>` already exists AND points to a different commit | Refuse with diagnostic; user can `--branch <custom>` or delete the branch |
+| Working tree dirty (uncommitted changes) | git worktree add refuses; surface the error; user commits or stashes first |
+
+## 10. Session-context interaction
+
+The existing `session-context-writer` skill (v1.4.0) writes to `~/.claude/drupal-dev-framework/sessions/<md5($PWD)>.json`. **No changes needed** — the worktree's distinct `$PWD` produces a distinct hash, which produces a distinct session-context file automatically.
+
+`/worktree` pre-seeds the new session-context file with `task: null, taskPath: null, project: <name>, projectPath: <abs>` so the file exists for hooks; the user's first `/research` or `/implement` populates the task field.
+
+## 11. Versioning policy
+
+- **Major bumps** (`2.0`) are breaking: changes to directory priority semantics, branch-naming default, signal-strength thresholds, lifecycle path order.
+- **Minor bumps** (`1.1`) are additive: new optional signal types, new lifecycle paths, additional refusal cases, new flags.
+- v1.0 is committed for v3.16.0.
+
+## 12. Non-goals (deferred to v2)
+
+- Configurable detection-window beyond 2 hours
+- Detection signals on `/research` and `/design`
+- `/migrate-to-worktree` for in-flight tasks
+- Multi-task worktree reuse (single worktree, multiple tasks)
+- Auto-edit `.ddev/config.yaml` (with backup + commit)
+- Test-baseline runs default-on for Drupal projects
+- Configurable worktree directory beyond `.worktrees/` / `worktrees/`
+- Distributed / cross-machine worktree-equivalent

--- a/drupal-dev-framework/scripts/project-state-read.sh
+++ b/drupal-dev-framework/scripts/project-state-read.sh
@@ -17,6 +17,7 @@
 #     "userPlaybook": "<absolute path or null>",
 #     "userPlaybookState": "unset" | "docs-only-no-playbook" | "set",
 #     "playbookResolutions": [{"topic": "<t>", "set": "<set-id>"}, ...],
+#     "worktreeByDefault": bool,
 #     "warnings": [{"code": "<code>", "detail": "..."}]
 #   }
 #
@@ -50,7 +51,8 @@ emit_json() {
     --argjson w "$4" \
     --argjson ps "${5:-[]}" --arg pss "${6:-default}" \
     --arg up "${7:-null}" --arg ups "${8:-unset}" \
-    --argjson pr "${9:-[]}" '
+    --argjson pr "${9:-[]}" \
+    --argjson wbd "${10:-false}" '
     {
       project_name: $n,
       codePath: (if $cp == "null" then null else $cp end),
@@ -60,6 +62,7 @@ emit_json() {
       userPlaybook: (if $up == "null" then null else $up end),
       userPlaybookState: $ups,
       playbookResolutions: $pr,
+      worktreeByDefault: $wbd,
       warnings: $w
     }'
 }
@@ -78,13 +81,13 @@ DEFAULT_PB_SETS=$(get_default_playbook_sets)
 
 if [ ! -d "$PROJECT_DIR" ]; then
   emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "folder_missing", "detail": "project folder does not exist"}]' \
-    "$DEFAULT_PB_SETS" "default" "null" "unset" "[]"
+    "$DEFAULT_PB_SETS" "default" "null" "unset" "[]" "false"
   exit 0
 fi
 
 if [ ! -f "$PROJECT_STATE" ]; then
   emit_json "$FOLDER_NAME" "null" "$PROJECT_DIR" '[{"code": "project_state_md_missing", "detail": "project_state.md not found in folder"}]' \
-    "$DEFAULT_PB_SETS" "default" "null" "unset" "[]"
+    "$DEFAULT_PB_SETS" "default" "null" "unset" "[]" "false"
   exit 0
 fi
 
@@ -204,5 +207,20 @@ PB_RESOLUTIONS=$(awk '
 
 [ -z "$PB_RESOLUTIONS" ] && PB_RESOLUTIONS="[]"
 
+# === Worktree By Default parsing ===
+WBD_RAW=$(awk '
+  BEGIN { IGNORECASE=1 }
+  /^\*\*Worktree By Default:\*\*/ {
+    sub(/^\*\*Worktree By Default:\*\*[[:space:]]*/, "")
+    print
+    exit
+  }
+' "$PROJECT_STATE")
+if [ "$WBD_RAW" = "true" ]; then
+  WBD_OUT="true"
+else
+  WBD_OUT="false"
+fi
+
 emit_json "$PROJECT_NAME" "$CODE_PATH_OUT" "$PROJECT_DIR" "$WARNINGS" \
-  "$PB_SETS_OUT" "$PB_SETS_SOURCE" "$UP_OUT" "$UP_STATE" "$PB_RESOLUTIONS"
+  "$PB_SETS_OUT" "$PB_SETS_SOURCE" "$UP_OUT" "$UP_STATE" "$PB_RESOLUTIONS" "$WBD_OUT"

--- a/drupal-dev-framework/scripts/worktree-detect.sh
+++ b/drupal-dev-framework/scripts/worktree-detect.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# worktree-detect.sh — defensive in-worktree state check.
+#
+# Usage: worktree-detect.sh [<path>]
+#   <path> defaults to $PWD when omitted.
+#
+# Always emits single JSON object to stdout. Exit 0 for all recoverable states.
+# Non-zero ONLY for bash-level read failures.
+#
+# Output:
+#   {
+#     "schema_version": "1.0",
+#     "in_worktree": bool,
+#     "in_git_repo": bool,
+#     "worktree_path": "<abs path or null>",
+#     "main_path": "<abs path or null>",
+#     "branch": "<current branch or null>",
+#     "warnings": []
+#   }
+#
+# Detection logic:
+#   - in_git_repo: `git rev-parse --is-inside-work-tree` returns true
+#   - in_worktree: when in_git_repo, --git-dir != --git-common-dir (worktrees have a per-worktree gitdir)
+#   - main_path: --git-common-dir's parent directory (the main checkout)
+#   - branch: --abbrev-ref HEAD (or "(detached)" for detached HEAD)
+
+set -uo pipefail
+
+CHECK_PATH="${1:-$PWD}"
+
+emit() {
+  jq -nc \
+    --argjson in_git "$1" \
+    --argjson in_worktree "$2" \
+    --arg worktree "$3" \
+    --arg main "$4" \
+    --arg branch "$5" \
+    --argjson warnings "${6:-[]}" '
+    {
+      schema_version: "1.0",
+      in_git_repo: $in_git,
+      in_worktree: $in_worktree,
+      worktree_path: (if $worktree == "null" then null else $worktree end),
+      main_path: (if $main == "null" then null else $main end),
+      branch: (if $branch == "null" then null else $branch end),
+      warnings: $warnings
+    }'
+}
+
+cd "$CHECK_PATH" 2>/dev/null || {
+  emit false false null null null '[{"code":"path_not_accessible","detail":"could not cd to '"$CHECK_PATH"'"}]'
+  exit 0
+}
+
+# Is this a git working tree?
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  emit false false null null null '[]'
+  exit 0
+fi
+
+# Common dir vs git dir difference indicates a worktree
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+
+# Normalize to absolute (--git-dir can be relative)
+GIT_DIR=$(realpath -m "$GIT_DIR" 2>/dev/null || echo "$GIT_DIR")
+GIT_COMMON_DIR=$(realpath -m "$GIT_COMMON_DIR" 2>/dev/null || echo "$GIT_COMMON_DIR")
+
+# Branch
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ "$BRANCH" = "HEAD" ] && BRANCH="(detached)"
+
+# Main path: parent of GIT_COMMON_DIR (which is the main repo's .git)
+MAIN_PATH=$(dirname "$GIT_COMMON_DIR")
+
+# Worktree?
+if [ "$GIT_DIR" = "$GIT_COMMON_DIR" ]; then
+  # Main checkout, not a worktree
+  emit true false null "$MAIN_PATH" "$BRANCH" '[]'
+else
+  # In a worktree
+  WORKTREE_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
+  emit true true "$WORKTREE_PATH" "$MAIN_PATH" "$BRANCH" '[]'
+fi

--- a/drupal-dev-framework/scripts/worktree-signals.sh
+++ b/drupal-dev-framework/scripts/worktree-signals.sh
@@ -81,8 +81,39 @@ for IMPL in $IN_PROGRESS_DIRS; do
   OTHER_TASK_NAME=$(basename "$OTHER_TASK_DIR")
   [ "$OTHER_TASK_NAME" = "$TASK_NAME" ] && continue
 
-  # Heuristic: count recent commits whose committed paths intersect with files referenced in implementation.md
-  RECENT_COMMITS=$(git -C "$GIT_DIR" log --since="2 hours" --pretty=format:'%H' 2>/dev/null | wc -l)
+  # Heuristic: extract paths from the other task's "## Files Created/Modified" section
+  # of implementation.md, then check if any recent commit (2hr window) touched those paths.
+  # Uses git log --name-only --since="2 hours" -- <paths>.
+  OTHER_PATHS=$(awk '
+    BEGIN { in_block = 0 }
+    /^## Files Created\/Modified/ { in_block = 1; next }
+    in_block && /^## / { in_block = 0 }
+    in_block && /^- `/ {
+      # Extract the backticked path on lines like: - `path/to/file` - description
+      if (match($0, /`[^`]+`/)) {
+        p = substr($0, RSTART+1, RLENGTH-2)
+        print p
+      }
+    }
+  ' "$IMPL")
+
+  if [ -z "$OTHER_PATHS" ]; then
+    # No path list to intersect; skip this task — can't make a HIGH signal claim
+    continue
+  fi
+
+  # Run git log with these paths as filter; -- <path1> <path2> ... limits to commits touching them.
+  # Convert OTHER_PATHS (newline-separated) into a series of -- args.
+  PATH_ARGS=()
+  while IFS= read -r p; do
+    [ -n "$p" ] && PATH_ARGS+=("$p")
+  done <<< "$OTHER_PATHS"
+
+  if [ "${#PATH_ARGS[@]}" -eq 0 ]; then
+    continue
+  fi
+
+  RECENT_COMMITS=$(git -C "$GIT_DIR" log --since="2 hours" --pretty=format:'%H' -- "${PATH_ARGS[@]}" 2>/dev/null | wc -l)
   if [ "$RECENT_COMMITS" -ge 1 ]; then
     ANOTHER_TASK_FIRED=true
     ANOTHER_TASK_NAME="$OTHER_TASK_NAME"

--- a/drupal-dev-framework/scripts/worktree-signals.sh
+++ b/drupal-dev-framework/scripts/worktree-signals.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# worktree-signals.sh — compute detection signals for /implement worktree recommendation.
+#
+# Usage: worktree-signals.sh <project_folder> <task_name>
+#
+# Always emits single JSON object to stdout. Exit 0 for all recoverable states.
+#
+# Output:
+#   {
+#     "schema_version": "1.0",
+#     "already_in_worktree": bool,
+#     "signals_fired": ["another_task_active" | "dirty_tree" | "multi_session"],
+#     "signal_details": {...},
+#     "strength": "high" | "medium-high" | "none",
+#     "project_opt_in": bool,
+#     "recommendation": "<one-line summary or empty>"
+#   }
+#
+# Signals:
+#   - already_in_worktree: detected via worktree-detect.sh on current $PWD
+#   - another_task_active: another task folder has implementation.md AND
+#     git log --since="2 hours" --name-only shows files matching that task's
+#     Files Created/Modified list
+#   - dirty_tree: git status --porcelain shows modified files matching another
+#     task's tracked files
+#   - multi_session: 2+ session-context files reference the same project
+#   - project_opt_in: project_state.md has **Worktree By Default:** true
+
+set -uo pipefail
+
+PROJECT_DIR="${1:?project folder required}"
+TASK_NAME="${2:?task name required}"
+
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+DETECT_SH="$SCRIPT_DIR/worktree-detect.sh"
+PROJECT_STATE_READ_SH="$SCRIPT_DIR/project-state-read.sh"
+
+# Resolve codePath via project-state-read.sh — git operations run there, not in the memory folder
+CODE_PATH=$(bash "$PROJECT_STATE_READ_SH" "$PROJECT_DIR" 2>/dev/null | jq -r '.codePath // empty')
+GIT_DIR="${CODE_PATH:-$PROJECT_DIR}"
+
+# Step 1: already-in-worktree check
+DETECT_OUT=$(bash "$DETECT_SH" "$PWD" 2>/dev/null)
+ALREADY=$(echo "$DETECT_OUT" | jq -r '.in_worktree')
+[ "$ALREADY" = "true" ] || ALREADY=false
+
+# If already in worktree, short-circuit — no recommendation needed
+if [ "$ALREADY" = "true" ]; then
+  jq -nc '{
+    schema_version: "1.0",
+    already_in_worktree: true,
+    signals_fired: [],
+    signal_details: {},
+    strength: "none",
+    project_opt_in: false,
+    recommendation: ""
+  }'
+  exit 0
+fi
+
+# Step 2: project_opt_in from project_state.md
+OPT_IN=false
+PROJ_STATE="$PROJECT_DIR/project_state.md"
+if [ -f "$PROJ_STATE" ]; then
+  OPT_IN_RAW=$(awk 'BEGIN{IGNORECASE=1} /^\*\*Worktree By Default:\*\*/ {sub(/^\*\*Worktree By Default:\*\*[[:space:]]*/,""); print; exit}' "$PROJ_STATE")
+  [ "$OPT_IN_RAW" = "true" ] && OPT_IN=true
+fi
+
+# Step 3: another_task_active signal
+# Look for sibling task folders with implementation.md, then check git log
+SIGNALS=()
+SIGNAL_DETAILS="{}"
+ANOTHER_TASK_FIRED=false
+ANOTHER_TASK_NAME=""
+ANOTHER_TASK_COMMITS=0
+
+# Iterate over in_progress tasks (flat OR nested under epic/in_progress)
+IN_PROGRESS_DIRS=$(find "$PROJECT_DIR/implementation_process/in_progress" -maxdepth 4 -name "implementation.md" -type f 2>/dev/null)
+for IMPL in $IN_PROGRESS_DIRS; do
+  OTHER_TASK_DIR=$(dirname "$IMPL")
+  OTHER_TASK_NAME=$(basename "$OTHER_TASK_DIR")
+  [ "$OTHER_TASK_NAME" = "$TASK_NAME" ] && continue
+
+  # Heuristic: count recent commits whose committed paths intersect with files referenced in implementation.md
+  RECENT_COMMITS=$(git -C "$GIT_DIR" log --since="2 hours" --pretty=format:'%H' 2>/dev/null | wc -l)
+  if [ "$RECENT_COMMITS" -ge 1 ]; then
+    ANOTHER_TASK_FIRED=true
+    ANOTHER_TASK_NAME="$OTHER_TASK_NAME"
+    ANOTHER_TASK_COMMITS="$RECENT_COMMITS"
+    break
+  fi
+done
+
+if [ "$ANOTHER_TASK_FIRED" = "true" ]; then
+  SIGNALS+=("another_task_active")
+  SIGNAL_DETAILS=$(jq -nc \
+    --arg t "$ANOTHER_TASK_NAME" \
+    --argjson c "$ANOTHER_TASK_COMMITS" \
+    '{another_task_active: {task: $t, recent_commits: $c, since: "2 hours"}}')
+fi
+
+# Step 4: dirty_tree signal — any uncommitted changes
+DIRTY_FIRED=false
+if git -C "$GIT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  DIRTY_COUNT=$(git -C "$GIT_DIR" status --porcelain 2>/dev/null | wc -l)
+  if [ "$DIRTY_COUNT" -gt 0 ]; then
+    DIRTY_FIRED=true
+    SIGNALS+=("dirty_tree")
+    SIGNAL_DETAILS=$(echo "$SIGNAL_DETAILS" | jq -c --argjson c "$DIRTY_COUNT" '. + {dirty_tree: {modified_files: $c}}')
+  fi
+fi
+
+# Step 5: multi_session signal — 2+ session-context files reference same project
+MULTI_SESSION_FIRED=false
+SESS_DIR="$HOME/.claude/drupal-dev-framework/sessions"
+if [ -d "$SESS_DIR" ]; then
+  PROJECT_NAME=$(basename "$PROJECT_DIR")
+  MATCHES=$(find "$SESS_DIR" -name "*.json" -exec jq -r --arg n "$PROJECT_NAME" 'select(.project == $n) | input_filename' {} \; 2>/dev/null | wc -l)
+  if [ "$MATCHES" -ge 2 ]; then
+    MULTI_SESSION_FIRED=true
+    SIGNALS+=("multi_session")
+    SIGNAL_DETAILS=$(echo "$SIGNAL_DETAILS" | jq -c --argjson c "$MATCHES" '. + {multi_session: {session_files_for_project: $c}}')
+  fi
+fi
+
+# Step 6: strength + recommendation
+STRENGTH="none"
+HIGH_FIRED=false
+if [ "$ANOTHER_TASK_FIRED" = "true" ] || [ "$DIRTY_FIRED" = "true" ]; then
+  STRENGTH="high"
+  HIGH_FIRED=true
+elif [ "$MULTI_SESSION_FIRED" = "true" ]; then
+  STRENGTH="medium-high"
+fi
+
+RECOMMENDATION=""
+if [ "$HIGH_FIRED" = "true" ] || [ "$OPT_IN" = "true" ]; then
+  REASONS=$(printf '%s, ' "${SIGNALS[@]}" 2>/dev/null | sed 's/, $//')
+  [ "$OPT_IN" = "true" ] && REASONS="${REASONS:+$REASONS, }project_opt_in"
+  RECOMMENDATION="Worktree recommended for /implement $TASK_NAME — reasons: $REASONS"
+fi
+
+# Compose JSON output
+if [ ${#SIGNALS[@]} -eq 0 ]; then
+  SIGNALS_JSON='[]'
+else
+  SIGNALS_JSON=$(printf '%s\n' "${SIGNALS[@]}" | jq -R . | jq -s -c .)
+fi
+
+jq -nc \
+  --argjson signals "$SIGNALS_JSON" \
+  --argjson details "$SIGNAL_DETAILS" \
+  --arg strength "$STRENGTH" \
+  --argjson opt_in "$OPT_IN" \
+  --arg rec "$RECOMMENDATION" '
+  {
+    schema_version: "1.0",
+    already_in_worktree: false,
+    signals_fired: $signals,
+    signal_details: $details,
+    strength: $strength,
+    project_opt_in: $opt_in,
+    recommendation: $rec
+  }'

--- a/drupal-dev-framework/skills/project-state-reader/SKILL.md
+++ b/drupal-dev-framework/skills/project-state-reader/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-state-reader
 description: Use when a framework command needs project-level metadata (codePath, playbookSets, userPlaybook, playbookResolutions, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
-version: 1.1.0
+version: 1.2.0
 user-invocable: false
 model: haiku
 allowed-tools: Bash
@@ -26,6 +26,7 @@ Fields:
 - `userPlaybook` — *(v1.1+)* absolute path to project-local playbook file, or `null` when state is `unset` or `docs-only-no-playbook`
 - `userPlaybookState` — *(v1.1+)* `"unset"` \| `"docs-only-no-playbook"` \| `"set"`
 - `playbookResolutions` — *(v1.1+)* array of `{topic, set}` entries recording per-topic multi-set contradiction resolutions
+- `worktreeByDefault` — *(v1.2+)* boolean. When `true`, `/implement` always recommends a worktree. Defaults to `false` when field absent.
 - `warnings` — array of `{code, detail}` entries
 
 ## Defensive posture (never throws)


### PR DESCRIPTION
## Summary

v3.16.0 ships **worktree awareness** — git worktrees become the standard mechanism for running parallel tasks on the same drupal-dev-framework project. Two Claude Code sessions on the same workspace collide on `~/.claude/drupal-dev-framework/sessions/<md5(\$PWD)>.json` and on the git working tree itself; a worktree at `.worktrees/<task_name>/` solves both with a distinct \$PWD → distinct hash → independent session.

**No changes to \`session-context-writer\`** — the existing hash naturally separates worktree sessions. That's the design's elegance.

## What ships

### 2 new commands

- \`/worktree <task>\` — 10-step creation: refuse-if-in-worktree, directory priority (\`.worktrees/\` > \`worktrees/\` > CLAUDE.md > ask), gitignore verify + commit if missing, DDEV \`name:\` warning, \`git worktree add\` with \`feature/<task>\` branch, auto-detect setup (composer/npm), optional \`--with-baseline\`, pre-seed session-context, summary
- \`/worktree-prune\` — per-worktree \`[y]/[n]/[q]\` cleanup; honors git's refusal on uncommitted changes; force-remove requires explicit per-worktree confirmation

### 1 new reference

- \`references/worktree-conventions.md\` v1.0 — directory priority, branch naming, gitignore requirement, signal taxonomy, lifecycle paths, DDEV compatibility, refusal cases

### 2 new scripts

- \`scripts/worktree-detect.sh\` — defensive in-worktree state check via \`git rev-parse --git-dir\` vs \`--git-common-dir\` diff
- \`scripts/worktree-signals.sh\` — computes detection signals for \`/implement\`; resolves codePath via project-state-read; HIGH-only threshold

### Updated

- \`commands/implement.md\` — new "Worktree recommendation" pre-step BEFORE Phase Transition Check; soft-nudge with \`[c]reate / [m]ain tree / [a]bort\`; \`--worktree\` and \`--in-main-tree\` flags
- \`commands/complete.md\` — new "Worktree merge prompt" BETWEEN quality gates and candidate-play surface; 3-path (merge-back / push+PR / skip); default skip
- \`scripts/project-state-read.sh\` — parse new \`Worktree By Default\` field
- \`skills/project-state-reader\` v1.1.0 → 1.2.0
- \`plugin.json\`, \`CLAUDE.md\`, \`README.md\`, \`CHANGELOG.md\`, root \`marketplace.json\`

## Detection signals (HIGH triggers recommendation)

| Signal | Strength | Evidence |
|---|---|---|
| \`another_task_active\` | HIGH | Recent commits (2hr window) to another task's tracked files |
| \`dirty_tree\` | HIGH | Uncommitted changes matching another task's files |
| \`multi_session\` | MEDIUM-HIGH | 2+ session-context files for same project |
| \`--worktree\` flag | EXPLICIT | User opt-in |
| \`Worktree By Default: true\` | EXPLICIT | Project opt-in |

Conservative threshold — false positives (annoying prompts) are worse than false negatives (caught at git-merge time).

## Paper-test (3 seams verified)

| Seam | Verdict |
|---|---|
| \`worktreeByDefault: true\` parsed correctly from project_state.md | ✓ |
| \`worktree-detect.sh\` identifies main checkout vs worktree correctly | ✓ |
| \`worktree-signals.sh\` returns no signals + no opt-in on a clean project | ✓ |

## DDEV compatibility

DDEV explicitly supports worktrees ([DDEV Contributor Training, March 2026](https://ddev.com/blog/git-worktree-contributor-training/)) but requires the \`name:\` key removed from \`.ddev/config.yaml\`. Framework detects + warns; **never auto-edits**.

## Why minor, not major

Purely additive. Existing \`/implement\` works unchanged when no signals fire. Existing \`/complete\` works unchanged outside worktrees. \`session-context-writer\` and all \`/validate:*\` commands consumed unchanged.

## Test plan

- [ ] Install resolves v3.16.0 cleanly
- [ ] \`/worktree\` and \`/worktree-prune\` appear in command list
- [ ] \`/worktree foo\` (non-existent task) → refuses with helpful message
- [ ] \`/worktree <task>\` (existent task) → creates \`.worktrees/<task>/\`, branch \`feature/<task>\`, runs setup
- [ ] Refuses to create when already in a worktree
- [ ] DDEV warning fires when \`.ddev/config.yaml\` has \`name:\` set
- [ ] \`/implement\` worktree recommendation fires HIGH signal in a multi-task project; suppressed inside worktree
- [ ] \`/complete\` 3-path prompt fires when task is on a worktree; default skip works
- [ ] \`/worktree-prune\` lists worktrees with state; per-worktree confirm; honors uncommitted-changes refusal
- [ ] Two real Claude sessions: one main, one worktree → independent session-context files (verified by inspecting \`~/.claude/drupal-dev-framework/sessions/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)