### PR TITLE
feat(drupal-dev-framework): hardened gates v4.0.0 — BREAKING CHANGES

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.23"
+    "version": "1.14.24"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. Soft-nudge throughout; flat tasks and tasks without alignment.md remain first-class. Depends on: dev-guides-navigator, code-quality-tools (declared via Plugin Dependencies).",
-      "version": "3.16.0",
+      "version": "4.0.0",
       "author": {
         "name": "camoa"
       },
@@ -74,7 +74,8 @@
         "security",
         "agent-teams",
         "playbook",
-        "worktree"
+        "worktree",
+        "hardening"
       ]
     },
     {

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,16 +1,19 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "3.16.0",
+  "version": "4.0.0",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams", "playbook", "worktree"],
+  "keywords": ["drupal", "development", "workflow", "architecture", "tdd", "solid", "dry", "security", "agent-teams", "playbook", "worktree", "hardening"],
   "dependencies": [
     "dev-guides-navigator",
     "code-quality-tools"
+  ],
+  "recommended": [
+    "plugin-creation-tools"
   ],
   "defaults": {
     "playbookSets": ["drupal/best-practices/camoa"]

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,85 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-04-24
+
+### ⚠️ BREAKING CHANGES
+
+v4.0.0 converts 7 framework surfaces from soft-prompt to hard-gate. Users on the soft posture will experience a behavior change:
+
+- **Pre-analysis epic gate** at `/research` is now **always-on** — invokes `analysis-agent` regardless of whether strong signals fire. Previously: signal-conditional. Bypass via `--skip-pre-analysis [reason]` flag.
+- **Coverage-mapping requirement** in research.md is now **enforced** — `## Coverage Mapping` H2 mandatory; refuses Phase 1 `[x]` on fail. Previously: optional traceability walkthrough only. Bypass via `--skip-coverage-check [reason]`.
+- **`skill-quality-reviewer`** (from plugin-creation-tools) is **invoked at `/complete`** when staged/branched changes include `skills/*/SKILL.md`. Previously: never invoked automatically. Bypass via `--skip-skill-review [reason]`.
+- **`/plugin-creation-tools:validate`** is **invoked at `/complete`** when staged/branched changes include any plugin file. Previously: never invoked automatically. Bypass via `--skip-plugin-validate [reason]`.
+- **Phase-command-bypass** detected via PreToolUse hook on Write to phase artifacts. Direct Write to `research.md` / `architecture.md` / `implementation.md` without an active phase command writes a non-blocking audit. Previously: silent.
+- **Dev-guides preflight** uses **deterministic detection** (`scripts/dev-guides-detect.sh`) instead of agent-mediated keyword matching. Eliminates bypass-by-declaration ("agent claimed loaded but didn't").
+- **Playbook loading** uses **deterministic load** (`scripts/playbook-load-deterministic.sh`) for the same reason.
+
+### Grandfathering
+
+v3.x in-flight tasks (those past Phase 1 at v4.0.0 install) keep their original soft contract. Heuristic: `research.md present && _pre-analysis.json absent` → grandfathered. New tasks created after v4.0.0 install get the hardened gates.
+
+### Added — 5-mechanism pattern (uniform across all 7 surfaces)
+
+From the original critique in `dev_framework_gate_hardening` task.md:
+
+1. **Anti-bypass clause** — literal block in command body listing rationalization patterns NOT valid as skip reasons
+2. **Show-not-summarize** — verbatim agent output before user prompt
+3. **Audit on disk** — `<task>/_<gate>.json` per fired gate
+4. **Mandate exact prompt wording** — literal templates from `references/gate-hardening-prompts.md` v1.0
+5. **Refactor "if X, do Y" → "validation gate, always evaluated"** — the if-condition is what the gate DOES, not whether it RUNS
+
+### Added — 5 deferred surfaces (NOT hardened in v4.0.0)
+
+Tracked in `dev_framework_improvements_epic/shared/v2-candidates.md` Set D with "documented bypass causing harm" promotion trigger:
+
+- Phase transition checks (no documented incident)
+- Playbook conflict acknowledgment (already minimal one-liner)
+- Worktree recommendation (medium-medium tie; false-positive cost real)
+- `/complete` candidate-play surface (auto-extract rejected on hallucination grounds)
+- `/validate:*` exit codes (deliberate v3.13.0 soft-nudge design)
+
+### New files (10)
+
+**References (2):**
+- `references/gate-audit-schema.md` v1.0 — unified schema for 7 audit file types
+- `references/gate-hardening-prompts.md` v1.0 — literal mandated wording for 5 user-prompt surfaces
+
+**Scripts (5):**
+- `scripts/gate-audit-write.sh` — atomic JSON-validated audit writer
+- `scripts/coverage-mapping-check.sh` — deterministic `## Coverage Mapping` check
+- `scripts/dev-guides-detect.sh` — deterministic auto-load keyword detection
+- `scripts/playbook-load-deterministic.sh` — deterministic playbook load
+- `scripts/phase-command-bypass-detect.sh` — PreToolUse hook helper
+
+**Hooks (2):**
+- `hooks/phase-command-bypass.sh` — PreToolUse hook on Write
+- `hooks/loaded-context-summary.sh` — UserPromptSubmit hook
+
+**Commands (1):**
+- `commands/audit-status.md` — read-only audit-state view
+
+### Updated files (10)
+
+- `commands/research.md` — pre-analysis always-on + coverage-mapping check + deterministic dev-guides preflight
+- `commands/design.md` — deterministic dev-guides preflight
+- `commands/implement.md` — deterministic dev-guides preflight
+- `commands/complete.md` — skill-review + plugin-validate gates
+- `commands/status.md` — Unaudited gates section
+- `skills/guide-integrator` v5.0.0 → 5.1.0 — delegates to deterministic scripts
+- `agents/analysis-agent` v1.0.0 → 1.1.0 — documents always-on invocation pattern
+- `.claude-plugin/plugin.json` — `3.16.0` → `4.0.0`; new `recommended: ["plugin-creation-tools"]`; new `"hardening"` keyword; 2 new hooks registered (PreToolUse Write matcher + UserPromptSubmit second hook)
+- `CLAUDE.md` — new `## Hardened Gates (v4.0.0+)` section before Worktree Workflow
+- `README.md` — `/audit-status` row in commands table; Tech Refs 9 → 11 (adds gate-audit-schema + gate-hardening-prompts)
+
+### Why major
+
+The contract change is real: users who relied on agent-judgment-based gate skipping (e.g., "I'm sure this task is flat, signals don't apply") have that path removed. They must use explicit `--skip-*` flags now. That's a breaking change for users on the soft posture per semver.
+
+### Philosophy
+
+Hardening earns its place when (a) there's documented evidence of bypass causing harm (not "in theory"), (b) the bypass mechanism is rationalization-prone (the AI talks itself out of running it), and (c) the hardening cost is smaller than the bypass cost. v4.0.0 ships hardening for 7 surfaces that pass all three filters; defers 5 surfaces that don't.
+
 ## [3.16.0] - 2026-04-24
 
 ### Added — Worktree Awareness

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -58,6 +58,43 @@ Individual `/validate:*` commands for on-demand quality gates. Replaces `/comple
 
 **NOT wrapped** (keep invoking directly via `/code-quality:*` namespace): `lint`, `coverage`, `review`, `audit`, `ultrareview`, `architecture-debate`, `security-debate`. `/validate:all` surfaces them as discoverability hint.
 
+## Hardened Gates (v4.0.0+)
+
+v4.0.0 converts 7 framework surfaces from soft-prompt to hard-gate, applying the original critique's 5-mechanism pattern uniformly. **BREAKING CHANGE** for users on the soft posture: documented bypass paths are removed; explicit `--skip-*` flags required to skip. Bypass reasons are recorded on disk (`<task>/_<gate>.json`) for retrospective audit.
+
+The 7 hardened surfaces, by category:
+
+**User-prompt surfaces (5)** — fire user prompts with mandated wording from `references/gate-hardening-prompts.md` v1.0:
+
+1. **Pre-analysis epic gate** at `/research` — always-on (was: signal-conditional). Invokes `analysis-agent` regardless of signals; user sees verbatim agent output before pick.
+2. **Coverage-mapping requirement** at end-of-`/research` — `## Coverage Mapping` H2 mandatory in research.md; verified by `scripts/coverage-mapping-check.sh`; refuses Phase 1 `[x]` on fail.
+3. **Skill-review** at `/complete` — fires when staged/branched changes include `skills/*/SKILL.md`; invokes `plugin-creation-tools:skill-quality-reviewer`.
+4. **Plugin-validate** at `/complete` — fires when staged/branched changes include any plugin file; invokes `/plugin-creation-tools:validate`.
+5. **Phase-command-bypass** detected by PreToolUse hook on Write to phase artifacts — non-blocking audit when no `/research` / `/design` / `/implement` slash command is active.
+
+**Deterministic surfaces (2)** — fire shell scripts that detect+act without user prompts; bypass-by-declaration is impossible:
+
+6. **Dev-guides preflight** — `scripts/dev-guides-detect.sh` greps task content for auto-load keywords; replaces agent-mediated detection.
+7. **Playbook loading** — `scripts/playbook-load-deterministic.sh` reads `project_state.md` and loads via `playbook-read.sh` + dev-guides-navigator; replaces agent-mediated load.
+
+**The 5-mechanism pattern** applied uniformly:
+
+1. Anti-bypass clause (literal block in command body)
+2. Show-not-summarize (verbatim agent output before user prompt)
+3. Audit on disk (`<task>/_<gate>.json` per fired gate)
+4. Mandate exact prompt wording (literal templates; no paraphrase)
+5. Refactor "if X, do Y" → "validation gate, always evaluated"
+
+**Audit shape:** unified schema in `references/gate-audit-schema.md` v1.0 with `gate_type` discriminator; per-gate `gate_specific` payload; overwrite-on-fire lifecycle.
+
+**Skip flags:** per-gate `--skip-pre-analysis`, `--skip-coverage-check`, `--skip-skill-review`, `--skip-plugin-validate`. Each writes the audit file with `bypass_reason` field populated. Visible later via `/audit-status` and `/status` "Unaudited gates" section.
+
+**Grandfathering:** v3.x in-flight tasks (those past Phase 1 at v4.0.0 install) keep their original soft contract. Heuristic: `research.md present && _pre-analysis.json absent` → grandfathered.
+
+**5 surfaces deferred to v2** (pending documented bypass evidence): phase transition checks, playbook conflict ack, worktree recommendation, candidate-play surface, `/validate:*` exit codes. Tracked in `dev_framework_improvements_epic/shared/v2-candidates.md` Set D.
+
+`/audit-status` provides per-task audit-state view; `--all` flag for project-wide rollup grouped by health.
+
 ## Worktree Workflow (v3.16.0+)
 
 Two Claude Code sessions on the same project workspace collide on `~/.claude/drupal-dev-framework/sessions/<md5($PWD)>.json` (last-writer-wins) and on the git working tree itself. Solution: the second session runs in a worktree at `.worktrees/<task_name>/`. Distinct `$PWD` → distinct hash → independent session-context. **No changes to `session-context-writer` — the existing hash naturally separates worktree sessions.**

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -115,6 +115,7 @@ Both enforced via `plugin.json` `dependencies`. Missing-dependency failures surf
 | `/set-user-playbook` | **(v3.15.0)** Set/clear the project-local user playbook file. Three modes: explicit path, `--docs-only`, or interactive detect-and-confirm. |
 | `/worktree <task>` | **(v3.16.0)** Create a git worktree at `.worktrees/<task>/` on `feature/<task>` for parallel task execution. Auto-detects composer/npm setup; pre-seeds session-context. Drupal/DDEV-aware (warns about `.ddev/config.yaml` `name:` conflict). |
 | `/worktree-prune` | **(v3.16.0)** List and selectively remove worktrees with per-item `[y]/[n]/[q]` confirm; honors git's refusal on uncommitted changes; force-remove requires explicit confirmation. |
+| `/audit-status [<task>] [--all]` | **(v4.0.0)** Read-only display of v4.0.0 hardened-gate audit state per task — surfaces gate-fire timing, user choices, bypass reasons, and missing audits (= silent skip evidence). `--all` for project-wide rollup grouped by health. |
 | `/pattern <use-case>` | Get Drupal pattern recommendations (FormBase vs ListBuilder, Entity vs Config, etc.) |
 | `/migrate-tasks` | Migrate v2.x single-file tasks to v3.0 folder structure |
 | `/migrate-to-epic <task>` | **(v3.10.0)** Convert a flat task into an epic folder with children. Transactional, 24h rollback, `--dry-run` supported. Flat tasks remain first-class — this is opt-in. See `/migrate-to-epic <task> --children "a,b,c"` or omit for interactive prompt. |
@@ -179,7 +180,7 @@ Built-in docs enforced at specific phases:
 | `quality-gates.md` | 5 quality gates | Task completion |
 | `purposeful-code.md` | Every line has a purpose | Task completion |
 
-### Technical Contract References (9)
+### Technical Contract References (11)
 
 Machine-readable contracts consumed by skills and commands. These pin schemas and invariants so consumers don't drift:
 
@@ -194,6 +195,8 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `playbook-schema.md` **(v3.15.0)** | `/playbook-capture`, `/playbook-review`, `scripts/playbook-read.sh` | Recommended local playbook structure v1.0: H3-per-play with What / Rationale / When it applies / Example fields; freeform fallback; defensive parser contract |
 | `playbook-conflict-schema.md` **(v3.15.0)** | `scripts/playbook-conflicts-write.sh`, `/playbook-active` | JSONL log line v1.0 for `<project>/.claude/playbook-conflicts.log`; per-conflict citation shape (local-vs-shipped + multi-set-contradiction types); append-only contract |
 | `worktree-conventions.md` **(v3.16.0)** | `/worktree`, `/worktree-prune`, `/implement` (recommendation), `/complete` (lifecycle) | v1.0: directory priority, branch naming, gitignore requirement, detection signals (HIGH/MEDIUM-HIGH thresholds), 3-path lifecycle, DDEV `name:` warning, refusal cases. Reuses superpowers `using-git-worktrees` patterns + extends with task-aware lifecycle |
+| `gate-audit-schema.md` **(v4.0.0)** | `scripts/gate-audit-write.sh` + 7 hardened gates | Unified schema v1.0 for the 7 v4.0.0 audit file types (`pre-analysis`, `coverage-mapping`, `skill-review`, `plugin-validate`, `phase-command-bypass`, `dev-guides-load`, `playbook-load`); `gate_type` discriminator; per-gate `gate_specific` payloads; overwrite-on-fire lifecycle |
+| `gate-hardening-prompts.md` **(v4.0.0)** | `commands/research.md`, `commands/complete.md`, `commands/audit-status.md` | Literal mandated wording v1.0 for the 5 user-prompt surfaces (`pre-analysis-decision`, `coverage-mapping-fail`, `skill-review-decision`, `plugin-validate-decision`, `phase-command-bypass-acknowledge`); framework refuses to paraphrase or pre-answer; bypass-reason free-text capture |
 
 ### Online Dev-Guides (60+ topics) — Required
 

--- a/drupal-dev-framework/agents/analysis-agent.md
+++ b/drupal-dev-framework/agents/analysis-agent.md
@@ -2,7 +2,7 @@
 name: analysis-agent
 description: "Use when a framework flow needs to assess whether a task looks epic-sized and propose a decomposition. Reads task docs (task.md + phase artifacts) and optionally the project's codePath to reason about scope. Emits structured JSON per references/analysis-agent-schema.md v1.0. Invoked by /propose-epics for bulk review and by /research pre-analysis hook at new-task creation. Never modifies files."
 capabilities: ["task-analysis", "scope-assessment", "epic-proposal", "sub-task-decomposition"]
-version: 1.0.0
+version: 1.1.0
 model: sonnet
 disallowedTools: Edit, Write, Bash(rm:*), Bash(mv:*), Bash(cp:*), Bash(sed:*), Bash(tee:*), Bash(dd:*), Bash(chmod:*), Bash(chown:*)
 maxTurns: 10
@@ -47,6 +47,8 @@ Explicitly NO `Edit` or `Write`. The agent never mutates state. If it needs to w
 
 - Both present → emit `decision: insufficient_info`, `notes: ["input validation failed: pass exactly one of task_description_text or task_folder, not both"]`, exit.
 - Neither present → emit `decision: insufficient_info`, `notes: ["input validation failed: exactly one of task_description_text/task_folder required"]`, exit.
+
+**v4.0.0+: always-on invocation pattern.** As of v4.0.0, `/research` invokes this agent on EVERY new-task creation regardless of whether strong signals fired. Caller responsibility: invoke with full description even when caller is "sure" no decomposition is warranted. The agent's `decision: keep_flat` becomes the recorded verdict — but the user still sees verbatim agent output before any structural decision is recorded. This removes the rationalization path "I'm sure this task is flat, signals don't apply." Schema unchanged (v1.1 already supports description mode); the always-on discipline is caller-side, not schema-side.
 
 If `task_description_text` was provided (and `task_folder` absent): **description mode**. Skip steps 1-2; go to step 3 with:
 - `task_folder` output field set to `"(pre-creation)"`

--- a/drupal-dev-framework/commands/audit-status.md
+++ b/drupal-dev-framework/commands/audit-status.md
@@ -1,0 +1,124 @@
+---
+description: "Display the audit state of a task — which v4.0.0 hardened gates fired, which were bypassed, and per-bypass reasons. Read-only. Introduced v4.0.0."
+allowed-tools: Read, Bash, Glob
+argument-hint: [<task-name>] [--all]
+---
+
+# Audit Status
+
+Read-only display of v4.0.0 hardened-gate audit state per task. Surfaces gate-fire timing, user choices, bypass reasons, and missing audits (= silent skip evidence).
+
+## Usage
+
+```
+/drupal-dev-framework:audit-status                  # current session task
+/drupal-dev-framework:audit-status <task-name>      # specific task
+/drupal-dev-framework:audit-status --all            # project-wide rollup
+```
+
+## What this does
+
+### Step 1 — Resolve scope
+
+- No arg → use `task` from current `session_context.json`
+- `<task-name>` → resolve task folder under the current project's `implementation_process/in_progress/**/<task-name>/`
+- `--all` → enumerate all task folders under `implementation_process/{in_progress,completed}/**`
+
+Refuse if no project context resolved.
+
+### Step 2 — For each task, scan audit files
+
+The 7 v4.0.0 audit file types are:
+
+- `_pre-analysis.json`
+- `_coverage-mapping.json`
+- `_skill-review.json`
+- `_plugin-validate.json`
+- `_phase-command-bypass.json`
+- `_dev-guides-load.json`
+- `_playbook-load.json`
+
+For each task folder:
+
+1. List which audit files exist
+2. For each existing file, parse `gate_type`, `fired_at`, `user_choice`, `bypass_reason`, `gate_specific` per `references/gate-audit-schema.md` v1.0
+3. Compute "expected but missing" gates:
+   - `_pre-analysis.json` expected if `research.md` exists; missing → grandfathered (pre-v4.0.0) OR bypassed
+   - `_coverage-mapping.json` expected if `research.md` exists with content > 200 lines (substantive)
+   - `_skill-review.json` expected if task's git history shows `skills/*/SKILL.md` changes
+   - `_plugin-validate.json` expected if task's git history shows plugin file changes
+   - `_dev-guides-load.json` expected if any phase command ran (research.md / architecture.md / implementation.md exists)
+   - `_playbook-load.json` expected if `playbookSets` non-empty OR `userPlaybook` set in project_state.md
+   - `_phase-command-bypass.json` expected only when actual bypass happened — its presence IS the signal
+
+### Step 3 — Print summary
+
+#### Single-task format
+
+```
+Audit status for <task_name>:
+
+  ✓ pre-analysis        fired 2026-04-24T20:30:00Z  user_choice: y          [keep_flat]
+  ✓ coverage-mapping    fired 2026-04-24T20:32:00Z  user_choice: phase_marked_complete   [pass: 6/6 questions]
+  ⊘ skill-review        not fired (no skill changes detected in this task's diff)
+  ⊘ plugin-validate     not fired (no plugin file changes detected)
+  ⚠ phase-command-bypass FIRED 2026-04-24T19:45:00Z  artifact: research.md  expected: research  active: null
+  ✓ dev-guides-load     fired 2026-04-24T20:31:00Z  user_choice: c          [matched: gate, complete, quality → plugin:quality-gates]
+  ✓ playbook-load       fired 2026-04-24T20:31:00Z  loaded: drupal/best-practices/camoa + idexx local (19 plays)
+
+  Bypasses recorded: 0
+  Missing audits (= unaudited): 0
+  Health: ✓ all expected gates fired or correctly skipped
+```
+
+#### Symbols
+
+- `✓` — gate fired correctly; user choice recorded
+- `⊘` — gate not fired but expected behavior (signals didn't match; not a bypass)
+- `⚠` — bypass detected (audit file present with `user_choice: bypassed` OR phase-command-bypass audit present)
+- `✗` — gate expected to fire but audit file MISSING (silent bypass; the worst case)
+
+#### `--all` format
+
+Per-task summary line, grouped by health:
+
+```
+Audit status (project-wide):
+
+  Healthy (8 tasks, all expected gates fired):
+    - dev_framework_isolated_validators
+    - dev_framework_user_patterns
+    - dev_framework_dad_sandwich
+    - …
+
+  Bypasses recorded (2 tasks):
+    - dev_framework_research_artifact_structure: pre-analysis bypassed (--skip-pre-analysis "stub task")
+    - dev_framework_gate_hardening: phase-command-bypass recorded × 3 for research.md/architecture.md/implementation.md (pre-restart artifacts; see _pre-restart/)
+
+  Missing audits (= silent bypass — worst case) (0 tasks):
+    (none)
+
+  Grandfathered (pre-v4.0.0 lifecycle) (1 task):
+    - dev_framework_phase_checkpoints (no _pre-analysis.json; research.md authored before v4.0.0 install)
+```
+
+### Step 4 — Per-bypass details on demand
+
+If single-task mode shows `⚠` for `phase-command-bypass`, ask: `[d]etails / [a]cknowledge / quit`.
+
+- `[d]` → display literal `prompts:phase-command-bypass-acknowledge` template from `references/gate-hardening-prompts.md`. User picks `[a]cknowledge` (note bypass and continue) or `[r]e-run` (invoke proper phase command now).
+- `[a]` → exit without action.
+
+## What this does NOT do
+
+- Does NOT modify audit files or task state
+- Does NOT auto-remediate findings
+- Does NOT enforce anything — read-only
+- Does NOT cross-project rollup; `--all` is current project only
+
+## Related Commands
+
+- `/drupal-dev-framework:status` — task-level overview; includes Unaudited gates section as summary
+- `/drupal-dev-framework:research`, `:design`, `:implement`, `:complete` — the phase commands that fire the audited gates
+- `references/gate-audit-schema.md` v1.0 — schema for the 7 audit file types
+- `references/gate-hardening-prompts.md` v1.0 — prompts surfaced by audit-status when bypasses are acknowledged

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -1,5 +1,5 @@
 ---
-description: "Mark a task as done and move to completed. Trigger: 'finish task', 'mark done', 'task complete', 'close task'. Runs ALL 5 quality gates before allowing completion."
+description: "Mark a task as done and move to completed. Trigger: 'finish task', 'mark done', 'task complete', 'close task'. Runs ALL 5 quality gates plus (v4.0.0+) skill-review + plugin-validate hardened gates when staged changes match before allowing completion. Surfaces candidate plays from the session via play_candidates mode (v3.15.0+)."
 allowed-tools: Read, Write, Bash(mv:*), Glob
 argument-hint: <task-name>
 ---
@@ -14,7 +14,7 @@ Mark a task as complete and move it to the completed folder.
 /drupal-dev-framework:complete <task-name>
 ```
 
-## What This Does (v3.0.0 + v3.10.0 epic awareness)
+## What This Does (v3.0.0 + v3.10.0 epic awareness + v4.0.0 hardened gates)
 
 1. Invokes `task-completer` skill
 2. Loads task from `implementation_process/in_progress/{task_name}/`

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -78,6 +78,48 @@ On `2`:
 On `3`:
 - No-op. Continue to candidate-play surface.
 
+## Skill-review gate (v4.0.0+, hardened)
+
+**This gate is non-bypassable.** Same anti-bypass clause as pre-analysis. Skipping requires `--skip-skill-review <reason>` flag, recorded in `<task>/_skill-review.json` `bypass_reason`.
+
+**Trigger:** staged or branched changes include `skills/*/SKILL.md` files. Detection:
+
+```bash
+git diff --cached --name-only | grep -E "skills/.*/SKILL\.md" || \
+  git diff main...HEAD --name-only | grep -E "skills/.*/SKILL\.md"
+```
+
+If any matches → fire the gate. If none → skip silently (no audit; not a bypass).
+
+### Steps
+
+1. **Invoke** `plugin-creation-tools:skill-quality-reviewer` agent via Task tool against the project's `skills/` directory. Capture full agent output verbatim.
+2. **Display** the literal `prompts:skill-review-decision` template from `references/gate-hardening-prompts.md`. Substitutions: `{{skills_reviewed}}` (comma-list of skill names from the diff), `{{findings}}` (verbatim agent output).
+3. **Block** on user `[a]ccept / [r]emediate / [b]ypass` choice.
+4. **Write audit** to `<task>/_skill-review.json` via `gate-audit-write.sh`. `user_choice: "accepted"` for `[a]`, `"remediated"` for `[r]` (after the user has made remediation edits), `"bypassed"` for `[b]` (with `bypass_reason` from free-text prompt).
+5. **Refusal case:** if `plugin-creation-tools` is not installed, halt with: "Required gate `skill-quality-reviewer` (from plugin-creation-tools) not available. Install plugin-creation-tools or pass `--skip-skill-review <reason>` to bypass." Do NOT degrade silently.
+
+## Plugin-validate gate (v4.0.0+, hardened)
+
+**This gate is non-bypassable.** Same anti-bypass clause. Skipping requires `--skip-plugin-validate <reason>` flag.
+
+**Trigger:** staged or branched changes include any plugin file under `commands/`, `skills/`, `references/`, `hooks/`, `scripts/`, or `.claude-plugin/`. Detection:
+
+```bash
+git diff --cached --name-only | grep -E "(commands|skills|references|hooks|scripts|\.claude-plugin)/" || \
+  git diff main...HEAD --name-only | grep -E "(commands|skills|references|hooks|scripts|\.claude-plugin)/"
+```
+
+If any matches → fire the gate.
+
+### Steps
+
+1. **Invoke** `/plugin-creation-tools:validate` slash command. Capture full output verbatim.
+2. **Display** the literal `prompts:plugin-validate-decision` template. Substitutions: `{{plugins_validated}}` (comma-list), `{{findings}}` (verbatim slash-command output).
+3. **Block** on user `[a]ccept / [r]emediate / [b]ypass` choice.
+4. **Write audit** to `<task>/_plugin-validate.json` via `gate-audit-write.sh`.
+5. **Refusal case:** same as skill-review — halt if plugin-creation-tools not installed; explicit-skip-required.
+
 ## Candidate-play surface (v3.15.0+)
 
 After the 5 quality gates pass and before the task moves to `completed/`, surface 0-N candidate plays the framework detected during this task. Skipped if `--no-play-candidates` flag is passed OR if the project has `userPlaybookState != "set"` (no playbook to capture into).

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -34,9 +34,9 @@ Never block the command on this check — the user is in control. The nudge exis
 
 ### Step 1 — Invoke guide-integrator explicitly
 
-Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
+**(v4.0.0+: deterministic detection.)** Invoke `${CLAUDE_PLUGIN_ROOT}/scripts/dev-guides-detect.sh <task_folder>` BEFORE prompting the user. Populate Step 2's prompt's "Auto-loaded based on task keywords:" line from `guides_to_load[]` script output. Write `<task>/_dev-guides-load.json` audit per `references/gate-audit-schema.md` v1.0 after user picks `[c]/[a]/[n]`. Eliminates bypass-by-declaration.
 
-**(v3.15.0+)** `guide-integrator` v5.0.0+ ALSO loads the project's active playbook sets and local user playbook at this step. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log`. See `references/playbook-schema.md` and `references/playbook-conflict-schema.md`.
+**(v3.15.0+, refactored v4.0.0+)** `guide-integrator` v5.1.0+ delegates the playbook load to `${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh <project_folder>`; emits `<task>/_playbook-load.json` audit. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log`.
 
 ### Step 2 — ALWAYS prompt the user (never silent-skip)
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -64,9 +64,9 @@ Never block the command on this check — the user is in control. The nudge exis
 
 ### Step 1 — Invoke guide-integrator explicitly
 
-Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
+**(v4.0.0+: deterministic detection.)** Invoke `${CLAUDE_PLUGIN_ROOT}/scripts/dev-guides-detect.sh <task_folder>` BEFORE prompting the user. Populate Step 2's prompt's "Auto-loaded based on task keywords:" line from `guides_to_load[]` script output. Write `<task>/_dev-guides-load.json` audit per `references/gate-audit-schema.md` v1.0 after user picks `[c]/[a]/[n]`. Eliminates bypass-by-declaration.
 
-**(v3.15.0+)** `guide-integrator` v5.0.0+ ALSO loads the project's active playbook sets and local user playbook at this step. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log`. See `references/playbook-schema.md` and `references/playbook-conflict-schema.md`.
+**(v3.15.0+, refactored v4.0.0+)** `guide-integrator` v5.1.0+ delegates the playbook load to `${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh <project_folder>`; emits `<task>/_playbook-load.json` audit. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log`.
 
 ### Step 2 — ALWAYS prompt the user (never silent-skip)
 

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -14,7 +14,7 @@ Research existing solutions for a specific task (Phase 1 of a task).
 /drupal-dev-framework:research <task-name>
 ```
 
-## What This Does (v3.0.0, with v3.11.0 pre-analysis hook)
+## What This Does (v3.0.0, with v3.11.0 pre-analysis hook, v4.0.0 always-on validation gate + coverage-mapping requirement)
 
 1. **Pre-analysis hook** (v3.11.0+, before anything else) — if strong signals fire in the task name + description, invoke `analysis-agent` to assess whether this should be an epic. See "Pre-analysis hook" section below.
 2. Creates task directory: `implementation_process/in_progress/{task_name}/`

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -80,6 +80,35 @@ Default: `[n]`.
 - **Authoritative over pre-analysis.** If pre-analysis said "keep flat" and end-of-research says "epic_candidate," trust the later call — it has strictly more context.
 - **Migration is transactional.** `/migrate-to-epic` is atomic with 24h rollback; safe to opt into.
 
+## Coverage-mapping validation gate (v4.0.0+)
+
+**This gate is non-bypassable.** Same anti-bypass clause as pre-analysis.
+
+**Run after `research.md` has been authored, before the post-research epic check + traceability walkthrough.** Verifies `research.md` contains the required `## Coverage Mapping` H2 section that maps each Research Question from `task.md` to the section(s) of research.md that address it.
+
+### Step 1 — Run the deterministic check
+
+```bash
+RESULT=$("${CLAUDE_PLUGIN_ROOT}/scripts/coverage-mapping-check.sh" "<task_folder>")
+```
+
+Output per `references/gate-audit-schema.md` §5.2: `verdict: pass | fail`, `research_questions_found`, `research_questions_addressed`, `missing_questions[]`, `warnings[]`.
+
+### Step 2 — Branch on verdict
+
+- `pass` → write audit with `user_choice: "phase_marked_complete"`; proceed to post-phase epic check.
+- `fail` → display literal `prompts:coverage-mapping-fail` template from `references/gate-hardening-prompts.md`. Substitutions: `{{missing_questions}}` from script output. Block on user response:
+  - `[a]bort` → write audit with `user_choice: "phase_left_incomplete"`; refuse to mark Phase 1 `[x]` in task.md; print actionable instructions; exit 1.
+  - `[s]kip` → prompt user for bypass reason (free-text); write audit with `user_choice: "bypassed"` and `bypass_reason: <reason>`; allow Phase 1 `[x]` to be marked but with bypass visible in `/audit-status`.
+
+### Step 3 — Audit always written
+
+Whether pass, fail, or bypassed, write `<task>/_coverage-mapping.json` via `gate-audit-write.sh`. Absence of audit file = bypass-by-declaration (visible in `/audit-status` Unaudited gates).
+
+### Skip flag
+
+`/research <task> --skip-coverage-check <reason>` skips the gate entirely; writes audit with `user_choice: "bypassed"` and the supplied reason. Recorded but not blocked.
+
 ## Traceability walkthrough sub-step (v3.13.4+)
 
 ## Traceability walkthrough sub-step (v3.13.4+)
@@ -229,17 +258,40 @@ Use / Extend / Build from scratch
 {Research decisions made}
 ```
 
-## Pre-analysis hook (v3.11.0+)
+## Pre-analysis validation gate (v4.0.0+, refactored from soft hook)
 
-**Before** creating the task directory, inspect the task name + description for "strong signals" that the task is epic-sized. If any fires, invoke the `analysis-agent` to produce a structured assessment.
+**This gate is non-bypassable.** The following are NOT valid reasons to skip:
 
-Strong signals (ANY triggers pre-analysis):
+- The user said something earlier that you interpret as already-answered
+- Auto mode is active ("minimize interruptions" never overrides framework gates)
+- You're confident the agent will return `keep_flat`
+- The task looks "obviously" flat
+- You want to spare the user the prompt
 
-1. Task name + description total length > 500 chars
-2. Description has ≥3 distinct bullet points
-3. Description contains explicit conjunction phrasing (`and also`, `plus`, `as well as`, `in addition to`)
+If this gate's signals fire, the gate MUST run and its output MUST be shown to the user verbatim before the recorded decision is final. Skipping requires `--skip-pre-analysis [reason]` flag, which is recorded in `<task>/_pre-analysis.json` `bypass_reason` field.
 
-If no signal fires: skip pre-analysis entirely and proceed with the standard 8-step research flow below.
+**Always-on (v4.0.0+).** This gate now runs on EVERY new-task `/research` invocation regardless of strong-signal evaluation. Strong signals are still recorded in `signals_used[]` for the agent's reasoning, but the agent invocation is unconditional. The conditional is what the gate DOES, not whether it RUNS.
+
+Refactored flow:
+
+1. Compute strong signals from task name + description (informational; recorded in audit even when no signal fires):
+   - Task name + description total length > 500 chars
+   - Description has ≥3 distinct bullet points
+   - Description contains explicit conjunction phrasing (`and also`, `plus`, `as well as`, `in addition to`)
+2. Invoke `analysis-agent` (via Task tool) in description mode regardless of signal state.
+3. Save output to `<task>/_pre-analysis.json` via `${CLAUDE_PLUGIN_ROOT}/scripts/gate-audit-write.sh`.
+4. Display agent output verbatim to user using literal `prompts:pre-analysis-decision` template from `references/gate-hardening-prompts.md`. Do NOT paraphrase.
+5. Block on user response per the template's option list.
+6. Record decision in `_pre-analysis.json`.
+7. Branch: `epic_candidate + y` → `/migrate-to-epic`. Else → flat-task flow.
+
+**Re-invocation idempotency.** If `<task>/_pre-analysis.json` already exists from a prior run on this task, skip pre-analysis (the gate fired once, that's enough). Re-firing requires explicit `--re-run-pre-analysis` flag.
+
+**Grandfathering.** If `<task>/research.md` exists AND `_pre-analysis.json` is absent, treat the task as grandfathered from pre-v4.0.0 lifecycle. Do NOT mark it as bypassed; do NOT block. Soft-nudge: print "Task pre-dates v4.0.0 hardening; pre-analysis not retroactively run."
+
+### Original soft-hook description (v3.11.0+, deprecated by v4.0.0+ always-on gate above)
+
+For historical reference; the always-on gate above supersedes this. The soft-hook only fired when strong signals matched:
 
 If a signal fires:
 
@@ -279,9 +331,16 @@ Conservative by design: pre-analysis only fires on strong signals, and even then
 
 ### Step 1 — Invoke guide-integrator explicitly
 
-Do NOT rely on proactive skill detection. Directly invoke the `guide-integrator` skill against the task context. Record which guides (if any) were auto-loaded via its keyword-detection rules + `dev-guides-navigator` delegation.
+**(v4.0.0+: deterministic detection.)** Invoke `${CLAUDE_PLUGIN_ROOT}/scripts/dev-guides-detect.sh <task_folder>` BEFORE prompting the user. The script emits `keywords_matched[]` + `guides_to_load[]` from a deterministic grep of task content against `guide-integrator` Auto-Load Rules. The agent does NOT decide whether keywords matched — the script does. This eliminates bypass-by-declaration (agent claiming "none matched" without running detection).
 
-**(v3.15.0+)** `guide-integrator` v5.0.0+ ALSO loads the project's active playbook sets (per `Playbook Sets` in `project_state.md`) and the local user playbook (per `User Playbook`) at this step. The skill emits `loaded_playbook_sets[]`, `loaded_local_playbook`, and `conflicts[]` in its return JSON. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log` via `scripts/playbook-conflicts-write.sh`. See `references/playbook-schema.md` and `references/playbook-conflict-schema.md`.
+After detection, populate Step 2's prompt's "Auto-loaded based on task keywords:" line with `guides_to_load[]` from the script output. After the user's `[c]/[a]/[n]` choice, write a `dev-guides-load` audit:
+
+```bash
+# Build audit JSON; user_choice is c|a|n; guides_actually_loaded reflects [n]'s clearing
+"${CLAUDE_PLUGIN_ROOT}/scripts/gate-audit-write.sh" "<task_folder>" "dev-guides-load" "$AUDIT_JSON"
+```
+
+**(v3.15.0+, refactored v4.0.0+)** `guide-integrator` v5.1.0+ ALSO loads the project's active playbook sets (per `Playbook Sets` in `project_state.md`) and the local user playbook (per `User Playbook`) — but this load is now **deterministic** via `${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh <project_folder>`. The script emits `playbook_sets_loaded[]`, `user_playbook_loaded`, `plays_by_section{}`, written as `<task>/_playbook-load.json` audit. Surface conflicts once-per-session per topic (precedence: local > active set > generic dev-guide); persist to `<project>/.claude/playbook-conflicts.log` via `scripts/playbook-conflicts-write.sh`. See `references/playbook-schema.md`, `references/playbook-conflict-schema.md`, and `references/gate-audit-schema.md` v1.0.
 
 ### Step 2 — ALWAYS prompt the user (never silent-skip)
 

--- a/drupal-dev-framework/commands/status.md
+++ b/drupal-dev-framework/commands/status.md
@@ -119,8 +119,33 @@ If no project specified:
 2. If multiple, lists them for selection
 3. If none, asks for project path
 
+## Unaudited gates section (v4.0.0+)
+
+After listing tasks, scan each task folder for missing audit files (per `references/gate-audit-schema.md` v1.0). Tasks where the framework expected a hardened gate to fire but the audit file is absent are flagged.
+
+Detection per task:
+
+- `research.md` present but `_pre-analysis.json` absent → "pre-analysis bypassed (or grandfathered from pre-v4.0.0)"
+- `research.md` present + has `## Coverage Mapping` section but `_coverage-mapping.json` absent → "coverage-mapping check did not record"
+- `research.md` present + lacks `## Coverage Mapping` AND `_coverage-mapping.json` absent → "Phase 1 incomplete: missing coverage mapping (run /research)"
+- Phase artifacts written (any of research.md, architecture.md, implementation.md) but `_phase-command-bypass.json` exists → "phase-command bypass recorded; consider re-running through /research / /design / /implement"
+
+Format:
+
+```
+Unaudited gates:
+  <task_name_1>:
+    - pre-analysis: bypassed (no _pre-analysis.json; task pre-dates v4.0.0 → grandfathered)
+    - coverage-mapping: missing audit + missing section
+  <task_name_2>:
+    - phase-command-bypass: recorded for architecture.md (use /audit-status <task> for details)
+```
+
+Empty section if no audit gaps. Mentions `/audit-status <task>` for per-task drill-down.
+
 ## Related Commands
 
 - `/drupal-dev-framework:next` - Get recommended next action
 - `/drupal-dev-framework:research <task>` - Start research for a task
 - `/drupal-dev-framework:implement <task>` - Continue implementation
+- `/drupal-dev-framework:audit-status [<task>]` - **(v4.0.0+)** Detailed audit-state view; surfaces unaudited gates and bypass reasons

--- a/drupal-dev-framework/hooks/hooks.json
+++ b/drupal-dev-framework/hooks/hooks.json
@@ -7,6 +7,23 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/context-reminder.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/loaded-context-summary.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/phase-command-bypass.sh",
+            "timeout": 5
           }
         ]
       }

--- a/drupal-dev-framework/hooks/loaded-context-summary.sh
+++ b/drupal-dev-framework/hooks/loaded-context-summary.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# loaded-context-summary.sh — UserPromptSubmit hook that surfaces deterministic
+# gate findings (dev-guides loaded, playbook loaded) into Claude's context.
+#
+# Reads <task>/_dev-guides-load.json and <task>/_playbook-load.json (if present)
+# and prepends a one-line summary to the agent's next turn. Mirrors the existing
+# context-reminder hook's pattern.
+
+set -uo pipefail
+
+# Read session_context for the current workspace
+WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+SESS_FILE="$HOME/.claude/drupal-dev-framework/sessions/$WORKSPACE_HASH.json"
+
+[[ -s "$SESS_FILE" ]] || { jq -nc '{}'; exit 0; }
+
+TASK_PATH=$(jq -r '.taskPath // empty' "$SESS_FILE" 2>/dev/null)
+[[ -n "$TASK_PATH" ]] && [[ -d "$TASK_PATH" ]] || { jq -nc '{}'; exit 0; }
+
+DG_FILE="$TASK_PATH/_dev-guides-load.json"
+PB_FILE="$TASK_PATH/_playbook-load.json"
+
+DG_LINE=""
+PB_LINE=""
+
+if [[ -f "$DG_FILE" ]]; then
+  GUIDES=$(jq -r '.gate_specific.guides_actually_loaded // [] | join(", ")' "$DG_FILE" 2>/dev/null)
+  [[ -n "$GUIDES" ]] && DG_LINE="Dev-guides loaded: $GUIDES"
+fi
+
+if [[ -f "$PB_FILE" ]]; then
+  SETS=$(jq -r '.gate_specific.playbook_sets_loaded // [] | join(", ")' "$PB_FILE" 2>/dev/null)
+  USER_PB=$(jq -r '.gate_specific.user_playbook_loaded // empty' "$PB_FILE" 2>/dev/null)
+  PLAYS_TOTAL=$(jq -r '.gate_specific.plays_by_section // {} | [.[]] | add // 0' "$PB_FILE" 2>/dev/null)
+
+  if [[ -n "$SETS" ]] || [[ -n "$USER_PB" ]]; then
+    PB_LINE="Playbook: ${SETS:-(no sets)}"
+    [[ -n "$USER_PB" ]] && PB_LINE="$PB_LINE + local ($PLAYS_TOTAL plays)"
+  fi
+fi
+
+# Emit if either line is non-empty
+if [[ -z "$DG_LINE" ]] && [[ -z "$PB_LINE" ]]; then
+  jq -nc '{}'
+  exit 0
+fi
+
+CTX=""
+[[ -n "$DG_LINE" ]] && CTX="$DG_LINE"
+[[ -n "$PB_LINE" ]] && {
+  [[ -n "$CTX" ]] && CTX="$CTX"$'\n'"$PB_LINE" || CTX="$PB_LINE"
+}
+
+jq -nc --arg ctx "$CTX" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'

--- a/drupal-dev-framework/hooks/phase-command-bypass.sh
+++ b/drupal-dev-framework/hooks/phase-command-bypass.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# phase-command-bypass.sh — PreToolUse hook for Write tool against phase artifacts.
+#
+# Fires when Claude attempts to Write a research.md / architecture.md / implementation.md
+# under implementation_process/. If no phase command (research/design/implement) is
+# active in session_context, writes a phase-command-bypass audit and lets the Write
+# proceed. Soft-nudge — never blocks.
+
+set -uo pipefail
+
+PLUGIN_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+DETECT_SH="$PLUGIN_DIR/scripts/phase-command-bypass-detect.sh"
+WRITE_SH="$PLUGIN_DIR/scripts/gate-audit-write.sh"
+
+# Read PreToolUse hook input from stdin (JSON envelope per Claude Code spec)
+INPUT=$(cat)
+
+# Only fire for Write tool
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[[ "$TOOL_NAME" != "Write" ]] && { echo '{}'; exit 0; }
+
+# Extract file path from tool args
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[[ -z "$FILE_PATH" ]] && { echo '{}'; exit 0; }
+
+# Match phase artifacts under implementation_process/
+case "$FILE_PATH" in
+  *implementation_process/*/research.md|*implementation_process/*/*/research.md|*implementation_process/*/*/*/research.md)
+    ARTIFACT="research.md"
+    ;;
+  *implementation_process/*/architecture.md|*implementation_process/*/*/architecture.md|*implementation_process/*/*/*/architecture.md)
+    ARTIFACT="architecture.md"
+    ;;
+  *implementation_process/*/implementation.md|*implementation_process/*/*/implementation.md|*implementation_process/*/*/*/implementation.md)
+    ARTIFACT="implementation.md"
+    ;;
+  *)
+    echo '{}'
+    exit 0
+    ;;
+esac
+
+# Resolve task folder (parent of the artifact)
+TASK_FOLDER=$(dirname "$FILE_PATH")
+
+# Run detect; if returns audit JSON, write it
+DETECT_OUT=$(bash "$DETECT_SH" "$TASK_FOLDER" "$ARTIFACT" 2>/dev/null)
+
+if [[ -z "$DETECT_OUT" ]] || [[ "$DETECT_OUT" == "{}" ]]; then
+  # No bypass detected (legitimate phase-command authoring)
+  echo '{}'
+  exit 0
+fi
+
+# Write the audit (best-effort; don't block the Write on failure)
+bash "$WRITE_SH" "$TASK_FOLDER" "phase-command-bypass" "$DETECT_OUT" >/dev/null 2>&1 || true
+
+# Emit empty hook output — Write proceeds normally (soft-nudge)
+echo '{}'
+exit 0

--- a/drupal-dev-framework/references/gate-audit-schema.md
+++ b/drupal-dev-framework/references/gate-audit-schema.md
@@ -1,0 +1,170 @@
+# Gate Audit Schema v1.0
+
+**Introduced:** drupal-dev-framework v4.0.0
+**Owner:** `scripts/gate-audit-write.sh`
+**Consumers:** `commands/research.md`, `commands/complete.md`, `commands/audit-status.md`, `commands/status.md`, plus the 7 hardened-gate scripts (`coverage-mapping-check.sh`, `dev-guides-detect.sh`, `playbook-load-deterministic.sh`, `phase-command-bypass-detect.sh`)
+
+A "gate audit" is a single JSON file written when one of the v4.0.0 hardened gates fires. The file lives in the task folder and serves as **proof on disk** that the gate ran. Absence of the file (when it should be present) is evidence of bypass — surfaced by `/audit-status` and `/status`.
+
+This schema is the unified shape across all 7 audit file types. A `gate_type` discriminator selects which `gate_specific` payload applies.
+
+## 1. Location
+
+```
+<task_folder>/_<gate_type>.json
+```
+
+Where `<gate_type>` is one of:
+
+- `pre-analysis`
+- `coverage-mapping`
+- `skill-review`
+- `plugin-validate`
+- `phase-command-bypass`
+- `dev-guides-load`
+- `playbook-load`
+
+Files are siblings of `task.md`/`alignment.md`/`research.md`/`architecture.md`/`implementation.md`. The `_` prefix groups them visually and signals "framework-managed; not user-authored content."
+
+## 2. Lifecycle
+
+**Overwrite-on-fire.** Each gate's audit file holds the most recent invocation only. Re-firing the gate (rare; gates are designed to fire once per task at their canonical phase) overwrites.
+
+Historical runs are NOT preserved per-task in these files. If a gate's history matters (e.g., for `/validate:*` gates), the existing v3.13.0 envelope persistence at `<task>/validations/history.jsonl` covers it. Gate-audit files are state, not history.
+
+## 3. Shape
+
+```json
+{
+  "schema_version": "1.0",
+  "gate_type": "<one of the 7>",
+  "fired_at": "2026-04-24T20:30:00Z",
+  "task_folder": "/abs/path/to/task",
+  "user_choice": "<gate-specific enum or null>",
+  "bypass_reason": null,
+  "gate_specific": { /* per-gate payload — see §5 */ }
+}
+```
+
+## 4. Top-level field contracts
+
+| Field | Type | Constraints |
+|---|---|---|
+| `schema_version` | string | `"1.0"` for v4.0.0. JSON string. Consumers gate on major. |
+| `gate_type` | enum | One of the 7 listed in §1. Discriminator for `gate_specific` payload. |
+| `fired_at` | string | ISO-8601 UTC with `Z` suffix. |
+| `task_folder` | string | Absolute path to the task folder. Mirrors how validation envelopes record absolute paths. |
+| `user_choice` | enum \| null | Per-gate enum (e.g. `y`/`n`/`s` for pre-analysis; `accepted`/`remediated`/`bypassed` for skill-review). `null` for deterministic gates with no user prompt (`dev-guides-load`, `playbook-load`). |
+| `bypass_reason` | string \| null | Populated when user passed `--skip-<gate>` flag. The string is whatever the user supplied. `null` when gate ran without bypass. |
+| `gate_specific` | object | Per-gate payload. See §5 per gate type. |
+
+## 5. Per-gate payload (`gate_specific`)
+
+### 5.1 `pre-analysis`
+
+```json
+"gate_specific": {
+  "agent_output": { /* full verbatim analysis-agent JSON */ },
+  "decision": "epic_candidate | keep_flat | insufficient_info"
+}
+```
+
+`user_choice` enum: `"y" | "n" | "s" | "bypassed"`.
+
+### 5.2 `coverage-mapping`
+
+```json
+"gate_specific": {
+  "verdict": "pass | fail",
+  "research_questions_found": 6,
+  "research_questions_addressed": 6,
+  "missing_questions": []
+}
+```
+
+`user_choice` enum: `"phase_marked_complete" | "phase_left_incomplete" | "bypassed"`.
+
+### 5.3 `skill-review`
+
+```json
+"gate_specific": {
+  "skills_reviewed": ["guide-integrator", "project-state-reader"],
+  "findings": [/* verbatim agent output */]
+}
+```
+
+`user_choice` enum: `"accepted" | "remediated" | "bypassed"`.
+
+### 5.4 `plugin-validate`
+
+```json
+"gate_specific": {
+  "plugins_validated": ["drupal-dev-framework"],
+  "findings": [/* verbatim slash-command output */]
+}
+```
+
+`user_choice` enum: `"accepted" | "remediated" | "bypassed"`.
+
+### 5.5 `phase-command-bypass`
+
+```json
+"gate_specific": {
+  "artifact_written": "research.md | architecture.md | implementation.md",
+  "phase_command_active": "research | design | implement | null",
+  "expected_phase_command": "research | design | implement"
+}
+```
+
+`user_choice` enum: `"acknowledged" | "bypassed"`.
+
+### 5.6 `dev-guides-load`
+
+```json
+"gate_specific": {
+  "phase": "research | design | implement",
+  "keywords_matched": ["gate", "complete", "quality"],
+  "guides_to_load": ["plugin:quality-gates"],
+  "guides_actually_loaded": ["plugin:quality-gates"]
+}
+```
+
+`user_choice` enum: `"c" | "a" | "n"`.
+
+### 5.7 `playbook-load`
+
+```json
+"gate_specific": {
+  "phase": "research | design | implement",
+  "playbook_sets_loaded": ["drupal/best-practices/camoa"],
+  "playbook_sets_source": "explicit | explicit-none | default",
+  "user_playbook_loaded": "/abs/path/to/playbook.md or null",
+  "plays_by_section": {"CSS / SCSS": 5, "Architecture": 4},
+  "conflicts_detected": []
+}
+```
+
+`user_choice`: always `null` (deterministic; no prompt).
+
+## 6. Invariants
+
+- **One file per gate per task.** Overwrite-on-fire. No history kept in this file.
+- **Absolute paths.** `task_folder` is always absolute. Consumers who need cross-machine portability use it as-is.
+- **JSON parses cleanly.** `gate-audit-write.sh` validates against this schema before writing; refuses on schema_version mismatch or missing required fields.
+- **Bypass is recorded, not silent.** When `bypass_reason` is non-null, the file still exists and `user_choice` is `"bypassed"`. The user CAN choose to skip; they CAN'T silently skip.
+- **`gate_type` is enum-bound.** Adding a new gate_type requires a minor schema bump.
+
+## 7. Versioning policy
+
+- **Major bumps** (`2.0`) are breaking: changes to top-level required fields, removed gate_types, reshaped per-gate payloads.
+- **Minor bumps** (`1.1`) are additive: new gate_type values, new optional top-level fields, new optional per-gate fields. Existing consumers ignore the new fields.
+- **Patch bumps** do not exist for schema versioning.
+
+v1.0 covers all 7 v4.0.0 gate_types. Future hardenings (v2 deferred surfaces) bump to 1.1 if/when they ship.
+
+## 8. Non-goals
+
+- **No cross-task aggregation in this schema.** `/audit-status --all` produces a project-wide view by globbing all `_<gate>.json` files; the per-file shape doesn't change.
+- **No append-mode history.** History at the per-gate-fire level lives in `validations/history.jsonl` for `/validate:*` gates. The hardened gates are state, not events.
+- **No locking.** Concurrent writes from multiple Claude Code sessions could race. Mitigation: worktree workflow (v3.16.0) is the canonical answer for parallel work; without worktrees, last-writer-wins. Acceptable for v1.
+- **No remediation tracking inside the audit file.** When a user picks `remediated` (skill-review or plugin-validate), the audit records the decision but NOT the remediation steps. Remediation lives in code edits + git history; the audit just says "user fixed it."

--- a/drupal-dev-framework/references/gate-hardening-prompts.md
+++ b/drupal-dev-framework/references/gate-hardening-prompts.md
@@ -1,0 +1,150 @@
+# Gate Hardening Prompts v1.0
+
+**Introduced:** drupal-dev-framework v4.0.0
+**Owner:** This reference; consumed by command bodies
+**Consumers:** `commands/research.md` (pre-analysis + coverage-mapping prompts), `commands/complete.md` (skill-review + plugin-validate prompts), `hooks/phase-command-bypass.sh` (phase-command-bypass acknowledgment)
+
+The framework's hardened gates use **literal mandated wording** for user prompts. The literal-wording requirement IS the rationalization-resistance mechanism — agents trained on English are constrained from paraphrasing English templates, which removes the "I'll soften this for the user" failure mode the original critique called out.
+
+This reference defines all 5 user-prompt templates. Command bodies reference templates by ID (e.g., `prompt-template: pre-analysis-decision`); the framework refuses to deviate from the literal wording. Substitutions are limited to `{{placeholder}}` markers documented per template.
+
+The 2 deterministic gates (`dev-guides-load`, `playbook-load`) have NO user prompts and therefore NO templates here.
+
+## Template authoring rules
+
+1. **Literal text** — exactly as written, including punctuation, capitalization, line breaks
+2. **Placeholders** — only `{{snake_case_marker}}` substitutions allowed; documented per template
+3. **No paraphrase** — framework refuses to "translate" or "soften" the text
+4. **No pre-answer** — framework refuses to add "I think the answer is X" or similar before the prompt
+5. **No reorder** — option lists ([y]/[n]/[s] etc.) preserve order
+6. **No truncate** — even on long content, the framework shows verbatim agent output (per the show-not-summarize mechanism)
+
+## Template ID: `pre-analysis-decision`
+
+Fired by `/research` after `analysis-agent` returns. Substitutions: `{{decision}}`, `{{signals_used}}`, `{{reasoning}}`, `{{children_list}}` (multi-line; only present when decision == "epic_candidate").
+
+```
+Pre-analysis verdict: {{decision}}
+Signals fired: {{signals_used}}
+
+Agent reasoning (verbatim):
+{{reasoning}}
+
+{{#if decision == "epic_candidate"}}
+Proposed children:
+{{children_list}}
+
+Create as epic with these children?
+[y]es — convert to epic via /migrate-to-epic
+[n]o flat — proceed as flat task
+[s]tandard — show edit list of proposed children
+{{/if}}
+{{#if decision == "keep_flat"}}
+Verdict recorded as keep_flat. Proceed as flat task.
+
+[y]es — proceed as flat (default)
+[n]o — abort and re-evaluate
+{{/if}}
+{{#if decision == "insufficient_info"}}
+Agent had insufficient context. Verdict recorded as insufficient_info. Proceed as flat task with the option to re-run pre-analysis after research.
+
+[y]es — proceed as flat
+[n]o — abort
+{{/if}}
+```
+
+Default for keep_flat / insufficient_info: `[y]`. For epic_candidate: no default — user MUST pick.
+
+## Template ID: `coverage-mapping-fail`
+
+Fired by `/research` at end-of-phase when `coverage-mapping-check.sh` returns `verdict: fail`. Substitutions: `{{missing_questions}}` (multi-line list).
+
+```
+Phase 1 incomplete: missing coverage mapping in research.md.
+
+The framework requires a `## Coverage Mapping` H2 section that maps each Research Question to the section(s) of research.md that address it.
+
+Missing or unaddressed questions:
+{{missing_questions}}
+
+To complete Phase 1, add the section to research.md and re-run /research, OR pass --skip-coverage-check <reason> to bypass (recorded in audit).
+
+[a]bort — leave Phase 1 incomplete; fix research.md and re-run
+[s]kip — bypass with reason (you'll be prompted for the reason)
+```
+
+Default: `[a]`.
+
+## Template ID: `skill-review-decision`
+
+Fired by `/complete` when `git diff --cached --name-only` shows `skills/*/SKILL.md` changes. Substitutions: `{{skills_reviewed}}` (comma-list), `{{findings}}` (multi-line agent output).
+
+```
+Skill quality review for {{skills_reviewed}}:
+
+{{findings}}
+
+[a]ccept — findings are acceptable; proceed with /complete
+[r]emediate — fix the findings now (you'll edit the skills, then return here)
+[b]ypass — skip with reason (you'll be prompted for the reason; recorded in audit)
+```
+
+Default: no default — user MUST pick.
+
+## Template ID: `plugin-validate-decision`
+
+Fired by `/complete` when `git diff --cached --name-only` shows plugin file changes. Substitutions: `{{plugins_validated}}` (comma-list), `{{findings}}` (multi-line slash-command output).
+
+```
+Plugin validation for {{plugins_validated}}:
+
+{{findings}}
+
+[a]ccept — findings are acceptable; proceed with /complete
+[r]emediate — fix the findings now (you'll edit, then return here)
+[b]ypass — skip with reason (you'll be prompted for the reason; recorded in audit)
+```
+
+Default: no default — user MUST pick.
+
+## Template ID: `phase-command-bypass-acknowledge`
+
+Fired post-hoc by `/audit-status` when listing tasks with `_phase-command-bypass.json` audit files. NOT fired at Write time (the hook is non-blocking; it just records). Substitutions: `{{artifact_written}}`, `{{phase_command_active}}`, `{{fired_at}}`.
+
+```
+Phase-command bypass detected:
+  Artifact: {{artifact_written}}
+  Time: {{fired_at}}
+  Phase command active: {{phase_command_active}}
+
+The framework expected a /research / /design / /implement slash command to be active when this artifact was written. Direct Write means the phase command's gates (pre-analysis, dev-guides preflight, alignment retrofit, traceability walkthrough) did not fire.
+
+[a]cknowledge — note the bypass and continue (recorded in audit)
+[r]e-run — invoke the proper phase command now to retroactively fire the gates
+```
+
+Default: `[a]` — non-blocking acknowledgment.
+
+## Bypass-reason capture
+
+When a user picks the bypass option (`[s]kip` on coverage-mapping; `[b]ypass` on skill-review or plugin-validate; `[r]e-run` is NOT a bypass), the framework prompts:
+
+```
+Reason for bypass: <free-text>
+```
+
+The free-text is stored verbatim in the audit file's `bypass_reason` field. Empty string is allowed but discouraged.
+
+## Versioning policy
+
+- **Major bumps** are breaking: template ID rename, placeholder rename, option-list reorder.
+- **Minor bumps** are additive: new templates (e.g., when a new hardened surface ships), new optional placeholders. Existing template IDs and shape preserved.
+
+v1.0 covers all 5 v4.0.0 user-prompt surfaces.
+
+## Non-goals
+
+- **No i18n.** v1 ships English-only. Translating risks losing rationalization-resistance unless per-locale literal templates ship with their own anti-paraphrase guarantee.
+- **No template inheritance / composition.** Each template is standalone literal text. Reuse via DRY would obscure what the user actually sees.
+- **No conditional UX modes.** No "verbose" vs "compact" prompts. The literal wording is the wording.
+- **No template authoring tool.** Templates live in this markdown reference, hand-edited. No generator script in v1.

--- a/drupal-dev-framework/scripts/coverage-mapping-check.sh
+++ b/drupal-dev-framework/scripts/coverage-mapping-check.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# coverage-mapping-check.sh — verify research.md has the required Coverage Mapping section.
+#
+# Usage: coverage-mapping-check.sh <task_folder>
+#
+# Always emits single JSON object to stdout. Exit 0 for all recoverable states.
+# Non-zero ONLY for bash-level read failures.
+#
+# Output (per references/gate-audit-schema.md §5.2 gate_specific shape):
+#   {
+#     "verdict": "pass | fail",
+#     "research_questions_found": <int>,
+#     "research_questions_addressed": <int>,
+#     "missing_questions": ["<question text>", ...],
+#     "warnings": []
+#   }
+#
+# Logic:
+#   1. research.md must exist
+#   2. research.md must contain a `## Coverage Mapping` H2 (synonyms accepted:
+#      `## Coverage Mapping`, `## Coverage`, `## Coverage Map`)
+#   3. Section must have ≥3 content lines below the heading
+#   4. Each Research Question from task.md (extracted from `## Research Questions`
+#      bullets) must have a corresponding row in the Coverage Mapping section
+#      (matched by case-insensitive substring of the question text against the row)
+#
+# verdict: pass requires all 4 conditions; fail otherwise.
+
+set -uo pipefail
+
+TASK_FOLDER="${1:?task folder required}"
+RESEARCH_MD="$TASK_FOLDER/research.md"
+TASK_MD="$TASK_FOLDER/task.md"
+
+emit() {
+  jq -nc \
+    --arg v "$1" \
+    --argjson found "$2" \
+    --argjson addressed "$3" \
+    --argjson missing "$4" \
+    --argjson warnings "${5:-[]}" '
+    {
+      verdict: $v,
+      research_questions_found: $found,
+      research_questions_addressed: $addressed,
+      missing_questions: $missing,
+      warnings: $warnings
+    }'
+}
+
+if [[ ! -f "$RESEARCH_MD" ]]; then
+  emit "fail" 0 0 '[]' '[{"code":"research_md_missing","detail":"research.md not found"}]'
+  exit 0
+fi
+
+# Find a Coverage Mapping H2 heading (synonyms accepted)
+COVERAGE_LINE=$(awk '
+  BEGIN { IGNORECASE = 1 }
+  /^## ([0-9]+\.?[[:space:]]+)?(Coverage Mapping|Coverage Map|Coverage)([[:space:]]|\.|$)/ {
+    print NR
+    exit
+  }
+' "$RESEARCH_MD")
+
+if [[ -z "$COVERAGE_LINE" ]]; then
+  emit "fail" 0 0 '[]' '[{"code":"coverage_section_missing","detail":"## Coverage Mapping (or Coverage / Coverage Map) H2 not found in research.md"}]'
+  exit 0
+fi
+
+# Count content lines below the heading until next H2
+CONTENT_LINES=$(awk -v start="$COVERAGE_LINE" '
+  NR > start {
+    if (/^## /) exit
+    if (NF > 0) count++
+  }
+  END { print count + 0 }
+' "$RESEARCH_MD")
+
+if [[ "$CONTENT_LINES" -lt 3 ]]; then
+  emit "fail" 0 0 '[]' "[{\"code\":\"coverage_section_thin\",\"detail\":\"## Coverage Mapping has fewer than 3 content lines (found $CONTENT_LINES)\"}]"
+  exit 0
+fi
+
+# Extract Research Questions from task.md if present
+QUESTIONS_FOUND=0
+QUESTIONS_ADDRESSED=0
+MISSING_JSON='[]'
+
+if [[ -f "$TASK_MD" ]]; then
+  # Extract bullets under ## Research Questions (case-insensitive)
+  QUESTIONS=$(awk '
+    BEGIN { in_block = 0; IGNORECASE = 1 }
+    /^## Research Questions/ { in_block = 1; next }
+    in_block && /^## / { in_block = 0 }
+    in_block && /^- / {
+      line = $0
+      sub(/^- */, "", line)
+      print line
+    }
+  ' "$TASK_MD")
+
+  if [[ -n "$QUESTIONS" ]]; then
+    # Extract Coverage Mapping section content
+    COVERAGE_BODY=$(awk -v start="$COVERAGE_LINE" '
+      NR > start {
+        if (/^## /) exit
+        print
+      }
+    ' "$RESEARCH_MD")
+
+    # For each question, check if a substring of it appears in coverage body
+    MISSING_ARR=()
+    while IFS= read -r q; do
+      [[ -z "$q" ]] && continue
+      QUESTIONS_FOUND=$((QUESTIONS_FOUND + 1))
+      # Use first 30 chars of the question as the substring (lowercase compare)
+      SUBSTR=$(echo "$q" | head -c 30 | tr '[:upper:]' '[:lower:]')
+      if echo "$COVERAGE_BODY" | tr '[:upper:]' '[:lower:]' | grep -qF "$SUBSTR"; then
+        QUESTIONS_ADDRESSED=$((QUESTIONS_ADDRESSED + 1))
+      else
+        MISSING_ARR+=("$q")
+      fi
+    done <<< "$QUESTIONS"
+
+    if [[ "${#MISSING_ARR[@]}" -gt 0 ]]; then
+      MISSING_JSON=$(printf '%s\n' "${MISSING_ARR[@]}" | jq -R . | jq -s -c .)
+    fi
+  fi
+fi
+
+# Verdict
+if [[ "$QUESTIONS_FOUND" -eq 0 ]]; then
+  # No declared questions — section presence is enough
+  emit "pass" 0 0 '[]' '[]'
+elif [[ "$QUESTIONS_ADDRESSED" -lt "$QUESTIONS_FOUND" ]]; then
+  emit "fail" "$QUESTIONS_FOUND" "$QUESTIONS_ADDRESSED" "$MISSING_JSON" '[]'
+else
+  emit "pass" "$QUESTIONS_FOUND" "$QUESTIONS_ADDRESSED" '[]' '[]'
+fi

--- a/drupal-dev-framework/scripts/dev-guides-detect.sh
+++ b/drupal-dev-framework/scripts/dev-guides-detect.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# dev-guides-detect.sh — deterministic auto-load keyword detection.
+#
+# Usage: dev-guides-detect.sh <task_folder>
+#
+# Replaces agent-mediated keyword detection in guide-integrator with a
+# deterministic shell scan. The auto-load keyword table mirrors
+# skills/guide-integrator/SKILL.md §"Auto-Load Rules" verbatim.
+#
+# Output (per references/gate-audit-schema.md §5.6 gate_specific shape):
+#   {
+#     "keywords_matched": ["gate", "complete", "quality"],
+#     "guides_to_load": ["plugin:quality-gates"],
+#     "scanned_files": [".../task.md", ".../research.md"],
+#     "warnings": []
+#   }
+#
+# Scanned content: task.md + research.md (if present) + alignment.md (if present) +
+# architecture.md (if present) + implementation.md (if present).
+# All converted to lowercase for case-insensitive matching.
+
+set -uo pipefail
+
+TASK_FOLDER="${1:?task folder required}"
+
+# Build scanned content set
+SCANNED_FILES=()
+SCANNED_CONTENT=""
+for f in task.md alignment.md research.md architecture.md implementation.md; do
+  PATH_F="$TASK_FOLDER/$f"
+  if [[ -f "$PATH_F" ]]; then
+    SCANNED_FILES+=("$PATH_F")
+    SCANNED_CONTENT+=$'\n'"$(cat "$PATH_F")"
+  fi
+done
+
+if [[ -z "$SCANNED_CONTENT" ]]; then
+  jq -nc '{
+    keywords_matched: [],
+    guides_to_load: [],
+    scanned_files: [],
+    warnings: [{code: "no_artifacts", detail: "task folder has no markdown artifacts to scan"}]
+  }'
+  exit 0
+fi
+
+# Lowercase for matching
+LC_CONTENT=$(echo "$SCANNED_CONTENT" | tr '[:upper:]' '[:lower:]')
+
+# Auto-load rules (mirrors skills/guide-integrator/SKILL.md verbatim).
+# Each row: keywords (regex-alternation) | guide ID
+# Format below: regex pattern + guide ID, separated by literal "::"
+declare -a RULES=(
+  "test|tdd|unit test|kernel test::plugin:tdd-workflow"
+  "service|dependency|inject|solid::plugin:solid-drupal"
+  "duplicate|reuse|dry|extract::plugin:dry-patterns"
+  "form|drush|command|service first::plugin:library-first"
+  "complete|done|quality|gate::plugin:quality-gates"
+)
+
+KEYWORDS_MATCHED=()
+GUIDES_TO_LOAD=()
+
+for rule in "${RULES[@]}"; do
+  PATTERN="${rule%%::*}"
+  GUIDE_ID="${rule##*::}"
+
+  # Check if any keyword in the pattern matches in scanned content
+  MATCHED_KEYWORDS=$(echo "$LC_CONTENT" | grep -oE "\\b($PATTERN)\\b" | sort -u | head -10)
+
+  if [[ -n "$MATCHED_KEYWORDS" ]]; then
+    GUIDES_TO_LOAD+=("$GUIDE_ID")
+    while IFS= read -r kw; do
+      [[ -n "$kw" ]] && KEYWORDS_MATCHED+=("$kw")
+    done <<< "$MATCHED_KEYWORDS"
+  fi
+done
+
+# Dedupe keywords
+if [[ "${#KEYWORDS_MATCHED[@]}" -gt 0 ]]; then
+  KEYWORDS_JSON=$(printf '%s\n' "${KEYWORDS_MATCHED[@]}" | sort -u | jq -R . | jq -s -c .)
+else
+  KEYWORDS_JSON='[]'
+fi
+
+if [[ "${#GUIDES_TO_LOAD[@]}" -gt 0 ]]; then
+  GUIDES_JSON=$(printf '%s\n' "${GUIDES_TO_LOAD[@]}" | sort -u | jq -R . | jq -s -c .)
+else
+  GUIDES_JSON='[]'
+fi
+
+FILES_JSON=$(printf '%s\n' "${SCANNED_FILES[@]}" | jq -R . | jq -s -c .)
+
+jq -nc \
+  --argjson keywords "$KEYWORDS_JSON" \
+  --argjson guides "$GUIDES_JSON" \
+  --argjson files "$FILES_JSON" '
+  {
+    keywords_matched: $keywords,
+    guides_to_load: $guides,
+    scanned_files: $files,
+    warnings: []
+  }'

--- a/drupal-dev-framework/scripts/gate-audit-write.sh
+++ b/drupal-dev-framework/scripts/gate-audit-write.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# gate-audit-write.sh — atomic gate audit file writer.
+#
+# Usage: gate-audit-write.sh <task_folder> <gate_type> <json_payload>
+#
+#   <task_folder>: absolute path to task folder
+#   <gate_type>: one of pre-analysis | coverage-mapping | skill-review |
+#                plugin-validate | phase-command-bypass | dev-guides-load |
+#                playbook-load
+#   <json_payload>: complete audit JSON object conforming to
+#                   references/gate-audit-schema.md v1.0
+#
+# Behavior:
+# - Validates the JSON parses + has schema_version "1.0"
+# - Validates gate_type is one of the 7 allowed values
+# - Validates required top-level fields (gate_type, fired_at, task_folder, gate_specific)
+# - Writes to <task_folder>/_<gate_type>.json (overwrite-on-fire)
+# - Atomic via temp + rename
+#
+# Exit codes:
+#   0 — written successfully
+#   1 — bash-level write failure (permissions, disk, missing folder)
+#   2 — invalid input (bad JSON, schema mismatch, missing fields, bad gate_type)
+
+set -uo pipefail
+
+TASK_FOLDER="${1:?task folder required}"
+GATE_TYPE="${2:?gate type required}"
+PAYLOAD="${3:?JSON payload required}"
+
+# Validate gate_type
+case "$GATE_TYPE" in
+  pre-analysis|coverage-mapping|skill-review|plugin-validate|phase-command-bypass|dev-guides-load|playbook-load)
+    ;;
+  *)
+    echo "gate-audit-write: invalid gate_type: $GATE_TYPE" >&2
+    echo "  must be one of: pre-analysis, coverage-mapping, skill-review, plugin-validate, phase-command-bypass, dev-guides-load, playbook-load" >&2
+    exit 2
+    ;;
+esac
+
+# Validate JSON parses
+if ! echo "$PAYLOAD" | jq empty >/dev/null 2>&1; then
+  echo "gate-audit-write: invalid JSON payload" >&2
+  exit 2
+fi
+
+# Validate schema_version
+SV=$(echo "$PAYLOAD" | jq -r '.schema_version // empty')
+if [[ "$SV" != "1.0" ]]; then
+  echo "gate-audit-write: schema_version must be \"1.0\" (got \"$SV\")" >&2
+  exit 2
+fi
+
+# Validate gate_type matches argument
+PAYLOAD_GT=$(echo "$PAYLOAD" | jq -r '.gate_type // empty')
+if [[ "$PAYLOAD_GT" != "$GATE_TYPE" ]]; then
+  echo "gate-audit-write: payload gate_type ($PAYLOAD_GT) does not match argument ($GATE_TYPE)" >&2
+  exit 2
+fi
+
+# Validate required fields
+for field in fired_at task_folder gate_specific; do
+  if ! echo "$PAYLOAD" | jq -e "has(\"$field\")" >/dev/null 2>&1; then
+    echo "gate-audit-write: missing required field: $field" >&2
+    exit 2
+  fi
+done
+
+# Validate task folder exists
+if [[ ! -d "$TASK_FOLDER" ]]; then
+  echo "gate-audit-write: task folder does not exist: $TASK_FOLDER" >&2
+  exit 1
+fi
+
+OUT_FILE="$TASK_FOLDER/_${GATE_TYPE}.json"
+TMP_FILE="$OUT_FILE.tmp.$$"
+
+# Atomic write: temp + rename
+if ! echo "$PAYLOAD" | jq . > "$TMP_FILE" 2>/dev/null; then
+  echo "gate-audit-write: failed to write temp file" >&2
+  rm -f "$TMP_FILE"
+  exit 1
+fi
+
+if ! mv "$TMP_FILE" "$OUT_FILE"; then
+  echo "gate-audit-write: failed to rename temp to $OUT_FILE" >&2
+  rm -f "$TMP_FILE"
+  exit 1
+fi
+
+echo "gate-audit-write: wrote $OUT_FILE"
+exit 0

--- a/drupal-dev-framework/scripts/phase-command-bypass-detect.sh
+++ b/drupal-dev-framework/scripts/phase-command-bypass-detect.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# phase-command-bypass-detect.sh — detect Write-tool-bypass of phase commands.
+#
+# Usage: phase-command-bypass-detect.sh <task_folder> <artifact_name>
+#
+#   <task_folder>: absolute path to the task folder
+#   <artifact_name>: research.md | architecture.md | implementation.md
+#
+# Behavior:
+# - Reads session_context.json for the current workspace
+# - Determines if a phase command is currently active (lastPhase field)
+# - Checks if the artifact's expected phase command matches the active one
+# - If mismatch (or no phase command active), emits a phase-command-bypass
+#   audit JSON to stdout for the caller (a PreToolUse hook) to write via
+#   gate-audit-write.sh
+# - If match, emits empty JSON `{}` (no bypass; legitimate phase-command authoring)
+#
+# Notes:
+# - Non-blocking. Returns the audit JSON; caller decides whether to write it.
+# - The hook that invokes this script does NOT abort the Write tool. The
+#   bypass is recorded but the Write proceeds. This is soft-nudge: we audit,
+#   we don't block.
+
+set -uo pipefail
+
+TASK_FOLDER="${1:?task folder required}"
+ARTIFACT="${2:?artifact name required}"
+
+# Map artifact → expected phase command
+EXPECTED=""
+case "$ARTIFACT" in
+  research.md) EXPECTED="research" ;;
+  architecture.md) EXPECTED="design" ;;
+  implementation.md) EXPECTED="implement" ;;
+  *)
+    # Unknown artifact; treat as no-op
+    echo "{}"
+    exit 0
+    ;;
+esac
+
+# Read session_context for current workspace
+WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
+SESS_FILE="$HOME/.claude/drupal-dev-framework/sessions/$WORKSPACE_HASH.json"
+
+ACTIVE_PHASE="null"
+if [[ -f "$SESS_FILE" ]]; then
+  RAW=$(jq -r '.lastPhase // empty' "$SESS_FILE" 2>/dev/null)
+  [[ -n "$RAW" ]] && ACTIVE_PHASE="$RAW"
+fi
+
+# Check match
+if [[ "$ACTIVE_PHASE" == "$EXPECTED" ]]; then
+  # Legitimate phase-command authoring; no bypass
+  echo "{}"
+  exit 0
+fi
+
+# Bypass detected — emit audit JSON
+FIRED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+jq -nc \
+  --arg artifact "$ARTIFACT" \
+  --arg active "$ACTIVE_PHASE" \
+  --arg expected "$EXPECTED" \
+  --arg task_folder "$TASK_FOLDER" \
+  --arg fired_at "$FIRED_AT" '
+  {
+    schema_version: "1.0",
+    gate_type: "phase-command-bypass",
+    fired_at: $fired_at,
+    task_folder: $task_folder,
+    user_choice: null,
+    bypass_reason: null,
+    gate_specific: {
+      artifact_written: $artifact,
+      phase_command_active: (if $active == "null" or $active == "" then null else $active end),
+      expected_phase_command: $expected
+    }
+  }'

--- a/drupal-dev-framework/scripts/playbook-load-deterministic.sh
+++ b/drupal-dev-framework/scripts/playbook-load-deterministic.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# playbook-load-deterministic.sh — deterministic playbook loader.
+#
+# Usage: playbook-load-deterministic.sh <project_folder>
+#
+# Replaces the agent-mediated load step in guide-integrator §6 with a
+# deterministic invocation. Reads project_state.md via project-state-read.sh,
+# resolves playbookSets, loads userPlaybook via playbook-read.sh.
+#
+# Output (per references/gate-audit-schema.md §5.7 gate_specific shape):
+#   {
+#     "playbook_sets_loaded": [...],
+#     "playbook_sets_source": "explicit | explicit-none | default",
+#     "user_playbook_loaded": "/abs/path or null",
+#     "plays_by_section": {"CSS / SCSS": 5, ...},
+#     "conflicts_detected": [],
+#     "warnings": []
+#   }
+#
+# Notes:
+# - This script does NOT actually fetch dev-guides content; it records
+#   intent ("these sets should be loaded"). The fetch is the consumer's job
+#   (e.g., guide-integrator orchestrates dev-guides-navigator calls).
+# - For userPlaybook, the script DOES invoke playbook-read.sh and counts
+#   plays by section.
+# - Conflicts: deferred to v4.0.x — this v1 script does NOT detect conflicts;
+#   that logic lives in guide-integrator's runtime cross-reference.
+
+set -uo pipefail
+
+PROJECT_FOLDER="${1:?project folder required}"
+
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+PROJECT_STATE_READ="$SCRIPT_DIR/project-state-read.sh"
+PLAYBOOK_READ="$SCRIPT_DIR/playbook-read.sh"
+
+# Read project state
+STATE_JSON=$(bash "$PROJECT_STATE_READ" "$PROJECT_FOLDER" 2>/dev/null)
+
+if [[ -z "$STATE_JSON" ]]; then
+  jq -nc '{
+    playbook_sets_loaded: [],
+    playbook_sets_source: "default",
+    user_playbook_loaded: null,
+    plays_by_section: {},
+    conflicts_detected: [],
+    warnings: [{code: "project_state_read_failed", detail: "could not read project_state.md"}]
+  }'
+  exit 0
+fi
+
+PB_SETS=$(echo "$STATE_JSON" | jq -c '.playbookSets // []')
+PB_SOURCE=$(echo "$STATE_JSON" | jq -r '.playbookSetsSource // "default"')
+USER_PB=$(echo "$STATE_JSON" | jq -r '.userPlaybook // empty')
+USER_PB_STATE=$(echo "$STATE_JSON" | jq -r '.userPlaybookState // "unset"')
+
+# Default outputs
+PLAYS_BY_SECTION='{}'
+USER_PB_OUT="null"
+WARNINGS='[]'
+
+# Load userPlaybook if set
+if [[ "$USER_PB_STATE" == "set" ]] && [[ -n "$USER_PB" ]] && [[ -f "$USER_PB" ]]; then
+  USER_PB_OUT="$USER_PB"
+  PB_OUTPUT=$(bash "$PLAYBOOK_READ" "$USER_PB" 2>/dev/null)
+  if [[ -n "$PB_OUTPUT" ]]; then
+    # Group plays by section, count
+    PLAYS_BY_SECTION=$(echo "$PB_OUTPUT" | jq -c '
+      [.plays[] | {section, count: 1}] |
+      group_by(.section) |
+      map({key: .[0].section, value: (map(.count) | add)}) |
+      from_entries
+    ')
+    [[ -z "$PLAYS_BY_SECTION" || "$PLAYS_BY_SECTION" == "null" ]] && PLAYS_BY_SECTION='{}'
+
+    # Surface parser warnings
+    PB_WARNINGS=$(echo "$PB_OUTPUT" | jq -c '.warnings // []')
+    if [[ "$PB_WARNINGS" != "[]" ]]; then
+      WARNINGS=$(echo "$PB_OUTPUT" | jq -c '[.warnings[] | {code: .code, detail: ("playbook-read: " + .detail)}]')
+    fi
+  fi
+elif [[ "$USER_PB_STATE" == "set" ]] && [[ -n "$USER_PB" ]]; then
+  # Path declared but file missing
+  WARNINGS=$(jq -nc --arg p "$USER_PB" '[{code: "user_playbook_missing", detail: ("declared path does not exist: " + $p)}]')
+fi
+
+# Compose output
+jq -nc \
+  --argjson sets "$PB_SETS" \
+  --arg source "$PB_SOURCE" \
+  --arg up "$USER_PB_OUT" \
+  --argjson plays "$PLAYS_BY_SECTION" \
+  --argjson warnings "$WARNINGS" '
+  {
+    playbook_sets_loaded: $sets,
+    playbook_sets_source: $source,
+    user_playbook_loaded: (if $up == "null" then null else $up end),
+    plays_by_section: $plays,
+    conflicts_detected: [],
+    warnings: $warnings
+  }'

--- a/drupal-dev-framework/skills/guide-integrator/SKILL.md
+++ b/drupal-dev-framework/skills/guide-integrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guide-integrator
 description: "Use when designing or researching features — loads plugin methodology refs (SOLID, DRY, TDD, Library-First, Quality Gates, Purposeful Code), delegates to dev-guides-navigator for online Drupal domain knowledge, AND loads active playbook sets + project-local user playbook (v3.15.0+). Cross-references plays-by-topic and emits conflicts[]. Records each loaded guide into session_context.json loadedGuides[] so re-loads are skipped."
-version: 5.0.0
+version: 5.1.0
 user-invocable: false
 model: sonnet
 ---
@@ -45,6 +45,8 @@ Activate when:
 | "duplicate", "reuse", "DRY", "extract" | `references/dry-patterns.md` |
 | "form", "drush", "command", "service first" | `references/library-first.md` |
 | "complete", "done", "quality", "gate" | `references/quality-gates.md` |
+
+**v4.0.0+: deterministic detection.** As of v4.0.0, keyword detection runs via `${CLAUDE_PLUGIN_ROOT}/scripts/dev-guides-detect.sh` (not agent judgment). The script greps `task.md` + phase artifacts + alignment.md for the keywords above and returns a structured JSON of matched keywords + guide IDs. Phase commands invoke the script BEFORE prompting the user, populating the prompt's "Auto-loaded based on task keywords:" line from script output. This eliminates bypass-by-declaration (agent claiming "none matched" without running detection).
 
 ## Workflow
 
@@ -147,27 +149,17 @@ After loading methodology refs and dev-guides topics, load the project's playboo
 
 Invoke `project-state-reader` skill to get `playbookSets[]`, `userPlaybook`, `userPlaybookState`, and `playbookResolutions[]`.
 
-#### 6b. Load shipped playbook sets
+#### 6b-c. Deterministic load (v4.0.0+)
 
-For each set ID in `playbookSets[]` (e.g., `drupal/best-practices/camoa`):
-
-- Delegate to `dev-guides-navigator` to fetch the set's index.md and individual guide pages relevant to the current task domain.
-- Record each loaded guide ID via the snippet in §2b.
-- Track loaded guide titles + summaries for cross-reference.
-
-When `playbookSets` is empty (`playbookSetsSource: "explicit-none"` or `"default"` with empty default), skip this step silently.
-
-#### 6c. Load local playbook
-
-If `userPlaybookState == "set"`, invoke:
+As of v4.0.0, the playbook load step is delegated to a single deterministic script that handles both shipped sets AND local playbook in one invocation:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/playbook-read.sh" "<userPlaybook absolute path>"
+"${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh" "<project_folder>"
 ```
 
-Parse the JSON. Each play is `{title, section, what, rationale, when_it_applies, applicability, ...}`. Track titles + sections + topics for cross-reference.
+The script reads `project_state.md` via `project-state-read.sh`, resolves `playbookSets[]` (records intent — actual fetch from dev-guides-navigator happens here in step 6b for guide CONTENT), loads `userPlaybook` via `playbook-read.sh`, and emits a structured JSON with `playbook_sets_loaded`, `user_playbook_loaded`, `plays_by_section` count map. The integrator stores the JSON as `<task>/_playbook-load.json` audit file (per `references/gate-audit-schema.md` v1.0). This replaces the previous agent-mediated load.
 
-If `userPlaybookState != "set"`, skip silently.
+For each set in `playbook_sets_loaded[]`: delegate to `dev-guides-navigator` to fetch individual guide pages relevant to the current task domain. Record each loaded guide ID via the snippet in §2b. Track loaded guide titles + summaries for cross-reference.
 
 #### 6d. Detect conflicts
 


### PR DESCRIPTION
## ⚠️ BREAKING CHANGES — major bump

v4.0.0 converts 7 framework surfaces from soft-prompt to hard-gate, applying the original critique's 5-mechanism pattern uniformly. **Behavior changes for users on the soft posture** — documented bypass paths are removed; explicit \`--skip-*\` flags required to skip; bypass reasons are recorded on disk for retrospective audit.

## Hardened surfaces (7)

**User-prompt surfaces (5)** — fire user prompts with mandated wording from \`references/gate-hardening-prompts.md\` v1.0:

1. **Pre-analysis epic gate** at \`/research\` — always-on (was: signal-conditional)
2. **Coverage-mapping requirement** at end-of-\`/research\` — refuses Phase 1 \`[x]\` without \`## Coverage Mapping\` H2
3. **Skill-review** at \`/complete\` — invokes \`plugin-creation-tools:skill-quality-reviewer\` when staged \`skills/*/SKILL.md\` changes
4. **Plugin-validate** at \`/complete\` — invokes \`/plugin-creation-tools:validate\` when staged plugin file changes
5. **Phase-command-bypass** — PreToolUse hook on Write to phase artifacts; non-blocking audit

**Deterministic surfaces (2)** — fire shell scripts that detect+act without user prompts:

6. **Dev-guides preflight** — \`scripts/dev-guides-detect.sh\` replaces agent-mediated keyword detection
7. **Playbook loading** — \`scripts/playbook-load-deterministic.sh\` replaces agent-mediated load

## Files

- **New (10):** 2 references, 5 scripts, 2 hooks, 1 command
- **Updated (10):** 4 phase commands, status.md, 1 skill, 1 agent, plugin.json, CLAUDE.md, README.md, CHANGELOG.md, root marketplace.json

Plus shared/v2-candidates.md gets new Set D in the camoa_skills memory project (5 deferred surfaces with \"wait for incident\" promotion triggers).

## 5-mechanism pattern (uniform)

1. Anti-bypass clause (literal block in command body)
2. Show-not-summarize (verbatim agent output before user prompt)
3. Audit on disk (\`<task>/_<gate>.json\` per fired gate)
4. Mandate exact prompt wording (no paraphrase)
5. Refactor \"if X, do Y\" → \"validation gate, always evaluated\"

## Audit infrastructure

- \`references/gate-audit-schema.md\` v1.0 — unified schema for all 7 audit file types
- \`references/gate-hardening-prompts.md\` v1.0 — 5 literal prompt templates
- \`scripts/gate-audit-write.sh\` — atomic JSON-validated audit writer
- New \`/audit-status [<task>] [--all]\` command — read-only audit-state view; surfaces unaudited gates as silent-skip evidence

## Skip flags

Per-gate explicit-skip required (no rationalization path):

- \`--skip-pre-analysis [reason]\`
- \`--skip-coverage-check [reason]\`
- \`--skip-skill-review [reason]\`
- \`--skip-plugin-validate [reason]\`

Each writes audit with \`bypass_reason\`. Visible later via \`/audit-status\` and \`/status\` Unaudited gates section.

## Grandfathering

v3.x in-flight tasks past Phase 1 at v4.0.0 install keep their original soft contract. Heuristic: \`research.md present && _pre-analysis.json absent\` → grandfathered.

## Audit + paper-test

- plugin-structure-auditor: **26/30 → expected 28+/30** after fixes
- 5 inline smoke tests passed during Phase A authoring (gate-audit-write, coverage-mapping-check, dev-guides-detect, playbook-load, phase-command-bypass-detect)
- 2 real MAJORs caught + fixed: complete.md stale description; research.md stale body header. 1 false-positive flagged.

## Real bypass evidence captured during this task

Documented in this task's research.md §2.2 (4 in-session bypasses captured live):

- Bypass A: skill-quality-reviewer skipped on v3.15.0 + v3.16.0
- Bypass B: /plugin-creation-tools:validate never invoked
- Bypass C: meta-bypass — agent wrote research.md/architecture.md/architecture.md directly (skipped /research /scope /design slash commands; user caught and triggered restart)
- Bypass D: bypass-by-declaration — agent printed \"Auto-loaded: — none auto-matched —\" without invoking guide-integrator's keyword detection

These are the gates v4.0.0 fixes.

## Test plan

- [ ] Install resolves v4.0.0 cleanly with both hard deps + recommended plugin-creation-tools
- [ ] Pre-analysis fires unconditionally — verified by \`/research <new-task>\` on a flat-shaped task; \`_pre-analysis.json\` written
- [ ] Coverage-mapping check fires — verified by running \`/research\` with research.md missing the section; Phase 1 \`[x]\` refused; adding the section unblocks
- [ ] Skill-review fires at \`/complete\` on a task with staged \`skills/*/SKILL.md\` changes
- [ ] Plugin-validate fires at \`/complete\` on any plugin file change
- [ ] Phase-command-bypass detected — verified by direct Write to phase artifact; \`_phase-command-bypass.json\` written; non-blocking
- [ ] Dev-guides deterministic detection — verified by running \`/research <task>\` with name matching auto-load keyword; correct guide loaded; \`_dev-guides-load.json\` records the match
- [ ] Playbook deterministic load — verified on idexx; \`_playbook-load.json\` written with actual loaded set
- [ ] All 7 audit files conform to gate-audit-schema.md v1.0 — \`jq\` validation passes
- [ ] Skip flags work — verified each \`--skip-*\` populates \`bypass_reason\`
- [ ] \`/audit-status\` lists unaudited gates correctly
- [ ] Grandfathering works — \`dev_framework_research_artifact_structure\` (v3.x in-flight stub) doesn't suddenly look broken
- [ ] Dog-food on this very task — invoke v4.0.0 hardened gates against gate_hardening's own \`_pre-restart/\` directory; \`_phase-command-bypass.json\` writes retroactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)