### PR TITLE
plugin-creation-tools v3.4.0 — Claude Code v2.1.120 → v2.1.136 doc-snapshot refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.33"
+    "version": "1.14.34"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Complete guide for creating Claude Code plugins — skills, commands, agents, hooks, MCP servers, and configuration. Covers 28 hook events, the if pre-spawn filter, the mcp_tool handler type, plugin themes, userConfig with type/title schema, allowCrossMarketplaceDependenciesOn, claude plugin tag, forked subagents, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
-      "version": "3.3.1",
+      "description": "Complete guide for creating Claude Code plugins — skills, commands, agents, hooks, MCP servers, and configuration. Covers 29 hook events (now including Setup for --init-only / --init -p / --maintenance -p one-time preparation, plus WorktreeCreate/WorktreeRemove for replacing default git worktree behavior with custom VCS logic), the if pre-spawn filter, the mcp_tool handler type, the effort.level adaptive-effort input + $CLAUDE_EFFORT env var, updatedToolOutput (supersedes MCP-only updatedMCPToolOutput), experimental.themes / experimental.monitors manifest migration with auto-migration diff offer, $schema field for editor autocomplete, array-only agents, plugin themes, userConfig with type/title schema, skillOverrides setting + the plugin-skills caveat, claude plugin prune + --prune flag on uninstall + --plugin-url session loader, Plugin Hints (CLI-driven install prompts) for first-party plugin authors, workspace-trust gating clarification on allowed-tools, plugin-root CLAUDE.md scoping clarification, allowCrossMarketplaceDependenciesOn, claude plugin tag, forked subagents, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
+      "version": "3.4.0",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
-  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 28 hook events (with the `if` pre-spawn filter and the `mcp_tool` handler type), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
-  "version": "3.3.1",
+  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter and the `mcp_tool` handler type), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
+  "version": "3.4.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-05-11
+
+Doc-snapshot refresh covering Claude Code **v2.1.120 → v2.1.136**. Source: tracking memo `claude_docs/improvements/plugin-creation-tools-2026-05-08.md`. Plan-driven, additive — no breaking changes for plugin authors who haven't migrated yet (top-level `themes`/`monitors` still load).
+
+### Added — Manifest schema (`experimental.*`, `$schema`, array-only `agents`)
+- **NEW migration section** in `references/08-configuration/plugin-json.md`: themes/monitors belong under `experimental.*`. Top-level still loads but `claude plugin validate` warns; a future release will require the nested form. Includes a `diff` block showing the wrapping change.
+- `templates/plugin.json.template`: emits `$schema` (SchemaStore JSON Schema URL — editor autocomplete only, Claude Code ignores it at load time), commented `experimental.{themes,monitors}` block, and array-form guidance for `commands`/`agents`/`skills`.
+- `references/08-configuration/themes.md`: examples updated to nest under `experimental.themes`.
+- `references/08-configuration/plugin-json.md`: `$schema` row added to metadata table; `agents` row tightened to array-only; `commands`/`skills` flagged as array-preferred.
+- `commands/add-component.md`: `theme` subcommand now writes paths under `experimental.themes` and warns about the top-level form.
+
+### Added — Hook event #29: `Setup`
+- **NEW `Setup` event** in `references/06-hooks/hook-events.md`. Fires only on `--init-only`, `--init -p`, `--maintenance -p` — distinct from `SessionStart` which fires every launch. Receives `trigger: "init" | "maintenance"`. Has `CLAUDE_ENV_FILE`. Cannot block (exit 2 shows stderr only). Only `command` and `mcp_tool` handler types supported. Documents the "check on first use, install on miss" pattern with `${CLAUDE_PLUGIN_DATA}` since Setup doesn't fire on every launch.
+- Hook event count drift sweep — 28 → **29** across `SKILL.md`, `commands/validate.md`, `commands/add-component.md`, `hook-events.md` (intro + See Also), `writing-hooks.md` (See Also), `plugin.json` description, `README.md`, root `CLAUDE.md` Drift to Watch list, `references/quick-reference.md` (was stale at 22 — caught during count audit).
+
+### Added — Worktree hook input/output schema
+- `references/06-hooks/hook-events.md`: `WorktreeCreate` and `WorktreeRemove` entries refined with input schema (stdin JSON `{ "name": "..." }`), the stdout-path contract for `WorktreeCreate` command hooks (`hookSpecificOutput.worktreePath` for HTTP hooks), and the "any non-zero exit aborts creation" exception (unlike most events where only exit 2 blocks). Use case framed as "replace default git worktree behavior with custom VCS logic" — SVN/Perforce/Mercurial wrapper plugins.
+
+### Added — Adaptive effort (`effort.level` / `${CLAUDE_EFFORT}`)
+- `references/06-hooks/hook-events.md`: `effort` object added to Common Input Fields — present on tool-use-context events (`PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`) when the current model supports effort. Reflects the level the model actually used (downgraded if requested level exceeded support).
+- `references/06-hooks/writing-hooks.md`: `$CLAUDE_EFFORT` env var added to the env-vars table; `${CLAUDE_ENV_FILE}` row extended to list all four events that can write to it (`SessionStart`, `Setup`, `CwdChanged`, `FileChanged`).
+- `references/03-skills/writing-skillmd.md`: `${CLAUDE_EFFORT}` added to skill body substitutions with usage note (terser steps at `low`, fuller checklists at `high`+).
+- `SKILL.md`: hooks section gets an "Adaptive hooks" paragraph linking the two.
+
+### Added — `updatedToolOutput` preferred over `updatedMCPToolOutput`
+- `references/06-hooks/hook-events.md`: PostToolUse return-fields block now documents `updatedToolOutput` (works for all tools) and explicitly marks `updatedMCPToolOutput` as legacy MCP-only. Includes the "tool already ran" warning — `updatedToolOutput` only changes what Claude sees, not what the tool did.
+- `commands/validate.md`: new info-level check flagging `updatedMCPToolOutput` usage in hook scripts/JSON.
+
+### Added — `skillOverrides` setting
+- **NEW `skillOverrides` section** in `references/08-configuration/settings.md`. Four states (`on` / `name-only` / `user-invocable-only` / `off`), how the `/skills` menu writes it to `.claude/settings.local.json`, and the upstream caveat that `skillOverrides` does NOT affect plugin-shipped skills — for those, point users at `/plugin disable`. Surface this distinction in plugin READMEs.
+- `SKILL.md`: new "Suppressing a plugin skill without forking" subsection under Configuring Plugin.
+- `README.md`: Distribution housekeeping paragraph mentioning the lever.
+
+### Added — Lifecycle CLI commands
+- `references/09-testing/cli-reference.md`: **`claude plugin prune`** (remove auto-installed dependencies no other plugin requires, requires v2.1.121+, alias `autoremove`, `--dry-run`/`--yes`/`--scope` flags), **`--prune` flag on `plugin uninstall`**, and **`--plugin-url`** session-only flag (load a packaged `.zip` from a URL — useful for previewing pre-release plugins without writing to `~/.claude/plugins`).
+- `README.md`: Distribution housekeeping section surfaces all three.
+
+### Added — Plugin Hints (CLI-driven install prompts)
+- **NEW section** in `references/10-distribution/packaging.md`. Mechanism: CLI checks `CLAUDECODE=1` env var, emits `<claude-code-hint plugin="namespace/plugin-name" />` on its own line (stderr preferred). Claude Code strips the line before sending to the model (zero token cost). User sees a one-time install prompt. Constraints: **official Anthropic marketplace only** (so out-of-scope for camoa-skills / palcera_skills plugins — documented as such); gate on the env var; one line, no surrounding text; stderr preferred.
+
+### Added — Workspace-trust gating clarification
+- `references/03-skills/writing-skillmd.md`: `allowed-tools` row rewritten to (a) clarify it *grants* permission not *restricts* (existing wording was wrong), and (b) document the workspace-trust gate for `.claude/skills/*` skills. Notes that plugin-shipped skills are not subject to this gate — trust is established at install time.
+- `commands/validate.md`: new info-level check for project-scoped skills with `allowed-tools`, pointing at the trust-dialog gate.
+
+### Added — Plugin-root `CLAUDE.md` clarification
+- `SKILL.md`: "Plugin Project Setup" section reframes plugin-root `CLAUDE.md` as authoring reference only (NOT loaded as project context when the plugin is installed). Instructions belong in a skill.
+- `commands/validate.md`: new info-level (not warning) notice when a plugin-root `CLAUDE.md` is present.
+
+### Validator drift sweep (`commands/validate.md`)
+New checks added in one batch:
+- Top-level `themes`/`monitors` → **warning** with auto-migration diff offer.
+- String-form `agents` → **warning** (array-only).
+- String-form `commands`/`skills` → **info** (array preferred).
+- Missing `$schema` → **info** (developer ergonomics).
+- `updatedMCPToolOutput` → **info** (prefer `updatedToolOutput`).
+- Plugin-root `CLAUDE.md` → **info** (not loaded as context).
+- Project-scoped skill `allowed-tools` → **info** (workspace-trust gate).
+- Hook event whitelist bumped to 29 names including `Setup`.
+
+### Out of scope (deferred to follow-up sessions)
+- **Existing-plugin audit.** Sister plugins (`brand-content-design`, design-* on the feature branch) were not run through `claude plugin validate` this cycle — that's a separate migration session.
+- **Native binary distribution / `claude project purge` / routines on web / `/ultrareview` / `/usage` / Agent SDK Python/TS API churn** — per the plan's "Out of Scope" list. Tracked in other docs.
+
+### Metadata sync
+- `.claude-plugin/plugin.json`: `version` 3.3.1 → **3.4.0**; description "28 hook events" → "29 hook events".
+- `skills/plugin-creation/SKILL.md` frontmatter `version` 3.3.0 → **3.4.0**.
+- Root `marketplace.json`: `plugin-creation-tools` entry version 3.3.1 → **3.4.0** + description sync; `metadata.version` 1.14.33 → **1.14.34** (patch bump per `feedback_marketplace_version_bump`).
+- `README.md`: hook count, validator coverage line, new Distribution housekeeping section.
+- Root `CLAUDE.md` Drift to Watch: 28 → 29, themes/monitors flagged as experimental.
+
+### Notes
+- Doc baseline: upstream `claude_memory/guides/claude/` snapshot from 2026-05-08 (per the tracking memo). Plan + Implementation notes live at `claude_docs/improvements/plugin-creation-tools-2026-05-08.md`.
+- Caught during this cycle: `references/quick-reference.md` "Hook Events" was stale at "22 total events" — drifted unnoticed since pre-v3.3.0. Fixed in the same sweep.
+- Did NOT touch `scripts/init_plugin.py` (no hardcoded `themes`/`monitors` strings found) or `examples/{simple-greeter,full-featured}-plugin/` (no manifest fields needing migration).
+
 ## [3.3.1] - 2026-04-27
 
 ### Skill visibility hygiene (Tier 2 of multi-plugin command-naming research)

--- a/plugin-creation-tools/CLAUDE.md
+++ b/plugin-creation-tools/CLAUDE.md
@@ -31,9 +31,9 @@ Bump in **all** of: `.claude-plugin/plugin.json`, the root `marketplace.json` pl
 
 Every revision must keep these counts in sync between SKILL.md, `commands/validate.md`, and the relevant reference files:
 
-- Hook event count (currently **28**).
+- Hook event count (currently **29** — added `Setup` in the 2026-05-08 doc snapshot).
 - Hook handler types (currently **5** — `command`, `http`, `mcp_tool`, `prompt`, `agent` with `agent` marked experimental).
-- Plugin component types (currently 7 — skills, commands, agents, hooks, mcpServers, lspServers, monitors, themes, outputStyles — drift if any are added upstream).
+- Plugin component types (skills, commands, agents, hooks, mcpServers, lspServers, outputStyles, **`experimental.themes`**, **`experimental.monitors`** — themes and monitors are upstream-marked experimental and live under the `experimental.*` key; top-level still loads but `claude plugin validate` warns).
 - Reserved marketplace names list.
 - The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).
 

--- a/plugin-creation-tools/README.md
+++ b/plugin-creation-tools/README.md
@@ -19,7 +19,7 @@ The plugin contains one large skill (`plugin-creation`) that progressively discl
 | Skill | `plugin-creation` | Progressive-disclosure authoring guide. Auto-triggered when creating skills, commands, agents, hooks, MCP servers, themes, or plugin manifests. |
 | Command | `/plugin-creation-tools:create` | Scaffold a new plugin (selects components interactively). |
 | Command | `/plugin-creation-tools:add-component` | Add a skill / command / agent / hook / MCP / **theme** to an existing plugin. |
-| Command | `/plugin-creation-tools:validate` | Validate plugin structure, frontmatter, dependency graph, hook events (28), `mcp_tool` server references, themes, `userConfig` schema, cross-marketplace allowlists. |
+| Command | `/plugin-creation-tools:validate` | Validate plugin structure, frontmatter, dependency graph, hook events (29), `experimental.themes` / `experimental.monitors` manifest migration, `mcp_tool` server references, themes, `userConfig` schema, cross-marketplace allowlists. |
 | Agent | `plugin-structure-auditor` | Deep structural audit (Architecture / Cross-Component Consistency / Performance) — areas the validator does not cover. Read-only. |
 | Agent | `skill-quality-reviewer` | Review skill description quality, SKILL.md structure, progressive-disclosure patterns, regression flags (stripped imperatives, dropped `` !`command` `` injections). Read-only. |
 
@@ -27,7 +27,7 @@ The plugin contains one large skill (`plugin-creation`) that progressively discl
 
 The bundled references map to every section of the upstream Claude Code docs that affects plugin authoring (snapshot at commit `c142d14`):
 
-- **Hooks** — all 28 events with payloads, decision controls, and matcher behavior; five handler types (`command` / `http` / `mcp_tool` / `prompt` / `agent`); the `if` pre-spawn filter; cross-platform polyglot wrapper; permission-mode-per-hook table.
+- **Hooks** — all 29 events (including `Setup` for `--init-only` / `--init -p` / `--maintenance -p` one-time preparation, and `WorktreeCreate` / `WorktreeRemove` for replacing default git worktree behavior with custom VCS logic) with payloads, decision controls, and matcher behavior; five handler types (`command` / `http` / `mcp_tool` / `prompt` / `agent`); the `if` pre-spawn filter; the `effort.level` adaptive-effort input + `$CLAUDE_EFFORT` env var; `updatedToolOutput` (supersedes MCP-only `updatedMCPToolOutput`); cross-platform polyglot wrapper; permission-mode-per-hook table.
 - **Skills** — frontmatter schema, voice and structure, progressive disclosure, dynamic context injection (`` !`command` ``), preload caveats, char/line caps.
 - **Agents** — frontmatter, model selection, tool restrictions, scoped hooks/MCP, agent teams, forked subagents (experimental), `--agent` main-session behavior.
 - **Configuration** — `plugin.json` (themes, `userConfig` with `type`/`title`, dependencies with semver ranges, `${user_config.KEY}` substitution); `marketplace.json` (sources, `allowCrossMarketplaceDependenciesOn`, `claude plugin tag`); `settings.json` (hierarchy, `prUrlTemplate`, `enabledPlugins`); permission modes; plugin themes.
@@ -41,6 +41,12 @@ The bundled references map to every section of the upstream Claude Code docs tha
 3. Run `/plugin-creation-tools:validate` before opening a PR — it catches schema, frontmatter, dependency, and hook-event issues.
 4. For structural review (architecture balance, naming consistency, performance footguns), invoke the `plugin-structure-auditor` agent.
 5. For skill description quality, invoke the `skill-quality-reviewer` agent.
+
+## Distribution housekeeping
+
+- After significant uninstalls, run `claude plugin prune --dry-run` to see auto-installed dependencies no other plugin needs; `claude plugin uninstall <name> --prune` does it in one step.
+- `claude --plugin-url <zip-url>` loads a packaged plugin for the current session only — handy for previewing a pre-release without writing to `~/.claude/plugins`.
+- Users who want to mute a single skill from a *non-plugin* source can use the `skillOverrides` setting (four states: `on` / `name-only` / `user-invocable-only` / `off`); for plugin-shipped skills, the right escape hatch is `/plugin disable`. Surface this distinction in your own plugin README so users know which lever to pull.
 
 ## Quality gates this plugin enforces on itself
 

--- a/plugin-creation-tools/commands/add-component.md
+++ b/plugin-creation-tools/commands/add-component.md
@@ -42,7 +42,7 @@ Add a new component to an existing Claude Code plugin.
 ### `hook`
 1. If `hooks/hooks.json` exists, add new event entry
 2. If not, create from `templates/hooks/hooks.json.template`
-3. Ask which event(s) to handle (28 available — see `references/06-hooks/hook-events.md`)
+3. Ask which event(s) to handle (29 available — see `references/06-hooks/hook-events.md`). New events worth flagging: **`Setup`** (one-time `--init-only` / `--init -p` / `--maintenance -p` preparation, distinct from `SessionStart`), **`WorktreeCreate`** / **`WorktreeRemove`** (replace default git worktree behavior with custom VCS logic — useful for SVN/Perforce/Mercurial wrappers).
 4. Consider the five handler types: `command` (shell, fastest), `mcp_tool` (call an already-connected MCP server tool — no shell, cross-platform-safe), `prompt` (single-turn LLM), `agent` (multi-turn subagent — **experimental**), `http` (POST to webhook — **settings.json only**, will be silently ignored in `hooks.json`)
 5. For cross-platform support when shell logic is genuinely needed, use `templates/hooks/run-hook.cmd.template`. If the hook only calls an MCP server, use `type: "mcp_tool"` instead — it removes the cross-platform footgun.
 
@@ -53,8 +53,9 @@ Add a new component to an existing Claude Code plugin.
 ### `theme`
 1. Create `themes/$2.json` with `name`, `base`, `overrides` fields (see `references/08-configuration/themes.md`)
 2. Default `base` to `"dark"`; keep `overrides` sparse (only the tokens you actually change)
-3. Remind: theme appears in `/theme` once the plugin is enabled, persisted as `custom:<plugin-name>:$2` when the user selects it
-4. Remind: users press `Ctrl+E` to copy the plugin theme into `~/.claude/themes/` for editing — your bundled file is read-only in the picker
+3. If the user is using a non-default theme directory, write the path under **`experimental.themes`** in `plugin.json` (not the top level — the top-level form warns under `claude plugin validate` and a future release will require the nested form)
+4. Remind: theme appears in `/theme` once the plugin is enabled, persisted as `custom:<plugin-name>:$2` when the user selects it
+5. Remind: users press `Ctrl+E` to copy the plugin theme into `~/.claude/themes/` for editing — your bundled file is read-only in the picker
 
 ## After Adding
 

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -26,6 +26,13 @@ Validate a plugin's structure and components against best practices.
 - [ ] `description` present and not placeholder text
 - [ ] README.md exists at plugin root
 - [ ] CHANGELOG.md exists at plugin root
+- [ ] **Info** (not warning) if a `CLAUDE.md` is present at the plugin root: "Plugin-root `CLAUDE.md` is NOT loaded as project context. Instructions belong in a skill — put them in `skills/<name>/SKILL.md` so they reach Claude. The file is fine to keep as authoring reference (this plugin uses it that way)."
+
+### plugin.json Schema Migration (soft-breaking — `experimental.*`)
+- [ ] **Warning** if top-level `themes` or `monitors` is set in `plugin.json`: "`themes` / `monitors` should live under `experimental.*`. `claude plugin validate` flags this and a future release will require the nested form." Offer an auto-migration diff that wraps both keys under an `experimental` object (preserve existing values, deduplicate if `experimental.themes` / `experimental.monitors` is already partially set).
+- [ ] **Warning** if `agents` is a bare string path: "The `agents` field is array-only. Wrap the path in an array: `\"agents\": [\"./agents/foo.md\"]`."
+- [ ] **Info** (not warning) if `commands` or `skills` is a bare string path: "The array form is preferred — `\"commands\": [\"./cmd.md\"]`. The string form still loads but is being phased out."
+- [ ] **Info** if `$schema` is missing: "Consider adding `\"$schema\": \"https://json.schemastore.org/claude-code-plugin-manifest.json\"` for editor autocomplete. Claude Code ignores the field at load time."
 
 ### Marketplace (`marketplace.json` if present)
 - [ ] `owner` field is present and non-empty (error if missing)
@@ -58,6 +65,7 @@ Validate a plugin's structure and components against best practices.
 - [ ] Referenced files in `references/` exist
 - [ ] Referenced scripts in `scripts/` exist
 - [ ] No README.md inside skill directories (belongs at plugin root)
+- [ ] **Info** when `allowed-tools` is present on a project-scoped skill (path matches `.claude/skills/`): "`.claude/skills/*` skills with `allowed-tools` only take effect after the workspace trust dialog is accepted. Review the skill carefully before trusting a repository — a skill can grant itself broad tool access this way." (Plugin-shipped skills are not subject to this — their trust is established at install time.)
 
 ### Commands (for each `commands/*.md`)
 - [ ] Valid YAML frontmatter — invalid frontmatter causes command to load with no metadata at runtime
@@ -87,7 +95,7 @@ Validate a plugin's structure and components against best practices.
 
 ### Hooks (`hooks/hooks.json`)
 - [ ] Valid JSON structure — **Note:** malformed hooks.json prevents the entire plugin from loading
-- [ ] Each event name is one of the 28 recognized events: `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
+- [ ] Each event name is one of the 29 recognized events: `Setup`, `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
 - [ ] Each hook entry has `type` — one of `command`, `prompt`, `agent`, or `mcp_tool` — plus the matching required fields for that type. `agent` is upstream-marked experimental; flag a one-line info note when used.
 - [ ] `mcp_tool` handlers: require `server` and `tool`; if `server` is not declared in the plugin's `mcpServers` (and isn't a known external server the user wires up themselves), emit a **warning**: "`mcp_tool` references server `<name>` not declared in this plugin's `mcpServers`. The handler will produce a non-blocking error if the server isn't already connected at runtime."
 - [ ] No `http` type hooks — `http` hooks only work in `settings.json`, not `hooks.json` (error if found)
@@ -96,6 +104,7 @@ Validate a plugin's structure and components against best practices.
 - [ ] `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` / `$CLAUDE_PLUGIN_ROOT` / `${CLAUDE_PLUGIN_ROOT}` / `$CLAUDE_PLUGIN_DATA` / `${CLAUDE_PLUGIN_DATA}` usage is quoted in all command strings (paths with spaces break otherwise)
 - [ ] **Warning**: hook handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) with a broad matcher (`*`, `""`, omitted, or `.*`) should include an `if` field to pre-filter. Emit a **suggestion** (not error): "Consider adding an `if` field to this handler to avoid spawning a process on every tool call."
 - [ ] `if` field is only valid on tool events — flag as warning if set on non-tool events (silently ignored at runtime)
+- [ ] **Info** when a `PostToolUse` JSON output example or hook script uses `updatedMCPToolOutput`: "Upstream now prefers `updatedToolOutput` (works for all tools, not just MCP). The old field still works; new code should use `updatedToolOutput`."
 
 ### Best Practices (warnings, not errors)
 - [ ] Skills use progressive disclosure (references for details)

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-creation
-version: 3.3.0
+version: 3.4.0
 description: Use when creating Claude Code plugins - covers skills, commands, agents, hooks, MCP servers, and plugin configuration. Use when user says "create plugin", "make a skill", "add command", "add hooks", "skill authoring", "SKILL.md", "plugin components", "package reusable behavior", "distribute skills", "scaffold plugin", "plugin structure", "write a skill description". NOT for: using existing plugins, installing plugins, plugin marketplace browsing. !`ls .claude-plugin/ 2>/dev/null`
 user-invocable: false
 ---
@@ -37,7 +37,7 @@ Create complete Claude Code plugins with any combination of components.
 
 When creating any plugin, also consider:
 - `.claude/rules/` with modular project rules (path-scoped if needed for different component directories)
-- `CLAUDE.md` at plugin root for project conventions
+- `CLAUDE.md` at plugin root **for authoring reference only** — it is NOT loaded as project context when the plugin is installed. To ship instructions Claude reads at runtime, put them in a skill (`skills/<name>/SKILL.md`). The validator emits an info notice when a plugin-root `CLAUDE.md` is present so you don't mistake it for runtime context.
 - README.md and CHANGELOG.md at plugin root (for humans — never inside skill directories)
 
 ## Documentation Principles
@@ -145,19 +145,23 @@ When user says "add agent", "create agent", "make agent":
 When user says "add hooks", "setup hooks", "event handlers":
 
 1. Read `references/06-hooks/writing-hooks.md`
-2. Read `references/06-hooks/hook-events.md` for all 28 events
+2. Read `references/06-hooks/hook-events.md` for all 29 events
 3. Copy template from `templates/hooks/hooks.json.template`
 4. Key events:
+   - `Setup` - one-time `--init-only` / `--init -p` / `--maintenance -p` preparation. **Distinct from `SessionStart`**: Setup does NOT fire on every launch, so a plugin that needs a dependency installed cannot rely on Setup alone — pair with a `${CLAUDE_PLUGIN_DATA}` "check on first use, install on miss" pattern.
    - `PreToolUse` - before tool execution (can block)
-   - `PostToolUse` - after tool execution (formatting, logging)
+   - `PostToolUse` - after tool execution (formatting, logging). Use the `updatedToolOutput` JSON return field to rewrite what Claude sees (replaces the older MCP-only `updatedMCPToolOutput`).
    - `PostToolBatch` - after a parallel batch resolves (one-shot summary)
    - `SessionStart` - setup, output directories
    - `SessionEnd` - cleanup
    - `UserPromptSubmit` - validation, context injection (can block)
    - `UserPromptExpansion` - intercept direct `/skillname` invocations (can block)
    - `SubagentStart`/`SubagentStop` - agent lifecycle
+   - `WorktreeCreate`/`WorktreeRemove` - replace default git worktree behavior with custom VCS logic (SVN/Perforce/Mercurial). Input: `name` via stdin; `WorktreeCreate` must print the worktree path on stdout, and any non-zero exit aborts creation.
    - `PreCompact` - inject context before compaction
    - `Notification`, `Stop`, `TaskCompleted`, `TeammateIdle`
+
+**Adaptive hooks**: Hook stdin JSON includes an `effort` object (`{ "level": ... }`) on tool-use-context events; the same level is exported as `$CLAUDE_EFFORT` to command hooks and the Bash tool. Use it to adapt verbosity, recursion depth, or external-call budget to the user's effort setting.
 
 **Five handler types** — choose the right one:
 - `command` — shell script, fastest, no LLM cost. Use for logging, file ops, env setup.
@@ -176,8 +180,18 @@ When user says "configure plugin", "setup plugin.json":
 
 1. Read `references/08-configuration/plugin-json.md` for full schema
 2. Required fields: `name`
-3. Recommended fields: `version`, `description`, `author`, `license`
-4. Component paths: `commands`, `agents`, `hooks`, `mcpServers`
+3. Recommended fields: `$schema` (SchemaStore JSON Schema for editor autocomplete), `version`, `description`, `author`, `license`
+4. Component paths: `commands` (array), `agents` (array — string form no longer accepted), `hooks`, `mcpServers`
+5. **Experimental components** (`themes`, `monitors`) belong under `experimental.*`. Top-level `themes` / `monitors` still load but `claude plugin validate` warns and a future release will require the nested form. The validator (`/plugin-creation-tools:validate`) flags top-level usage and offers an auto-migration diff.
+
+### Suppressing a plugin skill without forking
+
+Users who want to silence a single plugin skill don't need to uninstall the plugin or edit its SKILL.md. Two escape hatches, in priority order:
+
+- **`skillOverrides` setting** (`.claude/settings.local.json`) — four states: `on` / `name-only` / `user-invocable-only` / `off`. The `/skills` menu writes this for them. Note: upstream caveat is that `skillOverrides` does NOT affect plugin-shipped skills — for those, point users at `/plugin disable` for the whole plugin. Surface this in your README's troubleshooting section.
+- **`/plugin disable <name>@<marketplace>`** for the entire plugin, scoped per scope (user/project/local).
+
+See `references/08-configuration/settings.md#skilloverrides` for details.
 
 ## Settings and Output
 
@@ -275,7 +289,7 @@ Before creating a component, verify it's the right choice:
 |---------|--------------|-----|
 | Plugin doesn't appear after install | Components placed inside `.claude-plugin/` instead of plugin root | Move `commands/` / `agents/` / `skills/` / `hooks/` to the plugin root. Only `plugin.json` belongs in `.claude-plugin/`. |
 | Skill exists but Claude never invokes it | Description missing trigger phrase or imperatives | Rewrite to start with "Use when…", include WHAT and WHEN, preserve any `PROACTIVELY` / `MUST` / `NEVER` markers from the prior version. Run `skill-quality-reviewer` agent to audit. |
-| Hook configured but never fires | Wrong event name (case-sensitive) or `http` handler in `hooks/hooks.json` | Verify event name is exactly one of the 28 documented in `references/06-hooks/hook-events.md`. `http` handlers only work in `settings.json` — they are silently ignored in `hooks.json`. Run `/plugin-creation-tools:validate`. |
+| Hook configured but never fires | Wrong event name (case-sensitive) or `http` handler in `hooks/hooks.json` | Verify event name is exactly one of the 29 documented in `references/06-hooks/hook-events.md`. `http` handlers only work in `settings.json` — they are silently ignored in `hooks.json`. Run `/plugin-creation-tools:validate`. |
 | Hook spawns on every Bash call but only acts on `rm` | Filtering inside the script instead of with `if` | Add `if: "Bash(rm *)"` to the handler. The matcher fires the event; `if` is a cheap pre-spawn filter that avoids the "spawn-and-exit-0" anti-pattern. See `references/06-hooks/writing-hooks.md#the-if-field`. |
 | `mcp_tool` hook returns "not connected" on first run | `SessionStart` / `Setup` typically fire before MCP servers finish connecting | Expected on first run. Either accept the non-blocking error, or move the call to a later event (`PostToolUse`, `Stop`, etc.) where the server is reliably connected. |
 | Plugin theme doesn't appear in `/theme` | `themes/*.json` missing `name` / `base` / `overrides`, or invalid JSON | Run `/plugin-creation-tools:validate`. See `references/08-configuration/themes.md` for the schema. |

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
@@ -123,7 +123,7 @@ context: fork
 | `name` | Yes | Lowercase, numbers, hyphens only. Max 64 chars. No "anthropic" or "claude". |
 | `description` | Yes | Max 1024 chars. Must include WHAT and WHEN. Third person only. |
 | `model` | No | Override model for this skill. Values: `haiku`, `sonnet`, `opus`. Use for cost optimization -- `haiku` for simple/repetitive tasks, `opus` for complex reasoning. |
-| `allowed-tools` | No | Restricts available tools when skill is active. Syntax: `"Bash(python:*) Bash(npm:*) WebFetch"` |
+| `allowed-tools` | No | Grants permission for the listed tools while the skill is active (does not restrict — every tool remains callable, but listed tools skip the permission prompt). Syntax: `"Bash(python:*) Bash(npm:*) WebFetch"`. **Workspace-trust gating:** for skills checked into a project at `.claude/skills/`, `allowed-tools` only takes effect *after* the workspace trust dialog is accepted (same gate as permission rules in `.claude/settings.json`). Review project skills before trusting a repo — a hostile skill can grant itself broad tool access this way. Plugin-shipped skills are not subject to this gate (trust is established at install time). |
 | `context` | No | Set to `fork` to run skill in an isolated context (own context window). Use for heavy operations that would pollute the main context. |
 | `agent` | No | When `context: fork`, specify agent type for the forked context. |
 | `disable-model-invocation` | No | Set to `true` to prevent Claude from auto-invoking. User must call explicitly via `/name`. Reduces context cost to zero for triggered-only skills. |
@@ -201,6 +201,7 @@ Skill body text supports variable substitutions that are resolved at invocation 
 | `$ARGUMENTS[N]` / `$N` | 0-based positional argument (e.g., `$ARGUMENTS[0]` or `$0` is the first argument) |
 | `${CLAUDE_SKILL_DIR}` | Absolute path to the directory containing the SKILL.md file |
 | `${CLAUDE_SESSION_ID}` | Current session ID |
+| `${CLAUDE_EFFORT}` | Active [effort level](https://docs.anthropic.com/en/model-config#adjust-effort-level) for the current turn -- `low`, `medium`, `high`, `xhigh`, or `max`. Use it to adapt skill instructions to how much reasoning effort the user has dialed in (e.g. terser steps at `low`, fuller checklists at `high`+). Reflects the level the current model actually used (downgraded if requested effort exceeds support). |
 
 Example usage in SKILL.md body:
 ```markdown

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
@@ -1,11 +1,12 @@
 # Hook Events
 
-Complete reference for all 28 hook events in Claude Code.
+Complete reference for all 29 hook events in Claude Code.
 
 ## Event Reference Table
 
 | Event | Trigger | Can Block? | Matcher Support |
 |-------|---------|-----------|-----------------|
+| Setup | One-time preparation: `--init-only`, `--init -p`, `--maintenance -p`. Does **not** fire on every launch. | No | Yes (`init`, `maintenance`) |
 | SessionStart | Session begins or resumes | No | Yes (startup, resume, clear, compact) |
 | UserPromptSubmit | User submits prompt | Yes | No |
 | UserPromptExpansion | A user-typed slash command expands into a prompt | Yes (blocks expansion) | Yes (command name) |
@@ -55,6 +56,7 @@ All hook events receive JSON input with the following common fields:
 | `hook_event_name` | string | The event that triggered the hook |
 | `agent_id` | string | Identifier of the agent (or main session) running the hook |
 | `agent_type` | string | Type of agent (e.g., the agent name, or `main` for the primary session) |
+| `effort` | object | `{ "level": "low" \| "medium" \| "high" \| "xhigh" \| "max" }` — the active [effort level](https://docs.anthropic.com/en/model-config#adjust-effort-level) for the turn. Reflects the level the current model actually used (if requested effort exceeded what the model supports, it's downgraded). Present for events that fire within a tool-use context (`PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, etc.) when the current model supports effort. The same level is exported to command hooks and the Bash tool as the `$CLAUDE_EFFORT` environment variable. |
 
 ## Event Details
 
@@ -88,6 +90,48 @@ All hook events receive JSON input with the following common fields:
   ]
 }
 ```
+
+### Setup
+
+**Trigger**: One-time preparation. Fires only when Claude Code is launched with `--init-only` (runs Setup + `SessionStart` matcher `startup`, then exits), or with `--init` / `--maintenance` combined with `-p` (print mode). **Does not fire on every launch.** Intended for CI/dependency installation that should run on demand, distinct from `SessionStart` which fires on every session.
+
+**Matcher**: `trigger` value -- `init`, `maintenance`
+
+**Can Block**: No. Exit code 2 shows stderr to the user; other non-zero codes show stderr only with `--verbose`. Execution always continues.
+
+**Handler Types**: Only `type: "command"` and `type: "mcp_tool"` supported.
+
+**Input Fields**: In addition to common fields, Setup receives:
+- `trigger` -- `"init"` or `"maintenance"`
+
+**Special**: Access to `${CLAUDE_ENV_FILE}` -- variables written here persist into subsequent Bash commands for the session, same as `SessionStart`.
+
+**Important pattern**: Because Setup does not fire on every launch, a plugin that needs a dependency cannot rely on Setup alone. Use the `${CLAUDE_PLUGIN_DATA}` "check-and-install on first use" pattern documented in `writing-hooks.md` -- Setup is the *opt-in* one-shot path, not a replacement for lazy install.
+
+**Use Cases**:
+- One-time CI dependency install separate from session startup
+- Maintenance tasks (cache prune, schema migration) triggered manually
+- Plugin first-time configuration
+
+**Example**:
+```json
+{
+  "Setup": [
+    {
+      "matcher": "init",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "cd \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" . && npm install"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Return Fields** (JSON stdout):
+- `additionalContext` -- string injected into Claude's context. Plain stdout is debug-log only.
 
 ### UserPromptSubmit
 
@@ -270,6 +314,7 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
 - Log completed operations
 - Validate tool output
 - Trigger follow-up actions
+- Rewrite the tool output Claude sees (e.g. redact secrets, trim noisy diffs) via the `updatedToolOutput` JSON return field
 
 **Example**:
 ```json
@@ -288,6 +333,13 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
   ]
 }
 ```
+
+**Return Fields** (JSON stdout):
+- `updatedToolOutput` -- replaces the tool's output before Claude sees it. **Works for all tools.** The value must match the tool's output shape.
+- `updatedMCPToolOutput` -- **legacy** MCP-only variant; superseded by `updatedToolOutput`. The old field still works, but new code should use `updatedToolOutput` so it survives moves between MCP and built-in tools.
+- `decision: "block"` -- adds the `reason` next to the tool result; Claude still sees the original output unless `updatedToolOutput` is also set.
+
+> `updatedToolOutput` only changes what Claude sees. The tool has already run; any side effects (file writes, shell commands, HTTP requests) have already occurred. To prevent a tool call, use `PreToolUse`.
 
 ### PostToolUseFailure
 
@@ -839,16 +891,25 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
 
 ### WorktreeCreate
 
-**Trigger**: When a worktree is created for an agent
+**Trigger**: A worktree is being created (`--worktree` or `isolation: "worktree"`). The hook **replaces** the default git-based worktree behavior, so it's the entry point for plugins that target non-git VCS (SVN, Perforce, Mercurial) or want a custom isolation strategy.
 
 **Matcher**: Not supported
 
-**Can Block**: No
+**Can Block**: Yes — and unlike most events, **any non-zero exit code aborts worktree creation**, not just exit 2.
+
+**Input Fields**: In addition to common fields, receives a `name` field via stdin JSON:
+```json
+{ "hook_event_name": "WorktreeCreate", "name": "feature-branch-task" }
+```
+
+**Output**:
+- **Command hooks**: print the absolute path of the created worktree directory on stdout. Hook failure or missing path fails creation.
+- **HTTP hooks**: return `hookSpecificOutput.worktreePath`.
 
 **Use Cases**:
-- Initialize worktree-specific resources
+- Replace default git worktree behavior with SVN/Perforce/Mercurial equivalent
+- Initialize worktree-specific resources (env vars, copied configs)
 - Log worktree creation for tracking
-- Set up environment in the new worktree
 
 **Example**:
 ```json
@@ -858,7 +919,7 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-worktree-create.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/svn-checkout.sh"
         }
       ]
     }
@@ -868,15 +929,17 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
 
 ### WorktreeRemove
 
-**Trigger**: When a worktree is removed after agent completion
+**Trigger**: A worktree is being removed (at session exit or when a subagent finishes). Pairs with `WorktreeCreate`.
 
 **Matcher**: Not supported
 
-**Can Block**: No
+**Can Block**: No. Failures are logged in debug mode only.
+
+**Input Fields**: In addition to common fields, receives the worktree `name` (same shape as `WorktreeCreate`).
 
 **Use Cases**:
-- Clean up worktree-specific resources
-- Archive worktree results
+- Clean up the equivalent resources your `WorktreeCreate` hook provisioned (SVN working copy, Perforce client, etc.)
+- Archive worktree results before teardown
 - Log worktree lifecycle completion
 
 **Example**:
@@ -887,7 +950,7 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-worktree-remove.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/svn-cleanup.sh"
         }
       ]
     }
@@ -1081,5 +1144,5 @@ Multiple matcher groups and multiple hooks per group:
 
 ## See Also
 
-- `writing-hooks.md` -- hook configuration and handler types (references all 28 events)
+- `writing-hooks.md` -- hook configuration and handler types (references all 29 events)
 - `hook-patterns.md` -- common implementation patterns

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
@@ -75,7 +75,7 @@ Execute a shell script. Receives JSON on stdin with event context. Returns exit 
 }
 ```
 
-**Stdin JSON** includes: `hook_event_name`, `tool_name`, `tool_input`, `tool_output` (varies by event).
+**Stdin JSON** includes: `hook_event_name`, `tool_name`, `tool_input`, `tool_output` (varies by event), and an `effort` object (`{ "level": "low" | "medium" | "high" | "xhigh" | "max" }`) on tool-use-context events when the current model supports effort. The same level is exported as the `$CLAUDE_EFFORT` env var to command hooks and Bash-tool subprocesses — adapt verbosity or invocation depth to it.
 
 **Exit codes**: 0 = success/allow, non-zero = failure/block (for blocking events).
 
@@ -322,7 +322,8 @@ Available in hook scripts:
 | `${CLAUDE_PLUGIN_ROOT}` | Plugin installation directory |
 | `${CLAUDE_PLUGIN_DATA}` | Persistent data directory (`~/.claude/plugins/data/{plugin-id}/`). Survives plugin updates. |
 | `${CLAUDE_PROJECT_DIR}` | Project root directory |
-| `${CLAUDE_ENV_FILE}` | Env file path (SessionStart only) |
+| `${CLAUDE_ENV_FILE}` | Env file path. Available to `SessionStart`, `Setup`, `CwdChanged`, and `FileChanged` hooks. Variables written here persist into subsequent Bash commands for the session. |
+| `${CLAUDE_EFFORT}` | Active [effort level](../03-skills/writing-skillmd.md#string-substitutions) for the current turn -- `low`, `medium`, `high`, `xhigh`, `max`. Use to adapt hook behavior to the user's effort setting. |
 
 ## Example: Complete hooks.json
 
@@ -488,5 +489,5 @@ This pattern checks if `node_modules` exists in the persistent data directory an
 
 ## See Also
 
-- `hook-events.md` -- all 28 available events with return values
+- `hook-events.md` -- all 29 available events with return values
 - `hook-patterns.md` -- common patterns and examples

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -16,6 +16,7 @@ plugin-name/
 
 ```json
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "enterprise-tools",
   "version": "3.0.0",
   "description": "Enterprise automation, security, and deployment tools",
@@ -38,7 +39,11 @@ plugin-name/
   ],
   "hooks": "./hooks/hooks.json",
   "mcpServers": "./.mcp.json",
-  "lspServers": "./.lsp.json"
+  "lspServers": "./.lsp.json",
+  "experimental": {
+    "themes": "./themes/",
+    "monitors": "./monitors.json"
+  }
 }
 ```
 
@@ -54,6 +59,7 @@ The `name` field is the **only required field**.
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `$schema` | string | JSON Schema URL for editor autocomplete and validation (e.g., `"https://json.schemastore.org/claude-code-plugin-manifest.json"`). Ignored by Claude Code at load time — purely a developer-ergonomics hint. |
 | version | string | Semantic version (e.g., "2.1.0") |
 | description | string | Brief explanation of plugin purpose |
 | author | object/string | Author information |
@@ -85,16 +91,38 @@ Or simple string:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| commands | string/array | Custom command file paths |
-| agents | string/array | Custom agent file paths |
-| skills | string/array | Custom skill directory paths |
+| commands | array | Custom command file paths. The historical string form is being phased out — use an array, even for a single file (`["./custom/cmd.md"]`). |
+| agents | array | Custom agent file paths. Array-only — the string-path form no longer loads as of the current schema. |
+| skills | string/array | Custom skill directory paths (replaces default `skills/`) |
 | hooks | string/object | Hook config path or inline config |
 | mcpServers | string/object | MCP config path or inline config |
 | lspServers | string/object | LSP config path or inline config |
 | outputStyles | string/array | Custom output style paths |
-| themes | string/array | Color theme files/directories (replaces default `themes/`). Each file: `name`, `base`, `overrides`. See [`themes.md`](themes.md) for the full schema. |
+| `experimental.themes` | string/array | Color theme files/directories (replaces default `themes/`). Each file: `name`, `base`, `overrides`. See [`themes.md`](themes.md). **Was top-level `themes`** — see [Experimental components migration](#experimental-components-migration). |
+| `experimental.monitors` | string/array | Background [Monitor](https://docs.anthropic.com/en/tools-reference#monitor-tool) configurations that start automatically when the plugin is active. **Was top-level `monitors`** — see [Experimental components migration](#experimental-components-migration). |
 | userConfig | object | User-configurable values prompted at enable time. See [User configuration](#user-configuration) below. |
 | settings | string | Path to settings.json (only `agent` key supported) |
+
+### Experimental components migration
+
+`themes` and `monitors` belong under the `experimental` key. Their *manifest schema* is still stabilizing, but the *location migration* is independent and already underway:
+
+- Top-level `themes` / `monitors` still load.
+- `claude plugin validate` warns when they appear at the top level.
+- A future release will require them under `experimental.*`.
+
+Migrate now to silence the warning:
+
+```diff
+- "themes": "./themes/",
+- "monitors": "./monitors.json"
++ "experimental": {
++   "themes": "./themes/",
++   "monitors": "./monitors.json"
++ }
+```
+
+`/plugin-creation-tools:validate` mirrors the upstream warning and offers an auto-migration diff.
 
 ### Path Patterns
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
@@ -194,6 +194,39 @@ Set these environment variables in `.claude/settings.json`:
 | `MYPLUGIN_FEATURE_X` | `false` | Enable experimental feature X |
 ```
 
+### skillOverrides
+
+Per-skill visibility control without editing the skill's own SKILL.md. Useful for:
+
+- Skills checked into a shared project repo where you don't want to fork the SKILL.md
+- Skills provided by an MCP server
+- Enterprise admins silencing noisy plugin skills for a team via `.claude/settings.json`
+- End users who want to mute a plugin skill without uninstalling
+
+The `/skills` menu writes this for you — highlight a skill, press `Space` to cycle states, `Enter` to save to `.claude/settings.local.json`.
+
+```json
+{
+  "skillOverrides": {
+    "legacy-context": "name-only",
+    "deploy": "off"
+  }
+}
+```
+
+Each value is one of four states:
+
+| Value | Listed to Claude | In `/` menu |
+|-------|------------------|-------------|
+| `"on"` | Name and description | Yes |
+| `"name-only"` | Name only | Yes |
+| `"user-invocable-only"` | Hidden | Yes |
+| `"off"` | Hidden | Hidden |
+
+Skills absent from `skillOverrides` are treated as `"on"`.
+
+> **Plugin skills caveat:** `skillOverrides` does **not** affect skills shipped by plugins. Manage those through `/plugin` (enable/disable per scope) instead. This is the right escape hatch to surface in your plugin's README — point users who want to mute a single skill at `/plugin disable` for the whole plugin, or at the skill's own `disable-model-invocation` / `user-invocable` frontmatter if they're forking.
+
 ### prUrlTemplate
 
 Custom URL pattern for the PR link rendered in `/code-review` footers and similar review UIs. Useful when your remote isn't on github.com — `--from-pr` now also accepts GitLab, Bitbucket, and GHES URLs (release 2.1.119+), so the template lets you mirror the remote's URL shape.

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/themes.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/themes.md
@@ -17,7 +17,9 @@ plugin-name/
     └── high-contrast.json
 ```
 
-Default scan path is `themes/`. Override with the `themes` field in `plugin.json` (`string` or `array` of paths). When set, the default `themes/` directory is **not** scanned — your custom path replaces it.
+Default scan path is `themes/`. Override with `experimental.themes` in `plugin.json` (`string` or `array` of paths). When set, the default `themes/` directory is **not** scanned — your custom path replaces it.
+
+> **Schema migration:** Themes are an [experimental component](plugin-json.md#experimental-components-migration). Declare the path under `experimental.themes`; top-level `themes` still loads but `claude plugin validate` warns and a future release will require the nested form.
 
 ## Theme schema
 
@@ -62,7 +64,9 @@ Themes are auto-discovered from `themes/`. Declare an explicit path only when yo
 ```json
 {
   "name": "my-brand",
-  "themes": "./themes/"
+  "experimental": {
+    "themes": "./themes/"
+  }
 }
 ```
 
@@ -70,7 +74,9 @@ Or list specific files:
 
 ```json
 {
-  "themes": ["./themes/dark.json", "./themes/light.json"]
+  "experimental": {
+    "themes": ["./themes/dark.json", "./themes/light.json"]
+  }
 }
 ```
 

--- a/plugin-creation-tools/skills/plugin-creation/references/09-testing/cli-reference.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/09-testing/cli-reference.md
@@ -51,6 +51,11 @@ Complete reference for plugin-related CLI commands.
 # Uninstall but keep persistent data (${CLAUDE_PLUGIN_DATA})
 /plugin uninstall plugin-name@marketplace-name --keep-data
 
+# Uninstall a plugin AND remove auto-installed dependencies no other plugin needs
+/plugin uninstall plugin-name@marketplace-name --prune
+# Or, in one step from the CLI:
+claude plugin uninstall plugin-name@marketplace-name --prune --yes
+
 # Get plugin details
 /plugin info plugin-name@marketplace-name
 
@@ -60,6 +65,28 @@ Complete reference for plugin-related CLI commands.
 # Update all plugins in a scope (including managed/org-deployed plugins)
 /plugin update --scope managed
 ```
+
+### Plugin Prune (`claude plugin prune`)
+
+Remove auto-installed dependency plugins that no other installed plugin requires. Plugins you installed directly are never touched. Requires Claude Code v2.1.121+.
+
+```bash
+# Show what would be removed
+claude plugin prune --dry-run
+
+# Prune at user scope (default)
+claude plugin prune
+
+# Prune at project scope
+claude plugin prune --scope project
+
+# Non-interactive (CI/scripts) — required when stdin isn't a TTY
+claude plugin prune --yes
+```
+
+**Aliases:** `autoremove`.
+
+After any large set of plugin upgrades / uninstalls, run `claude plugin prune --dry-run` to see what's orphaned. The validator surfaces this as a reminder under its "after major changes" guidance.
 
 ### Plugin Release Tagging (`claude plugin tag`)
 
@@ -91,6 +118,11 @@ claude --plugin-dir ./my-plugins
 
 # Load from multiple directories
 claude --plugin-dir ./plugins1 --plugin-dir ./plugins2
+
+# Load a packaged plugin .zip from a URL for the current session only
+# (useful for previewing a pre-release plugin without adding it to the marketplace
+# or writing to ~/.claude/plugins)
+claude --plugin-url https://example.com/my-plugin-v1.2.0.zip
 ```
 
 ### Validation

--- a/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
@@ -280,6 +280,32 @@ ENV CLAUDE_CODE_PLUGIN_SEED_DIR=/opt/base-plugins:/opt/team-plugins
 
 Claude Code checks seed directories before attempting network fetches. Plugins found in seed directories are treated as installed, so no marketplace or internet access is required at runtime.
 
+## Plugin Hints (CLI-driven install prompts)
+
+If you ship a CLI/SDK that pairs with your plugin, your CLI can prompt the user to install the plugin when it runs inside Claude Code. Mechanism:
+
+1. CLI checks the `CLAUDECODE=1` env var (set by Claude Code in Bash/PowerShell tool subprocesses).
+2. CLI emits `<claude-code-hint plugin="namespace/plugin-name" />` on its own line (stderr preferred).
+3. Claude Code **strips the hint line** before sending output to the model — the line never counts toward tokens.
+4. The user sees a one-time install prompt for the matching plugin.
+
+```bash
+#!/usr/bin/env bash
+if [ "${CLAUDECODE:-}" = "1" ]; then
+  echo '<claude-code-hint plugin="anthropic/my-plugin" />' >&2
+fi
+# ... rest of CLI ...
+```
+
+### Constraints
+
+- **Official Anthropic marketplace only.** The hint is matched against the official marketplace, so this mechanism is for first-party plugins. camoa-skills / palcera_skills plugins **cannot** use this directly — the prompt will not surface for plugins distributed through third-party marketplaces.
+- **Gate on `CLAUDECODE`.** Emitting outside Claude Code is harmless (no consumer strips it) but adds noise — gate on the env var.
+- **One line, no surrounding text.** The strip is line-based; splitting the tag across lines or appending content on the same line leaks the tag to the model.
+- **Stderr is preferred** so the CLI's normal output is unaffected for non-Claude consumers.
+
+Surface this only for users who also maintain a CLI; out of scope for pure-plugin distribution.
+
 ## See Also
 
 - `marketplace.md` - marketplace distribution

--- a/plugin-creation-tools/skills/plugin-creation/references/quick-reference.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/quick-reference.md
@@ -187,10 +187,11 @@ Use when [triggers] - [what it does, third person]
 
 ## Hook Events
 
-22 total events. Key events:
+29 total events (see `references/06-hooks/hook-events.md` for the full list). Key events:
 
 | Event | Use Case | Matcher |
 |-------|----------|---------|
+| Setup | One-time `--init-only` / `--init -p` / `--maintenance -p` preparation | `init`, `maintenance` |
 | SessionStart | Setup, initialization | Optional |
 | SessionEnd | Cleanup | Optional |
 | PreToolUse | Validation before tools | Tool name regex |

--- a/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-name",
   "version": "1.0.0",
   "description": "Brief description of plugin purpose",
@@ -10,11 +11,21 @@
   "repository": "https://github.com/username/repo",
   "keywords": ["keyword1", "keyword2"]
 
-  // Optional: ship color themes alongside the plugin. Files in themes/*.json
-  // appear in /theme. Each file: {"name", "base", "overrides"}. See
-  // references/08-configuration/themes.md for the full schema and the
-  // Ctrl+E user-customization flow.
-  // "themes": "./themes/"
+  // Optional: experimental components have a manifest schema that may change
+  // between releases while they stabilize. Top-level "themes" / "monitors"
+  // still load but `claude plugin validate` emits a warning, and a future
+  // release will require them under "experimental.*". Migrate proactively.
+  //
+  // "experimental": {
+  //   "themes": "./themes/",
+  //   "monitors": "./monitors.json"
+  // }
+
+  // Optional: prefer the array form for "commands", "agents", "skills" —
+  // the string-path form is being phased out. Examples:
+  //   "agents":   ["./agents/reviewer.md"],
+  //   "commands": ["./commands/deploy.md"],
+  //   "skills":   ["./skills/"]
 
   // Optional: prompt the user for configuration when the plugin is enabled.
   // Each entry takes type, title, description (all required); add


### PR DESCRIPTION
## Summary

Plan-driven refresh covering 12 upstream deltas from the 2026-05-08 Claude Code docs snapshot. Additive — top-level `themes`/`monitors` still load (warning, not error), so plugins on the prior schema keep working.

Source plan: `~/workspace/claude_code_projects/claude_docs/docs/improvements/plugin-creation-tools-2026-05-08.md` (12 sections, all checked off except the sister-plugin audit, which is the next session's job).

## What's covered

- **Manifest schema migration** — `themes` / `monitors` → `experimental.*`. Templates emit nested form; validator warns on top-level + offers an auto-migration diff.
- **New hook event #29: `Setup`** — `--init-only` / `--init -p` / `--maintenance -p` preparation, distinct from `SessionStart`.
- **Worktree hooks refined** — input schema (stdin `name`), `WorktreeCreate` stdout-path contract, "any non-zero exit aborts creation" exception.
- **Adaptive effort** — `effort.level` hook input + `${CLAUDE_EFFORT}` env var + skill body substitution.
- **`updatedToolOutput`** preferred over MCP-only `updatedMCPToolOutput` (validator info-flags the old token).
- **`skillOverrides` setting** documented in settings.md + README; plugin-skills caveat surfaced.
- **CLI lifecycle** — `claude plugin prune` (v2.1.121+), `--prune` flag on uninstall, `--plugin-url` session loader.
- **Plugin Hints** — `<claude-code-hint plugin="..."/>` mechanism, gated on `CLAUDECODE=1`, official marketplace only (noted as out-of-scope for camoa-skills plugins).
- **Workspace-trust gating** on `allowed-tools` for `.claude/skills/*` skills (plugin-shipped skills exempt).
- **Plugin-root `CLAUDE.md`** clarified as authoring-reference-only (NOT loaded as context; instructions belong in a skill).
- **`\$schema` field** added to templates and the plugin-json reference.
- **`agents` field array-only** — validator warns on string form.

Hook event count drift swept across 9 files (28 → 29). Caught a stale `quick-reference.md` "22 total events" that had been wrong since pre-v3.3.0.

## Metadata sync

- `plugin.json` 3.3.1 → **3.4.0**; description "28 hook events" → "29 hook events" with the new feature list inline.
- `SKILL.md` frontmatter `version` 3.3.0 → **3.4.0**.
- Root `marketplace.json`: plugin entry version 3.3.1 → **3.4.0** + description rewritten; `metadata.version` 1.14.33 → **1.14.34** (patch bump per the marketplace-version-bump rule).
- `README.md`: hook count + validator coverage line + new Distribution housekeeping section.
- Plugin-root `CLAUDE.md` Drift to Watch: 28 → 29, themes/monitors flagged as experimental.

## Deferred

- **Sister-plugin audit.** Did not run \`claude plugin validate\` against \`brand-content-design\` and design-* plugins this cycle — separate migration session.
- Out of scope per the plan: native binary distribution, \`claude project purge\`, routines-on-web, \`/ultrareview\`, \`/usage\`, Agent SDK Python/TS API churn.

## Test plan

- [ ] Run `/plugin-creation-tools:validate` on this plugin → clean / all-warnings
- [ ] Smoke test `/plugin-creation-tools:create` end-to-end with a throwaway plugin → confirm scaffold emits `experimental.*` and `\$schema`
- [ ] Confirm new hook event count appears consistently in `/help` for the plugin-creation skill
- [ ] Verify validator new checks fire: top-level `themes` warning, string `agents` warning, missing `\$schema` info, `updatedMCPToolOutput` info, plugin-root `CLAUDE.md` info, project-scoped skill `allowed-tools` info
- [ ] Read CHANGELOG entry end-to-end → confirm scope matches diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)