### PR TITLE
feat(drupal-dev-framework): v4.1.0 adherence gates — validate-playbook-adherence + validate-guides hardening (subtask 2/4)

### DIFF
--- a/drupal-dev-framework/commands/validate-guides.md
+++ b/drupal-dev-framework/commands/validate-guides.md
@@ -13,11 +13,16 @@ This is a **framework-owned** gate — it does NOT wrap a `code-quality-tools` s
 ## Usage
 
 ```
-/drupal-dev-framework:validate-guides              # run against current task
+/drupal-dev-framework:validate-guides              # run against current task (soft-nudge)
 /drupal-dev-framework:validate-guides <task-name>  # run against a specific task
+/drupal-dev-framework:validate-guides <t> --hard-block  # /review-mode (warning→fail)
+/drupal-dev-framework:validate-guides <t> --strict      # CI escalation (warning→fail)
 ```
 
 ## What this does
+
+<!-- /review:hard-block -->
+This gate is **dual-mode** (v4.1.0+): standalone CLI invocation stays soft-nudge (existing v3.13.0 behavior); when invoked from `/drupal-dev-framework:review` with `--hard-block`, the gate promotes `warning` verdicts to `fail`. The HTML comment above is the **capability marker** read by `/review` Step 4 to assign `kind: "hard-block"` in `gates_run[]`.
 
 1. **Resolve task context** — same resolution as other `/validate:*` commands:
    (a) read `session_context.json` if present
@@ -60,6 +65,8 @@ This is a **framework-owned** gate — it does NOT wrap a `code-quality-tools` s
    - `skipped` → no phase artifacts exist yet (task hasn't progressed past creation)
 
    The 200-line substance threshold prevents false-positives on near-empty stub artifacts.
+
+   **Hard-block promotion (v4.1.0+):** if `--hard-block` flag is set (passed by `/review`) OR `--strict` flag is set (CI escalation), promote `warning` → `fail`. Soft-mode and standalone CLI invocation unchanged. The argv flag is the runtime mode selector; the HTML capability marker near the top of this file is what `/review` Step 4 reads to decide whether to invoke with `--hard-block`. Also write `details.invoked_by: "review" | "cli" | "validate-all" | "validate-team"` in the envelope for audit provenance.
 
 6. **Emit the shared envelope** (per `references/validation-gate-result.md`) with gate-specific details:
 

--- a/drupal-dev-framework/commands/validate-playbook-adherence.md
+++ b/drupal-dev-framework/commands/validate-playbook-adherence.md
@@ -1,0 +1,90 @@
+---
+description: "Verify that the task's phase artifacts cite plays from the loaded playbook (active sets + local user playbook). Framework-owned gate — heuristic any-of-three cite match (filename slug | normalized title | tldr-prefix). Soft-nudge standalone; promotes warning→fail when invoked from /review with --hard-block. Section-aware: skips 'Rejected'/'Considered Alternatives'/'Out of Scope' headings. Introduced v4.1.0."
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: [<task-name>]
+---
+
+# Validate: Playbook Adherence
+
+Verify that this task's phase artifacts (`research.md`, `architecture.md`, `implementation.md`, `git diff`) cite plays loaded from the project's active playbook sets and local user playbook. Premise: framework loads plays at every phase entry (`_playbook-load.json`); without a cite-check, plays can be silently ignored.
+
+Heuristic gate: cite-match is any-of-three (filename slug | normalized title | tldr-prefix), each searched as **literal strings** (Grep `-F`) — not regex — to avoid injection risk. False negatives expected with paraphrased citations; user override = `/review --skip-playbook-adherence <reason>`.
+
+## Usage
+
+```
+/drupal-dev-framework:validate-playbook-adherence              # current task, soft mode
+/drupal-dev-framework:validate-playbook-adherence <task-name>  # specific task
+/drupal-dev-framework:validate-playbook-adherence <t> --hard-block   # /review-mode (warning→fail)
+/drupal-dev-framework:validate-playbook-adherence <t> --strict       # CI escalation (warning→fail)
+```
+
+Task name must match `^[a-z0-9_-]+$` (path-traversal mitigation). When `--skip-playbook-adherence` audit exists from `/review`, it takes precedence over `--strict`.
+
+## What this does
+
+1. **Resolve task context** — (a) `session_context.json`; (b) walk up from `$PWD` to find `implementation_process/`; (c) abort with usage on neither. Validate task-name charset; locate task under `<project>/implementation_process/**/<task-name>/`.
+
+2. **Read playbook audit (defensive).** `jq -e .gate_specific <task>/_playbook-load.json 2>/dev/null` — on parse failure OR file absent, emit `verdict: "skipped"` reason `"no playbook audit found — task pre-dates v3.15.0 or playbook loader did not run"` and proceed to Step 8.
+
+3. **Applicability check.** Extract `playbook_sets_loaded // []` and `user_playbook_loaded // null` (jq defaults handle missing keys). If both empty/null → `verdict: "skipped"` reason `"no plays loaded — applicability check skipped gate"`. Proceed to Step 8.
+
+4. **Enumerate cite needles.** Build `needles[] = [{play_id, filename_slug, normalized_title, tldr_prefix}]`:
+   - For each `set` in `playbook_sets_loaded[]`: `Glob ~/workspace/dev-guides/docs/<set>/*.md` (skip `index.md`). Per file: `filename_slug` = basename minus `.md`; `normalized_title` = `# H1` lowercased + non-alphanum stripped; `tldr_prefix` = frontmatter `tldr` first 40 chars lowercased. Fallback: `dev-guides-navigator` skill if local cache absent.
+   - For `user_playbook_loaded`: `bash scripts/playbook-read.sh <path>`; per `.plays[]`, derive `filename_slug` from kebab-cased title, normalize title, take first 40 chars of `what` for `tldr_prefix`.
+
+5. **Build artifact list.** `<task>/{research,architecture,implementation}.md` (skip absent files); `git diff $(git merge-base main HEAD)..HEAD` written to a temp file.
+
+6. **Cite-check (literal-string match per match-type, NOT regex).** For each needle, run 3 separate `Grep` calls with `-F` (literal/fixed-string) — one per match-type. Glob over artifact list. Set `needle.cited = (any call returned matches)`; record `cite_locations[] = [{file, line, match_type}]` per match. Match-type is determined by **which call produced the hit** (no post-hoc string classification needed). Per-play 3 Grep calls; ~20 plays in default camoa = ~60 calls. Scales linearly with playbook size.
+
+7. **Section-aware skip.** Cite-locations falling under H2/H3 headings matching `^(##|###)\s+(rejected|not applied|considered alternatives|out of scope|anti-?patterns?)\b` (case-insensitive) DO NOT count toward `cited`. This prevents the "I considered but rejected this play" gaming vector. Implement: pre-scan each artifact for skip-section line ranges; `cite_locations` whose line falls inside a skip-range are filtered. Document caveat: only the listed heading patterns are excluded; novel "considered" sections will not.
+
+8. **Aggregate verdict.** `cited = count(needles where .cited == true after Step 7 filter)`, `total = len(needles)`, `ratio = cited/total`:
+   - `total == 0` → `verdict: "skipped"` (defensive; should be caught in Step 3)
+   - `ratio == 1.0` → `verdict: "pass"`
+   - `ratio >= 0.5` → `verdict: "warning"` (soft) OR `"fail"` (when `--hard-block` OR `--strict`)
+   - `ratio < 0.5` → `verdict: "fail"`
+
+9. **Build envelope** per `references/validation-gate-result.md` v1.0:
+
+   ```json
+   {
+     "schema_version": "1.0", "gate": "playbook-adherence", "task": "<name>",
+     "run_at": "<ISO-8601 UTC>", "verdict": "<...>",
+     "details": {
+       "source": "framework:playbook-adherence",
+       "invoked_by": "review | cli | validate-all | validate-team",
+       "playbook_sets_loaded": [...], "user_playbook_loaded": "<path|null>",
+       "cited_count": <int>, "total_plays": <int>,
+       "uncited": [{"play_id", "filename_slug", "tldr_prefix"}, ...],
+       "cite_locations": {"<play_id>": [{"file","line","match_type"}, ...]},
+       "skipped_sections": [{"file","heading","line_range"}, ...]
+     },
+     "messages": [...]
+   }
+   ```
+
+   `invoked_by`: argv `--invoked-by <source>` (default `cli`). `messages[]` includes per-uncited-play remediation hint (`"Uncited: <slug> — <tldr_prefix>"`); plus implicit-inheritance hint when `playbook_sets_source == "default"`. Write atomically to `<task>/validations/latest/playbook-adherence.json` (overwrite); append to `<task>/validations/history.jsonl`.
+
+10. **Print CLI summary + exit.** Tabular: verdict, ratio, uncited list, skipped-sections summary. Exit `0` in soft mode (always); exit `1` on `fail` when `--hard-block` OR `--strict` set; exit `2` on invalid args (charset, malformed flags).
+
+## Heuristic notes
+
+Cite-matching is approximate: any-of-three literal-string match. False negatives possible when authors paraphrase. `--strict` (CI) or `--hard-block` (/review) inverts the bias. Section-aware skip handles the most obvious gaming vector ("Rejected" headings); authors who want to game further can craft creative section headers — that's a known limit, not a bug.
+
+**Performance limit:** ~60 Grep calls per default camoa playbook (3 match-types × 20 plays × 1 multi-file glob). Sub-second on typical artifacts. ~100-play playbooks land at ~300 calls — still under tool-call rate limits but worth flagging. Mega-alternation batching is a v2 candidate (loses per-play attribution).
+
+## Pointers
+
+- Per-gate envelope: `references/validation-gate-result.md` v1.0
+- Cite-checker algorithm: architecture.md C3 in this subtask's design folder
+- Playbook structure: `references/playbook-schema.md` v1.0
+- Sibling: `/drupal-dev-framework:upgrade-project` (sets explicit `**Playbook Sets:**` per project)
+
+## Related
+
+- `/drupal-dev-framework:review <task>` — invokes this gate at Phase 4 with `--hard-block --invoked-by review`
+- `/drupal-dev-framework:validate-guides <task>` — sibling cite-check (dev-guides instead of plays)
+- `/drupal-dev-framework:validate-all <task>` — aggregator includes this gate
+- `/drupal-dev-framework:playbook-active` — see currently-loaded plays
+- `/drupal-dev-framework:upgrade-project` — fix `playbook_sets_source: "default"` implicit inheritance


### PR DESCRIPTION
## Summary

Subtask 2 of 4 in the `dev_framework_review_phase_and_adherence` epic (target: v4.1.0). Builds the two adherence gates that `/review` (PR #138, merged) consumes as soft-deps. After this lands, `/review` runs at full power — no more `skipped-not-shipped` placeholder for adherence gates.

**Driver:** feedback memo *"sometimes your analysis forgets to follow the rules"* — extends the v4.0.0 5-mechanism hardening to content-semantic adherence checking.

## Material changes

- **New `commands/validate-playbook-adherence.md`** (85/100 body lines) — heuristic cite-checker:
  - Literal-string match (Grep `-F`) per match-type to avoid regex injection
  - Section-aware skip (`## Rejected` / `## Considered Alternatives` / `## Out of Scope` / `## Anti-patterns` headings) blocks the cite-gaming vector
  - Defensive on missing/malformed `_playbook-load.json`
  - Per-play remediation hint in `messages[]`
  - Implicit-inheritance hint when `playbook_sets_source: "default"` (cross-ref to sibling `retrofit_tools`/`upgrade-project`)
  - Flags: `--hard-block` (passed by `/review`), `--strict` (CI escalation), `--invoked-by` (audit provenance)
- **Modified `commands/validate-guides.md`**:
  - Added `<!-- /review:hard-block -->` HTML capability marker at canonical line 24 (exactly 1 occurrence; line-69 prose re-quote was removed in paper-test fix H3 to prevent grep ambiguity)
  - `--hard-block` / `--strict` argv flags promote `warning` → `fail`
  - Standalone soft-nudge behavior preserved
  - `details.invoked_by` recorded in envelope

## Test plan

- [x] `/plugin-creation-tools:validate`: **PASS** (only pre-existing warnings remain)
- [x] `tests/gate-prompts-literal.sh`: 5/5 byte-identical (no v1.0/v1.1 template drift)
- [x] `scripts/command-body-lengths.sh`: 5/5 phase commands within budget (research 71, design 46, implement 67, complete 59, review 114)
- [x] **Paper-test inline (Step 5)** — alternation regex shape verified; cite-checker correctly identified 4 plays cited by filename in research.md (false-positive bias as designed per Decision Log #3)
- [x] **`code-paper-test:test-team`** (3 parallel agents) — caught 1 CRITICAL ÷ 6 HIGH + 5 MEDIUM + 8 LOW pre-merge blockers; **6 HIGH + 3 MEDIUM + 5 LOW fixed inline** before push. Report at task folder `paper-test/paper-test-team-report.md`. 3 LOW explicitly deferred to sibling `plumbing_docs_tests`.
- [ ] **Live dogfood** — `/review adherence_gates` invoking both new gates against this very subtask. **DEFERRED** to post-merge fresh session (Claude Code needs to discover the new command + `/review` plan needs marker re-detection).

## Sibling work pending in same epic

Per `alignment.md` non-goal #3:

- **`retrofit_tools`** — `/upgrade-project` (backfill `**Playbook Sets:**` / `**Review Required:**` on existing projects; reads the implicit-inheritance hint surfaced here) + `/upgrade-task` (write missing audit JSONs onto in-flight tasks)
- **`plumbing_docs_tests`** — `references/review-phase-walkthrough.md`, `gate-hardening-prompts.md` v1.2 templates for adherence gates (byte-identical to inline literals here), `tests/validate-playbook-adherence-spec.sh`, CLAUDE.md `## Review Phase` section, `plugin.json` / `marketplace.json` / `CHANGELOG.md` / `README.md` **v4.1.0** version bumps

Plugin still on v4.0.2 in this PR; v4.1.0 bump lands in `plumbing_docs_tests`.

## Out of scope (explicitly deferred)

- M4 from paper-test: 100-play DoS — documented limit; v2 mega-alternation batching loses per-play attribution
- M5: alternation-regex ambiguous attribution between similarly-titled plays — false-positive bias acceptable
- L1: `playbook-adherence` enumeration in `validation-gate-result.md` §2 gate list — sibling `plumbing_docs_tests`
- L8: tampered `_playbook-load.json` flipping inheritance hint — out of threat model (audit JSON is framework-written)

## Honest caveats

The v4.0.0 5-mechanism pattern (anti-bypass, mandated wording, audit, show-not-summarize, always-evaluated) was designed for **deterministic** gates. Adherence gates introduce **content-semantic interpretation**. Heuristics have inherent gaming surface (e.g., the "rejected plays" attack which is now mitigated by section-aware skip — but creative authors can craft novel section names). Defense-in-depth (LLM-grading citations vs. plays) is a v2 candidate. Documented in `paper-test/paper-test-team-report.md` Blind Spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)