### PR TITLE
feat(plugin-creation-tools): v3.3.0 — 2026-04-25 doc refresh deltas

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.25"
+    "version": "1.14.26"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Complete guide for creating Claude Code plugins \u2014 skills, commands, agents, hooks, MCP servers, and configuration. Covers 26 hook events, the if pre-spawn filter, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
-      "version": "3.2.1",
+      "description": "Complete guide for creating Claude Code plugins \u2014 skills, commands, agents, hooks, MCP servers, and configuration. Covers 28 hook events, the if pre-spawn filter, the mcp_tool handler type, plugin themes, userConfig with type/title schema, allowCrossMarketplaceDependenciesOn, claude plugin tag, forked subagents, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
+      "version": "3.3.0",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
-  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 26 hook events (with the `if` pre-spawn filter), MCP servers, plugin dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
-  "version": "3.2.1",
+  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 28 hook events (with the `if` pre-spawn filter and the `mcp_tool` handler type), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
+  "version": "3.3.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/.claude/rules/agent-conventions.md
+++ b/plugin-creation-tools/.claude/rules/agent-conventions.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - "agents/**"
+---
+
+# Agent Conventions (this plugin)
+
+## Required Frontmatter
+- `name` — kebab-case.
+- `description` — opens with imperative identity + delegation triggers ("Use proactively…", "Use when user mentions…"). Must include keywords users would actually say.
+- `tools` — minimum needed. Read-only agents (`plugin-structure-auditor`, `skill-quality-reviewer`) restrict to `Read, Glob, Grep` (`+Bash` for the auditor).
+- `model` — `sonnet` for the audit agents; `haiku` would under-reason on cross-component findings.
+
+## Optional Frontmatter
+- `maxTurns` — bounded for cost. Auditor uses 20 (multi-file traversal); reviewer uses 15 (per-skill loops). Don't raise without a justified reason.
+- `disallowedTools` — explicitly block `Edit`, `Write` on review-only agents to prevent accidental writes through the Task tool.
+
+## Body
+- One agent = one responsibility. The audit agent does NOT do skill-quality review, and vice versa.
+- Output format must be deterministic (fits in a single response — see auditor's "do not split across turns" rule).
+- Score on evidence cited from the files, not vibes.
+- Do NOT duplicate `/plugin-creation-tools:validate` checks — those are owned by the validator. Agents own structural / qualitative judgment that the validator can't make.
+
+## Behavior Notes
+- Plugin-packaged agents have `hooks`, `mcpServers`, `permissionMode` silently ignored for security. Don't author those fields here.
+- For agents users may launch as the main session via `--agent` (rare in this plugin), frontmatter `hooks` and inline `mcpServers` now fire as of Claude Code v2.1.117+ — but this plugin's agents are spawn-only, so it doesn't apply.

--- a/plugin-creation-tools/.claude/rules/command-conventions.md
+++ b/plugin-creation-tools/.claude/rules/command-conventions.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - "commands/**"
+---
+
+# Command Conventions (this plugin)
+
+## Required Frontmatter
+- `description` — clear, action-oriented, includes trigger phrases ("Use when…").
+- `allowed-tools` — minimum needed. `validate.md` is read-only (`Read, Glob, Grep`); `create.md` and `add-component.md` need write access.
+
+## Optional Frontmatter
+- `argument-hint` — when the command accepts arguments.
+- `context: fork` — when the command produces noisy output that would pollute the main context (used by `validate.md` and `add-component.md`).
+
+## Body
+- Step-by-step numbered workflow.
+- Reference the templates in `skills/plugin-creation/templates/` rather than reproducing them.
+- Include error handling for missing prerequisites (e.g., "if `.claude-plugin/plugin.json` is absent, ask the user to confirm the plugin root").
+- Validation rules belong in `validate.md`'s checklist sections, not in `create.md` or `add-component.md` — those scaffold; `validate` checks.
+
+## Checklist Discipline (`validate.md`)
+- Every recognized hook event, handler type, plugin component type, and reserved marketplace name must appear in the checklist text.
+- When upstream adds a new event/type/field, update `validate.md` in the same revision as the corresponding reference page.
+- Mark legacy forms as info-level (not warning) when the new schema is additive — let users opt in on their own schedule.
+- Section-name guidance must match upstream Claude Code docs. The Skills "Recommended Structure" uses `## Troubleshooting` (not `## Common Mistakes`); the validator's "missing troubleshooting/error handling section" check accepts either name but new templates should use `Troubleshooting`.

--- a/plugin-creation-tools/.claude/rules/skill-conventions.md
+++ b/plugin-creation-tools/.claude/rules/skill-conventions.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "skills/**"
+---
+
+# Skill Conventions (this plugin)
+
+## Required Frontmatter
+- `name` — kebab-case, max 64 chars, no `claude` / `anthropic`.
+- `description` — starts with "Use when…", third person, includes WHAT and WHEN, ≤ 1,536 chars.
+- `version` — semver, kept in sync with `.claude-plugin/plugin.json` and the marketplace entry.
+
+## Description Discipline
+- **Preserve** any `PROACTIVELY` / `MUST` / `NEVER` imperatives across revisions.
+- **Preserve** the `` !`command` `` dynamic-context injection (this plugin uses `` !`ls .claude-plugin/ 2>/dev/null` ``).
+- Include synonym coverage for every trigger phrase users might say.
+
+## Body
+- Imperative voice — instructions for Claude, not documentation about the skill.
+- Under 500 lines (soft cap). If approaching, move detail into `references/`.
+- Include both an `Examples` section (worked user scenarios) and a `Troubleshooting` section.
+- Use progressive disclosure — link to `references/` rather than reproducing content.
+
+## References
+- Live in `references/<NN>-<topic>/` directories.
+- One level deep — references must link directly from SKILL.md, not from each other.
+- Files >100 lines should have a table of contents.
+- Current state only — no historical narratives, no version migration stories.
+
+## Drift Watchlist
+The hook event count, hook handler types, plugin component types, reserved marketplace names, and skill-description budget numbers must stay in sync between SKILL.md, `commands/validate.md`, and the relevant references. See `../../CLAUDE.md` "Drift to Watch".

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-04-25
+
+Doc-snapshot: upstream `claude_memory/guides/claude/` at commit `c142d14` (135 guides). Covers Claude Code releases **2.1.116 → 2.1.119**. Single PR, additive — no breaking changes.
+
+### Added — Hooks (Track A)
+- **2 new hook events** in `references/06-hooks/hook-events.md`: `UserPromptExpansion` (intercept direct `/skillname` invocations — covers the path `PreToolUse` on the `Skill` tool does not) and `PostToolBatch` (one-shot context injection after a parallel batch resolves). Total event count: **26 → 28**.
+- `duration_ms` field on `PostToolUse` and `PostToolUseFailure` payloads (release 2.1.119).
+- **5th hook handler type** `mcp_tool` in `references/06-hooks/writing-hooks.md` — call a tool on an already-connected MCP server directly from a hook with `server` / `tool` / `input` fields. Worked example: file a Linear issue from a `Stop` hook.
+- Note that the `agent` handler type is upstream-marked **experimental** in writing-hooks.md.
+- Re-confirmed `if`-field Bash-subcommand semantics: `if: "Bash(rm *)"` matches both `FOO=bar rm file` and `npm test && rm file` (after stripping leading `VAR=value` assignments and splitting on subcommands), and runs when the command is too complex to parse.
+- New patterns in `references/06-hooks/hook-patterns.md`: **UserPromptExpansion skill-invocation guard** (block `/deploy` until an approval file exists; inject team checklist) and **PostToolBatch summary** (single batch-summary message instead of per-tool noise).
+- `references/06-hooks/cross-platform-hooks.md`: leading note that `mcp_tool` removes the `.cmd` polyglot-wrapper need when the work is an MCP call.
+- `templates/hooks/hooks.json.template`: commented-out `mcp_tool` example block.
+
+### Added — Plugin Themes (Track B)
+- **NEW `references/08-configuration/themes.md`**: full reference for `themes/*.json` — `name` / `base` / `overrides` schema, the `Ctrl+E` user-customization-by-copy flow, `custom:<plugin-name>:<slug>` persistence naming, when to ship a theme, complete Dracula-style worked example.
+- `themes` added to the component-paths table in `references/08-configuration/plugin-json.md`, with a one-line schema teaser and link to `themes.md`.
+- `templates/plugin.json.template`: optional `themes` field, commented out, with a comment pointing at `themes.md`.
+- `scripts/init_plugin.py`: new `theme` component option (`--components ...,theme` scaffolds `themes/default.json` from `THEME_TEMPLATE`).
+- `commands/add-component.md`: `theme` component with the Ctrl+E read-only reminder.
+- `commands/validate.md`: themes block validates `name` / `base` / `overrides` (warning on missing fields, error on invalid JSON).
+- `agents/plugin-structure-auditor.md`: low-severity opportunity flag in Cross-Component Consistency for visual-identity-named plugins (`*-theme`, `*-design`, `brand-*`, names containing `theme`/`palette`/`color`) shipping no `themes/` directory.
+
+### Added — `userConfig` schema (Track C)
+- **`userConfig` section** added to `references/08-configuration/plugin-json.md` — full `type` / `title` / `description` schema, plus `sensitive` / `required` / `default` / `multiple` / `min` / `max`. Notes the additive change (description-only entries still load) and the keychain ~2 KB shared-with-OAuth budget.
+- `templates/plugin.json.template`: full-schema `userConfig` example, commented out.
+- `commands/validate.md`: per-entry `type` / `title` recommended (info-level message marking description-only as legacy form), `sensitive` substitution restriction noted.
+
+### Added — Marketplace deps + tagging (Track D)
+- **`allowCrossMarketplaceDependenciesOn`** documented in `references/08-configuration/marketplace-json.md`. Replaces the previously-conflated section that mixed this field with `strictKnownMarketplaces` (managed-settings-only). Now a clean table distinguishes the two: `allowCrossMarketplaceDependenciesOn` lives in root `marketplace.json` and gates **dependency trust**; `hostPattern` / `pathPattern` (in `strictKnownMarketplaces` / `extraKnownMarketplaces`) live in user/managed `settings.json` and gate **marketplace install location**. Adds explicit "trust does not chain" note (only the root marketplace's allowlist is consulted).
+- `blockedMarketplaces` enforcement-points list expanded: now also runs on `update`, `refresh`, and `auto-update` (not just `add` / `install`).
+- **`claude plugin tag`** documented in `references/08-configuration/marketplace-json.md` (release-tagging workflow) and `references/09-testing/cli-reference.md` (CLI-subcommand block with `--push`, `--dry-run`, `--force` flags). Pinned plugins auto-update to the highest satisfying git tag (release 2.1.119).
+- `commands/validate.md`: cross-marketplace dep check rewritten to consult the root marketplace's `allowCrossMarketplaceDependenciesOn` (was previously checking `strictKnownMarketplaces`, which is the wrong field for trust). Error message points to the correct field.
+
+### Added — Forked subagents + `--agent` behavior fix (Track E)
+- New **"Forked Subagents (experimental)"** subsection in `references/05-agents/agent-patterns.md`: `CLAUDE_CODE_FORK_SUBAGENT=1` opt-in, manual `/fork <directive>`, what's inherited (system prompt, tools, model, message history), three side effects of fork mode (general-purpose becomes a fork; all spawns background; `/fork` no longer aliases `/branch`), when to use vs when not, fork-vs-named-subagent comparison table.
+- **Behavior change callout** in `references/05-agents/writing-agents.md`: frontmatter `hooks` and inline `mcpServers` now fire/connect when an agent runs as the main session via `--agent` (previously dropped). Plugin-packaged agents are unchanged — `hooks` / `mcpServers` / `permissionMode` still silently ignored there for security.
+- **Skill preload caveat** in `references/03-skills/writing-skillmd.md`: skills with `disable-model-invocation: true` cannot be preloaded via a subagent's `skills:` frontmatter list (preload draws from the same set Claude is allowed to invoke; disabled skills are silently skipped with a debug-log warning).
+
+### Added — Settings, env vars, and cross-references (Track F)
+- `references/08-configuration/settings.md`: **`prUrlTemplate`** setting with `{owner}` / `{repo}` / `{number}` substitutions for non-GitHub remotes. Notes `--from-pr` now accepts GitLab/Bitbucket/GHES URLs (release 2.1.119+).
+- `references/09-testing/debugging.md`: leading cross-link to the upstream **Debug Your Config** guide as the primary reference for runtime-introspection slash commands (`/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`). Note about `CLAUDE_CODE_HIDE_CWD` for sharing terminal logs and screenshots without leaking customer/internal paths.
+- `references/08-configuration/permission-modes.md`: cross-link to upstream **Auto Mode Config** guide (the full `autoMode` schema is now standalone — was previously embedded in the Permissions doc).
+- `references/02-philosophy/core-philosophy.md`: new **"Env Vars Relevant to Plugin Authors"** callout — `CLAUDE_CODE_HIDE_CWD`, `DISABLE_UPDATES` vs `DISABLE_AUTOUPDATER`, `CLAUDE_CODE_FORK_SUBAGENT` (experimental). Explicitly out of scope: terminal config, OTEL, voice (end-user concerns).
+
+### Changed — Skill body, version, descriptions (Track G)
+- `skills/plugin-creation/SKILL.md`: hook-event count 26 → 28, hook handler types 3 → 5 (`command` / `http` / `mcp_tool` / `prompt` / `agent` with `agent` marked experimental). New key events listed: `PostToolBatch`, `UserPromptExpansion`. References block updated for new themes.md and the v3.3.0 deltas in plugin-json/marketplace-json/settings.
+- `.claude-plugin/plugin.json`: `version` 3.2.1 → **3.3.0**; description updated to mention the 28 events, `mcp_tool` handler, plugin themes, `userConfig`, cross-marketplace dependencies.
+- Root `marketplace.json`: `plugin-creation-tools` entry version 3.2.1 → **3.3.0** with synced description; `metadata.version` 1.14.25 → 1.14.26 (patch bump for plugin-version pointer update per `feedback_marketplace_version_bump`).
+- `agents/plugin-structure-auditor.md`: Architecture section gains the `mcp_tool` migration-candidate flag (shell handlers shelling out to call MCP tools — e.g., `claude mcp call …` — should switch to `type: "mcp_tool"`).
+
+### Deferred — out of scope for this cycle
+- **Voice / interactive-mode deltas** (Gap 9 in findings): `voiceEnabled` → `voice.enabled` / `voice.mode` schema change and voice tap mode are end-user terminal config, not plugin authoring. PCT does not document end-user voice settings — no change.
+- **Monitoring / OTEL span schema** (Gap 10 in findings): the +315 lines on the upstream Monitoring guide are useful reference, but PCT does not currently teach OTEL instrumentation for plugins. The Agent SDK observability page (`references/11-agent-sdk/observability.md`) was authored against the prior snapshot and remains consistent with the new schema (no contradicting facts). Defer until we add a "monitor your plugin" track.
+
+### Notes
+- Doc baseline: `~/workspace/claude_memory/guides/claude/` at commit `c142d14`. Plan + findings (now deleted from `claude_docs/improvements/`) lived alongside this PR for review.
+- Per `feedback_no_half_measures`: the `marketplace-json.md` cross-marketplace section was incorrect (used `strictKnownMarketplaces`, the wrong field). Replaced wholesale with the correct `allowCrossMarketplaceDependenciesOn` model rather than patching around the existing text.
+
 ## [3.2.1] - 2026-04-21
 
 ### Changed

--- a/plugin-creation-tools/CLAUDE.md
+++ b/plugin-creation-tools/CLAUDE.md
@@ -1,0 +1,55 @@
+# Plugin Creation Tools — Plugin Conventions
+
+This plugin teaches plugin authoring; it must hold itself to the same standards it teaches.
+
+## Self-Application Rule
+
+Every change to this plugin must pass the gates this plugin defines:
+
+1. `/plugin-creation-tools:validate` (path-targeted at this plugin) — clean or all-warnings.
+2. `skill-quality-reviewer` agent on `skills/plugin-creation/SKILL.md` — no regressions.
+3. `plugin-structure-auditor` agent on the plugin root — score ≥ 24/30.
+
+If a gate flags this plugin, fix this plugin. Do not loosen the gate.
+
+## Doc-Snapshot Discipline
+
+This plugin tracks a specific upstream Claude Code doc snapshot. The active snapshot lives in `~/workspace/claude_memory/guides/claude/` and the commit it was captured at is recorded in the most recent `CHANGELOG.md` entry.
+
+- When upstream docs change, capture a new snapshot, write a *findings* doc that maps each delta to the affected reference files, and write a *plan* before editing.
+- "Upstream doc wins" — when this plugin's reference text disagrees with the snapshot, the snapshot is authoritative. Note any deliberate deviation in the CHANGELOG.
+
+## Versioning
+
+- Patch — typo / metadata / single-doc clarification with no schema change.
+- Minor — new reference page, new validator rule, new template, new optional component, version-table column added.
+- Major — breaking schema change, removed reference, renamed required field.
+
+Bump in **all** of: `.claude-plugin/plugin.json`, the root `marketplace.json` plugin entry, `skills/plugin-creation/SKILL.md` frontmatter, and `CHANGELOG.md`. Plugin-version pointer updates also bump the root `marketplace.json` `metadata.version` by one patch.
+
+## Drift to Watch
+
+Every revision must keep these counts in sync between SKILL.md, `commands/validate.md`, and the relevant reference files:
+
+- Hook event count (currently **28**).
+- Hook handler types (currently **5** — `command`, `http`, `mcp_tool`, `prompt`, `agent` with `agent` marked experimental).
+- Plugin component types (currently 7 — skills, commands, agents, hooks, mcpServers, lspServers, monitors, themes, outputStyles — drift if any are added upstream).
+- Reserved marketplace names list.
+- The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).
+
+## Anti-Patterns Specific to This Plugin
+
+- Don't strip `PROACTIVELY` / `MUST` / `NEVER` imperatives from the SKILL.md description across revisions.
+- Don't drop the `` !`ls .claude-plugin/ 2>/dev/null` `` dynamic-context injection from the SKILL.md description.
+- Don't add reference content that duplicates what's already in another reference file — link instead.
+- Don't web-fetch upstream guides during edits — read the local snapshot. The snapshot is the contract.
+
+## Components
+
+- `skills/plugin-creation/SKILL.md` — single large skill, progressive disclosure into `references/`.
+- `commands/create.md` — scaffold a new plugin.
+- `commands/add-component.md` — add a skill / command / agent / hook / MCP / theme.
+- `commands/validate.md` — validate plugin structure and wiring.
+- `agents/plugin-structure-auditor.md` — Architecture / Cross-Component Consistency / Performance audit (read-only).
+- `agents/skill-quality-reviewer.md` — SKILL.md description-and-body review (read-only).
+- `hooks/hooks.json` — `PreCompact` only, instructs Claude to read plugin files on demand instead of dumping metadata.

--- a/plugin-creation-tools/README.md
+++ b/plugin-creation-tools/README.md
@@ -1,0 +1,56 @@
+# Plugin Creation Tools
+
+Complete authoring guide for Claude Code plugins — skills, commands, agents, hooks, MCP servers, themes, `userConfig`, plugin dependencies, the Agent SDK, and distribution.
+
+The plugin contains one large skill (`plugin-creation`) that progressively discloses references for every component type, plus three commands and two structural-audit agents. Aimed at plugin authors building or maintaining plugins for the public marketplace.
+
+## Installation
+
+```bash
+/plugin install plugin-creation-tools@camoa-skills
+```
+
+## Components
+
+| Component | Name | Purpose |
+|-----------|------|---------|
+| Skill | `plugin-creation` | Progressive-disclosure authoring guide. Auto-triggered when creating skills, commands, agents, hooks, MCP servers, themes, or plugin manifests. |
+| Command | `/plugin-creation-tools:create` | Scaffold a new plugin (selects components interactively). |
+| Command | `/plugin-creation-tools:add-component` | Add a skill / command / agent / hook / MCP / **theme** to an existing plugin. |
+| Command | `/plugin-creation-tools:validate` | Validate plugin structure, frontmatter, dependency graph, hook events (28), `mcp_tool` server references, themes, `userConfig` schema, cross-marketplace allowlists. |
+| Agent | `plugin-structure-auditor` | Deep structural audit (Architecture / Cross-Component Consistency / Performance) — areas the validator does not cover. Read-only. |
+| Agent | `skill-quality-reviewer` | Review skill description quality, SKILL.md structure, progressive-disclosure patterns, regression flags (stripped imperatives, dropped `` !`command` `` injections). Read-only. |
+
+## What's covered
+
+The bundled references map to every section of the upstream Claude Code docs that affects plugin authoring (snapshot at commit `c142d14`):
+
+- **Hooks** — all 28 events with payloads, decision controls, and matcher behavior; five handler types (`command` / `http` / `mcp_tool` / `prompt` / `agent`); the `if` pre-spawn filter; cross-platform polyglot wrapper; permission-mode-per-hook table.
+- **Skills** — frontmatter schema, voice and structure, progressive disclosure, dynamic context injection (`` !`command` ``), preload caveats, char/line caps.
+- **Agents** — frontmatter, model selection, tool restrictions, scoped hooks/MCP, agent teams, forked subagents (experimental), `--agent` main-session behavior.
+- **Configuration** — `plugin.json` (themes, `userConfig` with `type`/`title`, dependencies with semver ranges, `${user_config.KEY}` substitution); `marketplace.json` (sources, `allowCrossMarketplaceDependenciesOn`, `claude plugin tag`); `settings.json` (hierarchy, `prUrlTemplate`, `enabledPlugins`); permission modes; plugin themes.
+- **Agent SDK** — overview, migration from the old Claude Code SDK, custom tools, subagents, permissions, structured outputs, tool search, observability, agent loop.
+- **Distribution** — packaging, marketplace strategies, semantic versioning, REVIEW.md v2, Routines-based auto-validate.
+
+## Workflow
+
+1. Run `/plugin-creation-tools:create` to scaffold a new plugin, or invoke the `plugin-creation` skill on an existing one.
+2. Add components with `/plugin-creation-tools:add-component <type> <name>`.
+3. Run `/plugin-creation-tools:validate` before opening a PR — it catches schema, frontmatter, dependency, and hook-event issues.
+4. For structural review (architecture balance, naming consistency, performance footguns), invoke the `plugin-structure-auditor` agent.
+5. For skill description quality, invoke the `skill-quality-reviewer` agent.
+
+## Quality gates this plugin enforces on itself
+
+- `/plugin-creation-tools:validate` is run on every PR.
+- `skill-quality-reviewer` and `plugin-structure-auditor` are run before any version bump.
+- Skill descriptions preserve `PROACTIVELY` / `MUST` / `NEVER` imperatives and `` !`command` `` dynamic-context injections across revisions.
+- Hook event count and handler-type count are kept in sync between `SKILL.md`, `commands/validate.md`, and the references.
+
+## Compatibility
+
+Targets Claude Code as of release **2.1.119** (2026-04-25 doc snapshot). Most content is forward-compatible; new features in later releases are added in subsequent minor versions.
+
+## Changelog
+
+See [`CHANGELOG.md`](CHANGELOG.md) — every release notes the upstream doc-snapshot commit it covers and the Claude Code release range, plus explicit deferral notes for any upstream deltas intentionally left out of scope.

--- a/plugin-creation-tools/agents/plugin-structure-auditor.md
+++ b/plugin-creation-tools/agents/plugin-structure-auditor.md
@@ -20,12 +20,14 @@ You are a plugin structure auditor. Focus ONLY on the three areas below — arch
 - Skill-vs-command choice (skills for workflows with progressive disclosure; commands for one-shot prompts)
 - Agent specialization (each agent = one clear responsibility; flag multi-purpose agents)
 - Hook event coverage — are the events used actually the right ones for the behavior claimed
+- **`mcp_tool` migration candidate** — flag any `bash` handler whose command shells out to call an MCP tool (e.g., `claude mcp call …`, `npx @modelcontextprotocol/inspector …`, or any wrapper script that exists only to invoke an MCP server). Suggest converting to `type: "mcp_tool"` to drop the shell layer. Reference `references/06-hooks/writing-hooks.md#5-mcp-tool-hook`.
 
 ### 2. Cross-Component Consistency
 - Naming conventions consistent across skills, commands, agents (kebab-case, similar prefix style)
 - Description style consistent — all use trigger phrases ("Use when…"), same imperative register
 - Tool permissions scoped appropriately per component (no skill granted `Write` when it only reads; no agent granted `Bash` when it only needs `Grep`)
 - Model selection justified per component (haiku for lookups, sonnet for balanced, opus for design-heavy)
+- **Visual-identity opportunity** (low severity) — when the plugin name implies brand/visual identity (matches `*-theme`, `*-design`, `brand-*`, or contains `theme`/`palette`/`color`) and ships no `themes/` directory, suggest adding a starter theme. One-line opportunity, never a blocker.
 
 ### 3. Performance
 - Skills use progressive disclosure (not loading all references upfront)

--- a/plugin-creation-tools/commands/add-component.md
+++ b/plugin-creation-tools/commands/add-component.md
@@ -1,7 +1,8 @@
 ---
-description: Add a skill, command, agent, or hook to an existing plugin. Use when user says "add skill", "add command", "add agent", "add hook", "add MCP", "new component", or wants to extend an existing plugin with additional functionality.
+description: Add a skill, command, agent, hook, MCP server, or theme to an existing plugin. Use when user says "add skill", "add command", "add agent", "add hook", "add MCP", "add theme", "new component", or wants to extend an existing plugin with additional functionality.
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 argument-hint: <component-type> <name>
+context: fork
 ---
 
 # Add Component
@@ -41,13 +42,19 @@ Add a new component to an existing Claude Code plugin.
 ### `hook`
 1. If `hooks/hooks.json` exists, add new event entry
 2. If not, create from `templates/hooks/hooks.json.template`
-3. Ask which event(s) to handle
-4. Consider all three handler types: `command`, `prompt`, `agent`
-5. For cross-platform support, use `templates/hooks/run-hook.cmd.template`
+3. Ask which event(s) to handle (28 available — see `references/06-hooks/hook-events.md`)
+4. Consider the five handler types: `command` (shell, fastest), `mcp_tool` (call an already-connected MCP server tool — no shell, cross-platform-safe), `prompt` (single-turn LLM), `agent` (multi-turn subagent — **experimental**), `http` (POST to webhook — **settings.json only**, will be silently ignored in `hooks.json`)
+5. For cross-platform support when shell logic is genuinely needed, use `templates/hooks/run-hook.cmd.template`. If the hook only calls an MCP server, use `type: "mcp_tool"` instead — it removes the cross-platform footgun.
 
 ### `mcp`
 1. Create or update `.mcp.json` from `templates/mcp.json.template`
 2. Guide user to configure server command and args
+
+### `theme`
+1. Create `themes/$2.json` with `name`, `base`, `overrides` fields (see `references/08-configuration/themes.md`)
+2. Default `base` to `"dark"`; keep `overrides` sparse (only the tokens you actually change)
+3. Remind: theme appears in `/theme` once the plugin is enabled, persisted as `custom:<plugin-name>:$2` when the user selects it
+4. Remind: users press `Ctrl+E` to copy the plugin theme into `~/.claude/themes/` for editing — your bundled file is read-only in the picker
 
 ## After Adding
 
@@ -59,5 +66,5 @@ Add a new component to an existing Claude Code plugin.
 
 ## Arguments
 
-- `$1`: Component type (skill, command, agent, hook, mcp)
+- `$1`: Component type (skill, command, agent, hook, mcp, theme)
 - `$2`: Component name (hyphen-case)

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -39,7 +39,7 @@ Validate a plugin's structure and components against best practices.
 - [ ] `dependencies` is an array
 - [ ] Each entry is either a bare string (plugin name) or an object with a required `name` field
 - [ ] Object entries with a `version` field use valid semver-range syntax (`~2.1.0`, `^2.0`, `>=1.4`, `=2.1.0`, hyphen ranges, `||` unions) — flag `range-conflict` on invalid syntax
-- [ ] Object entries with a `marketplace` field: flag as error if the referenced marketplace is not in the root marketplace's `strictKnownMarketplaces` allowlist
+- [ ] Object entries with a `marketplace` field (cross-marketplace dependency): flag as **error** if the root marketplace's `marketplace.json` does not list the referenced marketplace name in `allowCrossMarketplaceDependenciesOn`. Error message: "Cross-marketplace dependency on `<marketplace-name>` requires the root marketplace.json to include `<marketplace-name>` in `allowCrossMarketplaceDependenciesOn`. Trust does not chain — only the root marketplace's allowlist is consulted." Distinct from `strictKnownMarketplaces` (which lives in user/managed `settings.json` and gates marketplace install location, not dependency trust).
 - [ ] Pre-release ranges are only matched when the range opts in with a pre-release suffix (e.g. `^2.0.0-0`)
 - [ ] Use official error names when reporting: `range-conflict`, `dependency-version-unsatisfied`, `no-matching-tag` (align with `claude plugin list` output)
 
@@ -72,10 +72,24 @@ Validate a plugin's structure and components against best practices.
 - [ ] `tools` field present
 - [ ] `model` field present (haiku, sonnet, opus, or inherit)
 
+### Themes (for each `themes/*.json`)
+- [ ] Valid JSON — invalid JSON is an **error** (theme will not load)
+- [ ] Required fields present: `name` (display label), `base` (preset name), `overrides` (color-token map). Missing any of the three → **warning** with the field name.
+- [ ] `overrides` is an object (not an array or string)
+- [ ] No nested directories — `themes/` is a flat folder of `.json` files
+
+### userConfig (in `plugin.json`, if declared)
+- [ ] Each entry is an object (not a string or array)
+- [ ] Each entry has `type`, `title`, `description` — **info-level** (not warning) when only `description` is present, marking it as the legacy form. Suggest: "Add `type` and `title` for the v2.1.118+ schema; the description-only form still works."
+- [ ] `type` value is one of `string`, `number`, `boolean`, `directory`, `file` — flag unknown values as warning
+- [ ] If `sensitive: true`, the value is referenced via `${user_config.KEY}` in MCP/LSP/hook configs only (not in skill/agent body — sensitive substitution is blocked there)
+- [ ] If `min`/`max` are set, `type` is `number`
+
 ### Hooks (`hooks/hooks.json`)
 - [ ] Valid JSON structure — **Note:** malformed hooks.json prevents the entire plugin from loading
-- [ ] Each event name is one of the 26 recognized events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
-- [ ] Each hook entry has `type` (command, prompt, or agent) and matching field
+- [ ] Each event name is one of the 28 recognized events: `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
+- [ ] Each hook entry has `type` — one of `command`, `prompt`, `agent`, or `mcp_tool` — plus the matching required fields for that type. `agent` is upstream-marked experimental; flag a one-line info note when used.
+- [ ] `mcp_tool` handlers: require `server` and `tool`; if `server` is not declared in the plugin's `mcpServers` (and isn't a known external server the user wires up themselves), emit a **warning**: "`mcp_tool` references server `<name>` not declared in this plugin's `mcpServers`. The handler will produce a non-blocking error if the server isn't already connected at runtime."
 - [ ] No `http` type hooks — `http` hooks only work in `settings.json`, not `hooks.json` (error if found)
 - [ ] Command hooks reference executable files
 - [ ] Timeouts are reasonable (< 120s for sync hooks)

--- a/plugin-creation-tools/hooks/hooks.json
+++ b/plugin-creation-tools/hooks/hooks.json
@@ -2,6 +2,7 @@
   "hooks": {
     "PreCompact": [
       {
+        "matcher": "manual|auto",
         "hooks": [
           {
             "type": "command",

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-creation
-version: 3.2.0
+version: 3.3.0
 description: Use when creating Claude Code plugins - covers skills, commands, agents, hooks, MCP servers, and plugin configuration. Use when user says "create plugin", "make a skill", "add command", "add hooks", "skill authoring", "SKILL.md", "plugin components", "package reusable behavior", "distribute skills", "scaffold plugin", "plugin structure", "write a skill description". NOT for: using existing plugins, installing plugins, plugin marketplace browsing. !`ls .claude-plugin/ 2>/dev/null`
 ---
 
@@ -144,22 +144,26 @@ When user says "add agent", "create agent", "make agent":
 When user says "add hooks", "setup hooks", "event handlers":
 
 1. Read `references/06-hooks/writing-hooks.md`
-2. Read `references/06-hooks/hook-events.md` for all 26 events
+2. Read `references/06-hooks/hook-events.md` for all 28 events
 3. Copy template from `templates/hooks/hooks.json.template`
 4. Key events:
    - `PreToolUse` - before tool execution (can block)
    - `PostToolUse` - after tool execution (formatting, logging)
+   - `PostToolBatch` - after a parallel batch resolves (one-shot summary)
    - `SessionStart` - setup, output directories
    - `SessionEnd` - cleanup
    - `UserPromptSubmit` - validation, context injection (can block)
+   - `UserPromptExpansion` - intercept direct `/skillname` invocations (can block)
    - `SubagentStart`/`SubagentStop` - agent lifecycle
    - `PreCompact` - inject context before compaction
    - `Notification`, `Stop`, `TaskCompleted`, `TeammateIdle`
 
-**Three handler types** — choose the right one:
+**Five handler types** — choose the right one:
 - `command` — shell script, fastest, no LLM cost. Use for logging, file ops, env setup.
+- `http` — POST event JSON to a webhook (settings.json only). Use for external services.
+- `mcp_tool` — call a tool on an already-connected MCP server, no shell. Use to file an issue, sync state, log to an external system without spawning a process.
 - `prompt` — single-turn LLM evaluation, zero script overhead. Use for lightweight validation.
-- `agent` — multi-turn subagent with tools (Read, Grep, Glob). Use for complex verification.
+- `agent` — multi-turn subagent with tools (Read, Grep, Glob). **Experimental** upstream — behavior may change.
 
 **Async execution**: Add `"async": true` on command hooks for background operations (logging, analytics) that shouldn't block the main flow.
 
@@ -249,9 +253,10 @@ Before creating a component, verify it's the right choice:
 - `references/07-mcp/` - MCP overview
 
 ### Configuration
-- `references/08-configuration/plugin-json.md` - Plugin manifest
-- `references/08-configuration/marketplace-json.md` - Marketplace config
-- `references/08-configuration/settings.md` - Settings hierarchy
+- `references/08-configuration/plugin-json.md` - Plugin manifest (incl. `userConfig` schema with `type`/`title` fields, `themes` component path)
+- `references/08-configuration/marketplace-json.md` - Marketplace config (incl. `allowCrossMarketplaceDependenciesOn`, `claude plugin tag`)
+- `references/08-configuration/themes.md` - Plugin themes (`themes/*.json`, base + overrides, `Ctrl+E` user-copy flow)
+- `references/08-configuration/settings.md` - Settings hierarchy (incl. `prUrlTemplate`)
 - `references/08-configuration/output-config.md` - Output configuration
 
 ### Testing & Distribution
@@ -262,6 +267,23 @@ Before creating a component, verify it's the right choice:
 - `references/10-distribution/marketplace.md` - Marketplace guide
 - `references/10-distribution/versioning.md` - Version strategy
 - `references/10-distribution/complete-examples.md` - Full plugin examples
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| Plugin doesn't appear after install | Components placed inside `.claude-plugin/` instead of plugin root | Move `commands/` / `agents/` / `skills/` / `hooks/` to the plugin root. Only `plugin.json` belongs in `.claude-plugin/`. |
+| Skill exists but Claude never invokes it | Description missing trigger phrase or imperatives | Rewrite to start with "Use when…", include WHAT and WHEN, preserve any `PROACTIVELY` / `MUST` / `NEVER` markers from the prior version. Run `skill-quality-reviewer` agent to audit. |
+| Hook configured but never fires | Wrong event name (case-sensitive) or `http` handler in `hooks/hooks.json` | Verify event name is exactly one of the 28 documented in `references/06-hooks/hook-events.md`. `http` handlers only work in `settings.json` — they are silently ignored in `hooks.json`. Run `/plugin-creation-tools:validate`. |
+| Hook spawns on every Bash call but only acts on `rm` | Filtering inside the script instead of with `if` | Add `if: "Bash(rm *)"` to the handler. The matcher fires the event; `if` is a cheap pre-spawn filter that avoids the "spawn-and-exit-0" anti-pattern. See `references/06-hooks/writing-hooks.md#the-if-field`. |
+| `mcp_tool` hook returns "not connected" on first run | `SessionStart` / `Setup` typically fire before MCP servers finish connecting | Expected on first run. Either accept the non-blocking error, or move the call to a later event (`PostToolUse`, `Stop`, etc.) where the server is reliably connected. |
+| Plugin theme doesn't appear in `/theme` | `themes/*.json` missing `name` / `base` / `overrides`, or invalid JSON | Run `/plugin-creation-tools:validate`. See `references/08-configuration/themes.md` for the schema. |
+| Cross-marketplace dependency rejected at install | Root marketplace's `marketplace.json` is missing `allowCrossMarketplaceDependenciesOn` | Add the target marketplace name to the root marketplace's `allowCrossMarketplaceDependenciesOn` array. Trust does not chain — only the **root** marketplace's allowlist is consulted. See `references/08-configuration/marketplace-json.md`. |
+| Version mismatch errors after release | `version` drifted between `plugin.json` and the marketplace entry | Bump both. The validator enforces this. Use `claude plugin tag` (run from inside the plugin folder) to create the `{plugin-name}--v{version}` git tag dependents resolve against. |
+| Frontmatter `hooks` / `mcpServers` ignored on a plugin agent | Plugin-packaged agents silently strip `hooks` / `mcpServers` / `permissionMode` for security | Move the hooks to `hooks/hooks.json` at the plugin root, or scope them via SKILL.md frontmatter. (For agents launched via `--agent` from project-local `.claude/agents/`, those fields fire as of v2.1.117+.) |
+| `--debug` shows the plugin loading but components missing | Custom `commands` / `skills` / `agents` paths in `plugin.json` replace defaults — they don't supplement | When you set a custom path for a component, the default directory is no longer scanned. Either remove the override or include the default path in the array. |
+
+For a symptom-first walkthrough of "what state is the runtime actually in," see the upstream **Debug Your Config** guide (`/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`).
 
 ## Examples
 

--- a/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/core-philosophy.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/02-philosophy/core-philosophy.md
@@ -149,6 +149,19 @@ Documentation must reflect the current state of the system, not its history.
 
 Stale documentation is worse than no documentation. It teaches Claude wrong patterns, wastes context tokens on irrelevant history, and creates confusion about what is actually true. Keeping docs lean and current is not just style preference; it directly impacts Claude's ability to help effectively.
 
+## Env Vars Relevant to Plugin Authors
+
+A small set of environment variables affects how plugin code runs and how authors share repro logs. Most env-var documentation is end-user concerns; these four are worth knowing as a plugin author:
+
+| Variable | What it does | Why a plugin author cares |
+|----------|--------------|---------------------------|
+| `CLAUDE_CODE_HIDE_CWD` | Masks the working directory in UI output and screenshots | Set this before capturing logs/screenshots for tickets — prevents customer or internal-product paths from leaking. |
+| `DISABLE_UPDATES` | Blocks **all** Claude Code update paths, including manual `claude update` | Stricter than `DISABLE_AUTOUPDATER`. If your plugin's docs assume a specific Claude Code version, suggest `DISABLE_AUTOUPDATER` (lets users still update manually) rather than `DISABLE_UPDATES`. |
+| `DISABLE_AUTOUPDATER` | Disables automatic background updates only. `claude update` still works | Pair with `FORCE_AUTOUPDATE_PLUGINS=true` to keep plugins current while pinning Claude Code. |
+| `CLAUDE_CODE_FORK_SUBAGENT` | Opt in to the experimental forked-subagents feature (v2.1.117+) | Changes how `general-purpose` subagent spawns work and forces every spawn to background. If your plugin spawns the general-purpose subagent or relies on synchronous spawning, document that fork mode changes those guarantees. |
+
+Other env vars (terminal config, OTEL, voice, etc.) are end-user concerns and don't belong in plugin-author documentation.
+
 ## Summary
 
 The core philosophy is: **Minimum viable context for maximum effectiveness**.

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
@@ -72,15 +72,17 @@ description: Use when [triggers] - [what it does]
 ## Implementation
 [Step-by-step with examples]
 
-## Common Mistakes
-| Mistake | Fix |
-|---------|-----|
-| ... | ... |
+## Troubleshooting
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| ... | ... | ... |
 
 ## See Also
 - references/detailed-guide.md
 - scripts/helper.py
 ```
+
+> Section name follows the upstream Claude Code Skills guide, which uses `## Troubleshooting` (linked externally as the canonical anchor). Earlier templates used `## Common Mistakes`; that label only appears upstream as inline `**Common mistake**:` callouts inside Note blocks, never as a top-level section header.
 
 ## Word Count Targets
 
@@ -174,6 +176,8 @@ user-invocable: false
 > **Note:** `user-invocable: false` only controls `/` menu visibility. Claude can still invoke via the Skill tool. To block Claude from auto-invoking, use `disable-model-invocation: true` instead. These serve opposite purposes:
 > - `user-invocable: false` — user cannot call, Claude can
 > - `disable-model-invocation: true` — Claude cannot call, user can
+>
+> **Preload caveat:** A subagent with a `skills:` frontmatter list **cannot** preload a skill that sets `disable-model-invocation: true`. Preloading draws from the same set of skills Claude is allowed to invoke; a disabled-from-model skill is silently skipped (with a warning to the debug log). If you need a skill available to a specific subagent but not to the main session, use a different mechanism — don't combine `disable-model-invocation` with `skills:` preload.
 
 ### Naming Convention
 
@@ -300,10 +304,11 @@ This signals Claude to engage deeper reasoning before responding, which improves
 - Reference files, don't reproduce
 - Brief examples (5-15 lines max)
 
-### Common Mistakes
-- Table format: Mistake | Fix
-- Real issues, not hypothetical
+### Troubleshooting
+- Table format: Symptom | Likely Cause | Fix
+- Real issues users actually hit, not hypothetical
 - Brief, actionable fixes
+- Match the upstream Skills-guide section name (`## Troubleshooting`) so users searching upstream docs find the same anchor in your skill
 
 ### See Also
 - Link to references/ files

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-patterns.md
@@ -380,6 +380,49 @@ The grader agent receives all outputs and evaluates them against predefined crit
 
 The grader should have a structured rubric in its agent definition with specific dimensions and scoring criteria.
 
+## Forked Subagents (experimental)
+
+> **Experimental, requires Claude Code v2.1.117+.** Opt in by setting the `CLAUDE_CODE_FORK_SUBAGENT=1` environment variable. Behavior may change.
+
+A **fork** is a subagent that inherits the entire current conversation instead of starting fresh — same system prompt, tools, model, and message history as the main session. The fork's tool calls stay out of your conversation; only its final result returns. Use a fork when re-explaining context to a named subagent would cost more than the work itself, or when you want to try several approaches in parallel from the same starting point.
+
+### Enabling fork mode changes Claude Code in three ways
+
+1. Claude spawns a fork whenever it would otherwise use the **`general-purpose`** subagent. Named subagents (e.g., `Explore`, your plugin's agents) still spawn as before.
+2. **Every** subagent spawn runs in the background, fork or named. Set `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` to keep spawns synchronous.
+3. The `/fork` command spawns a fork instead of acting as an alias for `/branch`.
+
+### Manual fork
+
+```
+/fork draft unit tests for the parser changes so far
+```
+
+Claude names the fork from the first words of the directive. The fork appears in a panel below the prompt, runs in the background, and posts its result into your main conversation when it finishes.
+
+### When to use forks
+
+- Same context, different angle (try an alternative implementation, draft tests, explore a refactor)
+- Heavy context already loaded — re-explaining to a named subagent is the bottleneck
+- Cache-sensitive: a fork's first request reuses the parent's prompt cache, so it's cheaper than spawning a fresh subagent for the same context
+
+### When NOT to use forks
+
+- Clean-room investigation (you want a fresh perspective, not your own context echoed back)
+- Non-interactive / headless mode (Agent SDK and `-p`) — fork mode is interactive-only
+- Anything that needs to spawn further forks — forks cannot fork
+
+### Fork vs named subagent
+
+| | Fork | Named subagent |
+|---|---|---|
+| System prompt | Inherited | From its definition |
+| Tools | Inherited | From its definition |
+| Message history | Inherited | None |
+| Cache hit on first call | Yes (shares parent prompt) | No |
+| Available in headless / SDK | No | Yes |
+| Use when | Re-explaining context costs more than the task | Task has its own surface and rules |
+
 ## Context Management
 
 ### Fresh Context Advantage

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/writing-agents.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/writing-agents.md
@@ -79,6 +79,8 @@ How this agent decides what to focus on. Any constraints or special consideratio
 >
 > These fields work normally for project-local agents (in `.claude/agents/`), but are stripped when the agent is distributed via a plugin.
 
+> **Behavior change (Claude Code v2.1.117+):** Frontmatter `hooks` and inline `mcpServers` in agent files now **fire and connect** when the agent runs as the **main session** via `claude --agent <name>` or the `agent` setting. Previously they were silently dropped in `--agent` mode. If your agent was relying on hooks-not-firing (or MCP servers not loading) when run as the main session, audit and adjust — those handlers will now run alongside any hooks defined in `settings.json`. (No change for plugin-packaged agents: `hooks`/`mcpServers`/`permissionMode` are still silently ignored there for security.)
+
 ## The Description Field
 
 The description is **critical** for auto-delegation. Claude uses it to decide when to delegate tasks.

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/cross-platform-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/cross-platform-hooks.md
@@ -17,6 +17,10 @@ This creates challenges:
 | Environment variables | `%VAR%` syntax | `$VAR` syntax |
 | bash availability | Not in PATH by default | Always available |
 
+## When you don't need a `.cmd` wrapper
+
+If the work the hook actually does is "call a tool on an MCP server I already ship," use a `mcp_tool` handler instead of a shell command. `mcp_tool` runs identically on every OS — no `bash.exe`, no path quoting, no polyglot script. See [`writing-hooks.md`](writing-hooks.md#5-mcp-tool-hook). Reach for the polyglot wrapper below only when the hook genuinely needs shell logic (file ops, subprocess calls, anything outside an MCP tool's surface).
+
 ## The Solution: Polyglot `.cmd` Wrapper
 
 A polyglot script is valid syntax in multiple languages simultaneously. This wrapper works in both CMD and bash:

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
@@ -1,6 +1,6 @@
 # Hook Events
 
-Complete reference for all 26 hook events in Claude Code.
+Complete reference for all 28 hook events in Claude Code.
 
 ## Event Reference Table
 
@@ -8,11 +8,13 @@ Complete reference for all 26 hook events in Claude Code.
 |-------|---------|-----------|-----------------|
 | SessionStart | Session begins or resumes | No | Yes (startup, resume, clear, compact) |
 | UserPromptSubmit | User submits prompt | Yes | No |
+| UserPromptExpansion | A user-typed slash command expands into a prompt | Yes (blocks expansion) | Yes (command name) |
 | PreToolUse | Before tool execution | Yes | Yes (tool name) |
 | PermissionRequest | Permission dialog shown | Yes | Yes (tool name) |
 | PermissionDenied | Auto-mode classifier denies a tool call | No (can request retry) | Yes (tool name) |
 | PostToolUse | After tool succeeds | No | Yes (tool name) |
 | PostToolUseFailure | After tool fails | No | Yes (tool name) |
+| PostToolBatch | After every tool call in a parallel batch resolves | Yes (stops the agentic loop) | No |
 | Notification | Alert sent | No | Yes (notification type) |
 | SubagentStart | Subagent spawned | No | Yes (agent type) |
 | SubagentStop | Subagent finishes | Yes | Yes (agent type) |
@@ -120,6 +122,47 @@ All hook events receive JSON input with the following common fields:
 - Exit 0 + stdout: Stdout content is added as context to the prompt
 - Exit non-zero: Prompt is blocked
 
+### UserPromptExpansion
+
+**Trigger**: A user-typed slash command (skill, custom command, or MCP prompt) expands into a prompt, before it reaches Claude. Distinct from `UserPromptSubmit`: this fires for the direct `/skillname` path that bypasses `PreToolUse` matching on the `Skill` tool.
+
+**Matcher**: `command_name` (e.g. `deploy`, `example-skill`). Empty matcher fires on every prompt-type slash command.
+
+**Can Block**: Yes — `decision: "block"` prevents the expansion.
+
+**Input Fields**: In addition to common fields, UserPromptExpansion hooks receive `expansion_type` (`slash_command` or `mcp_prompt`), `command_name`, `command_args`, `command_source`, and the original `prompt` string.
+
+**Use Cases**:
+- Block specific commands from direct invocation (e.g., require an approval file before `/deploy`)
+- Inject context for a particular skill via `additionalContext` (e.g., team review checklist)
+- Log which commands users invoke
+
+**Example**:
+```json
+{
+  "UserPromptExpansion": [
+    {
+      "matcher": "deploy",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-deploy.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Return Fields** (JSON stdout):
+| Field | Description |
+|-------|-------------|
+| `decision` | `"block"` prevents the slash command from expanding. Omit to allow it to proceed. |
+| `reason` | Shown to the user when `decision` is `"block"`. |
+| `additionalContext` | String added to Claude's context alongside the expanded prompt. |
+
+Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) is added to Claude's visible context — not just the debug log.
+
 ### PreToolUse
 
 **Trigger**: Before Claude executes any tool
@@ -220,6 +263,8 @@ All hook events receive JSON input with the following common fields:
 
 **Can Block**: No
 
+**Input Fields**: In addition to common fields and the tool's `tool_input` / `tool_response`, the payload includes `duration_ms` — tool execution time in milliseconds (excludes time spent in permission prompts and `PreToolUse` hooks). Same field is also included on `PostToolUseFailure`.
+
 **Use Cases**:
 - Format code after writes
 - Log completed operations
@@ -274,6 +319,43 @@ All hook events receive JSON input with the following common fields:
   ]
 }
 ```
+
+### PostToolBatch
+
+**Trigger**: Once after every tool call in a batch of parallel calls has resolved, before Claude Code sends the next request to the model. `PostToolUse` fires once per tool concurrently; `PostToolBatch` fires once with the full batch — the right place to act on the *set* of tools that ran.
+
+**Matcher**: Not supported.
+
+**Can Block**: Yes — `decision: "block"` or `continue: false` stops the agentic loop before the next model call.
+
+**Input Fields**: In addition to common fields, receives `tool_calls` — an array of `{tool_name, tool_input, tool_use_id, tool_response}` objects, one per tool in the batch. The `tool_response` shape is the **serialized `tool_result` content the model sees** (line-number-prefixed text for `Read`, etc.), not the structured Output object that `PostToolUse` receives.
+
+**Use Cases**:
+- Inject a single batch-summary context message instead of per-tool noise
+- Run cross-tool checks (e.g., "if Read touched files A and B together, remind to update C")
+- Synchronize external state once after parallel writes
+
+**Example**:
+```json
+{
+  "PostToolBatch": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/batch-summary.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Return Fields** (JSON stdout):
+| Field | Description |
+|-------|-------------|
+| `additionalContext` | Context string injected once before the next model call. Persisted to the transcript and replayed on `--resume`, so prefer static guidance over dynamic values. |
+| `decision` | `"block"` stops the agentic loop. |
 
 ### PermissionDenied
 
@@ -999,5 +1081,5 @@ Multiple matcher groups and multiple hooks per group:
 
 ## See Also
 
-- `writing-hooks.md` -- hook configuration and handler types (references all 26 events)
+- `writing-hooks.md` -- hook configuration and handler types (references all 28 events)
 - `hook-patterns.md` -- common implementation patterns

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
@@ -604,6 +604,103 @@ exit 0
 
 **Strong reject:** Exit 2 with stderr both rejects the task creation and feeds the stderr back to the model as guidance. Return `{"continue": false, "stopReason": "..."}` instead to stop the teammate entirely.
 
+## UserPromptExpansion Skill-Invocation Guard Pattern
+
+Block direct invocation of a skill or command unless a precondition is met. `PreToolUse` matching the `Skill` tool only fires when **Claude** invokes a skill — typing `/skillname` directly bypasses it. `UserPromptExpansion` covers that path.
+
+### hooks.json
+
+```json
+{
+  "UserPromptExpansion": [
+    {
+      "matcher": "deploy",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-deploy.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/guard-deploy.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+APPROVAL_FILE="$CLAUDE_PROJECT_DIR/.deploy-approved"
+
+if [ ! -f "$APPROVAL_FILE" ]; then
+  jq -n '{
+    decision: "block",
+    reason: "Create .deploy-approved in the project root before running /deploy."
+  }'
+  exit 0
+fi
+
+# Approval present — allow the expansion and inject the team's deploy checklist as context
+jq -n --arg checklist "$(cat "$CLAUDE_PROJECT_DIR/docs/deploy-checklist.md")" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptExpansion",
+    additionalContext: $checklist
+  }
+}'
+
+exit 0
+```
+
+**Matcher note:** `command_name` matches the bare name without the leading `/` (e.g. `deploy`, not `/deploy`).
+
+## PostToolBatch Summary Pattern
+
+Inject one summary message after a batch of parallel tool calls instead of N per-tool messages. Useful when the tools share a topic (e.g., several `Read` calls that together touch a single module).
+
+### hooks.json
+
+```json
+{
+  "PostToolBatch": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/batch-summary.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### scripts/batch-summary.sh
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+
+# Count Read calls in the batch and list the unique directories touched
+DIRS=$(echo "$INPUT" | jq -r '
+  [.tool_calls[] | select(.tool_name == "Read") | .tool_input.file_path | sub("/[^/]+$"; "")]
+  | unique | join(", ")
+')
+
+[ -z "$DIRS" ] && exit 0
+
+jq -n --arg dirs "$DIRS" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolBatch",
+    additionalContext: ("Files in this batch span: " + $dirs + ". If a change touches more than one of these directories, run the cross-module test suite before completing the task.")
+  }
+}'
+
+exit 0
+```
+
+**Static-context note:** `additionalContext` from `PostToolBatch` is persisted to the transcript and replayed on `--resume`. Prefer durable framing ("these dirs require X") over dynamic values like timestamps or commit SHAs, which become misleading on resume.
+
 ## Best Practices
 
 1. **Fast hooks**: Keep execution time minimal

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
@@ -49,7 +49,7 @@ Or inline in `plugin.json`:
 |-------|------|----------|-------------|
 | matcher | string | No | Pattern to filter when the matcher group fires (see Matcher Patterns) |
 | hooks | array | **Yes** | Array of hook handlers |
-| type | string | **Yes** | Handler type: `command`, `prompt`, `agent`, or `http` |
+| type | string | **Yes** | Handler type: `command`, `http`, `mcp_tool`, `prompt`, or `agent` |
 | command | string | For command | Shell command to execute |
 | prompt | string | For prompt/agent | LLM prompt (`$ARGUMENTS` for context) |
 | if | string | No | Permission-rule syntax (e.g. `"Bash(git *)"`, `"Edit(*.ts)"`) to pre-filter tool events before spawning the handler. See [The `if` Field](#the-if-field). |
@@ -61,7 +61,7 @@ Or inline in `plugin.json`:
 
 ## Hook Handler Types
 
-Four handler types are available. Each serves a different complexity level.
+Five handler types are available. Each serves a different complexity level. (`agent` is upstream-marked **experimental** — behavior may change.)
 
 ### 1. Command Hook
 
@@ -143,6 +143,33 @@ Send event JSON as an HTTP POST to a URL. Configure via settings JSON only (not 
 - To block an action, return a 2xx response with a decision JSON body (e.g., `{"decision": "deny"}`)
 - Only configurable through settings JSON, not hooks.json files
 
+### 5. MCP Tool Hook
+
+Call a tool on an already-connected MCP server directly from a hook — no shell script, no `.cmd` shim. The tool's text output is treated like command-hook stdout: if it parses as a [JSON output](hook-events.md) decision it is honored, otherwise it is shown as plain text.
+
+```json
+{
+  "type": "mcp_tool",
+  "server": "linear",
+  "tool": "create_issue",
+  "input": {
+    "title": "Build failed in CI",
+    "description": "${tool_input.command}"
+  }
+}
+```
+
+**Configuration**:
+- `server` (required) — name of a configured MCP server. Must already be connected; the hook never triggers OAuth or connection flows.
+- `tool` (required) — name of the tool to call on that server.
+- `input` (optional) — arguments passed to the tool. String values support `${path}` substitution from the hook's [JSON input](hook-events.md) (e.g. `"${tool_input.file_path}"`).
+
+**Behavior**:
+- Available on every hook event once Claude Code has connected to the MCP servers. `SessionStart` and `Setup` typically fire before servers finish connecting, so expect a "not connected" non-blocking error on first run.
+- If the named server is not connected, or the tool returns `isError: true`, the hook produces a non-blocking error and execution continues.
+
+**Use cases**: file an issue from a `Stop` hook, sync state to a remote service from `PostToolUse`, log to an external system from `SessionEnd` — without spawning a shell or maintaining a separate webhook.
+
 ## Async Hooks
 
 Command hooks can run asynchronously in the background.
@@ -208,6 +235,8 @@ To filter more narrowly than the matcher allows — for example, "only `Bash` ca
 The `if` field on a hook handler is a **pre-spawn filter** evaluated before the handler runs. It uses [permission-rule syntax](../08-configuration/permission-modes.md) (same as Claude Code's permission rules), so it can match the tool name and arguments together.
 
 **Only evaluated on tool events**: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`. On any other event, a hook with `if` set never runs.
+
+**Bash subcommand semantics**: The rule matches each subcommand of the Bash input after leading `VAR=value` assignments are stripped. So `if: "Bash(rm *)"` matches **both** `FOO=bar rm file` and `npm test && rm file`. The hook also runs when the command is too complex to parse safely.
 
 ### Why it matters
 
@@ -459,5 +488,5 @@ This pattern checks if `node_modules` exists in the persistent data directory an
 
 ## See Also
 
-- `hook-events.md` -- all 26 available events with return values
+- `hook-events.md` -- all 28 available events with return values
 - `hook-patterns.md` -- common patterns and examples

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/marketplace-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/marketplace-json.md
@@ -58,6 +58,7 @@ marketplace-repo/
 | plugins | array | **Yes** | List of available plugins |
 | tags | array | No | Marketplace-level categorization tags for filtering and discovery |
 | strict | boolean | No | Default: `true`. When true, `plugin.json` in each plugin is the authority for plugin metadata. When false, the marketplace entry itself is the entire plugin definition (no separate `plugin.json` needed). |
+| allowCrossMarketplaceDependenciesOn | array | No | Names of other marketplaces whose plugins this marketplace's plugins are permitted to depend on. Without this allowlist, dependencies that name a different marketplace are blocked at install. See [Cross-marketplace dependencies](#allow-cross-marketplace-dependencies-allowcrossmarketplacedependencieson). |
 
 ### Metadata Object Fields
 
@@ -360,36 +361,58 @@ The `{plugin-name}--v` prefix lets one repository host multiple plugins with ind
 
 **Without matching tags**, dependents fail with `no-matching-tag` and are disabled.
 
-### 2. Allowlist cross-marketplace dependencies
+### 2. Allow cross-marketplace dependencies (`allowCrossMarketplaceDependenciesOn`)
 
-A plugin in your marketplace can depend on a plugin in a different marketplace by setting `"marketplace"` in its dependency entry. Cross-marketplace resolution is **blocked by default** — you must allowlist the target marketplace in your root marketplace's `marketplace.json`.
-
-Allowlist entries can use exact matches or regex-based `hostPattern` and `pathPattern`:
+A plugin in your marketplace can depend on a plugin in a **different** marketplace by setting `"marketplace": "<other-marketplace-name>"` in its dependency entry. This is **blocked by default**: name the trusted marketplaces in `allowCrossMarketplaceDependenciesOn` on the marketplace's root `marketplace.json`.
 
 ```json
 {
-  "name": "internal-plugins",
-  "strictKnownMarketplaces": {
-    "trusted-upstream": {
-      "source": {
-        "source": "github",
-        "repo": "partner-org/plugin-catalog"
-      }
-    },
-    "all-partner-repos": {
-      "source": {
-        "source": "github",
-        "hostPattern": "^github\\.com$",
-        "pathPattern": "^partner-org/.*"
-      }
+  "name": "camoa-skills",
+  "owner": {"name": "camoa"},
+  "allowCrossMarketplaceDependenciesOn": ["palcera_skills", "anthropic-tools"],
+  "plugins": [
+    {
+      "name": "design-toolkit",
+      "source": "./plugins/design-toolkit"
     }
-  }
+  ]
 }
 ```
 
-Dependents that reference a non-allowlisted marketplace are rejected at install time.
+With the entry above, `design-toolkit` may declare `{"name": "brand-engine", "marketplace": "palcera_skills"}` in its `dependencies`. Without the entry, the install fails with a clear cross-marketplace-dependency error.
 
-### 3. Validator behavior
+**Trust does not chain.** Only the **root** marketplace's allowlist is consulted — i.e., the marketplace the user installed the dependent plugin from. If `palcera_skills` itself allows `third-party-marketplace`, that does **not** transitively grant `camoa-skills` access; you must list `third-party-marketplace` in `camoa-skills`'s own `allowCrossMarketplaceDependenciesOn` if a `camoa-skills` plugin needs it.
+
+#### `allowCrossMarketplaceDependenciesOn` vs `hostPattern` / `pathPattern`
+
+These solve different problems. Don't confuse them:
+
+| Field | Lives in | Controls |
+|-------|----------|----------|
+| `allowCrossMarketplaceDependenciesOn` | Root `marketplace.json` (the marketplace you author) | Which **other marketplaces** your plugins are allowed to declare cross-marketplace dependencies on. |
+| `hostPattern` / `pathPattern` (inside `strictKnownMarketplaces` / `extraKnownMarketplaces` in managed/user `settings.json`) | User or admin `settings.json` | Which **sources** (host + path regex) the user's installation is allowed to add a marketplace from. Gates marketplace **install location**, not dependency trust. |
+
+A plugin install can fail for either reason: the marketplace the dependency lives in isn't allowlisted in your `allowCrossMarketplaceDependenciesOn` (your problem to fix), or the user's `strictKnownMarketplaces` doesn't permit the upstream marketplace's source (their admin's problem to fix).
+
+#### `blockedMarketplaces` enforcement points
+
+When admins configure `blockedMarketplaces` in managed settings, the block is checked at every entry point — `add`, `install`, **`update`**, **`refresh`**, and **`auto-update`** — not just at first install. A marketplace that gets added to the blocklist after install is denied on the next refresh/update cycle.
+
+### 3. Tag plugin releases (`claude plugin tag`)
+
+Use `claude plugin tag` (run from inside a plugin's folder) to create the `{plugin-name}--v{version}` git tag that version constraints resolve against. Pinned plugins (those whose dependents declare `version`) auto-update to the **highest satisfying tag** — without tags, dependents fail with `no-matching-tag` and stay disabled.
+
+```bash
+# From inside the plugin directory
+claude plugin tag             # create {plugin-name}--v{version} from plugin.json
+claude plugin tag --push      # also push the tag to origin
+claude plugin tag --dry-run   # show what would be tagged
+claude plugin tag --force     # tag even if working tree is dirty or tag exists
+```
+
+This replaces the manual `git tag {plugin-name}--v{version} && git push origin --tags` flow. The tag's `{version}` must match the `version` field in that commit's `plugin.json`.
+
+### 4. Validator behavior
 
 When a plugin is installed, Claude Code:
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/permission-modes.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/permission-modes.md
@@ -35,6 +35,8 @@ This is the table plugin authors most need. A hook that's safe in `default` can 
 
 ## Auto mode specifics
 
+> For the full `autoMode` configuration schema (allow/deny categories, classifier model overrides, fallback thresholds), see the upstream **Auto Mode Config** guide — it was previously embedded in the Permissions doc and is now a standalone reference. This page covers what plugin authors need to *design around*; that page is the schema source of truth.
+
 `auto` is the riskiest mode for plugin authors to design around because it suppresses the prompts that normally surface unsafe actions.
 
 **How it decides** (in order):

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -92,6 +92,8 @@ Or simple string:
 | mcpServers | string/object | MCP config path or inline config |
 | lspServers | string/object | LSP config path or inline config |
 | outputStyles | string/array | Custom output style paths |
+| themes | string/array | Color theme files/directories (replaces default `themes/`). Each file: `name`, `base`, `overrides`. See [`themes.md`](themes.md) for the full schema. |
+| userConfig | object | User-configurable values prompted at enable time. See [User configuration](#user-configuration) below. |
 | settings | string | Path to settings.json (only `agent` key supported) |
 
 ### Path Patterns
@@ -260,6 +262,55 @@ Example:
 ```
 
 `${CLAUDE_PLUGIN_ROOT}` is substituted at runtime in all path-accepting fields, including nested values in mcpServers and lspServers configurations.
+
+## User Configuration
+
+The `userConfig` field declares values that Claude Code prompts the user for when the plugin is enabled. Use this instead of asking users to hand-edit `settings.json`. Values are exported to plugin subprocesses as `CLAUDE_PLUGIN_OPTION_<KEY>` env vars and substituted as `${user_config.KEY}` in MCP and LSP server configs, hook commands, monitor commands, and (for non-sensitive values) skill and agent content.
+
+### Schema
+
+```json
+{
+  "userConfig": {
+    "api_endpoint": {
+      "type": "string",
+      "title": "API endpoint",
+      "description": "Your team's API endpoint"
+    },
+    "api_token": {
+      "type": "string",
+      "title": "API token",
+      "description": "API authentication token",
+      "sensitive": true
+    },
+    "max_retries": {
+      "type": "number",
+      "title": "Max retries",
+      "description": "How many times to retry a failed call",
+      "default": 3,
+      "min": 0,
+      "max": 10
+    }
+  }
+}
+```
+
+### Per-entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | One of `string`, `number`, `boolean`, `directory`, `file`. |
+| `title` | Yes | Label shown in the configuration dialog. |
+| `description` | Yes | Help text shown beneath the field. |
+| `sensitive` | No | If `true`, masks input and stores the value in the system keychain (or `~/.claude/.credentials.json` where unavailable) instead of `settings.json`. Keychain has ~2 KB total budget shared with OAuth tokens — keep secrets small. |
+| `required` | No | If `true`, validation fails when the field is empty. |
+| `default` | No | Value used when the user provides nothing. |
+| `multiple` | No | For `string` type, allow an array of strings. |
+| `min` / `max` | No | Bounds for `number` type. |
+
+> **Additive change (2.1.118+):** `type` and `title` were added alongside the original `description`-only form. Description-only entries still work but are treated as legacy — `/plugin-creation-tools:validate` flags them at info level so you can opt into the richer schema when convenient.
+
+Non-sensitive values land in `settings.json` under `pluginConfigs[<plugin-id>].options`. Use `${user_config.KEY}` substitution in MCP/LSP/hook/monitor configs and in skill/agent body text (sensitive values are blocked from skill/agent substitution).
 
 ## Dependencies (Version-Constrained)
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
@@ -194,6 +194,18 @@ Set these environment variables in `.claude/settings.json`:
 | `MYPLUGIN_FEATURE_X` | `false` | Enable experimental feature X |
 ```
 
+### prUrlTemplate
+
+Custom URL pattern for the PR link rendered in `/code-review` footers and similar review UIs. Useful when your remote isn't on github.com — `--from-pr` now also accepts GitLab, Bitbucket, and GHES URLs (release 2.1.119+), so the template lets you mirror the remote's URL shape.
+
+```json
+{
+  "prUrlTemplate": "https://gitlab.example.com/{owner}/{repo}/-/merge_requests/{number}"
+}
+```
+
+Available substitutions: `{owner}`, `{repo}`, `{number}`. If unset, Claude Code falls back to the GitHub URL shape.
+
 ### permissions
 
 Control tool permissions:

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/themes.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/themes.md
@@ -1,0 +1,85 @@
+# Plugin Themes
+
+Plugins can ship color themes that appear in the user's `/theme` picker alongside built-in presets and the user's local themes. Each theme is a JSON file in `themes/` with a `base` preset and a sparse `overrides` map of color tokens.
+
+## When to ship a theme
+
+Ship a theme when the plugin has a visual identity that the user would notice in the terminal — brand-styled tooling, dark-mode-first plugins, accessibility-focused contrast presets, or plugins that visualize state through color (status, progress, severity). Skip themes for plugins that have no visual surface (silent hooks, MCP servers, code-quality checkers).
+
+## File layout
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json
+└── themes/
+    ├── default.json
+    └── high-contrast.json
+```
+
+Default scan path is `themes/`. Override with the `themes` field in `plugin.json` (`string` or `array` of paths). When set, the default `themes/` directory is **not** scanned — your custom path replaces it.
+
+## Theme schema
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Display name shown in `/theme`. |
+| `base` | Yes | Built-in preset to inherit from. Common values: `dark`, `light`, `dark-daltonized`, `light-daltonized`. The base supplies every token; `overrides` only changes the ones you list. |
+| `overrides` | Yes | Sparse map of color tokens (hex strings) that replace values from the `base` preset. Common tokens: `claude`, `error`, `success`, `warning`, `info`, `text`, `dim`, `border`. |
+
+## Complete example
+
+`themes/dracula.json`:
+
+```json
+{
+  "name": "Dracula",
+  "base": "dark",
+  "overrides": {
+    "claude": "#bd93f9",
+    "error": "#ff5555",
+    "success": "#50fa7b",
+    "warning": "#f1fa8c",
+    "info": "#8be9fd"
+  }
+}
+```
+
+This validates as JSON and is enough to appear in `/theme`. The base preset fills in every token you didn't override — you don't have to enumerate the full palette.
+
+## How users select a plugin theme
+
+When a plugin is enabled, its themes appear in `/theme` alongside the built-in and user-local themes. Selecting a plugin theme persists `custom:<plugin-name>:<slug>` in the user's config — `<slug>` derives from the theme's filename, so `themes/dracula.json` shipped by `my-brand` persists as `custom:my-brand:dracula`.
+
+## User customization (read-only + Ctrl+E copy)
+
+Plugin themes are **read-only** in the picker. To customize one, the user presses **`Ctrl+E`** while a plugin theme is selected — Claude Code copies it to `~/.claude/themes/<filename>` so the user can edit the copy without modifying the plugin's bundled file. Updates to the plugin do not overwrite the user's local copy. (See [`../01-overview/claude-directory.md`](../01-overview/claude-directory.md) for the full `~/.claude/` layout.)
+
+## Plugin manifest entry
+
+Themes are auto-discovered from `themes/`. Declare an explicit path only when you store them elsewhere:
+
+```json
+{
+  "name": "my-brand",
+  "themes": "./themes/"
+}
+```
+
+Or list specific files:
+
+```json
+{
+  "themes": ["./themes/dark.json", "./themes/light.json"]
+}
+```
+
+## Validation
+
+`/plugin-creation-tools:validate` checks each `themes/*.json` for valid JSON and the three required fields (`name`, `base`, `overrides`). Missing fields produce warnings; invalid JSON is an error.
+
+## See also
+
+- `plugin-json.md` — the `themes` component-path field
+- `../01-overview/claude-directory.md` — where user-copied themes live
+- Upstream: Plugins Reference → Themes section

--- a/plugin-creation-tools/skills/plugin-creation/references/09-testing/cli-reference.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/09-testing/cli-reference.md
@@ -61,6 +61,26 @@ Complete reference for plugin-related CLI commands.
 /plugin update --scope managed
 ```
 
+### Plugin Release Tagging (`claude plugin tag`)
+
+Create the `{plugin-name}--v{version}` git tag that dependency-version constraints resolve against. Run from inside the plugin's folder. Pinned dependents auto-update to the highest satisfying git tag.
+
+```bash
+# Create the tag from plugin.json's "version" field
+claude plugin tag
+
+# Create and push to the configured git remote
+claude plugin tag --push
+
+# Show what would be tagged without creating it
+claude plugin tag --dry-run
+
+# Tag anyway when the working tree is dirty or the tag exists
+claude plugin tag --force
+```
+
+Replaces the manual `git tag {plugin-name}--v{version} && git push --tags` flow. See [`../08-configuration/marketplace-json.md`](../08-configuration/marketplace-json.md#3-tag-plugin-releases-claude-plugin-tag) for the full release-tagging workflow.
+
 ## Command Line Flags
 
 ### Plugin Directory Loading

--- a/plugin-creation-tools/skills/plugin-creation/references/09-testing/debugging.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/09-testing/debugging.md
@@ -2,6 +2,10 @@
 
 Troubleshoot plugin loading, component discovery, and execution issues.
 
+> **For "what actually loaded?" debugging,** see the upstream **Debug Your Config** guide. It is the symptom-first walkthrough for the runtime-introspection slash commands plugin authors reach for first: `/context` (token usage by source), `/memory` (which CLAUDE.md files were merged), `/doctor` (overall health), `/hooks` (which hooks fired), `/mcp` (MCP server status), `/skills` (which skills are visible), `/permissions` (effective rules), and `/status` (mode, model, agent). Use this page for plugin-specific troubleshooting recipes; use Debug Your Config when you need to know what state the runtime is in.
+
+> **Privacy when sharing logs:** set `CLAUDE_CODE_HIDE_CWD=1` to mask the current working directory in UI output and screenshots before sharing repro logs in tickets, on Slack, or in plugin-author bug reports. Helpful when your project paths leak customer or internal-product names.
+
 ## Debug Mode
 
 Run Claude Code with debug output:

--- a/plugin-creation-tools/skills/plugin-creation/scripts/init_plugin.py
+++ b/plugin-creation-tools/skills/plugin-creation/scripts/init_plugin.py
@@ -6,12 +6,13 @@ Usage:
     init_plugin.py <plugin-name> --path <path> [--components <components>]
 
 Components:
-    skill, command, agent, hook, mcp (comma-separated)
+    skill, command, agent, hook, mcp, theme (comma-separated)
 
 Examples:
     init_plugin.py my-tools --path ./plugins
     init_plugin.py enterprise-tools --path ./plugins --components command,agent,hook
     init_plugin.py doc-processor --path ./plugins --components skill
+    init_plugin.py brand-tools --path ./plugins --components skill,theme
 """
 
 import sys
@@ -218,6 +219,19 @@ MARKETPLACE_JSON_TEMPLATE = """{
 SETTINGS_JSON_TEMPLATE = """{
   "enabledPlugins": {
     "%s@%s-dev": true
+  }
+}
+"""
+
+THEME_TEMPLATE = """{
+  "name": "%s",
+  "base": "dark",
+  "overrides": {
+    "claude": "#bd93f9",
+    "error": "#ff5555",
+    "success": "#50fa7b",
+    "warning": "#f1fa8c",
+    "info": "#8be9fd"
   }
 }
 """
@@ -436,6 +450,19 @@ def init_plugin(plugin_name, path, components=None):
         except Exception as e:
             print(f"Error creating MCP config: {e}")
 
+    if 'theme' in components:
+        try:
+            themes_dir = plugin_dir / 'themes'
+            themes_dir.mkdir(exist_ok=True)
+            theme_display_name = plugin_title  # e.g. "My Brand"
+            (themes_dir / 'default.json').write_text(
+                THEME_TEMPLATE % theme_display_name
+            )
+            print("Created themes/default.json")
+            component_list.append("- **Theme**: `themes/default.json` (appears in /theme)")
+        except Exception as e:
+            print(f"Error creating theme: {e}")
+
     # Create README
     try:
         components_text = '\n'.join(component_list) if component_list else '- None'
@@ -465,6 +492,7 @@ def main():
         print("  agent   - Specialized assistant")
         print("  hook    - Event-triggered automation")
         print("  mcp     - MCP server configuration")
+        print("  theme   - Color theme JSON (appears in /theme)")
         print("\nExamples:")
         print("  init_plugin.py my-tools --path ./plugins")
         print("  init_plugin.py my-tools --path ./plugins --components command,hook")

--- a/plugin-creation-tools/skills/plugin-creation/templates/hooks/hooks.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/hooks/hooks.json.template
@@ -69,6 +69,23 @@
       }
     ],
 
+    "// mcp_tool example": "Use type: mcp_tool to call an already-connected MCP server tool directly — no shell script, no .cmd shim. Useful for filing issues, syncing state, or logging to external services from a hook.",
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "mcp_tool",
+            "server": "linear",
+            "tool": "create_issue",
+            "input": {
+              "title": "Build failed in CI",
+              "description": "${tool_input.command}"
+            }
+          }
+        ]
+      }
+    ],
+
     "// Additional events": "ConfigChange, WorktreeCreate, WorktreeRemove are also available",
     "ConfigChange": [
       {

--- a/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
@@ -10,6 +10,31 @@
   "repository": "https://github.com/username/repo",
   "keywords": ["keyword1", "keyword2"]
 
+  // Optional: ship color themes alongside the plugin. Files in themes/*.json
+  // appear in /theme. Each file: {"name", "base", "overrides"}. See
+  // references/08-configuration/themes.md for the full schema and the
+  // Ctrl+E user-customization flow.
+  // "themes": "./themes/"
+
+  // Optional: prompt the user for configuration when the plugin is enabled.
+  // Each entry takes type, title, description (all required); add
+  // sensitive/required/default/min/max as needed. Reference values as
+  // ${user_config.KEY} in MCP/LSP/hook/monitor configs and (non-sensitive)
+  // in skill/agent body. Old description-only entries still load.
+  // "userConfig": {
+  //   "api_endpoint": {
+  //     "type": "string",
+  //     "title": "API endpoint",
+  //     "description": "Your team's API endpoint"
+  //   },
+  //   "api_token": {
+  //     "type": "string",
+  //     "title": "API token",
+  //     "description": "API authentication token",
+  //     "sensitive": true
+  //   }
+  // }
+
   // Note: A separate settings.json file at the plugin root can set the
   // "agent" key to configure agent behavior for this plugin.
   // See the agent template for available agent configuration fields.


### PR DESCRIPTION
## Summary

- Brings `plugin-creation-tools` current with the upstream Claude Code doc snapshot at commit `c142d14` (covers releases **2.1.116 → 2.1.119**). v3.2.1 → **v3.3.0** — additive, no breaking changes.
- 7 tracks across 28 hook events (`UserPromptExpansion`, `PostToolBatch` added), the new `mcp_tool` hook handler type, plugin themes (NEW reference page + scaffolder), `userConfig` schema expansion, `allowCrossMarketplaceDependenciesOn` + `claude plugin tag`, forked subagents (experimental), `--agent` main-session hooks/mcpServers behavior fix, and cross-references to the new upstream Auto Mode Config / Debug Your Config pages.
- Self-application fixes: this plugin now ships the README, CLAUDE.md, `.claude/rules/`, Troubleshooting section, and explicit PreCompact matcher that the rules it teaches require.

## Tracks

| Track | Highlight |
|-------|-----------|
| A — Hooks | 2 new events, 5th handler type (`mcp_tool`), `duration_ms`, `if`-Bash semantics |
| B — Themes | NEW `references/08-configuration/themes.md`, validate / add-component / init_plugin.py recognize themes |
| C — userConfig | `type` / `title` / `description` schema, validate emits info-level legacy-form notice |
| D — Marketplace | `allowCrossMarketplaceDependenciesOn` (replacing prior `strictKnownMarketplaces` confusion), trust-does-not-chain note, `claude plugin tag` |
| E — Forks | Experimental Forked Subagents subsection, `--agent` behavior change, `disable-model-invocation` preload caveat |
| F — Settings/env/cross-refs | `prUrlTemplate`, Debug Your Config + Auto Mode Config cross-links, plugin-author env vars callout |
| G — Versioning | All four metadata files at 3.3.0; `metadata.version` 1.14.25 → 1.14.26 |

## Self-application fixes

- `README.md` created at plugin root.
- `CLAUDE.md` created (self-application rule, doc-snapshot discipline, drift watchlist).
- `.claude/rules/` created (`skill-conventions.md`, `command-conventions.md`, `agent-conventions.md`).
- `SKILL.md` gained `## Troubleshooting` section.
- `references/03-skills/writing-skillmd.md` Recommended Structure renamed `## Common Mistakes` → `## Troubleshooting` to match upstream Skills guide (which uses `## Troubleshooting` as the canonical anchor).
- `hooks/hooks.json` PreCompact handler given explicit `manual|auto` matcher.
- `commands/add-component.md` got `context: fork` (matches `validate.md`) and updated description for `add MCP` / `add theme`.

## Deferred (out of scope, documented in CHANGELOG)

- **Voice / `voiceEnabled` schema change** — end-user terminal config, not plugin authoring.
- **OTEL span schema** — PCT does not yet teach OTEL instrumentation for plugins; Agent SDK observability page (authored against the prior snapshot) remains consistent with the new schema.

## Test plan

- [x] `/plugin-creation-tools:validate` (path-targeted at the worktree plugin) — worktree internals clean (no warnings on README / CLAUDE.md / Troubleshooting / matcher / examples / SKILL.md line count); the FAIL the forked skill reports is reading main's `marketplace.json` from cwd, not the worktree's (which is at 3.3.0 with the synced description)
- [x] `skill-quality-reviewer` agent on `SKILL.md` — no regressions; description, `PROACTIVELY` / `MUST` imperatives, and `` !`ls .claude-plugin/ 2>/dev/null` `` dynamic-context injection all intact
- [x] `plugin-structure-auditor` agent — **26/30 (READY)** before the self-application fixes; ≥24/30 gate cleared
- [x] JSON validity verified via `jq .` on `plugin.json`, `marketplace.json`, `hooks/hooks.json`, `templates/hooks/hooks.json.template`, `themes.md` worked example
- [x] Smoke test: `init_plugin.py test-brand-plugin --components skill,theme` — produced valid `themes/default.json` with correct `name`/`base`/`overrides`
- [x] All four metadata locations sync at 3.3.0: `plugin.json`, `SKILL.md` frontmatter, marketplace plugin entry, CHANGELOG top entry; root `marketplace.json` `metadata.version` patch-bumped
- [ ] Re-run `/plugin-creation-tools:validate` post-merge to confirm the marketplace-vs-plugin drift error clears once main catches up

🤖 Generated with [Claude Code](https://claude.com/claude-code)