### PR TITLE
plugin-creation-tools v3.4.1 — audit patch (channels, bin/, subagentStatusLine)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.34"
+    "version": "1.14.35"
   },
   "plugins": [
     {
@@ -36,7 +36,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Complete guide for creating Claude Code plugins — skills, commands, agents, hooks, MCP servers, and configuration. Covers 29 hook events (now including Setup for --init-only / --init -p / --maintenance -p one-time preparation, plus WorktreeCreate/WorktreeRemove for replacing default git worktree behavior with custom VCS logic), the if pre-spawn filter, the mcp_tool handler type, the effort.level adaptive-effort input + $CLAUDE_EFFORT env var, updatedToolOutput (supersedes MCP-only updatedMCPToolOutput), experimental.themes / experimental.monitors manifest migration with auto-migration diff offer, $schema field for editor autocomplete, array-only agents, plugin themes, userConfig with type/title schema, skillOverrides setting + the plugin-skills caveat, claude plugin prune + --prune flag on uninstall + --plugin-url session loader, Plugin Hints (CLI-driven install prompts) for first-party plugin authors, workspace-trust gating clarification on allowed-tools, plugin-root CLAUDE.md scoping clarification, allowCrossMarketplaceDependenciesOn, claude plugin tag, forked subagents, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter and the `mcp_tool` handler type), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2026-05-12
+
+Post-v3.4.0 audit patch. A read-only comparison against the current `claude_memory/guides/claude/` snapshot surfaced three missing-content gaps (not stale-content). None affect the typical plugin-authoring path; all are scoped to short additions in existing reference files.
+
+### Added — `channels` manifest field
+- `references/08-configuration/plugin-json.md`: new `channels` row in the component-paths table + new "Channels" section with full schema (`server` required, must match a key in `mcpServers`; per-channel `userConfig` mirrors the top-level schema; Telegram/Slack/Discord-style message-injection use case).
+- `templates/plugin.json.template`: commented `channels` example block.
+- `commands/validate.md`: info-level check — when `channels` is declared, verify `server` matches a key in the plugin's `mcpServers` (warn on dangling reference); apply userConfig legacy/required checks to per-channel `userConfig`.
+
+### Added — `bin/` directory
+- `references/08-configuration/plugin-json.md`: new "`bin/` Directory" section. Auto-discovered (no manifest entry), executables added to the Bash tool's `PATH` while the plugin is enabled. Cross-platform shebang guidance; "use this over `hooks/` for utilities users invoke directly" distinction; chmod +x requirement.
+- `references/10-distribution/packaging.md`: `bin/` added to the standard plugin-layout diagram alongside `scripts/`, `output-styles/`, `themes/`, `monitors/`, `.lsp.json` (which were also missing from the diagram).
+- `references/quick-reference.md`: `bin/` added to the structure diagram.
+- `templates/plugin.json.template`: explanatory note about `bin/` auto-discovery.
+- `commands/validate.md`: info-level check — when `bin/` is present, warn on non-executable entries (they'll appear on `PATH` but fail to run).
+
+### Added — `subagentStatusLine` plugin setting
+- `references/08-configuration/settings.md`: new `subagentStatusLine` section with example, precedence note (user-level overrides plugin default), pointer to upstream Status Line guide.
+- `references/08-configuration/plugin-json.md`: settings.json supported-keys table updated — `agent` joined by `subagentStatusLine`. Confirmed upstream: these two are the only currently-supported plugin-settings keys (unknown keys silently ignored).
+- `templates/plugin.json.template`: settings.json note updated to mention both keys.
+
+### Added — Validator: plugin-root `settings.json`
+- `commands/validate.md`: new "Plugin settings.json" check block — valid JSON, recognized keys only (`agent` / `subagentStatusLine`), `agent` value must match an agent file, `subagentStatusLine` must match upstream schema shape. Forward-compat info note on unknown keys.
+
+### Changed — SKILL.md niche-fields pointer
+- `SKILL.md` "Configuring Plugin" section: added a 6th bullet covering `channels`, `bin/`, and plugin-root `settings.json` (both keys), so authors building atypical plugins are routed to the right reference without bloating the main flow.
+
+### Metadata sync
+- `.claude-plugin/plugin.json`: `version` 3.4.0 → **3.4.1**.
+- `skills/plugin-creation/SKILL.md` frontmatter `version` 3.4.0 → **3.4.1**.
+- Root `marketplace.json`: `plugin-creation-tools` entry version 3.4.0 → **3.4.1**; `metadata.version` 1.14.34 → **1.14.35** (patch bump per `feedback_marketplace_version_bump`).
+
+### Notes
+- Doc baseline unchanged from v3.4.0 (2026-05-08 snapshot).
+- Audit source: `claude_docs/improvements/plugin-creation-tools-audit-2026-05-12.md` (in-conversation).
+- Still deferred for the next refresh cycle (v3.5.0): output-style **authoring** depth (the field is documented but custom-style `.md` schema isn't) and Agent SDK coverage breadth (9 of 29 upstream pages — explicitly deferred in v3.4.0). Not blocking — manifest-field documentation exists; authors aren't stuck.
+
 ## [3.4.0] - 2026-05-11
 
 Doc-snapshot refresh covering Claude Code **v2.1.120 → v2.1.136**. Source: tracking memo `claude_docs/improvements/plugin-creation-tools-2026-05-08.md`. Plan-driven, additive — no breaking changes for plugin authors who haven't migrated yet (top-level `themes`/`monitors` still load).

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -33,6 +33,14 @@ Validate a plugin's structure and components against best practices.
 - [ ] **Warning** if `agents` is a bare string path: "The `agents` field is array-only. Wrap the path in an array: `\"agents\": [\"./agents/foo.md\"]`."
 - [ ] **Info** (not warning) if `commands` or `skills` is a bare string path: "The array form is preferred — `\"commands\": [\"./cmd.md\"]`. The string form still loads but is being phased out."
 - [ ] **Info** if `$schema` is missing: "Consider adding `\"$schema\": \"https://json.schemastore.org/claude-code-plugin-manifest.json\"` for editor autocomplete. Claude Code ignores the field at load time."
+- [ ] **Info** when `channels` is declared in `plugin.json`: each entry must have a `server` field that matches a key in the plugin's `mcpServers` (or an externally-known MCP server name). Flag a warning if `server` references an undeclared MCP server. Per-channel `userConfig` follows the same schema as the top-level `userConfig` — apply the same legacy/required checks.
+- [ ] **Info** when a `bin/` directory is present at the plugin root: confirm files are executable (warn on non-executable entries — they will appear on `PATH` but fail to run). Auto-discovered, no manifest entry needed.
+
+### Plugin settings.json (if present at plugin root)
+- [ ] Valid JSON.
+- [ ] Recognized keys only: `agent`, `subagentStatusLine`. Unknown keys are silently ignored upstream (forward-compatible) — emit **info** noting the value will be ignored at runtime.
+- [ ] `agent` value matches an agent file under `agents/` (warn on dangling reference).
+- [ ] `subagentStatusLine` matches the upstream status-line schema (object with `type` + `command`/`script`, or string command).
 
 ### Marketplace (`marketplace.json` if present)
 - [ ] `owner` field is present and non-empty (error if missing)

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-creation
-version: 3.4.0
+version: 3.4.1
 description: Use when creating Claude Code plugins - covers skills, commands, agents, hooks, MCP servers, and plugin configuration. Use when user says "create plugin", "make a skill", "add command", "add hooks", "skill authoring", "SKILL.md", "plugin components", "package reusable behavior", "distribute skills", "scaffold plugin", "plugin structure", "write a skill description". NOT for: using existing plugins, installing plugins, plugin marketplace browsing. !`ls .claude-plugin/ 2>/dev/null`
 user-invocable: false
 ---
@@ -183,6 +183,7 @@ When user says "configure plugin", "setup plugin.json":
 3. Recommended fields: `$schema` (SchemaStore JSON Schema for editor autocomplete), `version`, `description`, `author`, `license`
 4. Component paths: `commands` (array), `agents` (array — string form no longer accepted), `hooks`, `mcpServers`
 5. **Experimental components** (`themes`, `monitors`) belong under `experimental.*`. Top-level `themes` / `monitors` still load but `claude plugin validate` warns and a future release will require the nested form. The validator (`/plugin-creation-tools:validate`) flags top-level usage and offers an auto-migration diff.
+6. **Niche but valid manifest fields**: `channels` (Telegram/Slack/Discord-style message injection — each entry binds to one of the plugin's `mcpServers`); `bin/` directory auto-discovered (executables there are added to the Bash tool's `PATH` while the plugin is enabled — chmod +x; useful for CLI helpers users invoke directly, distinct from `hooks/` which are event-driven). Plugin-root `settings.json` supports two keys: `agent` (activates one of the plugin's agents as the main thread agent) and `subagentStatusLine` (default status-line config for subagents). See `references/08-configuration/plugin-json.md` and `references/08-configuration/settings.md`.
 
 ### Suppressing a plugin skill without forking
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -100,8 +100,9 @@ Or simple string:
 | outputStyles | string/array | Custom output style paths |
 | `experimental.themes` | string/array | Color theme files/directories (replaces default `themes/`). Each file: `name`, `base`, `overrides`. See [`themes.md`](themes.md). **Was top-level `themes`** — see [Experimental components migration](#experimental-components-migration). |
 | `experimental.monitors` | string/array | Background [Monitor](https://docs.anthropic.com/en/tools-reference#monitor-tool) configurations that start automatically when the plugin is active. **Was top-level `monitors`** — see [Experimental components migration](#experimental-components-migration). |
+| `channels` | array | Channel declarations for message injection (Telegram, Slack, Discord style). Each channel binds to an MCP server the plugin provides. See [Channels](#channels) below. |
 | userConfig | object | User-configurable values prompted at enable time. See [User configuration](#user-configuration) below. |
-| settings | string | Path to settings.json (only `agent` key supported) |
+| settings | string | Path to settings.json. Supported keys: `agent` (activates one of the plugin's agents as the main thread agent), `subagentStatusLine` (default status-line config for spawned subagents — see [`settings.md`](settings.md#subagentstatusline)). Unknown keys are silently ignored (forward-compatible). |
 
 ### Experimental components migration
 
@@ -479,6 +480,60 @@ This minimal plugin will still load:
 }
 ```
 
+## Channels
+
+The `channels` field lets a plugin declare one or more **message channels** that inject content into the conversation (Telegram, Slack, Discord-style integrations). Each channel binds to an MCP server that the plugin also provides.
+
+```json
+{
+  "channels": [
+    {
+      "server": "telegram",
+      "userConfig": {
+        "bot_token": {
+          "type": "string",
+          "title": "Bot token",
+          "description": "Telegram bot token",
+          "sensitive": true
+        },
+        "owner_id": {
+          "type": "string",
+          "title": "Owner ID",
+          "description": "Your Telegram user ID"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Per-entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `server` | Yes | Must match a key in the plugin's `mcpServers`. The channel binds to that server. |
+| `userConfig` | No | Same schema as the top-level `userConfig` field — prompts the user for per-channel values (bot tokens, owner IDs) when the plugin is enabled. |
+
+Channels is a niche but documented manifest field. If your plugin doesn't ship a message-injection MCP server, omit the field entirely.
+
+## `bin/` Directory (executables on Bash PATH)
+
+A `bin/` directory at the plugin root is a standard plugin component — **not** a manifest field. Files placed in `bin/` are added to the Bash tool's `PATH` while the plugin is enabled, so they're invokable as bare commands in any Bash tool call:
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json
+└── bin/
+    ├── my-tool          # invokable as `my-tool` in Bash
+    └── my-other-tool
+```
+
+- Files must be **executable** (`chmod +x`).
+- Use cross-platform shebangs (`#!/usr/bin/env bash`, `#!/usr/bin/env python3`) or pair with a `.cmd` wrapper like the hooks polyglot pattern (`templates/hooks/run-hook.cmd.template`).
+- Prefer this over `hooks` for utilities the *user* (or another plugin's hook) calls directly, rather than event-driven automation.
+- Auto-discovered — no manifest entry needed.
+
 ## Validation
 
 Ensure your plugin.json is valid JSON:
@@ -509,6 +564,7 @@ plugin-name/
 | Key | Type | Description |
 |-----|------|-------------|
 | `agent` | string | Activates one of the plugin's agents as the main thread agent |
+| `subagentStatusLine` | object/string | Default status-line configuration for subagents spawned from this plugin. Same shape as the user-level `subagentStatusLine` setting. See [`settings.md`](settings.md#subagentstatusline). |
 
 ### Behavior
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
@@ -227,6 +227,24 @@ Skills absent from `skillOverrides` are treated as `"on"`.
 
 > **Plugin skills caveat:** `skillOverrides` does **not** affect skills shipped by plugins. Manage those through `/plugin` (enable/disable per scope) instead. This is the right escape hatch to surface in your plugin's README — point users who want to mute a single skill at `/plugin disable` for the whole plugin, or at the skill's own `disable-model-invocation` / `user-invocable` frontmatter if they're forking.
 
+### subagentStatusLine
+
+Status-line configuration applied to subagents spawned in the session. Pairs with the regular `statusLine` setting (which governs the main thread). Plugins can ship a default `subagentStatusLine` in their plugin-root `settings.json` (alongside the `agent` key — those are the two currently-supported plugin-settings keys).
+
+```json
+{
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "${CLAUDE_PLUGIN_ROOT}/scripts/subagent-status.sh",
+    "padding": 0
+  }
+}
+```
+
+User precedence still applies: a user-level `subagentStatusLine` in `~/.claude/settings.json` overrides a plugin's default. Plugins should treat their `settings.json` value as a reasonable default for their own subagents — not as a UX dictation.
+
+See upstream **Status Line** guide for the full status-line schema (it's identical for main-thread and subagent status lines — they just live in different setting keys).
+
 ### prUrlTemplate
 
 Custom URL pattern for the PR link rendered in `/code-review` footers and similar review UIs. Useful when your remote isn't on github.com — `--from-pr` now also accepts GitLab, Bitbucket, and GHES URLs (release 2.1.119+), so the template lets you mirror the remote's URL shape.

--- a/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
@@ -38,10 +38,19 @@ plugin-name/
 │       └── SKILL.md
 ├── hooks/                    # Optional
 │   └── hooks.json
+├── bin/                      # Optional — executables auto-added to Bash PATH
+│   └── my-tool               #   (chmod +x; invokable as bare command)
 ├── scripts/                  # Optional
 │   └── *.sh
+├── output-styles/            # Optional
+│   └── *.md
+├── themes/                   # Optional — see experimental.themes
+│   └── *.json
+├── monitors/                 # Optional — see experimental.monitors
+│   └── monitors.json
 ├── .mcp.json                # Optional
-├── settings.json            # Optional
+├── .lsp.json                # Optional
+├── settings.json            # Optional (agent + subagentStatusLine keys)
 ├── README.md                # Recommended
 ├── CHANGELOG.md             # Recommended
 └── LICENSE                  # Recommended

--- a/plugin-creation-tools/skills/plugin-creation/references/quick-reference.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/quick-reference.md
@@ -27,6 +27,8 @@ plugin-name/
 │       └── SKILL.md
 ├── hooks/
 │   └── hooks.json
+├── bin/                      # Executables auto-added to Bash PATH
+│   └── my-tool
 ├── scripts/
 │   └── script.sh
 ├── .mcp.json

--- a/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
@@ -46,7 +46,31 @@
   //   }
   // }
 
+  // Optional: declare message channels (Telegram, Slack, Discord style) that
+  // inject content into the conversation. Each channel binds to an MCP server
+  // the plugin also provides. The "server" field is required and must match
+  // a key in this plugin's "mcpServers". Per-channel "userConfig" uses the
+  // same schema as the top-level field.
+  // "channels": [
+  //   {
+  //     "server": "telegram",
+  //     "userConfig": {
+  //       "bot_token": {
+  //         "type": "string",
+  //         "title": "Bot token",
+  //         "description": "Telegram bot token",
+  //         "sensitive": true
+  //       }
+  //     }
+  //   }
+  // ]
+
   // Note: A separate settings.json file at the plugin root can set the
-  // "agent" key to configure agent behavior for this plugin.
-  // See the agent template for available agent configuration fields.
+  // "agent" key (activates one of the plugin's agents as the main thread
+  // agent) and "subagentStatusLine" key (default status-line config for
+  // spawned subagents). Other keys are silently ignored (forward-compatible).
+  //
+  // Note: A bin/ directory at the plugin root is auto-discovered (no manifest
+  // entry needed) — executables there are added to the Bash tool's PATH while
+  // the plugin is enabled. Useful for CLI helpers users invoke directly.
 }


### PR DESCRIPTION
## Summary

Post-v3.4.0 read-only audit (run against current `~/workspace/claude_memory/guides/claude/` snapshot) surfaced three missing-content gaps. v3.4.0 was correct on every surface it touched — these are the surfaces it didn't reach. Patch bump because all three are short additions to existing reference files; no schema change, no behavior change for existing plugins.

## Gaps closed

1. **`channels` manifest field** — Telegram/Slack/Discord-style MCP-backed message injection. Documented in upstream Plugins Reference (line 438 + 484–511); was absent from the plugin.
2. **`bin/` directory** — auto-discovered executables added to the Bash tool's `PATH`. Documented in upstream Plugins Reference (line 673 + 706); was absent from the plugin's layout diagrams.
3. **`subagentStatusLine` plugin setting** — second supported key in plugin-root `settings.json` (alongside `agent`). Documented in upstream Plugins Reference (line 707) and Status Line guide (line 985); was absent from the plugin's settings.md.

## Bonus

The packaging.md standard-layout diagram was missing `.lsp.json`, `output-styles/`, `themes/`, `monitors/` too — added them in the same diagram pass since the rendering was clearly stale.

## Metadata sync

- plugin.json 3.4.0 → **3.4.1**
- SKILL.md frontmatter 3.4.0 → **3.4.1**
- Root marketplace.json plugin entry 3.4.0 → **3.4.1**
- Root marketplace.json metadata.version 1.14.34 → **1.14.35** (patch per `feedback_marketplace_version_bump`)

## Still deferred (v3.5.0 / next refresh cycle)

- Output-style authoring depth — the field is documented but the `.md` schema for custom styles isn't.
- Agent SDK coverage — 9 of 29 upstream pages covered. Explicitly deferred in v3.4.0; no new urgency.

## Test plan

- [ ] Run `/plugin-creation-tools:validate` on this plugin → confirm clean / all-warnings
- [ ] Confirm the new validator checks fire on a throwaway plugin: declare `channels` with a server name that isn't in `mcpServers` → warning; ship a `bin/` file that isn't `chmod +x` → warning; ship a `settings.json` with an unknown key → info
- [ ] Spot-check rendered SKILL.md "Configuring Plugin" section reads cleanly with the new 6th bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)