### PR TITLE
plugin-creation-tools v3.5.0: Hook Authoring Depth

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.39"
+    "version": "1.14.40"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Complete guide for creating Claude Code plugins — skills, commands, agents, hooks, MCP servers, and configuration. Covers 29 hook events (now including Setup for --init-only / --init -p / --maintenance -p one-time preparation, plus WorktreeCreate/WorktreeRemove for replacing default git worktree behavior with custom VCS logic), the if pre-spawn filter, the mcp_tool handler type, the effort.level adaptive-effort input + $CLAUDE_EFFORT env var, updatedToolOutput (supersedes MCP-only updatedMCPToolOutput), experimental.themes / experimental.monitors manifest migration with auto-migration diff offer, $schema field for editor autocomplete, array-only agents, plugin themes, userConfig with type/title schema, skillOverrides setting + the plugin-skills caveat, claude plugin prune + --prune flag on uninstall + --plugin-url session loader, Plugin Hints (CLI-driven install prompts) for first-party plugin authors, workspace-trust gating clarification on allowed-tools, plugin-root CLAUDE.md scoping clarification, allowCrossMarketplaceDependenciesOn, claude plugin tag, forked subagents, Agent SDK (overview/migration/custom-tools/subagents/permissions/structured-outputs/tool-search/observability/agent-loop), plugin dependencies, permission modes, claude directory layout, REVIEW.md v2, Routines-based auto-validate, and skill-description quality patterns.",
-      "version": "3.4.1",
+      "description": "Authoritative quality gate + authoring guide for Claude Code plugins. Covers all 29 hook events (Setup, WorktreeCreate/WorktreeRemove, PostToolBatch, UserPromptExpansion, …), five handler types (command / http / mcp_tool / prompt / agent), the if pre-spawn filter, the effort.level adaptive-effort input + $CLAUDE_EFFORT env var, experimental.themes / experimental.monitors manifest migration, $schema field, array-only agents, channels, bin/ auto-discovery, plugin-root settings.json (agent + subagentStatusLine), userConfig with type/title schema, skillOverrides, claude plugin prune + --plugin-url + --plugin-dir, Plugin Hints, workspace-trust gating, allowCrossMarketplaceDependenciesOn, forked subagents, Agent SDK, REVIEW.md v2, Routines auto-validate. v3.5.0 ships **Hook Authoring Depth**: exec form (`args` field) preferred for path placeholders, `systemMessage` / `terminalSequence` JSON output (v2.1.139+ no controlling terminal), 10,000-character output cap, parallel-then-merge execution with `deny > defer > ask > allow` PreToolUse precedence — and seven paired validator rules (H05 shell→exec form with `--fix`; H06 `$VAR`→`${VAR}` with `--fix`; H08 broad-matcher missing `if`; H09 `if` on non-tool events; H10 updatedMCPToolOutput → updatedToolOutput with `--fix`; H11 SessionStart install → Setup; H12 hook writes to `/dev/tty` is an error; H13 hook output >10K). Opt-in `--fix` flag with `.claude-plugin/.validate-fixes.log` audit trail.",
+      "version": "3.5.0",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
-  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter and the `mcp_tool` handler type), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate.",
-  "version": "3.4.1",
+  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter, the `mcp_tool` handler type, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, and parallel-then-merge precedence), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate. v3.5.0 ships hook authoring depth + 7 paired validator rules (H05–H13) with opt-in `--fix`.",
+  "version": "3.5.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-05-19
+
+**Theme: Hook Authoring Depth.** First release of the consolidated roadmap (2026-05-12). Catches up on the v2.1.139 → v2.1.144 hook revolution and ships paired enforcement rules so the same regressions can't reappear in other plugins.
+
+Snapshot baseline: Claude Code v2.1.144, `~/workspace/claude_memory/guides/claude/` refreshed 2026-05-12 (`552b666`).
+
+### Added — Exec form vs shell form
+
+- `references/06-hooks/writing-hooks.md`: new section "Exec form vs shell form" — covers the `args` field, when exec form is preferred (any time a placeholder appears), the Windows `.cmd`/`.bat` caveat (invoke `node` with the script path), and the bare-name + whitespace warning condition. Fields table gains `args` and `shell` rows.
+- All canonical hook examples in `templates/hooks/hooks.json.template`, `references/06-hooks/hook-events.md` (25 examples), `references/06-hooks/hook-patterns.md` (16 examples), `references/06-hooks/writing-hooks.md`, `hooks/hooks.json` (plugin self-application), and `skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json` (the cross-platform `.cmd` wrapper stays in shell form with an inline note explaining why).
+
+### Added — JSON output return fields
+
+- `references/06-hooks/writing-hooks.md`: new section "JSON Output Return Fields" — table of `continue` / `stopReason` / `suppressOutput` / `systemMessage` / `terminalSequence` / `hookSpecificOutput.additionalContext`. Covers the v2.1.139 "no controlling terminal" change (hooks can no longer write to `/dev/tty` or emit raw escape sequences), the OSC allowlist for `terminalSequence` (0/1/2/9/99/777 + BEL), and the 10,000-character output cap with file-fallback behavior.
+- `references/06-hooks/hook-events.md`: top-of-file callout summarising the three v2.1.139+ rules (no controlling terminal, 10K cap, exec form for placeholders) with links to the writing-hooks section.
+
+### Added — Hook execution semantics
+
+- `references/06-hooks/writing-hooks.md`: new section "Hook Execution Order & Precedence" — parallel-then-merge, dedup-by-`command`+`args` for command hooks (HTTP by URL), and PreToolUse decision precedence `deny > defer > ask > allow`. Replaces the "most restrictive setting wins" misconception that authors sometimes ship.
+
+### Added — Validator rules H05–H13 (paired with `--fix` machinery)
+
+`commands/validate.md` gains:
+
+- **H05 (warn, `--fix`)** — Command hook with a `${CLAUDE_*}` path placeholder in `command` but no `args` field → suggest exec form. Auto-fix inserts `"args": []`; skips when the command contains shell metacharacters (`|`, `&&`, `;`, redirects, etc.).
+- **H06 (warn, `--fix`)** — Bare `$CLAUDE_PROJECT_DIR` / `$CLAUDE_PLUGIN_ROOT` / `$CLAUDE_PLUGIN_DATA` / `$CLAUDE_ENV_FILE` / `$CLAUDE_EFFORT` inside JSON command-string values in `hooks.json` → rewrite to `${VAR}`. Only scans JSON command strings; bare `$VAR` inside `.sh` scripts is correct bash and is **not** flagged.
+- **H07 (warn)** — Shell-form command hooks must quote `${CLAUDE_*}` placeholders. Skipped when `args` is present (exec form needs no quoting).
+- **H08 (info)** — Broad-matcher tool-event hooks (`*` / `""` / `.*` / omitted) without `if` field may spawn on every tool call. Info-level suggestion, not warn — some authors intentionally spawn for logging.
+- **H09 (warn)** — `if` field on non-tool events (silently ignored at runtime).
+- **H10 (warn, `--fix`)** — `updatedMCPToolOutput` literal → `updatedToolOutput` in `hooks.json` and referenced hook scripts. Old field still works, but the rename means the hook also catches built-in tools, not only MCP.
+- **H11 (info)** — `SessionStart` hook script doing one-time install (check-then-install + package-install heuristic) → suggest moving to `Setup` event.
+- **H12 (error)** — Hook script writes to `/dev/tty`. Broken as of v2.1.139; surfaces as error with pointer to `terminalSequence` / `systemMessage`.
+- **H13 (warn)** — Best-effort heuristic on hook output approaching the 10K cap (large heredocs, `cat` of large files used as the only stdout).
+
+`--fix` is opt-in and reversible. All auto-fixes are logged to `.claude-plugin/.validate-fixes.log` (append-only, timestamp + rule + summary) so the author can grep the change history if a later version regresses.
+
+### Updated
+
+- `skills/plugin-creation/SKILL.md`: new "Exec form vs shell form" + "No controlling terminal" paragraphs in the Hooks section.
+- `README.md`: hook bullet expanded with exec form / JSON output fields / 10K cap / no controlling terminal / parallel-then-merge precedence. Compatibility line bumped from 2.1.119 → 2.1.144.
+- `CLAUDE.md`: Drift to Watch list gains hook command-form pair, output cap, controlling-terminal note, terminal-sequence allowlist, and PreToolUse decision precedence.
+- Marketplace description rewritten as an elevator pitch + v3.5.0 highlight (down from ~3500-char history dump).
+- Root marketplace.json `metadata.version` 1.14.39 → 1.14.40 (plugin-version pointer update).
+
+### Notes
+
+- **Rule numbering follows the roadmap (H05–H13).** Enforcement-design §4 uses overlapping IDs for different rules; the next release will reconcile if needed. The roadmap is authoritative for what each release ships.
+- **Ecosystem migration deferred.** The `--fix` machinery lands here; bulk migration of camoa-skills + palcera_skills hooks is a separate `chore/ecosystem-hook-migration` PR so the change history per plugin stays auditable.
+- **Out of scope** (parked for later releases per the roadmap): single-skill-at-root auto-discovery, recursive `agents/` subfolder scoping, `init_plugin.py` template-source refactor (v3.6.0); `$schema` / `experimental.*` auto-fix, `TodoWrite` deprecation, `WaitForMcpServers` / LSP tool rows (v3.6.1); skill-listing budget guidance, workspace-trust UI gate, `effort.level` skill examples (v3.6.2); cross-plugin session-remembrance helper (v3.7.0, conditional on DDF adopting the pattern first).
+
 ## [3.4.1] - 2026-05-12
 
 Post-v3.4.0 audit patch. A read-only comparison against the current `claude_memory/guides/claude/` snapshot surfaced three missing-content gaps (not stale-content). None affect the typical plugin-authoring path; all are scoped to short additions in existing reference files.

--- a/plugin-creation-tools/CLAUDE.md
+++ b/plugin-creation-tools/CLAUDE.md
@@ -33,6 +33,11 @@ Every revision must keep these counts in sync between SKILL.md, `commands/valida
 
 - Hook event count (currently **29** — added `Setup` in the 2026-05-08 doc snapshot).
 - Hook handler types (currently **5** — `command`, `http`, `mcp_tool`, `prompt`, `agent` with `agent` marked experimental).
+- **Hook command-form pair** (v2.1.139+ — exec form via `args` field is preferred whenever a path placeholder appears; shell form remains valid for pipes/redirects/chains).
+- **Hook output cap** (10,000 characters across `additionalContext` / `systemMessage` / stdout; overflow becomes a file-path preview).
+- **No controlling terminal in hooks** (v2.1.139+ — `/dev/tty` writes from hook scripts no longer reach the user; surface via `systemMessage` / `terminalSequence` JSON output).
+- **Terminal sequence allowlist** (OSC `0`/`1`/`2`/`9`/`99`/`777` + BEL — anything else is rejected and the field is ignored).
+- **PreToolUse decision precedence** (`deny > defer > ask > allow`) and parallel-then-merge across all matching hooks.
 - Plugin component types (skills, commands, agents, hooks, mcpServers, lspServers, outputStyles, **`experimental.themes`**, **`experimental.monitors`** — themes and monitors are upstream-marked experimental and live under the `experimental.*` key; top-level still loads but `claude plugin validate` warns).
 - Reserved marketplace names list.
 - The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).

--- a/plugin-creation-tools/README.md
+++ b/plugin-creation-tools/README.md
@@ -27,7 +27,7 @@ The plugin contains one large skill (`plugin-creation`) that progressively discl
 
 The bundled references map to every section of the upstream Claude Code docs that affects plugin authoring (snapshot at commit `c142d14`):
 
-- **Hooks** — all 29 events (including `Setup` for `--init-only` / `--init -p` / `--maintenance -p` one-time preparation, and `WorktreeCreate` / `WorktreeRemove` for replacing default git worktree behavior with custom VCS logic) with payloads, decision controls, and matcher behavior; five handler types (`command` / `http` / `mcp_tool` / `prompt` / `agent`); the `if` pre-spawn filter; the `effort.level` adaptive-effort input + `$CLAUDE_EFFORT` env var; `updatedToolOutput` (supersedes MCP-only `updatedMCPToolOutput`); cross-platform polyglot wrapper; permission-mode-per-hook table.
+- **Hooks** — all 29 events (including `Setup` for `--init-only` / `--init -p` / `--maintenance -p` one-time preparation, and `WorktreeCreate` / `WorktreeRemove` for replacing default git worktree behavior with custom VCS logic) with payloads, decision controls, and matcher behavior; five handler types (`command` / `http` / `mcp_tool` / `prompt` / `agent`); **exec form vs shell form** with the `args` field (preferred whenever a path placeholder appears); the `if` pre-spawn filter; the `effort.level` adaptive-effort input + `$CLAUDE_EFFORT` env var; `updatedToolOutput` (supersedes MCP-only `updatedMCPToolOutput`); **JSON output return fields** (`systemMessage`, `terminalSequence`, `additionalContext`, 10,000-character output cap, no controlling terminal as of v2.1.139); **parallel-then-merge execution** with `deny > defer > ask > allow` PreToolUse precedence; cross-platform polyglot wrapper; permission-mode-per-hook table.
 - **Skills** — frontmatter schema, voice and structure, progressive disclosure, dynamic context injection (`` !`command` ``), preload caveats, char/line caps.
 - **Agents** — frontmatter, model selection, tool restrictions, scoped hooks/MCP, agent teams, forked subagents (experimental), `--agent` main-session behavior.
 - **Configuration** — `plugin.json` (themes, `userConfig` with `type`/`title`, dependencies with semver ranges, `${user_config.KEY}` substitution); `marketplace.json` (sources, `allowCrossMarketplaceDependenciesOn`, `claude plugin tag`); `settings.json` (hierarchy, `prUrlTemplate`, `enabledPlugins`); permission modes; plugin themes.
@@ -57,7 +57,7 @@ The bundled references map to every section of the upstream Claude Code docs tha
 
 ## Compatibility
 
-Targets Claude Code as of release **2.1.119** (2026-04-25 doc snapshot). Most content is forward-compatible; new features in later releases are added in subsequent minor versions.
+Targets Claude Code as of release **2.1.144** (2026-05-12 doc snapshot). Most content is forward-compatible; new features in later releases are added in subsequent minor versions.
 
 ## Changelog
 

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -1,7 +1,7 @@
 ---
 description: Validate plugin structure, frontmatter, and best practices. Use when user says "validate plugin", "check plugin", "audit plugin", "verify plugin", "is my plugin correct", or before distributing/publishing a plugin.
 allowed-tools: Read, Glob, Grep
-argument-hint: [plugin-path]
+argument-hint: "[plugin-path] [--fix] [--strict]"
 context: fork
 ---
 
@@ -12,9 +12,29 @@ Validate a plugin's structure and components against best practices.
 ## Steps
 
 1. Determine plugin path: use `$1` if provided, otherwise detect from current directory
-2. Find `.claude-plugin/plugin.json` to confirm it's a plugin root
-3. Run all validation checks below
-4. Report results as a structured checklist
+2. Parse flags: `--fix` enables auto-migration for rules tagged below; `--strict` promotes warnings to errors for CI gating
+3. Find `.claude-plugin/plugin.json` to confirm it's a plugin root
+4. Run all validation checks below
+5. If `--fix` is set, after the report ask the user to confirm before applying any auto-migration. Apply each fix atomically (write-tempfile-then-rename) and append an entry to `.claude-plugin/.validate-fixes.log`
+6. Report results as a structured checklist
+
+## Auto-fix (`--fix`)
+
+The validator gains an opt-in `--fix` flag that performs **only** mechanical, reversible migrations. Every fix:
+
+- Is logged to `.claude-plugin/.validate-fixes.log` (append-only) with timestamp + rule ID + summary
+- Writes atomically (tempfile + rename), so a failure leaves the original intact
+- Is reversible via `git diff` / `git restore`
+- Requires user confirmation before any file is changed in this release
+
+Rules that ship with `--fix` in v3.5.0: **H05**, **H06**, **H10**. Other auto-fixable rules (M07/M08/M09/M10, C05/C06, etc.) land in later releases.
+
+Log entry format:
+
+```
+2026-05-19T14:22:01Z  H05  hooks/hooks.json: SessionStart → exec form (added "args": [])
+2026-05-19T14:22:01Z  H10  scripts/post-write.sh: updatedMCPToolOutput → updatedToolOutput
+```
 
 ## Validation Checks
 
@@ -102,17 +122,97 @@ Validate a plugin's structure and components against best practices.
 - [ ] If `min`/`max` are set, `type` is `number`
 
 ### Hooks (`hooks/hooks.json`)
-- [ ] Valid JSON structure — **Note:** malformed hooks.json prevents the entire plugin from loading
-- [ ] Each event name is one of the 29 recognized events: `Setup`, `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
-- [ ] Each hook entry has `type` — one of `command`, `prompt`, `agent`, or `mcp_tool` — plus the matching required fields for that type. `agent` is upstream-marked experimental; flag a one-line info note when used.
-- [ ] `mcp_tool` handlers: require `server` and `tool`; if `server` is not declared in the plugin's `mcpServers` (and isn't a known external server the user wires up themselves), emit a **warning**: "`mcp_tool` references server `<name>` not declared in this plugin's `mcpServers`. The handler will produce a non-blocking error if the server isn't already connected at runtime."
-- [ ] No `http` type hooks — `http` hooks only work in `settings.json`, not `hooks.json` (error if found)
-- [ ] Command hooks reference executable files
-- [ ] Timeouts are reasonable (< 120s for sync hooks)
-- [ ] `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` / `$CLAUDE_PLUGIN_ROOT` / `${CLAUDE_PLUGIN_ROOT}` / `$CLAUDE_PLUGIN_DATA` / `${CLAUDE_PLUGIN_DATA}` usage is quoted in all command strings (paths with spaces break otherwise)
-- [ ] **Warning**: hook handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) with a broad matcher (`*`, `""`, omitted, or `.*`) should include an `if` field to pre-filter. Emit a **suggestion** (not error): "Consider adding an `if` field to this handler to avoid spawning a process on every tool call."
-- [ ] `if` field is only valid on tool events — flag as warning if set on non-tool events (silently ignored at runtime)
-- [ ] **Info** when a `PostToolUse` JSON output example or hook script uses `updatedMCPToolOutput`: "Upstream now prefers `updatedToolOutput` (works for all tools, not just MCP). The old field still works; new code should use `updatedToolOutput`."
+
+#### H01–H04 — structural
+
+- [ ] **H01 (error)** — Valid JSON structure. Malformed `hooks.json` prevents the entire plugin from loading.
+- [ ] **H02 (error)** — Each event name is one of the 29 recognized events: `Setup`, `SessionStart`, `UserPromptSubmit`, `UserPromptExpansion`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, `SessionEnd`
+- [ ] **H03 (error)** — Each hook entry has `type` — one of `command`, `prompt`, `agent`, or `mcp_tool` — plus the matching required fields for that type. `agent` is upstream-marked experimental; flag a one-line info note when used.
+- [ ] **H04 (error)** — No `http` type hooks in `hooks.json`. `http` hooks only work in `settings.json` (silently ignored when placed in `hooks.json`).
+- [ ] **(error)** — `mcp_tool` handlers: require `server` and `tool`; if `server` is not declared in the plugin's `mcpServers` (and isn't a known external server the user wires up themselves), emit a **warning**: "`mcp_tool` references server `<name>` not declared in this plugin's `mcpServers`. The handler will produce a non-blocking error if the server isn't already connected at runtime."
+- [ ] **(warn)** — Command hooks reference executable files (chmod +x missing → warn).
+- [ ] **(warn)** — Timeouts are reasonable (< 120s for sync hooks).
+
+#### H05 — Exec form preferred for path placeholders (warn, `--fix`)
+
+For each command hook in `hooks.json` whose `command` string contains a path placeholder (`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_DATA}`) AND lacks an `args` field, emit:
+
+> "Hook `<event>` handler uses shell form with a path placeholder. Prefer exec form: add `\"args\": []` so the script path is passed as one argument with no quoting needed. See `references/06-hooks/writing-hooks.md` § Exec form vs shell form."
+
+**`--fix`**: Insert `"args": []` as a sibling to `command` in the hook handler. Do **not** auto-migrate when the command string contains shell metacharacters (`|`, `&&`, `||`, `;`, `>`, `<`, `` ` ``, `$(`, glob `*`/`?` outside placeholder, `~`) — those need shell form. In that case, emit the warning but skip the fix and note "shell form required for this command".
+
+#### H06 — Curly-brace placeholders in command strings (warn, `--fix`)
+
+In each `hooks.json` command-string value (and only in command-string values — NOT inside referenced `.sh` script files, where bare `$VAR` is normal bash), flag bare-dollar `$CLAUDE_PROJECT_DIR` / `$CLAUDE_PLUGIN_ROOT` / `$CLAUDE_PLUGIN_DATA` / `$CLAUDE_ENV_FILE` / `$CLAUDE_EFFORT` references:
+
+> "Use `${VAR}` (curly-brace form) instead of bare `$VAR` inside JSON command strings — the curly form is the canonical placeholder syntax and is unambiguous to the placeholder resolver."
+
+**`--fix`**: Literal rewrite of `$CLAUDE_<NAME>` → `${CLAUDE_<NAME>}` inside JSON string values in `hooks.json` only. Skip script files (`.sh`, `.py`, etc.) entirely.
+
+#### H07 — Placeholder quoting (warn)
+
+In **shell form** command hooks (no `args` field), path placeholders inside the `command` string must be wrapped in double quotes (`"${CLAUDE_PROJECT_DIR}"`) — paths with spaces break otherwise. Exec form does not need quoting. Skip this check when `args` is present.
+
+#### H08 — Broad-matcher tool hooks without `if` (info)
+
+Hook handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`) with a broad matcher (`*`, `""`, omitted, or `.*`) **may** spawn a process on every tool call. Emit an info-level suggestion (not warn, not error):
+
+> "Consider adding an `if` field to this handler to pre-filter tool calls cheaply — broad-matcher hooks spawn a process on every call. See `references/06-hooks/writing-hooks.md` § The if Field."
+
+This is intentionally **info**, not warn — some authors deliberately spawn on every call (logging, analytics). Don't punish them.
+
+#### H09 — `if` on non-tool events (warn)
+
+The `if` field is only evaluated on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`). On any other event, `if` is silently ignored at runtime. Flag as warn so authors notice the dead config.
+
+#### H10 — `updatedMCPToolOutput` → `updatedToolOutput` (warn, `--fix`)
+
+`updatedMCPToolOutput` is the legacy MCP-only field; `updatedToolOutput` supersedes it and works for all tools. Search for `updatedMCPToolOutput` literally in:
+
+1. `hooks.json` JSON output snippets (rare — usually only seen in `command` strings that emit JSON inline).
+2. Referenced hook scripts (`.sh`, `.py`, `.js`, etc.) in `hooks/`, `scripts/`, and `bin/`.
+
+Emit warn: "`updatedMCPToolOutput` is the legacy field. Rewrite to `updatedToolOutput` so the hook works for built-in tools too."
+
+**`--fix`**: Literal string rewrite `updatedMCPToolOutput` → `updatedToolOutput` in matched files. Old field still works, but the rename is semantically equivalent.
+
+#### H11 — `Setup` hook recommended for one-time install (info)
+
+Heuristic: if a `SessionStart` hook's referenced script grep-matches **all three** of:
+
+- `mkdir -p` OR an existence check (`[ -d`, `[ -f`, `test -d`, `test -e`)
+- A package-install command (`npm install`, `pip install`, `composer install`, `bundle install`, `yarn install`, `pnpm install`, `python -m venv`, `python3 -m venv`)
+- A "skip-if-already-installed" pattern (`||` after the check, OR an `if ... else` guard)
+
+Then the script is doing one-time install on every session start. Emit info:
+
+> "This `SessionStart` hook looks like a one-time install (check-then-install pattern). Consider moving the install to a `Setup` hook (fires on `--init-only` / `--init -p` / `--maintenance -p`) and keeping `SessionStart` for per-session state. See `references/06-hooks/hook-events.md` § Setup."
+
+Info-only; don't autofix — moving install logic is a content decision.
+
+#### H12 — Hook writes to `/dev/tty` (error)
+
+For each referenced hook script (any file under `hooks/`, `scripts/`, `bin/` referenced by a command hook), grep for `/dev/tty`. Any match is an **error**:
+
+> "Hook script writes to `/dev/tty`. Command hooks run without a controlling terminal as of Claude Code v2.1.139 — `/dev/tty` writes fail silently. Return `terminalSequence` or `systemMessage` in JSON output instead. See `references/06-hooks/writing-hooks.md` § Terminal Sequences."
+
+Heuristic exclusions: commented-out lines (`# .* /dev/tty`), lines inside a heredoc clearly marked as documentation, lines inside string literals that are JSON output snippets (`"systemMessage": "...wrote to /dev/tty..."`). Best-effort grep — surface the line for human review.
+
+#### H13 — Hook output >10K chars (warn)
+
+Hook output strings (`additionalContext`, `systemMessage`, plain stdout) are capped at 10,000 characters. Heuristic best-effort:
+
+- Heredocs (`<<EOF ... EOF`, `<<'EOF' ... EOF`) inside hook scripts that exceed 10K characters between the open and close marker.
+- `cat` of files known to be large (>10K) inside a hook script.
+- Large string-literal assignments to a variable used as the only `echo`/`printf`/`jq` output.
+
+Emit warn: "This hook may emit >10K characters. Claude Code truncates oversize output to a file with a preview; large diffs/logs should be written to a side file under `${CLAUDE_PLUGIN_DATA}/` and referenced by path instead."
+
+Best-effort heuristic. Don't autofix.
+
+#### Hooks: legacy / cross-form
+
+- [ ] `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` / `$CLAUDE_PLUGIN_ROOT` / `${CLAUDE_PLUGIN_ROOT}` / `$CLAUDE_PLUGIN_DATA` / `${CLAUDE_PLUGIN_DATA}` usage is quoted in **shell-form** command strings (covered by H07 above; exec-form hooks need no quoting).
 
 ### Best Practices (warnings, not errors)
 - [ ] Skills use progressive disclosure (references for details)

--- a/plugin-creation-tools/hooks/hooks.json
+++ b/plugin-creation-tools/hooks/hooks.json
@@ -7,6 +7,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.sh",
+            "args": [],
             "timeout": 10
           }
         ]

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -163,6 +163,10 @@ When user says "add hooks", "setup hooks", "event handlers":
 
 **Adaptive hooks**: Hook stdin JSON includes an `effort` object (`{ "level": ... }`) on tool-use-context events; the same level is exported as `$CLAUDE_EFFORT` to command hooks and the Bash tool. Use it to adapt verbosity, recursion depth, or external-call budget to the user's effort setting.
 
+**Exec form vs shell form** (v2.1.139+): Command hooks run in **exec form** when `args` is set — `command` resolves as an executable and is spawned directly with each `args` element passed as one argument, no shell tokenization, no quoting. Prefer exec form for any hook that references a path placeholder (`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_DATA}`). Omit `args` to fall back to shell form when you need pipes, `&&`, or redirects.
+
+**No controlling terminal** (v2.1.139+): On macOS and Linux, command hooks run without `/dev/tty`. To surface a message, return `systemMessage` in JSON stdout; to ring the bell or fire a desktop notification, return `terminalSequence` (allowlisted OSC sequences). All hook output is capped at 10,000 characters — longer output is replaced with a file-path preview.
+
 **Five handler types** — choose the right one:
 - `command` — shell script, fastest, no LLM cost. Use for logging, file ops, env setup.
 - `http` — POST event JSON to a webhook (settings.json only). Use for external services.

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Example hooks demonstrating cross-platform setup",
+  "description": "Example hooks demonstrating cross-platform setup. These intentionally use shell form: the `.cmd` wrapper is a Windows shim that cannot be spawned in exec form (per upstream Windows caveat). For pure-Linux/macOS plugins that don't need the polyglot wrapper, prefer exec form with `\"args\": []`. See references/06-hooks/writing-hooks.md.",
   "hooks": {
     "SessionStart": [
       {

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-events.md
@@ -2,6 +2,12 @@
 
 Complete reference for all 29 hook events in Claude Code.
 
+> **No controlling terminal (v2.1.139+).** Command hooks on macOS and Linux run without a controlling terminal — `/dev/tty` writes and raw escape sequences from a hook fail. To surface a message to the user, return `systemMessage` in JSON output. To ring the bell, set a window title, or fire a desktop notification, return `terminalSequence`. See [writing-hooks.md › JSON Output Return Fields](writing-hooks.md#json-output-return-fields).
+>
+> **10,000-char output cap.** `additionalContext`, `systemMessage`, and plain stdout are capped at 10,000 characters; longer output is replaced with a file path and a preview.
+>
+> **Exec form for path placeholders.** The command-hook examples below set `"args": []` to use [exec form](writing-hooks.md#exec-form-vs-shell-form) — preferred whenever `command` references a `${CLAUDE_*}` placeholder. Omit `args` to use shell form when you need pipes, `&&`, or redirects.
+
 ## Event Reference Table
 
 | Event | Trigger | Can Block? | Matcher Support |
@@ -83,7 +89,8 @@ All hook events receive JSON input with the following common fields:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh",
+          "args": []
         }
       ]
     }
@@ -154,7 +161,8 @@ All hook events receive JSON input with the following common fields:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-prompt.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-prompt.sh",
+          "args": []
         }
       ]
     }
@@ -190,7 +198,8 @@ All hook events receive JSON input with the following common fields:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-deploy.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-deploy.sh",
+          "args": []
         }
       ]
     }
@@ -229,7 +238,8 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-bash.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-bash.sh",
+          "args": []
         }
       ]
     }
@@ -326,6 +336,7 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+          "args": [],
           "timeout": 30
         }
       ]
@@ -364,7 +375,8 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-failure.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-failure.sh",
+          "args": []
         }
       ]
     }
@@ -395,7 +407,8 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/batch-summary.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/batch-summary.sh",
+          "args": []
         }
       ]
     }
@@ -433,7 +446,8 @@ Stdout from `UserPromptExpansion` (like `UserPromptSubmit` and `SessionStart`) i
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-denial-and-retry.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-denial-and-retry.sh",
+          "args": []
         }
       ]
     }
@@ -475,7 +489,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-notification.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-notification.sh",
+          "args": []
         }
       ]
     }
@@ -505,7 +520,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-subagent-start.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-subagent-start.sh",
+          "args": []
         }
       ]
     }
@@ -644,7 +660,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-task.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-task.sh",
+          "args": []
         }
       ]
     }
@@ -712,7 +729,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/save-context.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/save-context.sh",
+          "args": []
         }
       ]
     }
@@ -744,7 +762,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.sh",
+          "args": []
         }
       ]
     }
@@ -773,7 +792,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-instructions-loaded.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-instructions-loaded.sh",
+          "args": []
         }
       ]
     }
@@ -802,7 +822,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-config-change.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-config-change.sh",
+          "args": []
         }
       ]
     }
@@ -837,7 +858,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-cwd-change.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on-cwd-change.sh",
+          "args": []
         }
       ]
     }
@@ -878,7 +900,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/reload-env.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/reload-env.sh",
+          "args": []
         }
       ]
     }
@@ -919,7 +942,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/svn-checkout.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/svn-checkout.sh",
+          "args": []
         }
       ]
     }
@@ -950,7 +974,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/svn-cleanup.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/svn-cleanup.sh",
+          "args": []
         }
       ]
     }
@@ -979,7 +1004,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-api-error.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-api-error.sh",
+          "args": []
         }
       ]
     }
@@ -1008,7 +1034,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/restore-context.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/restore-context.sh",
+          "args": []
         }
       ]
     }
@@ -1039,7 +1066,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-elicitation.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-elicitation.sh",
+          "args": []
         }
       ]
     }
@@ -1068,7 +1096,8 @@ When `retry: true`, Claude Code adds a message telling the model it may retry th
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-elicitation-result.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-elicitation-result.sh",
+          "args": []
         }
       ]
     }
@@ -1091,6 +1120,7 @@ Set `once: true` on a hook to fire it only once per session, regardless of how m
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/first-write-notification.sh",
+          "args": [],
           "once": true
         }
       ]

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/hook-patterns.md
@@ -16,6 +16,7 @@ Create output directories and initialize environment at session start:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup-session.sh",
+          "args": [],
           "timeout": 30
         }
       ]
@@ -66,6 +67,7 @@ Auto-format code after file modifications:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format-code.sh",
+          "args": [],
           "timeout": 30
         }
       ]
@@ -121,6 +123,7 @@ Log all tool operations:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log-operation.py",
+          "args": [],
           "timeout": 5
         }
       ]
@@ -178,6 +181,7 @@ Validate code before git commits:
         {
           "type": "validation",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/pre-commit-check.sh",
+          "args": [],
           "timeout": 60
         }
       ]
@@ -253,6 +257,7 @@ Add context to user prompts:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/inject-context.sh",
+          "args": [],
           "timeout": 10
         }
       ]
@@ -293,6 +298,7 @@ Clean up on session end:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.sh",
+          "args": [],
           "timeout": 15
         }
       ]
@@ -332,11 +338,13 @@ Multiple hooks for the same event:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+          "args": []
         },
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/log.sh",
+          "args": []
         }
       ]
     }
@@ -360,7 +368,8 @@ Show custom status text during tool execution:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/status-message.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/status-message.sh",
+          "args": []
         }
       ]
     }
@@ -400,6 +409,7 @@ Fire a hook only once per session using `once: true`:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/first-modification-alert.sh",
+          "args": [],
           "once": true
         }
       ]
@@ -422,7 +432,8 @@ Use `ask` to escalate uncertain decisions to the user:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/risk-assessment.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/risk-assessment.sh",
+          "args": []
         }
       ]
     }
@@ -469,6 +480,7 @@ Run a linter automatically when specific config files change on disk:
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/relint-on-config-change.sh",
+          "args": [],
           "async": true,
           "timeout": 60
         }
@@ -514,7 +526,8 @@ In auto mode, log classifier denials and tell the model it may retry when approp
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/bash-denial-handler.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/bash-denial-handler.sh",
+          "args": []
         }
       ]
     }
@@ -565,7 +578,8 @@ Enforce task-subject conventions and log created tasks for observability:
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/track-task-creation.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/track-task-creation.sh",
+          "args": []
         }
       ]
     }
@@ -618,7 +632,8 @@ Block direct invocation of a skill or command unless a precondition is met. `Pre
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-deploy.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/guard-deploy.sh",
+          "args": []
         }
       ]
     }
@@ -667,7 +682,8 @@ Inject one summary message after a batch of parallel tool calls instead of N per
       "hooks": [
         {
           "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/batch-summary.sh"
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/batch-summary.sh",
+          "args": []
         }
       ]
     }

--- a/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/06-hooks/writing-hooks.md
@@ -50,7 +50,9 @@ Or inline in `plugin.json`:
 | matcher | string | No | Pattern to filter when the matcher group fires (see Matcher Patterns) |
 | hooks | array | **Yes** | Array of hook handlers |
 | type | string | **Yes** | Handler type: `command`, `http`, `mcp_tool`, `prompt`, or `agent` |
-| command | string | For command | Shell command to execute |
+| command | string | For command | Executable (exec form) or shell command (shell form). See [Exec form vs shell form](#exec-form-vs-shell-form). |
+| args | string[] | No | Argument list. When present, `command` is resolved as an executable and spawned directly with `args` as the argument vector — no shell. **Prefer this whenever the hook references a path placeholder**, since each element is passed as one argument with no quoting. |
+| shell | string | No | `"bash"` (default) or `"powershell"`. Selects the shell for shell form on Windows; ignored when `args` is set. |
 | prompt | string | For prompt/agent | LLM prompt (`$ARGUMENTS` for context) |
 | if | string | No | Permission-rule syntax (e.g. `"Bash(git *)"`, `"Edit(*.ts)"`) to pre-filter tool events before spawning the handler. See [The `if` Field](#the-if-field). |
 | timeout | number | No | Timeout in seconds (default varies by type) |
@@ -59,21 +61,77 @@ Or inline in `plugin.json`:
 | statusMessage | string | No | Message shown in the TUI while the hook runs |
 | once | boolean | No | Fires once per session then is removed. Only honored in skill frontmatter; ignored in settings/agent frontmatter. |
 
+## Exec Form vs Shell Form
+
+A command hook runs in **exec form** when the `args` field is set, and **shell form** when `args` is omitted. The shape you choose determines whether a shell tokenizes the command — and whether path placeholders need quoting.
+
+Set `args` whenever the hook references a [path placeholder](#environment-variables) like `${CLAUDE_PLUGIN_ROOT}`. Omit `args` when you need shell features (pipes, `&&`, redirects, globs).
+
+### Exec form (preferred for path placeholders)
+
+```json
+{
+  "type": "command",
+  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+  "args": ["--fix"]
+}
+```
+
+- `command` resolves as an executable on `PATH` and is spawned directly.
+- No shell tokenization. Each `args` element is one argument exactly as written.
+- Placeholders (`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_DATA}`) are substituted into `command` and each `args` element as plain strings.
+- Apostrophes, `$`, backticks, and other special characters pass through verbatim.
+- No quoting needed for paths with spaces.
+
+### Shell form (use for pipes, redirects, conditional chains)
+
+```json
+{
+  "type": "command",
+  "command": "[ -d \"${CLAUDE_PLUGIN_DATA}/node_modules\" ] || npm install --prefix \"${CLAUDE_PLUGIN_DATA}\""
+}
+```
+
+- `command` is passed to a shell: `sh -c` on macOS and Linux, Git Bash on Windows (or PowerShell when Git Bash isn't installed). Set `shell` to choose explicitly.
+- The shell tokenizes, expands variables, and interprets pipes / `&&` / redirects / globs.
+- **Wrap every placeholder in double quotes** so paths with spaces don't split.
+
+### Windows caveat
+
+In exec form, `command` must resolve to a **real executable** (e.g. a `.exe`). The `.cmd` and `.bat` shims that npm/npx/eslint install in `node_modules/.bin` are **not** executables and cannot be spawned without a shell. To run them in exec form, invoke the underlying script with `node` directly:
+
+```json
+{
+  "type": "command",
+  "command": "node",
+  "args": ["${CLAUDE_PLUGIN_ROOT}/node_modules/eslint/bin/eslint.js"]
+}
+```
+
+The `node` + script-path pattern works on every platform because `node.exe` is a real binary. To run a `.cmd` / `.bat` shim by its bare name, use shell form.
+
+### Bare-name + whitespace warning
+
+In exec form, if `command` is a bare name (no path separator) and contains whitespace alongside `args`, Claude Code logs a warning because the spawn will fail — there is no executable named `node script.js`. Move the extra tokens into `args`. Absolute paths with spaces, such as `C:\Program Files\nodejs\node.exe`, are a single valid executable and do not trigger the warning.
+
 ## Hook Handler Types
 
 Five handler types are available. Each serves a different complexity level. (`agent` is upstream-marked **experimental** — behavior may change.)
 
 ### 1. Command Hook
 
-Execute a shell script. Receives JSON on stdin with event context. Returns exit code + stdout.
+Execute a script or binary. Receives JSON on stdin with event context. Returns exit code + stdout.
 
 ```json
 {
   "type": "command",
   "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+  "args": [],
   "timeout": 30
 }
 ```
+
+The `"args": []` puts this hook in [exec form](#exec-form-vs-shell-form). Omit `args` if you need shell features (pipes, `&&`); see the form comparison above.
 
 **Stdin JSON** includes: `hook_event_name`, `tool_name`, `tool_input`, `tool_output` (varies by event), and an `effort` object (`{ "level": "low" | "medium" | "high" | "xhigh" | "max" }`) on tool-use-context events when the current model supports effort. The same level is exported as the `$CLAUDE_EFFORT` env var to command hooks and Bash-tool subprocesses — adapt verbosity or invocation depth to it.
 
@@ -251,7 +309,8 @@ The `if` field avoids the "spawn a process just to check and exit 0" anti-patter
       "hooks": [
         {
           "type": "command",
-          "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-rm.sh"
+          "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-rm.sh",
+          "args": []
         }
       ]
     }
@@ -270,7 +329,8 @@ The script itself checks whether the command is `rm *` and exits 0 otherwise. Ev
         {
           "type": "command",
           "if": "Bash(rm *)",
-          "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-rm.sh"
+          "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-rm.sh",
+          "args": []
         }
       ]
     }
@@ -338,6 +398,7 @@ Available in hook scripts:
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -349,7 +410,8 @@ Available in hook scripts:
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-bash.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-bash.sh",
+            "args": []
           }
         ]
       }
@@ -361,6 +423,7 @@ Available in hook scripts:
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -393,6 +456,7 @@ Available in hook scripts:
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.sh",
+            "args": [],
             "timeout": 10
           }
         ]
@@ -401,6 +465,74 @@ Available in hook scripts:
   }
 }
 ```
+
+## JSON Output Return Fields
+
+Exit codes let you allow or block; JSON output gives finer-grained control. Exit 0 and print a JSON object on stdout — Claude Code parses these fields:
+
+| Field | Description |
+|-------|-------------|
+| `continue` | If `false`, Claude stops processing entirely after the hook runs. Takes precedence over any event-specific decision. |
+| `stopReason` | Message shown to the user when `continue` is `false`. Not shown to Claude. |
+| `suppressOutput` | If `true`, omits stdout from the debug log. |
+| `systemMessage` | Warning message shown to the user. Use for user-facing notes the hook needs to surface. |
+| `terminalSequence` | Allowlisted OSC escape sequence Claude Code emits on the hook's behalf — desktop notification, window title, bell. Requires v2.1.141. See [Terminal sequences](#terminal-sequences). |
+| `hookSpecificOutput.additionalContext` | String injected into Claude's context (system reminder). The insertion point depends on the event. |
+
+Choose **one** approach per hook: either exit codes alone, or exit 0 + JSON. Claude Code only processes JSON on exit 0; if you exit 2, the JSON is ignored.
+
+> **10,000-character output cap:** Hook output strings — `additionalContext`, `systemMessage`, and plain stdout — are capped at 10,000 characters. Output that exceeds this limit is saved to a file and replaced with a preview plus file path, the same way large tool results are handled. Plan around this when logging verbose diffs or test output.
+
+### No controlling terminal (v2.1.139+)
+
+On macOS and Linux, command hooks run in their own session **without a controlling terminal** as of v2.1.139. The hook process and any child processes:
+
+- **Cannot** open `/dev/tty`.
+- **Cannot** send escape sequences directly to the Claude Code interface.
+
+Windows has no `/dev/tty`. To surface a message to the user on any platform:
+
+- Return `systemMessage` for a plain warning message.
+- Return `terminalSequence` to ring the bell, set a window title, or fire a desktop notification.
+
+### Terminal sequences
+
+`terminalSequence` requires Claude Code v2.1.141 or later. The field accepts an allowlisted OSC escape sequence; anything outside the allowlist is rejected and the field is ignored.
+
+Allowlist:
+
+- OSC `0`, `1`, `2`: window and icon titles
+- OSC `9`: iTerm2, ConEmu, Windows Terminal, WezTerm notifications (including `9;4` taskbar progress)
+- OSC `99`: Kitty notifications
+- OSC `777`: urxvt, Ghostty, Warp notifications
+- Bare BEL
+
+Sequences may terminate with BEL or ST. CSI cursor/color sequences, OSC palette sequences, OSC 8 hyperlinks, OSC 52 clipboard writes, and OSC 1337 are **rejected**.
+
+Example — fire a desktop notification from a `Notification` hook:
+
+```bash
+#!/bin/bash
+input=$(cat)
+title="Claude Code"
+body=$(jq -r '.message // "Needs your attention"' <<<"$input")
+seq=$(printf '\033]777;notify;%s;%s\007' "$title" "$body")
+jq -nc --arg seq "$seq" '{terminalSequence: $seq}'
+```
+
+Use `printf` octal escapes so the control bytes never appear on the shell command line, and `jq -n --arg` so quotes/backslashes in the body are escaped correctly. `terminalSequence` is the supported replacement for hooks that previously wrote escape sequences directly to `/dev/tty`.
+
+## Hook Execution Order & Precedence
+
+When multiple hooks match the same event:
+
+- **All matching hooks run in parallel.** There is no sequential ordering across handlers, matcher groups, or settings layers. If you need ordered execution, combine the logic into a single script.
+- **Identical handlers are deduplicated.** Command hooks are deduplicated by their `command` string **and** `args` array; HTTP hooks are deduplicated by URL. If the same plugin and a user `settings.json` define the same command + args, it runs once.
+- **PreToolUse decision precedence is `deny > defer > ask > allow`.** When multiple PreToolUse hooks return different decisions, Claude Code resolves to the strictest. A single `deny` wins over any number of `allow` votes.
+- **`continue: false` overrides event-specific decisions.** Any handler can stop the conversation entirely; the event's normal decision logic is ignored.
+- **`additionalContext` is additive.** When several hooks return `additionalContext` for the same event, Claude receives all of the values. Values over 10K characters are written to a file with a preview passed inline.
+
+> Common misconception: "most restrictive setting wins." The rule is parallel-then-merge with the specific precedence above, not a settings-layer override.
 
 ## Hook Scripts
 

--- a/plugin-creation-tools/skills/plugin-creation/templates/hooks/hooks.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/hooks/hooks.json.template
@@ -1,12 +1,14 @@
 {
   "description": "Plugin hooks for [purpose]",
   "hooks": {
+    "// Exec form": "Command hooks below set `args` (often `[]`), which puts them in exec form: `command` resolves to an executable on PATH and is spawned directly, with each `args` element passed as one argument and no shell tokenization. Prefer exec form for any hook that references a path placeholder — `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PROJECT_DIR}` / `${CLAUDE_PLUGIN_DATA}` are substituted into `command` and into each `args` element with no quoting needed. Omit `args` to fall back to shell form when you need pipes or `&&`. See references/06-hooks/writing-hooks.md.",
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -19,6 +21,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -33,7 +36,8 @@
           {
             "type": "command",
             "if": "Bash(rm *)",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-destructive-rm.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-destructive-rm.sh",
+            "args": []
           }
         ]
       }
@@ -44,13 +48,14 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.sh",
+            "args": [],
             "timeout": 15
           }
         ]
       }
     ],
 
-    "// HTTP hook example": "Use type: http to call a webhook instead of a local command",
+    "// HTTP hook example": "Use type: http to call a webhook instead of a local command. http hooks are valid only in settings.json — not in hooks.json — and are silently ignored if placed here. The schema below is shown for reference only.",
     "InstructionsLoaded": [
       {
         "hooks": [
@@ -93,6 +98,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on_config_change.sh",
+            "args": [],
             "timeout": 15,
             "statusMessage": "Reloading configuration..."
           }
@@ -105,6 +111,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/worktree_setup.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -116,6 +123,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/worktree_cleanup.sh",
+            "args": [],
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary

First release of the [consolidated 2026-05-12 roadmap](../blob/main/docs-not-present). Catches up on the Claude Code v2.1.139 → v2.1.144 hook revolution and ships paired validator rules so the same regressions can't reappear in other plugins.

Scope per the roadmap (one release per PR):
- Plugin docs + templates migrated to current hook authoring patterns
- New validator rules H05–H13 (paired with `--fix` machinery for H05/H06/H10)
- One minor version bump (3.4.1 → 3.5.0)

## What changed

### Plugin docs + templates

- **`writing-hooks.md`** gains three new sections:
  - "Exec form vs shell form" — `args` field, Windows `.cmd`/`.bat` caveat, bare-name + whitespace warning
  - "JSON Output Return Fields" — `continue` / `stopReason` / `suppressOutput` / `systemMessage` / `terminalSequence` (with OSC allowlist) / `additionalContext`, 10,000-character output cap, no controlling terminal (v2.1.139+)
  - "Hook Execution Order & Precedence" — parallel-then-merge, dedup by `command`+`args`, PreToolUse `deny > defer > ask > allow`
- **`hook-events.md`** gets a top-of-file callout summarising the three v2.1.139+ rules; 25 representative examples migrated to exec form
- **`hook-patterns.md`** — 16 examples migrated to exec form
- **`hooks.json.template`** (canonical scaffold) — exec form throughout, inline note explaining the choice
- **Plugin's own `hooks/hooks.json`** (self-application) — PreCompact hook migrated to exec form
- **`full-featured-plugin` example** — intentionally stays in shell form for the cross-platform `.cmd` wrapper, with an inline note pointing at the upstream Windows caveat (Hooks Reference §329)

### Validator rules (commands/validate.md)

| Rule | Severity | `--fix` | Catches |
|---|---|---|---|
| **H05** | warn | yes | Command hook with `${CLAUDE_*}` placeholder but no `args` → suggest exec form |
| **H06** | warn | yes | Bare `$CLAUDE_*` inside JSON command strings → `${CLAUDE_*}` (script files exempted) |
| **H07** | warn | — | Placeholder quoting in shell-form command strings |
| **H08** | info | — | Broad-matcher tool hooks missing `if` (info, not warn — some authors spawn intentionally) |
| **H09** | warn | — | `if` field on non-tool events (silently ignored) |
| **H10** | warn | yes | `updatedMCPToolOutput` → `updatedToolOutput` |
| **H11** | info | — | `SessionStart` doing one-time install → suggest `Setup` |
| **H12** | **error** | — | Hook script writes to `/dev/tty` (broken since v2.1.139) |
| **H13** | warn | — | Best-effort heuristic on hook output approaching the 10K cap |

### `--fix` machinery

Opt-in, atomic (tempfile + rename), reversible via `git`. Every fix appended to `.claude-plugin/.validate-fixes.log` (timestamp + rule ID + summary). Three rules ship with `--fix` in v3.5.0: H05, H06, H10. Later releases extend it.

### Metadata

- `plugin.json`: `3.4.1` → `3.5.0`
- Root `marketplace.json`: `metadata.version` `1.14.39` → `1.14.40`; plugin entry version + description rewritten as an elevator pitch + v3.5.0 highlight (down from a ~3500-char history dump)
- `CHANGELOG.md`: v3.5.0 entry with the full task list
- `README.md`: compatibility line `2.1.119` → `2.1.144`; hook bullet expanded with exec form / JSON output / 10K cap / no controlling terminal / parallel-then-merge precedence
- `CLAUDE.md`: Drift to Watch list gains 5 new items (command-form pair, output cap, controlling-terminal note, terminal-sequence allowlist, PreToolUse decision precedence)
- `SKILL.md`: brief mention of exec form + no controlling terminal in the Hooks section

## Validation

- ✅ `claude plugin validate` (upstream) — no new errors. Pre-existing `CLAUDE.md root-info` warning and `SKILL.md frontmatter` parse error remain unchanged (the latter is caused by the protected `!\`backticks\`` dynamic-context injection — see the CLAUDE.md anti-pattern list).
- ✅ All JSON templates and example `hooks.json` files parse with `json.loads`.
- ✅ All command/agent frontmatters parse with PyYAML. Fixed one regression I introduced (`argument-hint` with multiple bracket tokens needed quoting).
- ✅ JSON snippets inside `06-hooks/*.md` parse where they're complete (some are intentionally fragmentary).

## Validator rule hits against ecosystem plugins (paper-trace, dry-run)

Read-only scan against current `hooks.json` files (no `--fix` applied here — see below):

| Plugin | H05 | H06 | H08 | H10 | H11 | H12 | H13 |
|---|---|---|---|---|---|---|---|
| drupal-dev-framework | likely fires (multiple PreCompact / UserPromptSubmit hooks reference `${CLAUDE_PLUGIN_ROOT}` in shell form) | clean | likely fires on broad-matcher Write/UserPromptSubmit | clean | n/a | n/a | n/a |
| brand-content-design | likely fires (shell-form `${CLAUDE_PLUGIN_ROOT}` PreCompact hook) | clean | clean | clean | n/a | n/a | n/a |
| code-quality-tools | likely fires (shell-form `${CLAUDE_PLUGIN_ROOT}` PreCompact hook) | clean | clean | clean | n/a | n/a | n/a |

A separate `chore/ecosystem-hook-migration` PR will run `--fix` against these and surface the actual diff for review.

## Notes

- **Rule-ID divergence between roadmap (H05–H13) and enforcement-design §4** — the next release should pick one canonical ID space and reconcile. Not a blocker.
- **`PostToolBatch` and `Setup` documentation** in `hook-events.md` was already current per the gap deep dive §1 inventory; the v3.5.0 contribution there is just the top-of-file callout linking to the new writing-hooks sections.
- **Ecosystem migration is deliberately a separate PR** per the no-half-measures + real-smoke-tests feedback memos.

## Test plan

- [ ] `claude plugin validate ~/workspace/claude_memory/marketplaces/camoa-skills/plugin-creation-tools` — no v3.5.0 regressions
- [ ] `/plugin-creation-tools:validate` (self-apply) on this branch — exercise the new H-rules manually
- [ ] Sanity-check: the canonical scaffolds (`hooks.json.template`, `full-featured-plugin/hooks/hooks.json`, plugin self `hooks/hooks.json`) emit no H05/H06/H07/H10 warnings
- [ ] Spot-check the JSON output return fields section against `Hooks Reference` lines 561, 690, 703–743
- [ ] Spot-check the execution-order section against `Hooks Reference` lines 441 + 1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)