### PR TITLE
chore: add root .gitignore for per-machine Claude Code state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Per-machine Claude Code local state (settings.local.json, logs, agent-memory).
+# Anchored to root so plugin-internal .claude/ dirs (e.g. code-quality-tools/.claude/rules/)
+# remain tracked.
+/.claude/
+/.claude-telemetry/
+
+# Skill runtime telemetry (design-intelligence Wave-4 gates, motion auditor, etc.)
+/.design-intelligence/
+/.design-intelligence-audit/


### PR DESCRIPTION
## Summary

Marketplace had no root \`.gitignore\`, so Claude Code local state and skill runtime telemetry (created during normal sessions) showed up as untracked.

Ignored at root only:
- \`/.claude/\` — \`settings.local.json\`, logs, agent-memory
- \`/.claude-telemetry/\` — visual-style-commitment gate placeholders
- \`/.design-intelligence/\` — cross-medium-discipline Wave-4 telemetry
- \`/.design-intelligence-audit/\` — motion-direction audit log

Paths use leading \`/\` to anchor to root, so plugin-internal \`.claude/\` dirs (e.g. \`code-quality-tools/.claude/rules/\`) stay tracked.

## Test plan
- [x] \`git check-ignore -v\` confirms root dirs match
- [x] \`git check-ignore -v code-quality-tools/.claude/rules/skill-conventions.md\` returns no match (still tracked)
- [ ] After merge: confirm no plugin-internal \`.claude/\` files disappear from \`git ls-files\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)