### PR TITLE
feat: 2026-04-25 doc-refresh deltas across 5 plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.27"
+    "version": "1.14.28"
   },
   "plugins": [
     {
       "name": "dev-guides-navigator",
       "source": "./dev-guides-navigator",
-      "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
-      "version": "0.4.0",
+      "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content. v0.5.0 documents that Claude Code platform docs (Debug Your Config, Auto Mode Config, Admin Setup) live at code.claude.com and are out-of-scope for this navigator.",
+      "version": "0.5.0",
       "author": {
         "name": "camoa"
       },
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research \u2192 Architecture \u2192 Implementation phases with enforced SOLID, TDD, DRY, and security principles. Chrome-based visual parity checks against Figma comps, PostCompact state recovery, StopFailure logging, continuous task-context reminder via UserPromptSubmit hook. v3.10.0 adds epic/sub-task hierarchy (/migrate-to-epic, task-frontmatter-reader, hierarchy-aware /status /next /complete). v3.11.0 adds project codePath metadata (/set-code-path, /new detect+confirm, project-state-reader) and the analysis-agent (read-only, sonnet) with JSON schema v1.0 consumed by /propose-epics and /research pre-analysis hook. v3.12.0 adds the P7 alignment step: /scope command, alignment-reader skill, alignment.md grammar v1.0, scope_contract_recommended signal (orthogonal to epic_candidate), and phase-alignment sub-steps in /research /design /implement. v3.13.1 extends task-level alignment retrofit to /design and /implement (previously only /research) so tasks that completed prior phases outside the plugin still get the alignment offer at Phase 2/3 entry. v3.14.0 adds /validate:team \u2014 sibling orchestrator to /validate:all that runs the 7 v3.13.0 validation gates in isolated Claude Code agent teams (4 teammates) for honest validation free of main-session bias; graceful fallback to /validate:all when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is unset or TeamCreate fails; new references/team-manifest-schema.md v1.0 contract. v3.15.0 adds the Playbook System: opinionated Drupal best-practices via two-layer model (shipped opinion-sets via dev-guides + per-project local user playbook); 5 new commands (/playbook-active, :playbook-capture, :playbook-review, :set-playbook-sets, :set-user-playbook); plugin.json defaults.playbookSets opinionation-by-default; analysis-agent v1.1 with play_candidates mode for /complete candidate-play surface. v3.16.0 adds Worktree Awareness: parallel task execution via git worktrees with /worktree + /worktree-prune commands; deterministic detection signals; Drupal/DDEV-aware. v4.0.0 \u2014 first major bump since 3.0 \u2014 Hardened Gates with BREAKING CHANGES: 7 hardened surfaces (5 user-prompt + 2 deterministic) replacing soft-nudge versions; 5-mechanism pattern (anti-bypass / show-not-summarize / audit-on-disk / mandate-wording / refactor-as-gate); unified gate-audit-schema v1.0; literal mandated wording in gate-hardening-prompts.md v1.0; new /audit-status command; per-gate --skip-* flags with bypass_reason recorded; v3.x in-flight tasks grandfathered. v4.0.2 token-efficiency patches: phase command bodies (research/design/implement/complete) split runtime \u2194 references/<phase>-walkthrough.md (1465 \u2192 265 lines, 82% reduction); UserPromptSubmit hooks (context-reminder, loaded-context-summary) gain md5 cache + skip-emit on unchanged state; gate-hardening-prompts.md v1.0 \u2192 v1.1 additive compression (literal blocks preserved byte-for-byte, verified by tests/gate-prompts-literal.sh); new scripts/command-body-lengths.sh enforces runtime budgets in CI. v4.1.0 adds Phase 4 (/review): pre-PR validation orchestrator with v4.0.0 5-mechanism hardening (anti-bypass, mandated wording, audit JSON, show-not-summarize, always-evaluated); slimmed /complete (11\u21929 steps, honors **Review Required:** field); new validate-playbook-adherence cite-checker + hardened validate-guides (dual-mode); /upgrade-project retrofits old projects + tasks via wizard delegating to /set-* with journal-backed atomic batch + --resume + symlink rejection; gate-hardening-prompts v1.2 adds 2 templates (review-gate-fail, review-summary) byte-identical to inline literals; gate-audit-schema v1.1 adds review gate_type + retrofitted/replaced_corrupt optional flags; project-state-read.sh case-sensitivity audit + parse_bool DRY refactor + RCE fix (eval\u2192parameter expansion); 5 new test harnesses (tests/{review-command,validate-playbook-adherence,upgrade-project,project-state-read}-spec.sh, tests/gate-prompts-vs-inline.sh). Depends on: dev-guides-navigator, code-quality-tools. Recommended: plugin-creation-tools (used by skill-review + plugin-validate hardened gates).",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "author": {
         "name": "camoa"
       },
@@ -100,8 +100,8 @@
     {
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
-      "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). v3.0.0 ships REVIEW.md v2 injection-model generator, /ultrareview wrapper with platform pre-flight, skill-scoped watch-mode linting via FileChanged hook, scheduled quality sweeps (Desktop + Cloud Routine + /loop), API-triggered pre-merge CI gate, check-run JSON parsing for gh+jq, and --json mode on /audit /review /security with a stable schema v1.0 for CI gating.",
-      "version": "3.0.0",
+      "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). v3.0.0 ships REVIEW.md v2 injection-model generator, /ultrareview wrapper with platform pre-flight, skill-scoped watch-mode linting via FileChanged hook, scheduled quality sweeps (Desktop + Cloud Routine + /loop), API-triggered pre-merge CI gate, check-run JSON parsing for gh+jq, and --json mode on /audit /review /security with a stable schema v1.0 for CI gating. v3.1.0 adds the PostToolBatch aggregation pattern reference, Type-B reading-strategy citations on audit/review/security/SOLID/DRY commands, Debug Your Config cross-link, and the if-Bash subcommand clarification (Hooks Reference 2026-04-25).",
+      "version": "3.1.0",
       "author": {
         "name": "camoa"
       },
@@ -132,8 +132,8 @@
     {
       "name": "code-paper-test",
       "source": "./code-paper-test",
-      "description": "Systematically test code, skills, commands, and configs through mental execution \u2014 trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase single agent (50\u2013300 lines), or 3-agent competing team with isolated worktrees (300+ lines, security-critical, skills). Supports `--json` output for CI integration.",
-      "version": "0.7.0",
+      "description": "Systematically test code, skills, commands, and configs through mental execution \u2014 trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase single agent (50\u2013300 lines), or 3-agent competing team with isolated worktrees (300+ lines, security-critical, skills). Supports `--json` output for CI integration. v0.8.0 documents forked subagents as a future avenue, adds Type-B reading-strategy citation for AI-code auditing, and cross-links the PostToolBatch hook for team-result aggregation.",
+      "version": "0.8.0",
       "author": {
         "name": "camoa"
       },
@@ -157,8 +157,8 @@
     {
       "name": "brand-content-design",
       "source": "./brand-content-design",
-      "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, 26 visual styles, 114 infographic templates, 19 commands, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF/PPTX generation, HTML composition, and infographic rendering.",
-      "version": "3.2.0",
+      "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, 26 visual styles, 114 infographic templates, 19 commands, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF/PPTX generation, HTML composition, and infographic rendering. v3.3.0 — plugin themes feature available upstream (Claude Code 2.1.118+); branded themes/default.json deferred to a follow-up PR pending color tokens.",
+      "version": "3.3.0",
       "author": {
         "name": "camoa"
       },

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-content-design",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, visual components, 26 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-04-27
+
+### 2026-04-25 doc-refresh deltas
+
+Closes the 2026-04-25 Claude Code doc-refresh deltas affecting this plugin (snapshot pinned at upstream commit `c142d14`). No code or behavior changes — version-only bump aligning with the cross-plugin cycle.
+
+### Note
+
+- **Plugin themes** — Claude Code 2.1.118+ added a first-class plugin themes feature: plugins can ship a `themes/` directory of JSON theme files (`{ name, base, overrides }`) that appear in `/theme` alongside built-in presets. A branded `themes/default.json` for brand-content-design was scoped for this version but **deferred** — shipping a starter theme requires confident brand color tokens for the plugin's own visual identity, which were not authored in this cycle. Will land in a follow-up PR once tokens are decided. The feature itself is documented upstream (Plugins Reference, Terminal Configuration, Claude Directory) and available to users today; this plugin simply has no opinionated theme to ship yet.
+
 ## [3.2.0] - 2026-04-08
 
 ### Changed

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-27
+
+### 2026-04-25 doc-refresh deltas
+
+Closes the 2026-04-25 Claude Code doc-refresh deltas affecting this plugin (snapshot pinned at upstream commit `c142d14`). Additive throughout — no behavior change.
+
+### Added
+- **Forked subagents (experimental)** documented in `skills/paper-test/references/ai-code-auditing.md` — Claude Code 2.1.117+'s `CLAUDE_CODE_FORK_SUBAGENT=1` opt-in is a strong fit for paper-test team mode (shared loaded codebase context across the 3 teammates). Marked experimental; **not enabled by default** — the cross-challenge debate phase relies on each agent reasoning independently from a fresh frame, so the current 3-agent fresh-context spawn is intentional, not a workaround. Re-evaluation criteria included.
+- **Reading-strategy citation** in `skills/paper-test/references/ai-code-auditing.md` — paper-testing AI-generated code is **Type B** (full-read, no grep-first); inherited methods, decorators, and config-wired classes that an AI hallucinated are exactly the surface grep cannot see. Cites `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+- **`PostToolBatch` cross-link** in `commands/test-team.md` — Claude Code 2.1.118+'s `PostToolBatch` hook is the right primitive for users who want to aggregate per-teammate JSON outputs into a single batch summary. Plugin does not ship the hook; users copy it into their own project hooks if needed.
+
 ## [0.7.0] - 2026-04-22
 
 ### Added

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -20,6 +20,8 @@ Pass `--json` to emit a CI-consumable JSON report alongside the markdown report.
 
 Spawns a 3-teammate agent team that paper-tests the specified code files from competing perspectives. Each teammate traces the code with different input strategies, then they cross-challenge findings. The lead synthesizes a prioritized flaw report next to the target code.
 
+> **Aggregating across parallel teammates:** Claude Code 2.1.118+ ships a `PostToolBatch` hook that fires once after a batch of parallel tool calls resolves (Hooks Reference). For users who want to aggregate per-teammate JSON outputs into a single batch summary (e.g., posting one consolidated finding count to Slack instead of three), `PostToolBatch` is the right primitive. This plugin does not ship the hook — copy it into your project's `.claude/hooks.json` if needed. Reference, don't implement.
+
 ## Instructions
 
 When this command is invoked with `$ARGUMENTS`:

--- a/code-paper-test/skills/paper-test/references/ai-code-auditing.md
+++ b/code-paper-test/skills/paper-test/references/ai-code-auditing.md
@@ -2,6 +2,18 @@
 
 AI (LLMs) generates code based on patterns, not actual knowledge of your codebase. This creates specific risks that paper testing helps catch.
 
+> **Reading strategy:** Paper-testing AI-generated code is **Type B** work (audit / review / architecture analysis) — read the full target file plus every file it references in full. Do NOT grep-first. Inherited methods, decorators, and config-wired classes that an AI hallucinated are exactly the surface that grep cannot see. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+
+## Forked subagents (experimental upstream)
+
+Paper-test team mode (`/code-paper:test-team`) currently spawns 3 agents in fresh contexts. Claude Code 2.1.117+ ships **forked subagents** as an experimental opt-in (`CLAUDE_CODE_FORK_SUBAGENT=1`) — a subagent that inherits the full conversation history (system prompt, tools, model, messages) instead of starting fresh. For paper-test, this is a strong fit: the Happy Path Validator, Edge Case Hunter, and Red Team Attacker all benefit from the same loaded codebase context (the target file's dependencies, config, and contracts) without each one re-reading them.
+
+**Why not enabled by default in v0.8.0:**
+- Experimental upstream — schema and behavior may shift before stable.
+- The cross-challenge debate phase relies on each agent having reasoned independently from a fresh frame; forks would share too much. The current 3-agent fresh-context pattern is intentional, not a workaround.
+
+**Re-evaluation criteria when upstream stabilizes:** if forks gain a "share-context-but-isolate-reasoning" mode, switch the team-test spawn pattern. Until then, fresh-context spawns remain the right default. Upstream reference: Subagents guide → "Fork the current conversation".
+
 ## Contents
 
 - [Common AI Code Problems](#common-ai-code-problems)

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks, Roave via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks, Socket CLI). REVIEW.md v2 generator, /ultrareview wrapper, skill-scoped watch-mode linting, scheduled sweeps (Desktop + Cloud Routine), API-triggered pre-merge gate, check-run JSON gating, and --json mode on audit/review/security for CI pipelines.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-04-27
+
+### 2026-04-25 doc-refresh deltas
+
+Closes the 2026-04-25 Claude Code doc-refresh deltas affecting this plugin (snapshot pinned at upstream commit `c142d14`, covers Claude Code releases 2.1.116–2.1.119). Additive throughout — no behavior change to existing audits, commands, or hooks.
+
+### Added
+- **`PostToolBatch` aggregation pattern reference** — new `skills/code-quality-audit/references/post-batch-aggregation.md` documents how to aggregate findings across a batch of parallel lint/audit tool calls into a single summary using the new `PostToolBatch` hook (Claude Code 2.1.118+, Hooks Reference). Includes worked example with a project-local `hooks.json` snippet + aggregator script. Plugin does **not** ship the hook by default — `PostToolBatch` lacks skill-scoping and a matcher field, so a plugin-scoped hook would fire across every conversation. Users copy the snippet into their own project's `hooks.json` if they want it. Tracked as a future avenue if upstream gains skill-scoping.
+- **Reading-strategy callouts** in `commands/audit.md`, `commands/review.md`, `commands/security.md`, `commands/solid.md`, `commands/dry.md` and the skill body (`skills/code-quality-audit/SKILL.md`) — explicit Type-B (full-read, no grep-first) discipline citing `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`. Inherited methods, annotations, and config-wired classes are invisible to grep — audit/review/security/SOLID/DRY commands must read full files.
+- **Debug Your Config cross-link** in `skills/code-quality-audit/references/troubleshooting.md` — symptom-first reference to upstream `/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status` slash commands for diagnosing plugin/hook/MCP load issues. Plugin's own troubleshooting handles tool-installation issues; platform-level issues route upstream.
+- **`if`-Bash subcommand clarification** documented inline in `post-batch-aggregation.md` — `Bash(rm *)` matches `FOO=bar rm file` and `npm test && rm file` (per Hooks Reference 2026-04-25 clarification). There is no `&&`/`||` in `if` — register separate handlers for compound conditions.
+
+### Changed
+- `skills/code-quality-audit/SKILL.md` line count remains under the 500-line soft cap.
+
+### Out of scope (deferred)
+- **OTEL span instrumentation** — no current OTEL surface in this plugin. The 2026-04-25 Monitoring docs added a full span-attribute schema (gated behind `ENABLE_BETA_TRACING_DETAILED=1`); evaluating an instrumentation pass for `/code-quality:audit` and `/code-quality:security` deferred to a later cycle.
+- **JSON schema v2** — existing v1 contracts are stable; no breaking changes warranted by the doc refresh.
+- **Default-on `PostToolBatch` hook** — until upstream adds skill-scoping or a matcher field, plugin-scoped is too noisy. Documented optional pattern only.
+
 ## [3.0.0] - 2026-04-20
 
 ### Added

--- a/code-quality-tools/commands/audit.md
+++ b/code-quality-tools/commands/audit.md
@@ -8,6 +8,8 @@ argument-hint: [--json] [project-path]
 
 Run a comprehensive code quality and security audit on your project.
 
+> **Reading strategy:** This is **Type B** work (audit / review / architecture analysis) — read full source and config files; do NOT grep-first. Inherited methods, annotations, and config-wired classes are invisible to a grep-first pass. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/commands/dry.md
+++ b/code-quality-tools/commands/dry.md
@@ -8,6 +8,8 @@ argument-hint: optional|project-path
 
 Find duplicated code blocks that violate the DRY (Don't Repeat Yourself) principle.
 
+> **Reading strategy:** This is **Type B** work — duplicate detection often reveals near-duplicates that need full-file context to assess intent. Do NOT grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/commands/review.md
+++ b/code-quality-tools/commands/review.md
@@ -8,6 +8,8 @@ argument-hint: [--json] <file-or-directory-path>
 
 Structured code review with rubric-based scoring. Produces a graded assessment with per-category scores and prioritized action items.
 
+> **Reading strategy:** This is **Type B** work — read full source and config files; do NOT grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/commands/security.md
+++ b/code-quality-tools/commands/security.md
@@ -8,6 +8,8 @@ argument-hint: [--json] [project-path]
 
 Run a comprehensive security scan across multiple layers.
 
+> **Reading strategy:** This is **Type B** work — read full source and config files; do NOT grep-first. Security audits especially must follow inheritance, decorators, and config-wired hooks. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/commands/solid.md
+++ b/code-quality-tools/commands/solid.md
@@ -8,6 +8,8 @@ argument-hint: optional|project-path
 
 Analyze code architecture and adherence to SOLID principles.
 
+> **Reading strategy:** This is **Type B** work — read full class hierarchies, interfaces, and service definitions; do NOT grep-first. SOLID violations span inherited methods that grep cannot see. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -24,6 +24,8 @@ hooks:
 
 Run quality and security audits for **Drupal** and **Next.js** projects with consistent tooling and reporting.
 
+> **Reading strategy:** Audit, review, security, SOLID, and DRY commands are **Type B** work (audit / review / architecture analysis) — agents must read full source and config files. Do NOT grep-first these flows. Inherited methods, annotations, and config-wired classes are invisible to a grep-first pass. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+
 ## Quick Commands
 
 **For direct access, use these commands:**

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -266,6 +266,7 @@ All reports must follow `schemas/audit-report.schema.json`:
 - `references/solid-detection.md` - SOLID detection patterns and fixes
 - `references/composer-scripts.md` - Ready-to-use composer scripts
 - `references/scope-targeting.md` - Target specific modules/components
+- `references/post-batch-aggregation.md` - Optional `PostToolBatch` aggregation pattern (Claude Code 2.1.118+); not shipped by default
 
 ### Operations
 - `references/operations/drupal-setup.md` - Drupal setup operations

--- a/code-quality-tools/skills/code-quality-audit/references/post-batch-aggregation.md
+++ b/code-quality-tools/skills/code-quality-audit/references/post-batch-aggregation.md
@@ -1,0 +1,82 @@
+# PostToolBatch Aggregation Pattern
+
+> Status: documented optional pattern. **Not shipped as a default-on hook** in this plugin. Copy the snippets below into your project's `.claude/hooks.json` (or a project-local hooks file) if you want batch-level aggregation. Requires Claude Code 2.1.118+ (Hooks Reference).
+
+## What it is
+
+`PostToolBatch` fires after a full batch of parallel tool calls resolves, **before the next model call**. There is no matcher — it fires once per batch. Compare to `PostToolUse`, which fires once per individual tool call.
+
+For audit / review workflows that fan out across many files (`/code-quality:audit`, `/code-quality:security`, `/code-quality:solid`, `/code-quality:dry`), per-tool firing is noisy: each lint result emits its own hook event, the user sees N separate summaries, and per-tool aggregation has to be reconstructed downstream. `PostToolBatch` lets a single handler aggregate across all tool calls in the batch and emit one summary.
+
+## When to use
+
+- Aggregating findings across a batch of parallel `Bash` invocations of linters/scanners (PHPStan + Psalm + PHPMD running in parallel).
+- Logging a single timestamped batch row to `.reports/batch-log.jsonl` instead of N rows per tool.
+- Posting a single Slack summary on batch completion instead of per-tool fragments.
+- Triggering a state sync (e.g., refreshing a check-run JSON) once after all parallel scanners settle.
+
+## When **not** to use
+
+- Per-tool gating where you need to block individual tool calls — that's `PreToolUse`.
+- Per-tool error alerting where each failure should fire independently — that's `PostToolUse` / `PostToolUseFailure`.
+- Single-tool flows (`/code-quality:lint` on one file) — the batch is size 1; standard `PostToolUse` is simpler.
+
+## Worked example — batch summary aggregator
+
+Project-local `.claude/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolBatch": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/scripts/quality-batch-summary.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Aggregator script `~/.claude/scripts/quality-batch-summary.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Reads the batch payload from stdin (JSON), summarizes audit findings.
+set -eu
+PAYLOAD=$(cat)
+
+# Each tool call's output is in PAYLOAD.tool_calls[].output.
+# Filter to lint/audit-flavored calls (heuristic: command starts with phpstan/psalm/phpmd/eslint/semgrep).
+echo "$PAYLOAD" | jq -r '
+  .tool_calls
+  | map(select(.input.command? | test("^(ddev exec )?(phpstan|psalm|phpmd|eslint|semgrep|trivy|gitleaks)")))
+  | "Quality batch — \(length) scanner(s):" ,
+    (.[] | "  \(.input.command | split(" ")[0:2] | join(" ")): exit \(.exit_code // "?")")
+'
+
+exit 0
+```
+
+The script receives the batch payload on stdin (per Hooks Reference); each tool call has `input`, `output`, and `exit_code`. Filter to relevant tools, summarize, and emit one consolidated message.
+
+## Why this plugin doesn't ship it by default
+
+- Plugin-scoped `PostToolBatch` would fire across **every** Claude Code conversation while this plugin is enabled — including conversations that have nothing to do with quality auditing. That is the same noise problem `code-quality-audit/SKILL.md` solves for `FileChanged` by scoping linter-config watches to the skill (active only while the skill is loaded).
+- `PostToolBatch` does not currently support a matcher (per the Hooks Reference). There's no way to scope it to "only during audit-style batches" at the hook layer; the handler script has to filter the payload itself (the example above does this with a `jq` test against the command name).
+- Until upstream adds skill-scoped `PostToolBatch` or a matcher mechanism, the right place for this hook is **the user's project**, not the plugin.
+
+## Future avenue
+
+If `PostToolBatch` gains skill-scoping (matching this plugin's existing skill-scoped `FileChanged` + `PermissionDenied` pattern), or gains a matcher field, this plugin can ship a default-on aggregator. Track upstream changes in the Hooks Reference and re-evaluate.
+
+## Cross-references
+
+- `references/troubleshooting.md` — `Debug Your Config` cross-link for verifying the hook actually loads (`/hooks` slash command).
+- Skill-scoped vs plugin-scoped hooks — see `CLAUDE.md` in plugin root.
+- `if`-Bash subcommand semantics: `Bash(rm *)` matches `FOO=bar rm file` and `npm test && rm file` (per Hooks Reference 2026-04-25 clarification). There is no `&&`/`||` in `if` — register separate handlers for compound conditions.

--- a/code-quality-tools/skills/code-quality-audit/references/troubleshooting.md
+++ b/code-quality-tools/skills/code-quality-audit/references/troubleshooting.md
@@ -2,6 +2,21 @@
 
 Common issues and solutions for code-quality-tools plugin.
 
+## Claude Code platform diagnostics
+
+If audits fail because the plugin or its hooks didn't load, settings didn't take effect, or MCP servers are unreachable, the upstream **Debug Your Config** guide is the authoritative reference. It documents the Claude Code introspection slash commands that show what actually loaded:
+
+- `/context` — current context contents
+- `/memory` — loaded CLAUDE.md / AGENTS.md
+- `/doctor` — installation, plugin load errors, environment
+- `/hooks` — registered hooks per event/matcher
+- `/mcp` — MCP server connection state
+- `/skills` — loaded skills and source plugin
+- `/permissions` — current allow/deny/ask ruleset
+- `/status` — session info (model, settings paths)
+
+Upstream guide: `https://code.claude.com/docs/en/configuration/debug-your-config`. Auto-mode classifier denials have a dedicated reference (`Auto Mode Config`); enterprise rollout has `Admin Setup`. None of those live in `camoa/dev-guides`.
+
 ## Installation Issues
 
 ### "Command not found: ddev" (Drupal)

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guides-navigator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"

--- a/dev-guides-navigator/CHANGELOG.md
+++ b/dev-guides-navigator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.0 (2026-04-27)
+
+### 2026-04-25 doc-refresh deltas
+
+The 2026-04-25 Claude Code doc refresh promoted three new platform-level pages: `Admin Setup` (enterprise rollout), `Auto Mode Config` (auto-mode classifier reference, previously embedded in Permissions), and `Debug Your Config` (symptom-first triage via `/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`). Decision: this navigator routes to **project guides** at `camoa/dev-guides` only — it does NOT route to Claude Code platform docs at `code.claude.com`. No keyword/routing changes; the three pages are listed only as out-of-scope cross-links so calling code knows they exist.
+
+### Added
+- `references/guide-index.md` — new "Out of scope: Claude Code platform docs" section listing the three new upstream pages with direct URLs and a one-line scope explanation.
+
+### Verified
+- No stale references to the old auto-mode location (auto-mode config used to live inside Permissions; now standalone). Index has no auto-mode entries.
+
 ## 0.4.0 (2026-04-20)
 
 ### Added

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/guide-index.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/guide-index.md
@@ -3,6 +3,16 @@
 Use this keyword-to-URL mapping as a built-in fallback when `llms.hash` / `llms.txt` cannot be fetched.
 When online, prefer the live `llms.txt` + topic `index.md` flow (includes disambiguation via guide-meta).
 
+## Out of scope: Claude Code platform docs
+
+This navigator routes to **project guides** at `https://camoa.github.io/dev-guides/` only — not to Claude Code platform documentation. For Claude Code platform debugging or configuration, see the upstream pages directly:
+
+- **Debug Your Config** — symptom-first triage using `/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`. `https://code.claude.com/docs/en/configuration/debug-your-config`
+- **Auto Mode Config** — full reference for the auto-mode classifier (`autoMode.environment`, `autoMode.allow/soft_deny`, scope precedence, `$defaults` sentinel, `claude auto-mode` subcommands). Was previously embedded in Permissions; promoted to a standalone page in the 2026-04-25 doc refresh.
+- **Admin Setup** — decision-map for organization administrators rolling out Claude Code (provider choice, managed settings, enforcement, usage visibility, data handling).
+
+These three pages live at `code.claude.com`, not in `camoa/dev-guides`. The navigator does not index or route to them — calling code should fetch them directly when relevant.
+
 ## Discovery
 
 Index URL: `https://camoa.github.io/dev-guides/llms.txt`

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -17,7 +17,7 @@ Closes the 2026-04-25 Claude Code doc-refresh deltas affecting this plugin (snap
 - `references/troubleshooting.md` — symptom-first framework triage table + cross-link to upstream `Debug Your Config` for Claude Code platform-level issues (`/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`).
 - Reading-strategy callouts in `commands/research.md`, `commands/design.md`, `commands/implement.md`, `commands/review.md` — explicit Type-B (full-read, no grep-first) discipline, citing `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
 - `commands/validate-playbook-adherence.md` "Future hardening" section — `UserPromptExpansion` hook (Claude Code 2.1.118+) as a v2 candidate for platform-layer adherence enforcement at slash-command-expansion time.
-- `commands/review.md` "Reading strategy" callout includes a `PostToolBatch` future-avenue note for batch-summary aggregation across hard-block gates.
+- `PostToolBatch` future-avenue note (batch-summary aggregation) intentionally NOT inlined into `commands/review.md` — pattern is documented in detail in `code-quality-tools/skills/code-quality-audit/references/post-batch-aggregation.md` and cross-linked in `code-paper-test/commands/test-team.md`. Avoiding compound blockquotes in review.md preserves the one-liner consistency across phase commands.
 - CLAUDE.md gains `## Reading Strategy (v4.2.0+)`, `## Forked Subagents (v4.2.0+, experimental upstream)`, and `## Troubleshooting` sections.
 
 ### Changed

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-04-27
+
+### 2026-04-25 doc-refresh deltas
+
+Closes the 2026-04-25 Claude Code doc-refresh deltas affecting this plugin (snapshot pinned at upstream commit `c142d14`, covers Claude Code releases 2.1.116–2.1.119). Additive throughout — no behavior change to existing gates or commands.
+
+### Added
+
+- `references/forked-subagents.md` — documents experimental forked subagents (`CLAUDE_CODE_FORK_SUBAGENT=1`, Claude Code 2.1.117+), evaluation criteria for adopting in `/propose-epics` and parallel sub-task investigation, why v4.2.0 keeps `/validate:team`'s honest-validation guarantee on fresh-context spawns instead of forks.
+- `references/troubleshooting.md` — symptom-first framework triage table + cross-link to upstream `Debug Your Config` for Claude Code platform-level issues (`/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`).
+- Reading-strategy callouts in `commands/research.md`, `commands/design.md`, `commands/implement.md`, `commands/review.md` — explicit Type-B (full-read, no grep-first) discipline, citing `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+- `commands/validate-playbook-adherence.md` "Future hardening" section — `UserPromptExpansion` hook (Claude Code 2.1.118+) as a v2 candidate for platform-layer adherence enforcement at slash-command-expansion time.
+- `commands/review.md` "Reading strategy" callout includes a `PostToolBatch` future-avenue note for batch-summary aggregation across hard-block gates.
+- CLAUDE.md gains `## Reading Strategy (v4.2.0+)`, `## Forked Subagents (v4.2.0+, experimental upstream)`, and `## Troubleshooting` sections.
+
+### Changed
+
+- Body line counts after additive callouts: research 73, design 48, implement 69, review 116, validate-playbook-adherence 89 — all within v4.0.2 budgets (research ≤100, design ≤80, implement ≤120, review ≤120, adherence ≤100).
+
+### Audit results — `--agent` frontmatter hooks behavior fix (Claude Code 2.1.117+)
+
+Re-audited all 6 frontmatter agents for inline `hooks` and `mcpServers` declarations. The upstream fix makes frontmatter hooks fire in `--agent` (main-session) mode — previously they did not. Result:
+
+- `analysis-agent`, `architecture-drafter`, `contrib-researcher`, `pattern-recommender`, `project-orchestrator` — **no inline hooks or mcpServers**. Fix is **additive benefit only** for these 5 agents.
+- `architecture-validator` — **HAS** a `PreToolUse` hook matching `Write|Edit` that returns `block` (enforces the agent's read-only design). The fix making this hook fire in `--agent` mode is **also additive benefit** — the read-only enforcement is desired in main-session mode, not a regression. No code change required.
+
+**Conclusion:** no agent depends on hooks NOT firing in `--agent` mode. Behavior fix is purely additive across the agent surface; no `--agent` invocation pattern needs to be revised.
+
+### Out of scope (deferred to a later cycle)
+
+- OTEL span instrumentation for framework-emitted spans — no framework surface currently emits OTEL.
+- Routine templates (nightly audit, PR auto-review, release verification) — defer to v4.3.0 once the v4.1.0 epic pattern stabilizes further.
+- Plugin Dependencies declaration on `dev-guides-navigator` — already declared at the `plugin.json` level (`dependencies: ["dev-guides-navigator", "code-quality-tools"]`); deeper dependency-constraints work deferred.
+- Linux package manager install docs — host-installation guidance lives in `dev-guides-navigator`/upstream, not this plugin.
+
 ## [4.1.0] - 2026-04-26
 
 ### Phase 4 review + adherence gates + retrofit + closing pass

--- a/drupal-dev-framework/CLAUDE.md
+++ b/drupal-dev-framework/CLAUDE.md
@@ -221,6 +221,18 @@ Optional scope contract authored before Phase 1 via `/scope <task>`. Produces `a
 - Use `argument-hint:` for discoverability
 - Restrict `allowed-tools` to minimum needed
 
+## Reading Strategy (v4.2.0+)
+
+D-A-D phases (Research → Architecture → Design) are **Type B** work — audit / review / architecture analysis. Read full source and config files; do NOT grep-first. Inherited methods, annotations, config-wired classes, and docblock metadata are invisible to a grep-first pass. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`. Cited inline in `commands/research.md`, `commands/design.md`, `commands/implement.md`, `commands/review.md`.
+
+## Forked Subagents (v4.2.0+, experimental upstream)
+
+Claude Code 2.1.117+ ships forked subagents (`CLAUDE_CODE_FORK_SUBAGENT=1`) — context-inheriting parallel work. Relevant to `/propose-epics` bulk review and parallel sub-task investigation where shared loaded context (research, dev-guides, playbook) avoids re-establishment cost. **Not enabled by default** — `/validate:team`'s honest-validation guarantee deliberately wants fresh context. See `references/forked-subagents.md` for the framework's evaluation criteria.
+
+## Troubleshooting
+
+Symptom-first triage at `references/troubleshooting.md`. For Claude Code platform-level issues (CLAUDE.md ignored, hooks not firing, MCP not connecting, plugin not loaded), the upstream `Debug Your Config` guide is the authoritative reference — uses `/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status` to inspect what actually loaded.
+
 ## Online Dev-Guides — Proactive Usage
 **ALWAYS consult dev-guides before making Drupal development decisions** unless the relevant guide was already loaded in this session.
 - Use the `dev-guides-navigator` skill for topic discovery, caching, and disambiguation

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -263,7 +263,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.1.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.2.0**.
 
 ## License
 

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -8,6 +8,8 @@ argument-hint: <task-name>
 
 Phase 2 of a task. Behavior current as of v4.0.2; full prose / examples / version history in `references/design-walkthrough.md`.
 
+> **Reading strategy:** Phase 2 is **Type B** work — read full architecture refs, service definitions, and pattern docs; do NOT grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
+
 ## Usage
 
 ```

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -8,6 +8,8 @@ argument-hint: <task-name>
 
 Phase 3 of a task. Behavior current as of v4.0.2; full prose / examples / version history in `references/implement-walkthrough.md`.
 
+> **Reading strategy:** Implementation reads inherited classes, annotations, and config-wired services in full (**Type B**) — never grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
+
 ## Usage
 
 ```

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -8,6 +8,8 @@ argument-hint: <task-name>
 
 Phase 1 of a task. Behavior current as of v4.0.2; full prose / examples / version history in `references/research-walkthrough.md`.
 
+> **Reading strategy:** Phase 1 is **Type B** work (audit / review / architecture analysis) — read full source and config files; do NOT grep-first. Inherited methods, annotations, and config-wired classes are invisible to grep. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+
 ## Usage
 
 ```

--- a/drupal-dev-framework/commands/review.md
+++ b/drupal-dev-framework/commands/review.md
@@ -8,6 +8,8 @@ argument-hint: <task-name>
 
 Phase 4 of a task — run all hard-blocking validation gates before PR creation. Behavior current as of v4.1.0; full prose / examples / version history in `references/review-phase-walkthrough.md`.
 
+> **Reading strategy:** Gates run **Type B** reads — full source and config files, no grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`. **Future hardening:** `PostToolBatch` hook (Claude Code 2.1.118+) could aggregate per-gate findings into a single batch summary instead of firing per-gate; see `references/forked-subagents.md` for related epic-decomposition future work.
+
 ## Usage
 
 ```

--- a/drupal-dev-framework/commands/review.md
+++ b/drupal-dev-framework/commands/review.md
@@ -8,7 +8,7 @@ argument-hint: <task-name>
 
 Phase 4 of a task — run all hard-blocking validation gates before PR creation. Behavior current as of v4.1.0; full prose / examples / version history in `references/review-phase-walkthrough.md`.
 
-> **Reading strategy:** Gates run **Type B** reads — full source and config files, no grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`. **Future hardening:** `PostToolBatch` hook (Claude Code 2.1.118+) could aggregate per-gate findings into a single batch summary instead of firing per-gate; see `references/forked-subagents.md` for related epic-decomposition future work.
+> **Reading strategy:** Gates run **Type B** reads — full source and config files, no grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
 
 ## Usage
 

--- a/drupal-dev-framework/commands/validate-playbook-adherence.md
+++ b/drupal-dev-framework/commands/validate-playbook-adherence.md
@@ -81,6 +81,10 @@ Cite-matching is approximate: any-of-three literal-string match. False negatives
 - Playbook structure: `references/playbook-schema.md` v1.0
 - Sibling: `/drupal-dev-framework:upgrade-project` (sets explicit `**Playbook Sets:**` per project)
 
+## Future hardening
+
+`UserPromptExpansion` hook (Claude Code 2.1.118+, Hooks Reference) fires when a slash command expands into a prompt and **can block the expansion**. A future v2 could intercept `/complete` and other PR-creating commands at expansion time, validate that `_review.json` + `_playbook-adherence.json` audits exist with acceptable verdicts, and hard-block at the platform layer instead of the command-body layer. Tracked as a v2 candidate; not a v4.2.0 deliverable.
+
 ## Related
 
 - `/drupal-dev-framework:review <task>` — invokes this gate at Phase 4 with `--hard-block --invoked-by review`

--- a/drupal-dev-framework/references/forked-subagents.md
+++ b/drupal-dev-framework/references/forked-subagents.md
@@ -1,0 +1,43 @@
+# Forked Subagents (experimental)
+
+> Status: experimental upstream feature. Requires Claude Code v2.1.117+ and explicit opt-in via `CLAUDE_CODE_FORK_SUBAGENT=1`. **Not enabled by default.** Documented here as a future avenue for epic decomposition; v4.2.0 does not change framework behavior.
+
+## What it is
+
+A *fork* is a subagent that inherits the **entire conversation history** instead of starting fresh — same system prompt, tools, model, messages. Standard subagents start with a clean context. Forks are useful when re-explaining context would be too costly.
+
+When `CLAUDE_CODE_FORK_SUBAGENT=1` is set:
+
+- General-purpose subagent spawns become forks.
+- All subagent spawns run in background.
+- `/fork <directive>` spawns a fork from the current conversation.
+- A panel UI lets the user observe and steer running forks.
+
+## Why it matters for this framework
+
+Epic decomposition (`/migrate-to-epic`, `/propose-epics`) and parallel sub-task investigation are the obvious fits — multiple agents inspecting different aspects of the **same loaded codebase context** without each one re-loading research artifacts, dev-guides, and playbook content. The cost of re-establishing context per agent is real; forks amortize it.
+
+Concrete patterns where forks could help:
+
+- **Bulk epic review** — `/propose-epics` calls `analysis-agent` per task; with forks, each per-task assessment inherits the project research already loaded (`project_state.md`, `_playbook-load.json`, dev-guides) instead of starting fresh.
+- **Parallel sub-task scoping** — when a newly-promoted epic has 3–5 children needing scope assessment, fork once per child from the loaded epic context.
+- **Cross-cutting validation** — `/validate:team` already isolates per-gate context for honest validation; forks invert that for cases where shared context is *desired* (e.g., comparing two architecture options against the same loaded research).
+
+## Why we are not enabling it in v4.2.0
+
+- **Experimental upstream.** Schema, behavior, and UI may shift before stable.
+- **Honest-validation tradeoff.** `/validate:team` (v3.14.0+) deliberately runs gates in fresh contexts to avoid self-review bias. Forks are the opposite primitive — useful, but the team-mode roster should NOT switch to forks without an explicit decision.
+- **Opt-in only.** Until upstream stabilizes, users who want to experiment should set `CLAUDE_CODE_FORK_SUBAGENT=1` per session and use `/fork` directly.
+
+## When upstream stabilizes
+
+Re-evaluate whether `/propose-epics` and the post-phase `analysis-agent` re-invocations should switch from standard sub-agent spawns to forks. The decision criteria are:
+
+1. Does the agent need the loaded session context (research artifacts, dev-guides, playbook) to make a better-quality call?
+2. Is the framework's existing fresh-context guarantee load-bearing for that surface?
+
+If (1) is yes and (2) is no, fork. Otherwise stay with standard subagent.
+
+## Upstream reference
+
+`https://docs.claude.com/en/docs/claude-code/sub-agents` (Subagents guide; "Fork the current conversation" section).

--- a/drupal-dev-framework/references/troubleshooting.md
+++ b/drupal-dev-framework/references/troubleshooting.md
@@ -1,0 +1,35 @@
+# Troubleshooting
+
+Symptom-first triage for framework + Claude Code platform issues.
+
+## Framework state diagnostics
+
+Use these when framework behavior is unexpected:
+
+| Symptom | First check |
+|---------|-------------|
+| `/next` picks the wrong task | `/drupal-dev-framework:status` (tree view + active task) and `~/.claude/drupal-dev-framework/sessions/<workspace_hash>.json` |
+| Hardened gate appears to skip | `/drupal-dev-framework:audit-status <task>` — lists fired and unaudited gates per task |
+| Playbook citation fails | `/drupal-dev-framework:playbook-active` (subscribed sets, local playbook, recent conflicts) |
+| Phase artifact missing fields after upgrade | `/drupal-dev-framework:upgrade-project` (active project only — backfills + journal-resumable) |
+| `/research` epic gate didn't fire | `_pre-analysis.json` in task folder; if absent for a v3.x task, it's grandfathered (pre-v4.0.0) |
+| Coverage-mapping gate keeps failing | `scripts/coverage-mapping-check.sh <task_folder>` — verbose output shows per-question matching |
+
+## Claude Code platform diagnostics
+
+For platform-level issues (CLAUDE.md ignored, hooks not firing, MCP not connecting, settings not taking effect, plugin/skill not loaded), see the upstream **Debug Your Config** guide:
+
+- `/context` — what content is currently in context
+- `/memory` — loaded CLAUDE.md / AGENTS.md files
+- `/doctor` — installation, plugin load errors, environment issues
+- `/hooks` — registered hooks and their sources (per-event, per-matcher)
+- `/mcp` — MCP server connection state
+- `/skills` — loaded skills and their source plugin
+- `/permissions` — current permission ruleset (allow/deny/ask)
+- `/status` — session info (model, working directory, settings paths loaded)
+
+Upstream guide: `https://code.claude.com/docs/en/configuration/debug-your-config`. The auto-mode classifier has its own dedicated reference (`Auto Mode Config`); enterprise rollout has `Admin Setup`. None of those live in the `camoa/dev-guides` corpus — `dev-guides-navigator` only routes to project guides, not Claude Code platform docs.
+
+## Reading-strategy reminder
+
+Before debugging framework code, treat the work as **Type B** (audit / review / architecture analysis): read full source and config files, do not grep-first. Inherited methods, annotations, and config-wired classes are invisible to a grep-first pass. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.


### PR DESCRIPTION
## Summary

Closes the 2026-04-25 Claude Code doc-refresh deltas across 5 affected camoa-skills plugins in a single coordinated PR. Snapshot pinned at upstream commit `c142d14` (covers Claude Code releases 2.1.116–2.1.119). Additive throughout — no behavior changes.

## Plugins bumped

| Plugin | Bump | One-line summary |
|---|---|---|
| drupal-dev-framework | 4.1.0 → **4.2.0** | Agent audit + forked-subagents ref + Type-B reading-strategy callouts + UserPromptExpansion / PostToolBatch future-avenue notes + Debug Your Config cross-link |
| code-quality-tools | 3.0.0 → **3.1.0** | PostToolBatch aggregation pattern reference (optional, not shipped by default) + Type-B reading-strategy callouts on audit/review/security/solid/dry + `if`-Bash subcommand clarification + Debug Your Config cross-link |
| code-paper-test | 0.7.0 → **0.8.0** | Forked subagents documented + Type-B reading-strategy citation + PostToolBatch cross-link on `/test-team` |
| dev-guides-navigator | 0.4.0 → **0.5.0** | Out-of-scope cross-links for the 3 new platform docs at `code.claude.com` (Debug Your Config, Auto Mode Config, Admin Setup) — navigator does not route to them |
| brand-content-design | 3.2.0 → **3.3.0** | Plugin themes feature acknowledged; branded `themes/default.json` deferred pending color tokens |

`marketplace.json` bumps all 5 plugin pointers and the catalog `metadata.version` 1.14.27 → 1.14.28 (patch per the pointer-bump rule).

## Drupal-dev-framework agent audit (re-verified during implementation)

Re-read all 6 agents for inline `hooks` / `mcpServers` declarations:

- `analysis-agent`, `architecture-drafter`, `contrib-researcher`, `pattern-recommender`, `project-orchestrator` — none declared. Upstream `--agent` fix is **additive benefit only**.
- `architecture-validator` — declares a `PreToolUse` hook matching `Write|Edit` returning `block` (enforces the agent's read-only design). The fix making this hook fire in `--agent` mode is **also additive** — read-only enforcement is desired in main-session mode, not a regression.

**Conclusion:** no agent depends on hooks not firing. No `--agent` invocation pattern needs revision.

## Validation

- All 6 plugin/marketplace JSON files: valid (`jq empty`).
- Local drupal-dev-framework test harnesses: all 6 pass (`tests/*.sh`).
- Body line counts under v4.0.2 budgets across all touched commands.
- `code-quality-tools/skills/code-quality-audit/SKILL.md` at 309 lines (under 500-line soft cap).

## Out of scope (deferred to later cycles)

- OTEL span instrumentation for any plugin.
- `mcp_tool` hook handler — no migration candidates exist (audited every plugin).
- Routine templates (nightly audit, PR auto-review, release verification) for drupal-dev-framework.
- Branded `themes/default.json` for brand-content-design (no confident color tokens authored this session).
- Default-on `PostToolBatch` hook in code-quality-tools — pending upstream skill-scoping or matcher field.
- plugin-creation-tools v3.3.0 plan ships separately (per triage).

## Test plan

- [x] Baseline preflight matched expected versions (3.0.0 / 4.1.0 / 0.7.0 / 0.4.0 / 3.2.0)
- [x] All 5 plugin.json + marketplace.json updates valid JSON
- [x] All 6 drupal-dev-framework local tests pass
- [x] No Tier C plugin (drupal-htmx, palcera plugins) modified
- [x] Reading-strategy citation present in code-quality-tools, drupal-dev-framework, code-paper-test
- [x] No source code in `claude_code_projects/claude_docs/` modified
- [ ] `/plugin-creation-tools:validate` per plugin (run by user — slash-command, not invokable from agent context)
- [ ] `skill-quality-reviewer` on each touched SKILL.md (run by user)
- [ ] `plugin-structure-auditor` on code-quality-tools new ref file (run by user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)