### PR TITLE
feat(drupal-dev-framework): v4.1.0 /review phase command + /complete slimming (subtask 1/4)

### DIFF
--- a/drupal-dev-framework/agents/analysis-agent.md
+++ b/drupal-dev-framework/agents/analysis-agent.md
@@ -4,6 +4,7 @@ description: "Use when a framework flow needs to assess task scope or propose de
 capabilities: ["task-analysis", "scope-assessment", "epic-proposal", "sub-task-decomposition"]
 version: 1.1.0
 model: sonnet
+tools: Read, Grep, Glob, Bash
 disallowedTools: Edit, Write, Bash(rm:*), Bash(mv:*), Bash(cp:*), Bash(sed:*), Bash(tee:*), Bash(dd:*), Bash(chmod:*), Bash(chown:*)
 maxTurns: 10
 ---

--- a/drupal-dev-framework/agents/architecture-drafter.md
+++ b/drupal-dev-framework/agents/architecture-drafter.md
@@ -4,6 +4,7 @@ description: "Use when designing project architecture - creates architecture/mai
 capabilities: ["architecture-design", "component-breakdown", "pattern-selection", "dependency-mapping", "solid-enforcement", "library-first"]
 version: 2.0.0
 model: opus
+tools: Read, Write, Edit, Glob, Grep, Bash, Skill
 memory: project
 skills: guide-integrator
 maxTurns: 30

--- a/drupal-dev-framework/agents/architecture-validator.md
+++ b/drupal-dev-framework/agents/architecture-validator.md
@@ -4,6 +4,7 @@ description: "Use when validating implementation against architecture - checks a
 capabilities: ["architecture-validation", "pattern-matching", "solid-principles", "dependency-check", "architecture-principles", "security-validation"]
 version: 3.2.0
 model: sonnet
+tools: Read, Grep, Glob, Bash
 memory: project
 disallowedTools: Edit, Write
 hooks:

--- a/drupal-dev-framework/agents/contrib-researcher.md
+++ b/drupal-dev-framework/agents/contrib-researcher.md
@@ -4,6 +4,7 @@ description: "Use when researching Drupal contrib modules or existing solutions 
 capabilities: ["drupal-org-search", "contrib-analysis", "pattern-extraction", "integration-discovery"]
 version: 1.0.0
 model: haiku
+tools: Read, Grep, Glob, WebFetch, WebSearch
 disallowedTools: Edit, Write, Bash
 maxTurns: 15
 ---

--- a/drupal-dev-framework/agents/pattern-recommender.md
+++ b/drupal-dev-framework/agents/pattern-recommender.md
@@ -4,6 +4,7 @@ description: "Use when choosing between Drupal patterns (FormBase vs ListBuilder
 capabilities: ["pattern-recommendation", "drupal-best-practices", "core-reference", "decision-guidance"]
 version: 1.0.0
 model: sonnet
+tools: Read, Grep, Glob, WebFetch, WebSearch
 disallowedTools: Edit, Write, Bash
 maxTurns: 15
 ---

--- a/drupal-dev-framework/agents/project-orchestrator.md
+++ b/drupal-dev-framework/agents/project-orchestrator.md
@@ -4,6 +4,7 @@ description: "Use when checking project status or deciding next steps - reads me
 capabilities: ["project-status", "task-management", "workflow-routing", "next-action-suggestion"]
 version: 3.1.0
 model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash, Skill
 memory: project
 maxTurns: 25
 ---

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -1,12 +1,12 @@
 ---
-description: "Mark a task as done and move to completed. Trigger: 'finish task', 'mark done', 'task complete', 'close task'. Runs ALL 7 quality gates (5 standard + skill-review + plugin-validate when staged changes match) before allowing completion. Surfaces candidate plays from the session via play_candidates mode (v3.15.0+)."
+description: "Mark a task as done and move to completed. Trigger: 'finish task', 'mark done', 'task complete', 'close task'. Verifies /review ran (Phase 4 gates green per _review.json) when **Review Required:** true; legacy projects (Review Required: false) keep the v4.0.2 inline-gates posture. Surfaces candidate plays from the session via play_candidates mode (v3.15.0+). Slimmed v4.1.0+ — gates moved to /review."
 allowed-tools: Read, Write, Bash(mv:*), Bash, Glob, Skill, Task
 argument-hint: <task-name>
 ---
 
 # Complete
 
-Mark a task complete and move to `completed/`. Behavior current as of v4.0.2; full prose / examples / version history in `references/complete-walkthrough.md`.
+Mark a task complete and move to `completed/`. Behavior current as of v4.1.0; full prose / examples / version history in `references/complete-walkthrough.md`.
 
 ## Usage
 
@@ -26,41 +26,39 @@ Mark a task complete and move to `completed/`. Behavior current as of v4.0.2; fu
    - User confirms tests pass (Claude does NOT auto-run).
    - No blocking issues in `implementation.md` Blockers section.
    - `implementation.md` Progress section all `[x]`.
+   - Phase Status section: Phase 1, 2, 3 all `[x]`. Phase 4 status enforced by Step 3.
    On any fail: list remaining items, do NOT complete, offer to continue.
 
-3. **Skill-review hardened gate (v4.0.0+, conditional non-bypassable).** If `git diff --cached --name-only` (or branch diff vs main) shows `skills/*/SKILL.md` changes: invoke `plugin-creation-tools:skill-quality-reviewer` agent. Display findings using literal `prompts:skill-review-decision` template. Block on `[a]ccept/[r]emediate/[b]ypass` (no default — user MUST pick). Write `_skill-review.json` audit. Skip flag: `--skip-skill-review <reason>`.
+3. **Review Required check (v4.1.0+).** Read `**Review Required:**` field from `project_state.md`:
+   - **`true` OR (absent AND `completed/` empty):** Phase 4 must be `[x]`. Verify `<task>/_review.json` exists with `gate_specific.pr_ready: true` (or `overall_verdict: "bypassed"` with all `bypass_reason` populated). On missing/incomplete audit: print soft-warn ("`/review` did not run; gates not validated. Continue without `/review`? [y/N]") default `[N]`. User declines → exit; suggest `/drupal-dev-framework:review <task>`.
+   - **`false`:** legacy v4.0.2 posture. Run inline the gates that previously lived here: skill-review (conditional, see `references/complete-walkthrough.md`), plugin-validate (conditional), `/validate:all` standard gates. Soft-nudge / hard-block per existing v4.0.0 contract.
+   - **Absent AND `completed/` non-empty:** treat as `false` (project predates v4.1.0; legacy posture). Print one-time soft-nudge: "v4.1.0 introduced /review as the pre-PR gate phase. Run `/drupal-dev-framework:upgrade-project` to opt into the new posture." Then proceed inline as legacy.
 
-4. **Plugin-validate hardened gate (v4.0.0+, conditional non-bypassable).** If staged changes include any plugin file: invoke `/plugin-creation-tools:validate`. Display findings using literal `prompts:plugin-validate-decision` template. Block on `[a]ccept/[r]emediate/[b]ypass` (no default). Write `_plugin-validate.json` audit. Skip flag: `--skip-plugin-validate <reason>`.
+4. **Candidate-play surface (v3.15.0+).** Invoke `analysis-agent` in `play_candidates` mode (analyzes task artifacts + `git diff` for repeated decisions worth capturing). For each candidate, prompt `[y]/[n]/[d]`. `[y]` hands off to `/playbook-capture`. Opt-out: `--no-play-candidates`.
 
-5. **Standard quality gates** (5 from v3.13.0+ `code-quality-tools` skills). Run/verify TDD, SOLID, DRY, Security, Guides per usual `/validate:all` semantics. Soft-nudge on fail; never blocks.
+5. **Update `task.md`.** Add Completion section (date, status, files created/modified, summary, notes).
 
-6. **Candidate-play surface (v3.15.0+).** Invoke `analysis-agent` in `play_candidates` mode (analyzes task artifacts + `git diff` for repeated decisions worth capturing). For each candidate, prompt `[y]/[n]/[d]`. `[y]` hands off to `/playbook-capture`. Opt-out: `--no-play-candidates`.
+6. **Move task folder** per kind rules (Step 1) using `mv`.
 
-7. **Update `task.md`.** Add Completion section (date, status, files created/modified, summary, notes).
+7. **Update `project_state.md`.** Mark task completed; clear current-implementation-task field; if subtask completion empties `<epic>/in_progress/`, surface "epic ready for completion" hint to user (do NOT auto-complete the epic — user owns that decision).
 
-8. **Move task folder** per kind rules (Step 1) using `mv`.
+8. **Suggest next task.** Surface `/next` recommendation. If all tasks done: print summary + offer to mark project done.
 
-9. **Update `project_state.md`.** Mark task completed; clear current-implementation-task field; if subtask completion empties `<epic>/in_progress/`, surface "epic ready for completion" hint to user (do NOT auto-complete the epic — user owns that decision).
-
-10. **Suggest next task.** Surface `/next` recommendation. If all tasks done: print summary + offer to mark project done.
-
-11. **Invoke `session-context-writer`** with project resolved and task set to `null`.
-
-## Anti-bypass clause (applies to gates 3, 4)
-
-Skipping requires the documented `--skip-*` flag with free-text reason; bypass is recorded on disk and surfaced via `/audit-status` Unaudited gates.
+9. **Invoke `session-context-writer`** with project resolved and task set to `null`.
 
 ## Pointers
 
 - Full walkthrough: `references/complete-walkthrough.md`
 - Mandated wording: `references/gate-hardening-prompts.md`
-- Audit shape: `references/gate-audit-schema.md` v1.0
+- Audit shape: `references/gate-audit-schema.md`
 - Quality-gate methodology: `references/quality-gates.md`
+- Review phase (where gates moved to in v4.1.0): `references/review-phase-walkthrough.md`
 
 ## Related
 
 - `/drupal-dev-framework:implement <task>` — continue Phase 3
-- `/drupal-dev-framework:validate <task>` — validate before completing
+- `/drupal-dev-framework:review <task>` — run Phase 4 gates before completing (v4.1.0+)
+- `/drupal-dev-framework:upgrade-project` — set `**Review Required:**` explicitly on existing projects
 - `/drupal-dev-framework:next` — see what's next
 - `/drupal-dev-framework:status` — see all task statuses
 - `/drupal-dev-framework:audit-status` — see hardened-gate audit state

--- a/drupal-dev-framework/commands/review.md
+++ b/drupal-dev-framework/commands/review.md
@@ -1,0 +1,119 @@
+---
+description: "Phase 4 of a task. Run all hard-blocking validation gates before PR creation. Trigger: 'review task', 'pre-PR review', 'gate check'. Aggregates per-gate verdicts into _review.json audit; writes PR_BODY.md on green. Slimmed /complete depends on this — projects with **Review Required:** true require /review before /complete archives. Introduced v4.1.0."
+allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
+argument-hint: <task-name>
+---
+
+# Review
+
+Phase 4 of a task — run all hard-blocking validation gates before PR creation. Behavior current as of v4.1.0; full prose / examples / version history in `references/review-phase-walkthrough.md`.
+
+## Usage
+
+```
+/drupal-dev-framework:review <task-name>                # default mode (/validate:all)
+/drupal-dev-framework:review <task> --team              # use /validate:team (with fallback)
+/drupal-dev-framework:review <task> --dry-run           # run, write audit, don't mark Phase 4 [x]
+/drupal-dev-framework:review <task> --rerun-failed      # only re-run gates that failed last run
+/drupal-dev-framework:review <task> --no-pr-body        # skip writing PR_BODY.md
+/drupal-dev-framework:review <task> --skip-<gate> <r>   # bypass a gate; reason recorded in audit
+/drupal-dev-framework:review <task> --allow-dirty       # skip working-tree warning
+```
+
+`<gate>` whitelist: `tdd | solid | dry | security | guides | playbook-adherence | skill-review | plugin-validate`. Unknown gate names → exit 2. Reasons must be non-empty and must NOT start with `--` (would eat the next flag) → exit 2.
+
+`<task-name>` must match `^[a-z0-9_-]+$`. Path traversal (`..`, `/`) and special chars rejected → exit 2. Missing arg AND no session-context task → exit 2 with usage.
+
+## Runtime Steps
+
+Run in order. Each "gate" step writes audit; non-bypassable unless documented `--skip-*` flag supplied (records `bypass_reason`).
+
+1. **Phase Transition Check.** Read `task.md` Phase Status. If Phase 3 not `[x]`, soft-nudge once. If `## Phase Status` H2 absent entirely, append it with the four standard phase lines (1 Research, 2 Architecture, 3 Implementation, 4 Review). If only Phase 4 line missing, idempotently insert before next `## ` boundary (or EOF if none).
+
+2. **Resolve task + project context.** Validate `<task-name>` charset (above). If absent, try session-context-reader; if also null, exit 2 with usage. Resolve project folder via project-state-reader.
+
+3. **Working-tree warning.** Run `git diff --name-only`. If non-empty AND `--allow-dirty` not set: print warning ("gates run on staged + working tree state, not committed state. Continue? [y/N]"). Default `[N]`. User declines → exit 0.
+
+4. **Resolve gate plan.** Build `gates_run[]` skeleton. For conditional-gate file detection use **merge-base diff** (`git diff $(git merge-base main HEAD)..HEAD --name-only`) — committed-on-branch changes count, NOT just working tree. Detect:
+   - `skill-review`: merge-base diff includes `skills/*/SKILL.md`
+   - `plugin-validate`: merge-base diff includes any plugin file
+   - `validate-playbook-adherence`: file `commands/validate-playbook-adherence.md` exists OR mark `verdict: "skipped-not-shipped"` with `bypass_reason: "sibling adherence_gates not yet shipped"`
+   - hardened `validate-guides`: command body contains `<!-- /review:hard-block -->` marker OR fall back to soft mode (note in audit)
+
+5. **Run hard-block gates sequentially.** For each: invoke flow inline (do NOT shell out). Capture per-gate envelope at `<task>/validations/latest/<gate>.json` per `references/validation-gate-result.md` v1.0. Add to `gates_run[]`. Order: tdd → solid → dry → security → guides → validate-playbook-adherence → skill-review (conditional) → plugin-validate (conditional).
+
+6. **Run soft gates** (visual-regression, visual-parity per `commands/validate-all.md` semantics — interactive classification, never auto-block).
+
+7. **Apply `--skip-<gate> <reason>` flags.** Validate gate name against whitelist + reason non-empty + reason not `--`-prefixed (else exit 2). For each valid flag: don't run the gate; set `gates_run[].verdict: "bypassed"` and `bypass_reason: <reason>`.
+
+8. **Aggregate `overall_verdict`.** Per-gate parse errors don't crash aggregation — surface in `gates_run[].messages[]` and continue with `verdict: "skipped"` for that gate. Logic:
+   - `bypassed` if any hard-block gate has `bypass_reason` populated AND no `fail`
+   - `fail` if any hard-block gate has `verdict: fail` AND no bypass
+   - `pass` only if all hard-block gates `pass` (warnings/skipped/skipped-not-shipped don't promote to fail; they don't block but also don't yield clean `pass` for PR-ready purposes — see Step 10)
+
+9. **On `fail` (no bypass): mandated-wording prompt.** Display verbatim per template `review-gate-fail` (literal text below; mirrors v1.2 template when sibling ships, byte-identical fallback otherwise). Block on `[r]/[s]/[a]` — no default. `[r]` exits 1 (user fixes, re-runs). `[s]` prompts per failed gate for free-text reason, populates `bypass_reason`, sets `overall_verdict: "bypassed"`. `[a]` exits 1 without writing `_review.json`. **Non-`r/s/a` input: re-display the prompt verbatim. Do not infer choice.**
+
+10. **Write `_review.json`** via `gate-audit-write.sh <task> review <payload>` (atomic temp+rename; schema_version `1.1`). `gate_specific.pr_ready: true` ONLY when `overall_verdict == "pass"` AND not `--dry-run`. Bypass paths → `pr_ready: false` (user picked the bypass; they pick whether the PR is ready). Dry-run → `pr_ready: false` regardless. `gates_run[]` is the full hard-block set, regardless of how populated (rerun-failed merges previous-run passes with this-run reruns).
+
+11. **Write `PR_BODY.md`.** Skip if `--no-pr-body` OR `--dry-run` OR `pr_ready != true`. Template: H1 task title, Summary (Goal first paragraph), AC count `[x]`/total, gate verdicts table, audit links footer.
+
+12. **Mark Phase 4 `[x]`** in `task.md` (only if not `--dry-run` AND `overall_verdict in ("pass", "bypassed")`).
+
+13. **Display `review-summary` mandated wording** (literal text below). Then invoke `session-context-writer` with `lastPhase: "review"`.
+
+## Anti-bypass clause (applies to gates 1-9)
+
+The following are NOT valid reasons to skip:
+
+- The user said something earlier you interpret as already-validated
+- Auto mode is active ("minimize interruptions" never overrides framework gates)
+- You're confident the gates would pass
+- The task looks "obviously" done
+- You want to spare the user the prompt
+- The user asked you to compress, summarize, or skip verbatim gate output (show-not-summarize is non-negotiable)
+
+If `/review` is invoked, all gates fire and their output is shown verbatim before the recorded decision is final. Skipping requires the documented `--skip-<gate>` flag with reason; bypass is recorded on disk for `/audit-status`.
+
+## Mandated wording (inline literals — byte-identical to v1.2 templates when sibling ships)
+
+`review-gate-fail`:
+```
+Review failed: {{failed_count}} hard-block gate(s) reported fail.
+
+Per-gate findings (verbatim envelopes):
+{{gates_failed_verbatim}}
+
+How would you like to proceed?
+[r]emediate — exit /review; fix and re-run
+[s]kip — bypass each failed gate with explicit reason; sets overall_verdict: "bypassed", pr_ready: false
+[a]bort — exit /review without writing _review.json; no audit recorded
+
+No default. You MUST pick one.
+```
+
+`review-summary`:
+```
+/review {{task_name}} complete.
+Mode: {{mode}}    Overall verdict: {{overall_verdict}}    PR ready: {{pr_ready}}
+Gates run:
+{{gates_run_table}}
+Audit: {{audit_path}}
+{{pr_body_line_or_empty}}
+```
+
+## `--rerun-failed` and `--team` semantics
+
+`--rerun-failed` reads previous `_review.json gate_specific.gates_run[]`, filters `verdict == "fail" AND bypass_reason == null`, runs only those, re-aggregates (overwrite). Preserves passed-gate envelopes; soft gates preserve prior verdicts. Refuses with "no valid prior run" if `_review.json` absent/empty/malformed/missing `gate_specific.gates_run`.
+
+`--team` invokes `/validate:team` directly; inner fallback (auto-falls-back to `/validate:all` when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS != "1"` or `TeamCreate` fails) handles unavailability. `_review.json gate_specific.mode` records actual: `"team"`, `"all"`, `"team-fallback-to-all"`.
+
+## Pointers
+
+- Full walkthrough: `references/review-phase-walkthrough.md` (sibling `plumbing_docs_tests`)
+- Audit shape: `references/gate-audit-schema.md` v1.1 (`gate_type: "review"`)
+- Per-gate envelope: `references/validation-gate-result.md` v1.0
+- Project opt-out: `**Review Required:** false` keeps gates at `/complete` (legacy v4.0.2 posture)
+
+## Related
+
+- `/drupal-dev-framework:implement` (Phase 3) · `:complete` (archive; consumes `_review.json`) · `:validate-all` / `:validate-team` (invoked by `/review`) · `:upgrade-project` (set `**Review Required:**`) · `:audit-status` (audit visibility)

--- a/drupal-dev-framework/references/gate-audit-schema.md
+++ b/drupal-dev-framework/references/gate-audit-schema.md
@@ -1,12 +1,12 @@
-# Gate Audit Schema v1.0
+# Gate Audit Schema v1.1
 
-**Introduced:** drupal-dev-framework v4.0.0
+**Introduced:** drupal-dev-framework v4.0.0 (v1.0); v4.1.0 adds `review` gate_type (v1.1, additive).
 **Owner:** `scripts/gate-audit-write.sh`
-**Consumers:** `commands/research.md`, `commands/complete.md`, `commands/audit-status.md`, `commands/status.md`, plus the 7 hardened-gate scripts (`coverage-mapping-check.sh`, `dev-guides-detect.sh`, `playbook-load-deterministic.sh`, `phase-command-bypass-detect.sh`)
+**Consumers:** `commands/research.md`, `commands/complete.md`, `commands/review.md` (v4.1.0+), `commands/audit-status.md`, `commands/status.md`, plus the v4.0.0 hardened-gate scripts (`coverage-mapping-check.sh`, `dev-guides-detect.sh`, `playbook-load-deterministic.sh`, `phase-command-bypass-detect.sh`)
 
-A "gate audit" is a single JSON file written when one of the v4.0.0 hardened gates fires. The file lives in the task folder and serves as **proof on disk** that the gate ran. Absence of the file (when it should be present) is evidence of bypass — surfaced by `/audit-status` and `/status`.
+A "gate audit" is a single JSON file written when one of the framework's hardened gates fires. The file lives in the task folder and serves as **proof on disk** that the gate ran. Absence of the file (when it should be present) is evidence of bypass — surfaced by `/audit-status` and `/status`.
 
-This schema is the unified shape across all 7 audit file types. A `gate_type` discriminator selects which `gate_specific` payload applies.
+This schema is the unified shape across all 8 audit file types. A `gate_type` discriminator selects which `gate_specific` payload applies.
 
 ## 1. Location
 
@@ -23,6 +23,7 @@ Where `<gate_type>` is one of:
 - `phase-command-bypass`
 - `dev-guides-load`
 - `playbook-load`
+- `review` (v1.1+)
 
 Files are siblings of `task.md`/`alignment.md`/`research.md`/`architecture.md`/`implementation.md`. The `_` prefix groups them visually and signals "framework-managed; not user-authored content."
 
@@ -50,8 +51,8 @@ Historical runs are NOT preserved per-task in these files. If a gate's history m
 
 | Field | Type | Constraints |
 |---|---|---|
-| `schema_version` | string | `"1.0"` for v4.0.0. JSON string. Consumers gate on major. |
-| `gate_type` | enum | One of the 7 listed in §1. Discriminator for `gate_specific` payload. |
+| `schema_version` | string | `"1.0"` for v4.0.0; `"1.1"` for v4.1.0+ when `gate_type: "review"`. JSON string. Consumers gate on major. |
+| `gate_type` | enum | One of the 8 listed in §1. Discriminator for `gate_specific` payload. |
 | `fired_at` | string | ISO-8601 UTC with `Z` suffix. |
 | `task_folder` | string | Absolute path to the task folder. Mirrors how validation envelopes record absolute paths. |
 | `user_choice` | enum \| null | Per-gate enum (e.g. `y`/`n`/`s` for pre-analysis; `accepted`/`remediated`/`bypassed` for skill-review). `null` for deterministic gates with no user prompt (`dev-guides-load`, `playbook-load`). |
@@ -146,6 +147,31 @@ Historical runs are NOT preserved per-task in these files. If a gate's history m
 
 `user_choice`: always `null` (deterministic; no prompt).
 
+### 5.8 `review` (v1.1+)
+
+```json
+"gate_specific": {
+  "mode": "all | team | team-fallback-to-all",
+  "rerun_only_failed": false,
+  "dry_run": false,
+  "gates_run": [
+    {
+      "name": "tdd | solid | dry | security | guides | playbook-adherence | skill-review | plugin-validate | visual-regression | visual-parity",
+      "kind": "hard-block | soft",
+      "verdict": "pass | warning | fail | skipped | bypassed | skipped-not-shipped",
+      "envelope_path": "<task>/validations/latest/<gate>.json or null",
+      "bypass_reason": "<string from --skip-<gate> flag> or null",
+      "messages": []
+    }
+  ],
+  "overall_verdict": "pass | fail | bypassed",
+  "pr_ready": true,
+  "pr_body_path": "<task>/PR_BODY.md or null"
+}
+```
+
+`user_choice` enum: `"automatic" | "r" | "s" | "a"` (`"automatic"` when no `review-gate-fail` prompt fired; `"r"`/`"s"`/`"a"` from the prompt). `pr_ready: true` only when `overall_verdict == "pass"` AND not `--dry-run` — bypass paths get `pr_ready: false`. `gates_run[]` is always the full hard-block set, regardless of how populated (rerun-failed merges previous-run passes with this-run reruns).
+
 ## 6. Invariants
 
 - **One file per gate per task.** Overwrite-on-fire. No history kept in this file.
@@ -160,7 +186,7 @@ Historical runs are NOT preserved per-task in these files. If a gate's history m
 - **Minor bumps** (`1.1`) are additive: new gate_type values, new optional top-level fields, new optional per-gate fields. Existing consumers ignore the new fields.
 - **Patch bumps** do not exist for schema versioning.
 
-v1.0 covers all 7 v4.0.0 gate_types. Future hardenings (v2 deferred surfaces) bump to 1.1 if/when they ship.
+v1.0 covers all 7 v4.0.0 gate_types. v1.1 (drupal-dev-framework v4.1.0) adds `review` gate_type — additive only, existing v1.0 consumers unaffected.
 
 ## 8. Non-goals
 

--- a/drupal-dev-framework/references/research-walkthrough.md
+++ b/drupal-dev-framework/references/research-walkthrough.md
@@ -218,6 +218,7 @@ implementation_process/in_progress/{task_name}/
 - [🔄] Phase 1: Research → See [research.md](research.md)
 - [ ] Phase 2: Architecture → See [architecture.md](architecture.md)
 - [ ] Phase 3: Implementation → See [implementation.md](implementation.md)
+- [ ] Phase 4: Review (_review.json) → run `/drupal-dev-framework:review <task>` (v4.1.0+)
 
 ## Acceptance Criteria
 - [ ] {criterion 1}

--- a/drupal-dev-framework/scripts/command-body-lengths.sh
+++ b/drupal-dev-framework/scripts/command-body-lengths.sh
@@ -21,12 +21,13 @@ JSON_MODE=0
 [ "${1:-}" = "--json" ] && JSON_MODE=1
 
 # Phase-command budgets. Keep in lockstep with task.md ACs in
-# dev_framework_token_efficiency.
+# dev_framework_token_efficiency (v4.0.2) and dev_framework_review_phase_and_adherence (v4.1.0).
 declare -A BUDGETS=(
   [research]=100
   [design]=80
   [implement]=120
   [complete]=100
+  [review]=120
 )
 
 # Body line count = total lines minus frontmatter (between first two --- lines, inclusive).
@@ -42,7 +43,7 @@ body_lines() {
 
 FAIL=0
 RESULTS=""
-for phase in research design implement complete; do
+for phase in research design implement complete review; do
   file="${PLUGIN_ROOT}/commands/${phase}.md"
   if [ ! -f "$file" ]; then
     if [ "$JSON_MODE" -eq 1 ]; then

--- a/drupal-dev-framework/scripts/fm-helpers.sh
+++ b/drupal-dev-framework/scripts/fm-helpers.sh
@@ -169,5 +169,6 @@ $fm
 - [ ] Phase 1: Research
 - [ ] Phase 2: Architecture
 - [ ] Phase 3: Implementation
+- [ ] Phase 4: Review (_review.json)
 EOF
 }

--- a/drupal-dev-framework/scripts/gate-audit-write.sh
+++ b/drupal-dev-framework/scripts/gate-audit-write.sh
@@ -6,13 +6,15 @@
 #   <task_folder>: absolute path to task folder
 #   <gate_type>: one of pre-analysis | coverage-mapping | skill-review |
 #                plugin-validate | phase-command-bypass | dev-guides-load |
-#                playbook-load
+#                playbook-load | review
 #   <json_payload>: complete audit JSON object conforming to
-#                   references/gate-audit-schema.md v1.0
+#                   references/gate-audit-schema.md (v1.0 for the original 7
+#                   gate types; v1.1+ adds `review` — sibling plumbing_docs_tests
+#                   bumps the schema doc itself)
 #
 # Behavior:
-# - Validates the JSON parses + has schema_version "1.0"
-# - Validates gate_type is one of the 7 allowed values
+# - Validates the JSON parses + has schema_version starting with "1." (1.0, 1.1+ accepted)
+# - Validates gate_type is one of the 8 allowed values
 # - Validates required top-level fields (gate_type, fired_at, task_folder, gate_specific)
 # - Writes to <task_folder>/_<gate_type>.json (overwrite-on-fire)
 # - Atomic via temp + rename
@@ -30,11 +32,11 @@ PAYLOAD="${3:?JSON payload required}"
 
 # Validate gate_type
 case "$GATE_TYPE" in
-  pre-analysis|coverage-mapping|skill-review|plugin-validate|phase-command-bypass|dev-guides-load|playbook-load)
+  pre-analysis|coverage-mapping|skill-review|plugin-validate|phase-command-bypass|dev-guides-load|playbook-load|review)
     ;;
   *)
     echo "gate-audit-write: invalid gate_type: $GATE_TYPE" >&2
-    echo "  must be one of: pre-analysis, coverage-mapping, skill-review, plugin-validate, phase-command-bypass, dev-guides-load, playbook-load" >&2
+    echo "  must be one of: pre-analysis, coverage-mapping, skill-review, plugin-validate, phase-command-bypass, dev-guides-load, playbook-load, review" >&2
     exit 2
     ;;
 esac
@@ -45,12 +47,15 @@ if ! echo "$PAYLOAD" | jq empty >/dev/null 2>&1; then
   exit 2
 fi
 
-# Validate schema_version
+# Validate schema_version (accept any 1.x — backward-compat for v1.1 review gate)
 SV=$(echo "$PAYLOAD" | jq -r '.schema_version // empty')
-if [[ "$SV" != "1.0" ]]; then
-  echo "gate-audit-write: schema_version must be \"1.0\" (got \"$SV\")" >&2
-  exit 2
-fi
+case "$SV" in
+  1.0|1.1) ;;
+  *)
+    echo "gate-audit-write: schema_version must be \"1.0\" or \"1.1\" (got \"$SV\")" >&2
+    exit 2
+    ;;
+esac
 
 # Validate gate_type matches argument
 PAYLOAD_GT=$(echo "$PAYLOAD" | jq -r '.gate_type // empty')


### PR DESCRIPTION
## Summary

Subtask 1 of 4 in the `dev_framework_review_phase_and_adherence` epic (target: v4.1.0). Adds `/review` as Phase 4 orchestrator between `/implement` and PR creation; slims `/complete` to its archival role.

**Driver:** feedback memo *"sometimes your analysis forgets to follow the rules"* (2026-04-24, 2026-04-25). The v4.0.0 5-mechanism hardened gates work where applied; this PR extends the pattern to the pre-PR validation surface.

## Material changes

- **New `commands/review.md`** (114/120 body lines) — anti-bypass clause (6 invalid-skip reasons including show-not-summarize), inline literal templates `review-gate-fail` and `review-summary` (rationalization-resistance), 13 runtime steps, flags `--team` / `--dry-run` / `--rerun-failed` / `--no-pr-body` / `--skip-<gate> <reason>` / `--allow-dirty`. Task-name charset validation. Merge-base diff for conditional gate detection. `pr_ready: true` only on `pass` (bypass paths get `pr_ready: false`).
- **`commands/complete.md` slimmed** (11→9 steps; 61→59 body lines) — gates 3/4/5 removed; new Step 3 honors `**Review Required:**` field. Legacy posture preserved for projects with completed tasks pre-v4.1.0.
- **`references/gate-audit-schema.md` v1.0 → v1.1** (additive) — new `gate_type: "review"` + §5.8 payload spec.
- **Tooling**:
  - `scripts/gate-audit-write.sh` — accepts `review` + schema_version `1.1` (backward-compat with v1.0).
  - `scripts/command-body-lengths.sh` — review budget added; all 5 phase commands within budget.
  - `scripts/fm-helpers.sh` `write_stub_task_md` + `references/research-walkthrough.md` — Phase 4 line in scaffolds.
- **`agents/*.md`** (6 files) — explicit `tools:` allowlist (was a pre-existing `/plugin-creation-tools:validate` finding).

## Test plan

- [x] `/plugin-creation-tools:validate`: **PASS**
- [x] `tests/gate-prompts-literal.sh`: 5/5 byte-identical (no v1.0 template drift)
- [x] `scripts/command-body-lengths.sh`: 5/5 within budget (research 71, design 46, implement 67, complete 59, review 114)
- [x] `gate-audit-write.sh` smoke-test: v1.0 + v1.1 + invalid gate-type rejection (5/5 cases)
- [x] **`code-paper-test:test-team`** (3 parallel agents) — caught 1 CRITICAL + 8 HIGH + 7 MEDIUM blockers pre-merge; all 12 fixed inline. Report at task folder `paper-test/paper-test-team-report.md`.
- [ ] **Live dogfood** — `/review review_phase_command` against this very subtask. **DEFERRED** to post-merge fresh session (Claude Code needs to discover the new command).

## Sibling work pending in same epic

Per `alignment.md` non-goal #3, this subtask is bounded to the `/review` command + `/complete` slimming. Following subtasks ship the rest of v4.1.0:

- **`adherence_gates`** — `validate-playbook-adherence` (new) + harden `validate-guides` (consumed by `/review` Step 4 hard-block detection).
- **`retrofit_tools`** — `/upgrade-project` (backfill `**Playbook Sets:**` / `**Review Required:**` on existing projects) + `/upgrade-task` (write missing audit JSONs onto in-flight tasks).
- **`plumbing_docs_tests`** — `references/review-phase-walkthrough.md`, `gate-hardening-prompts.md` v1.2 templates (byte-identical to inline literals here), `tests/review-command-spec.sh`, CLAUDE.md `## Review Phase` section, plugin.json/marketplace.json/CHANGELOG/README **v4.1.0** version bumps.

Plugin still on v4.0.2 in this PR; v4.1.0 bump lands in `plumbing_docs_tests`.

## Out of scope (explicitly deferred)

- M4 from paper-test report: concurrency lock on `_review.json` writes — `gate-audit-write.sh` is shared infrastructure; defer to a separate cleanup PR.
- M5: hardened-`validate-guides` marker token mechanism — defined in `adherence_gates` sibling.
- M6: `--team` refuse-path audit-on-disk — sibling territory (depends on `/validate:team` semantics).
- M7: duplicate `--skip-<gate>` flag handling — minor polish.
- L1-L7: low-severity polish; sibling `plumbing_docs_tests` walkthrough doc covers most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)