### PR TITLE
docs: marketplace portability guide (PORTABILITY.md + CURSOR.md)

### DIFF
--- a/CURSOR.md
+++ b/CURSOR.md
@@ -1,0 +1,78 @@
+# Using camoa-skills with Cursor
+
+**Audience:** Developers using [Cursor](https://cursor.com/) who want to bring camoa-skills plugins into their Cursor projects.
+**Spec basis:** Cursor 2.4+ (May 2026). Follow the linked Cursor docs for live schemas.
+
+## Why a separate doc
+
+Cursor has the highest emulation fidelity (~70–80%) among non-Claude-Code tools because it ships near-1:1 native analogs for slash commands, sub-agents, and hooks. Everything else (other tools, the universal pattern, per-plugin portability) lives in [PORTABILITY.md](PORTABILITY.md). This file is the Cursor-specific quick reference.
+
+## TL;DR
+
+**Point your AI assistant** (Cursor's own composer agent works fine, or any other) **at this doc plus the plugin you want, and ask it to produce the converted `.cursor/` tree.** No script needed. Cursor's formats evolve; your AI will read the current Cursor docs (linked below) and adapt the conversion accordingly.
+
+## Surface mapping table
+
+| Claude Code artifact (canonical) | Cursor location | Notes |
+|---|---|---|
+| `<plugin>/commands/<name>.md` | `.cursor/commands/<name>.md` | Same prompt body. Cursor custom commands are **plain markdown with no required frontmatter** — strip the CC YAML frontmatter (`description`, `allowed-tools`, `argument-hint`, etc.) and the file works as-is. See [hamzafer/cursor-commands](https://github.com/hamzafer/cursor-commands) for examples. |
+| `<plugin>/agents/<name>.md` | `.cursor/agents/<name>.md` *or* `.claude/agents/<name>.md` (Cursor reads both as of 2.4+) | Frontmatter fields: `name`, `description`, `model` (default `inherit`), `readonly`, `is_background` |
+| `<plugin>/hooks/hooks.json` | `.cursor/hooks.json` (schema version `1`) | Event names match closely (`sessionStart`, `preToolUse`, `postToolUse`, `preCompact`, `stop`, etc.); a few CC events (e.g., `Notification`) have no Cursor equivalent and should be skipped |
+| `<plugin>/skills/<name>/SKILL.md` | `.cursor/skills/<name>/SKILL.md` | Pure passthrough — SKILL.md is an open standard, no rewriting |
+| `<plugin>/scripts/*.sh` | wherever convenient in your project (Cursor's `beforeShellExecution` hook can wrap them) | Pure passthrough — they're plain bash + jq |
+| `<plugin>/.mcp.json` | `<project>/.mcp.json` | Pure passthrough — Cursor is an MCP client |
+| `<plugin>/CLAUDE.md` | `<project>/AGENTS.md` (Cursor reads `AGENTS.md` natively) | Rewrite the heading; body content typically passes through |
+
+**Important schema notes for your AI to use during conversion:**
+
+- Cursor agents accept the **same `.claude/agents/` path** Claude Code uses (compat path) — so for plugins with agents only, sometimes no path move is needed.
+- Cursor hooks live in `.cursor/hooks.json` (one file with a `version: 1` envelope and a `hooks` object keyed by event name). They are NOT a `.cursor/hooks/` directory.
+- Cursor `readonly: true` is the equivalent of CC's `disallowedTools: Edit, Write, …` for read-only agents — your AI should detect this pattern and convert.
+
+## Live spec links
+
+Do not duplicate these in your conversion output — follow them for current schemas:
+
+- **Cursor sub-agents:** https://cursor.com/docs/context/subagents
+- **Cursor hooks:** https://cursor.com/docs/hooks
+- **Cursor slash commands & customization:** start at https://cursor.com/docs and search "custom commands" / "rules"; community reference at [hamzafer/cursor-commands](https://github.com/hamzafer/cursor-commands) (plain `.md` files in `.cursor/commands/`, no required frontmatter)
+- **AGENTS.md universal standard:** https://agents.md/
+
+## How to convert (delegate to your AI)
+
+This is the actual install path. Open a Cursor (or Claude Code, or any AI) chat in the marketplace root and try a prompt like:
+
+> "Read `PORTABILITY.md` and `CURSOR.md` from this repo, then look at the plugin at `<plugin-name>/`. Produce a `.cursor/` tree at `./<plugin-name>/.cursor-export/.cursor/` that mirrors the surface mapping table in `CURSOR.md`:
+>
+> - Copy `skills/` verbatim into `.cursor/skills/`.
+> - Translate `commands/*.md` into `.cursor/commands/*.md` — Cursor custom commands are plain markdown with no required frontmatter, so strip the CC YAML frontmatter (`description`, `allowed-tools`, `argument-hint`, etc.) and copy the body as-is. Reference: https://github.com/hamzafer/cursor-commands
+> - Translate `agents/*.md` into `.cursor/agents/*.md` using the Cursor sub-agent frontmatter (`name`, `description`, `model: inherit`, `readonly`, `is_background`).
+> - Translate `hooks/hooks.json` into `.cursor/hooks.json` (schema version 1). Skip any CC events with no Cursor equivalent and report them.
+> - Pass `scripts/*.sh` and `.mcp.json` through unchanged.
+> - Rewrite `CLAUDE.md` to an `AGENTS.md` at the project root with a heading reflecting that it's a project-wide AI instructions file.
+> - Report any frontmatter fields, events, or features that didn't map and tell me what to do about them."
+
+Your AI handles the mechanics. Re-run when Cursor updates its formats — your AI will re-fetch the live docs and adapt.
+
+## Deterministic gates
+
+The reason this matters for `drupal-dev-framework` users: Cursor hooks preserve `drupal-dev-framework`'s deterministic gate enforcement. The `gate-audit-write.sh`, `coverage-mapping-check.sh`, `dev-guides-detect.sh`, and `playbook-load-deterministic.sh` scripts from `drupal-dev-framework/scripts/` run as-is from a Cursor `preToolUse` or `postToolUse` hook handler — pure bash + `jq`, no Claude-Code-specific runtime.
+
+In Cursor: the v4.0+ anti-bypass clauses, mandated wording, and audit-JSON outputs work. The gates remain non-bypassable.
+
+In tools without hooks: the gates degrade to soft-nudges, per the disclosure in [PORTABILITY.md](PORTABILITY.md).
+
+## What we explicitly didn't ship
+
+- **An auto-converted `.cursor/` tree per plugin.** It would drift as Cursor evolves. Your AI doing the conversion on demand stays fresh.
+- **A `cursor-transform.sh` script.** Same reason — and modern AI assistants are perfectly capable of frontmatter rewriting and event mapping without a hand-coded script.
+- **Field-by-field mirrors of Cursor's schemas.** The linked Cursor docs are authoritative. We name *what* maps, you read *how* there.
+- **Per-plugin conversion examples.** Out of scope. The prompt template above generalizes; pick a plugin, run the prompt.
+
+## Sources
+
+- [Cursor sub-agents](https://cursor.com/docs/context/subagents)
+- [Cursor hooks](https://cursor.com/docs/hooks)
+- [Cursor general docs](https://cursor.com/docs)
+- [agents.md universal AGENTS.md standard](https://agents.md/)
+- [InfoQ: Cursor 1.7 hooks coverage](https://www.infoq.com/news/2025/10/cursor-hooks/)

--- a/PORTABILITY.md
+++ b/PORTABILITY.md
@@ -1,0 +1,152 @@
+# camoa-skills Portability Guide
+
+**Audience:** Developers — especially Drupal developers — using AI-assisted dev tools **other than Claude Code** who want to use the plugins in this marketplace.
+
+**Spec basis:** May 2026. The AGENTS.md, SKILL.md (agentskills.io), and per-tool specs cited here may evolve; this guide is not a maintained living spec mirror.
+
+## TL;DR
+
+1. **Skills are portable.** The `skills/` directory in each plugin conforms to the open [agentskills.io](https://agentskills.io/specification) standard. They drop into Cursor, Codex CLI, VS Code Copilot, Gemini CLI, Cline, OpenCode, Windsurf, and others — only the destination folder differs.
+2. **Commands, agents, and hooks are Claude-Code-specific by format**, but their *content* is plain markdown — your AI assistant can convert them on demand. See the Tier 2 section.
+3. **For Cursor specifically**, see [CURSOR.md](CURSOR.md) — Cursor 2.4+ ships near-1:1 native analogs for slash commands, subagents, and hooks, giving the highest emulation fidelity outside Claude Code.
+
+## How to use this guide
+
+Pick a tier based on what you need and how much setup you'll tolerate:
+
+- **Tier 1** = skills only. Lowest effort, works everywhere. Gives you knowledge but not workflow orchestration.
+- **Tier 2** = framework emulation. Higher effort, recovers most of the orchestration value. Best fidelity in Cursor; varies elsewhere.
+
+If you only want one or two specific skills, stop at Tier 1. If you want a plugin's full workflow (gates, multi-step commands, sub-agent coordination), read Tier 2.
+
+---
+
+## Tier 1 — Skills only (works everywhere)
+
+### What's portable: `SKILL.md` as an open standard
+
+Every plugin in this marketplace has a `skills/` directory. Each skill is a folder containing a `SKILL.md` with YAML frontmatter (`name` + `description` required) plus a markdown body. Optional `references/`, `scripts/`, and `assets/` subfolders ship with the skill. This is the [agentskills.io](https://agentskills.io/specification) open standard, originated at Anthropic and now adopted as a portable format by multiple AI dev tools.
+
+You can copy a skill folder verbatim from any camoa-skills plugin into the destination folder your tool expects, and it will work.
+
+### Native SKILL.md support — destination folders
+
+| Tool | Project-level destination | User-level destination |
+|---|---|---|
+| Claude Code | `<plugin>/skills/` (already there) | `~/.claude/skills/` |
+| Cursor 2.4+ | `.cursor/skills/<name>/` | `~/.cursor/skills/` |
+| Codex CLI | per [Codex skills docs](https://developers.openai.com/codex/skills) | per docs |
+| VS Code Copilot | per [Copilot agent skills docs](https://code.visualstudio.com/docs/copilot/customization/agent-skills) | per docs |
+| Gemini CLI | per `activate_skill` config; `GEMINI.md` references | per docs |
+| OpenCode | per [OpenCode skills docs](https://opencode.ai/docs/skills) | per docs |
+| Windsurf | per Windsurf skills docs | per docs |
+
+Follow your tool's own docs for the most current destination path. The SKILL.md file itself is the same.
+
+### Per-plugin portability table
+
+| Plugin | Skills | Commands | Agents | Hooks | Tier 1 fit | What ships in Tier 1 |
+|---|---|---|---|---|---|---|
+| **dev-guides-navigator** | 1 | 0 | 0 | yes | **High** | The whole plugin — it's a pure-skill plugin |
+| **code-paper-test** | 1 | 1 | 0 | yes | **Medium** | Paper-testing skill (mental execution methodology) — the `/test` command is the wrapper |
+| **plugin-creation-tools** | 3 | 3 | 2 | yes | **Medium** | Skill-quality / plugin-structure / skill-conventions guidance |
+| **brand-content-design** | 4 | 19 | 1 | yes | **Low–Medium** | Brand-analyst + design-system generation skills; commands provide the user-facing surface |
+| **code-quality-tools** | 1 | 13 | 0 | yes | **Low** | One overarching audit skill; the value is in 13 audit commands (Tier 2) |
+| **drupal-htmx** | 1 | 5 | 3 | yes | **Low** | HTMX-pattern skill; migration commands are the workflow (Tier 2) |
+| **drupal-dev-framework** | 22 | 36 | 7 | yes | **Skills-rich, framework-locked** | 22 skills give knowledge (alignment-reader, project-state-reader, contrib patterns, etc.); the lifecycle orchestration (research → design → implement → review with deterministic gates) is in the commands + agents + hooks |
+
+**Honest verdict:** for `dev-guides-navigator`, Tier 1 gives you the entire plugin. For `code-quality-tools` and `drupal-htmx`, Tier 1 alone gives you a fraction of the value. For `drupal-dev-framework`, skills give you reusable knowledge but **not** the deterministic 3-phase lifecycle that's the framework's primary value proposition.
+
+### How to install (Tier 1)
+
+1. **Locate the skills you want.** Browse `<plugin>/skills/` in this marketplace. Pick the folders you need.
+2. **Copy to your tool's skills directory.** Match your tool's destination from the table above; follow your tool's docs for the exact path.
+3. **Invoke.** Your tool's skill discovery mechanism will surface the skill by its frontmatter `name` and `description`. Usage depends on the tool — Cursor uses skill cards, Codex CLI uses the `activate_skill` flow, etc.
+
+That's the whole Tier 1 install path. No conversion needed. The same SKILL.md works in every agentskills.io-compatible tool.
+
+### Caveat: skills give knowledge, not orchestration
+
+A skill is a *capability* — it teaches your AI how to think about something. A plugin's *workflow* (e.g., "first research existing solutions, then design, then implement with gates between phases") lives in commands + agents + hooks, which Tier 1 skips. If you load just the skills, your AI will know the patterns but won't run the lifecycle. That's Tier 2's job.
+
+---
+
+## Tier 2 — Framework emulation (brief overview)
+
+### Why this exists
+
+`drupal-dev-framework`'s value isn't its 22 skills — it's the 36 commands + 7 sub-agents + lifecycle hooks + 18 deterministic shell scripts that together enforce a Research → Architecture → Implementation → Review workflow with anti-bypass gates. Skills alone are roughly 10% of that value. Tier 2 explains how to get the other 90% in tools where the surface partially maps.
+
+### Per-tool fidelity tier table
+
+Honest estimate of how much framework-style orchestration you can preserve outside Claude Code, as of May 2026:
+
+| Tool | Realistic fidelity | Mechanism |
+|---|---|---|
+| **Cursor 2.4+** | **70–80%** | Native `.cursor/commands/`, `.cursor/agents/`, `.cursor/hooks.json` — see [CURSOR.md](CURSOR.md) |
+| **Codex CLI** | **50–60%** | Native slash commands + native subagents (2026); hooks RFC open ([openai/codex#14882](https://github.com/openai/codex/issues/14882)), so deterministic gate enforcement is missing |
+| **VS Code Copilot / Gemini CLI / Cline** | **30–50%** | Slash commands map (`.github/prompts/`, `.gemini/commands/`, `.clinerules/workflows/`); no sub-agent parallelism; no lifecycle hooks |
+| **JetBrains Junie** | **20–30%** | No slash commands, no sub-agents, no hooks — collapses to `AGENTS.md` + always-on rules |
+
+### Universal pattern: AGENTS.md learn-and-emulate
+
+[`AGENTS.md`](https://agents.md/) is a cross-tool standard for project-context instructions, read by Cursor, Codex, Copilot, Junie, Windsurf, and many others. The pattern for emulating a Claude Code plugin's workflow in any AGENTS.md-aware tool:
+
+1. **Drop an `AGENTS.md` at your project root.** Reference the camoa-skills plugins you've installed (paths or vendored copies).
+2. **Point your AI at the plugin's `commands/` and `agents/` directories.** These are markdown files — your AI can read them and treat their bodies as prompts.
+3. **Tell your AI in `AGENTS.md`**: "When the user invokes `/<command>`, read `<plugin>/commands/<command>.md` and follow its body as your prompt." Same pattern for agents: "When you spawn a subagent named `<name>`, use the system prompt in `<plugin>/agents/<name>.md`."
+
+Your AI handles the rest — frontmatter interpretation, body execution, sub-task spawning, etc. — by reading the canonical Claude Code artifacts directly.
+
+### Honest disclosure: deterministic gate degradation
+
+`drupal-dev-framework` v4.0+ hardened its quality gates (anti-bypass clauses, mandated wording, audit JSONs) precisely because *hooks* run them — making the gates non-bypassable. In tools without hooks:
+
+- The gates degrade to **soft-nudges in the AI's prompt context**. The AI *can* skip them.
+- **There is no audit trail.** No `_pre-analysis.json` / `_coverage-mapping.json` files get written automatically.
+- "Show verbatim before user choice" semantics depend on AI compliance with the loaded command body, not on a deterministic guard.
+
+This isn't a reason to skip Tier 2 — it's a reason to **know what you're losing**. In Cursor (with hooks), the spine is preserved. In Junie (no hooks), it's gone.
+
+### See CURSOR.md for the highest-fidelity option
+
+If you're on Cursor 2.4+, [CURSOR.md](CURSOR.md) covers the surface mapping in detail and gives you a prompt template for asking *your own AI* to produce the converted `.cursor/` tree on demand. We deliberately don't ship a transformer script — Cursor's formats evolve, and modern AI assistants are perfectly capable of doing the conversion when pointed at the canonical Claude Code artifacts.
+
+---
+
+## What does NOT port (anywhere)
+
+| Surface | Why it doesn't port |
+|---|---|
+| `plugin.json` + `.claude-plugin/marketplace.json` | Claude Code distribution wrapper — no other tool consumes this schema |
+| Lifecycle behaviors that depend on `session-context-writer`, `hook-cache-status`, etc. | These rely on Claude Code's session-state model and specific hook events |
+| `SessionStart` / `PreCompact` semantics in tools with no equivalent event | Compaction-aware context restoration only works in tools that surface a compaction event to a hook |
+
+Tier 2 emulation recovers a lot, but it isn't 100% even in Cursor. The doc tier estimates account for these gaps.
+
+## MCP wiring
+
+**No camoa-skills plugin currently ships an MCP server** (as of May 2026). If a future plugin adds one, MCP itself is universally portable — every major tool listed in this guide is an MCP client. You'd point your tool at the server's `.mcp.json` per the tool's own MCP setup docs.
+
+## FAQ / Caveats
+
+- **Why no transformer script?** Cursor (and others) update their formats periodically. A frozen transformer script would drift. Your AI assistant — including the one already in Cursor — can produce the conversion on demand from the canonical Claude Code artifacts, which keeps the conversion fresh against current schemas.
+- **Why "May 2026 specs"?** Specs evolve. We write to what's true now and link out to the live docs. We don't commit to chasing every update.
+- **Per-tool deep-dives?** Out of scope for this doc. Cursor gets a short sibling ([CURSOR.md](CURSOR.md)) because the fidelity ceiling is genuinely highest there. Other tools follow the AGENTS.md learn-and-emulate pattern above.
+- **Will commands/agents/hooks ever port natively?** Each tool decides. Cursor already has them. Codex CLI has commands + subagents (hooks RFC open). Watch the linked spec sites for live updates.
+
+## Sources
+
+- [agentskills.io specification](https://agentskills.io/specification)
+- [agentskills GitHub org](https://github.com/agentskills/agentskills)
+- [Anthropic Agent Skills spec (anthropics/skills)](https://github.com/anthropics/skills/blob/main/spec/agent-skills-spec.md)
+- [agents.md (universal AGENTS.md standard)](https://agents.md/)
+- [Claude Code Skills docs](https://code.claude.com/docs/en/skills)
+- [Claude API Agent Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [OpenAI Codex Skills](https://developers.openai.com/codex/skills)
+- [OpenAI Codex AGENTS.md](https://developers.openai.com/codex/guides/agents-md)
+- [VS Code Copilot Agent Skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
+- [OpenCode Skills](https://opencode.ai/docs/skills)
+- [Cursor subagents docs](https://cursor.com/docs/context/subagents)
+- [Cursor hooks docs](https://cursor.com/docs/hooks)
+- [Anthropic engineering: Equipping agents with Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ I wrote more about this methodology in [My Journey with AI Tools](https://adrupa
 /plugin install code-paper-test@camoa-skills
 ```
 
+## Using these plugins outside Claude Code
+
+Skills in this marketplace conform to the open [agentskills.io](https://agentskills.io/specification) standard and work in Cursor, Codex CLI, VS Code Copilot, Gemini CLI, Cline, OpenCode, and more. Commands, agents, and hooks are Claude-Code-specific by format but can be emulated. See **[PORTABILITY.md](PORTABILITY.md)** for the full guide and **[CURSOR.md](CURSOR.md)** for Cursor-specific notes.
+
 ## Known Issues
 
 ### Skills not auto-discovered on startup

--- a/brand-content-design/README.md
+++ b/brand-content-design/README.md
@@ -4,6 +4,8 @@
 
 Create branded presentations, LinkedIn carousels, infographics, and HTML pages with consistent visual identity.
 
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
+
 ## The Flow
 
 ```

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -2,6 +2,8 @@
 
 Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, AI hallucinations, and contract violations before deployment.
 
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
+
 ## What is Paper Testing?
 
 Paper testing is the practice of mentally executing code with concrete test cases to find issues before running it. Unlike code review (which focuses on style and patterns), paper testing **actually runs** the code in your head with real values to catch:

--- a/code-quality-tools/README.md
+++ b/code-quality-tools/README.md
@@ -2,6 +2,8 @@
 
 Code quality and security auditing plugin for Claude Code. Provides TDD, SOLID, DRY, and OWASP security checks for **Drupal** (via DDEV) and **Next.js** projects with Semgrep, Trivy, and Gitleaks.
 
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
+
 ## How Detection Works
 
 **All commands are the same for both project types.** When you run any command, the plugin auto-detects your project by checking:

--- a/dev-guides-navigator/README.md
+++ b/dev-guides-navigator/README.md
@@ -2,6 +2,8 @@
 
 Smart guide discovery and routing for the [dev-guides](https://camoa.github.io/dev-guides/) site. Routes AI to the correct guide using hash-based caching and KG metadata for disambiguation.
 
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — this plugin is pure-skill and the highest-portability one in the marketplace.
+
 ## Installation
 
 ```bash

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -4,6 +4,8 @@ A Claude Code plugin that guides AI through a disciplined **Research → Archite
 
 > **New here?** Read [GETTING_STARTED.md](GETTING_STARTED.md) — a 5-minute walkthrough that takes you from install to your first task. This README is the reference.
 
+> **Not using Claude Code?** This framework's value is its orchestration (commands + agents + hooks), most of which is Claude-Code-specific. See the marketplace [PORTABILITY.md](../PORTABILITY.md) for what ports + [CURSOR.md](../CURSOR.md) for the highest-fidelity option (~70-80% in Cursor 2.4+).
+
 ## How It Works
 
 You create a **project** (a Drupal module, theme, or set of related work), then break it into **tasks**. Each task goes through three phases before any code is written:

--- a/drupal-htmx/README.md
+++ b/drupal-htmx/README.md
@@ -2,6 +2,8 @@
 
 HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+.
 
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
+
 ## Features
 
 - **Analyze** existing AJAX patterns for migration opportunities

--- a/plugin-creation-tools/README.md
+++ b/plugin-creation-tools/README.md
@@ -4,6 +4,8 @@ Complete authoring guide for Claude Code plugins — skills, commands, agents, h
 
 The plugin contains one large skill (`plugin-creation`) that progressively discloses references for every component type, plus three commands and two structural-audit agents. Aimed at plugin authors building or maintaining plugins for the public marketplace.
 
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- **Add `PORTABILITY.md`** at the marketplace root — Tier 1 (skills via the [agentskills.io](https://agentskills.io/specification) open standard, works in Cursor / Codex CLI / VS Code Copilot / Gemini CLI / Cline / OpenCode / Windsurf) plus a brief Tier 2 covering framework emulation, the universal `AGENTS.md` learn-and-emulate pattern, per-tool fidelity tiers, and an honest deterministic-gate-degradation disclosure. Includes a per-plugin portability table (Low/Medium/High) for all 7 active plugins.
- **Add `CURSOR.md`** — short Cursor-specific quick reference (surface mapping, live spec links, AI-driven conversion prompt template). Deliberately no transformer script — modern AI assistants do conversion on demand from canonical CC artifacts, which stays fresh as Cursor's formats evolve.
- **Link from root README + all 7 plugin READMEs** — uniform 1-line callout, tailored for `dev-guides-navigator` (highest-portability, pure-skill) and `drupal-dev-framework` (most CC-locked; points at `CURSOR.md` too).

## Why now

Drupal community signal (drupal.org AI coding tools wiki, Talking Drupal #538, DrupalCon Chicago 2026, `ai_best_practices` issue #3582943) shows Drupal devs increasingly using AI tools beyond Claude Code. The marketplace had no story for them.

## Scope discipline

Three scope revisions during the dev-framework task:
- R1 "simple guide" → R2 added Tier 2 + a Cursor transformer script → **R3 dropped the transformer** (and any hand-coded conversion artifacts) on the realization that modern AI assistants can produce the conversion on demand. Final scope is closest to R1 simplicity with R2's depth where it actually matters.

## Test plan

- [ ] Render PORTABILITY.md on GitHub; confirm all internal links resolve (`PORTABILITY.md` ↔ `CURSOR.md`, root + 7 plugin READMEs → root `PORTABILITY.md`)
- [ ] Render CURSOR.md; confirm external Cursor doc links + `hamzafer/cursor-commands` reference resolve
- [ ] Spot-check 2 plugin READMEs (e.g., `dev-guides-navigator`, `drupal-dev-framework`) — callout appears under the tagline, before the first H2
- [ ] Skim the per-plugin portability table — verify skill/command/agent counts match the marketplace at the time of merge

## What this doesn't include (intentional non-goals)

- Per-tool deep-dives beyond the brief Tier 2 table + the Cursor sibling
- Transformer scripts of any kind (R3 decision)
- Field-by-field mirroring of Cursor's schemas (we link, we don't duplicate)
- Per-plugin conversion examples (the prompt template in CURSOR.md generalizes)
- Tracking AGENTS.md / agentskills.io / Cursor spec drift (May 2026 basis, no commitment to chase)

## No version bumps

Additive marketplace-root documentation. No `plugin.json` / `marketplace.json` plugin-pointer changes. No `metadata.version` bump warranted under the documented rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)