### PR TITLE
plugin-creation-tools v3.6.0: Layout & Discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.40"
+    "version": "1.14.41"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Authoritative quality gate + authoring guide for Claude Code plugins. Covers all 29 hook events (Setup, WorktreeCreate/WorktreeRemove, PostToolBatch, UserPromptExpansion, …), five handler types (command / http / mcp_tool / prompt / agent), the if pre-spawn filter, the effort.level adaptive-effort input + $CLAUDE_EFFORT env var, experimental.themes / experimental.monitors manifest migration, $schema field, array-only agents, channels, bin/ auto-discovery, plugin-root settings.json (agent + subagentStatusLine), userConfig with type/title schema, skillOverrides, claude plugin prune + --plugin-url + --plugin-dir, Plugin Hints, workspace-trust gating, allowCrossMarketplaceDependenciesOn, forked subagents, Agent SDK, REVIEW.md v2, Routines auto-validate. v3.5.0 ships **Hook Authoring Depth**: exec form (`args` field) preferred for path placeholders, `systemMessage` / `terminalSequence` JSON output (v2.1.139+ no controlling terminal), 10,000-character output cap, parallel-then-merge execution with `deny > defer > ask > allow` PreToolUse precedence — and seven paired validator rules (H05 shell→exec form with `--fix`; H06 `$VAR`→`${VAR}` with `--fix`; H08 broad-matcher missing `if`; H09 `if` on non-tool events; H10 updatedMCPToolOutput → updatedToolOutput with `--fix`; H11 SessionStart install → Setup; H12 hook writes to `/dev/tty` is an error; H13 hook output >10K). Opt-in `--fix` flag with `.claude-plugin/.validate-fixes.log` audit trail.",
-      "version": "3.5.0",
+      "description": "Authoritative quality gate + authoring guide for Claude Code plugins. Covers all 29 hook events, five handler types, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, parallel-then-merge precedence, recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, experimental.themes / experimental.monitors migration, $schema field, array-only agents, channels, bin/ auto-discovery, plugin-root settings.json (agent + subagentStatusLine), userConfig with type/title schema, skillOverrides, claude plugin prune + --plugin-url + --plugin-dir, Plugin Hints, workspace-trust gating, allowCrossMarketplaceDependenciesOn, forked subagents, Agent SDK, REVIEW.md v2, Routines auto-validate. v3.5.0 shipped Hook Authoring Depth + 7 paired validator rules (H05–H13) with opt-in `--fix`. v3.6.0 adds Layout & Discovery: 5 paired validator rules (A02 subfolder scoped-id awareness; A03 missing `name` on subfolder agents; ST04 redundant `skills: [\"./\"]` on auto-discovered single-skill plugins; ST05 manifest path doesn't exist; ST06 manifest override leaves a populated default folder ignored), `init_plugin.py` refactored to read the canonical `templates/plugin.json.template` (kills divergence). Auto-fix audit trail at `.claude-plugin/.validate-fixes.log`.",
+      "version": "3.6.0",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
-  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter, the `mcp_tool` handler type, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, and parallel-then-merge precedence), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate. v3.5.0 ships hook authoring depth + 7 paired validator rules (H05–H13) with opt-in `--fix`.",
-  "version": "3.5.0",
+  "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter, the `mcp_tool` handler type, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, and parallel-then-merge precedence), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate. v3.5.0 added hook authoring depth + 7 paired validator rules (H05–H13). v3.6.0 adds layout & discovery: recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, and 5 paired validator rules (A02 / A03 / ST04 / ST05 / ST06). `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding a divergent string.",
+  "version": "3.6.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-05-19
+
+**Theme: Layout & Discovery.** Second release of the consolidated 2026-05-12 roadmap. Catches up on plugin-author-relevant layout features (recursive `agents/` subfolder scoping, single-skill-at-root auto-discovery) and kills one of the longest-standing divergences — `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding its own truncated copy.
+
+Snapshot baseline: Claude Code v2.1.144, `~/workspace/claude_memory/guides/claude/` refreshed 2026-05-12 (`552b666`). No upstream-version bump from v3.5.0.
+
+### Added — Recursive `agents/` subfolder scoping
+
+- `references/05-agents/writing-agents.md`: new section "Organizing Agents Into Subfolders" — covers recursive scanning, the **plugin-specific** scoped-id behavior (`agents/review/security.md` → `my-plugin:review:security`), contrast with project/user scopes (where subfolders are organizational only), and the `name`-uniqueness-across-tree rule.
+- `references/10-distribution/packaging.md`: layout diagram updated with a subfolder example and an inline note distinguishing plugin scope from project/user scope.
+- `skills/plugin-creation/SKILL.md`: the directory-structure block now annotates `agents/` with the recursive-scan + scoped-id behavior.
+
+Source: Subagents guide L181–183.
+
+### Added — Single-skill-at-root auto-discovery (v2.1.142+)
+
+- `references/08-configuration/plugin-json.md`: new item #4 in "Important Path Rules" — a plugin with `SKILL.md` at root + no `skills/` subdir + no `skills` field is auto-loaded as a single-skill plugin. No need for `"skills": ["./"]`.
+- `references/10-distribution/packaging.md`: flat-layout diagram added beside the standard layout, with the "migrate to standard when you add a second component" caveat.
+- `skills/plugin-creation/SKILL.md`: brief mention in the plugin-init section pointing at the plugin-json.md rule.
+
+Source: Plugins Reference L530, L532.
+
+### Added — v2.1.140+ `/doctor` ignored-folder semantics
+
+- `references/08-configuration/plugin-json.md`: "Important Path Rules" item #1 rewritten. **The previous text said "Custom paths SUPPLEMENT default directories" — this was wrong.** For `commands`, `agents`, `outputStyles`, `experimental.themes`, `experimental.monitors`, custom paths **replace** the default. Only `skills` adds; `hooks` / `mcpServers` / `lspServers` have their own merge rules. The rule now explicitly cites the v2.1.140+ tooling that surfaces the ignored folder in `/doctor`, `claude plugin list`, and the `/plugin` detail view.
+- `skills/plugin-creation/SKILL.md` troubleshooting row updated: the "components missing" symptom now mentions `/doctor` will name the folder being skipped.
+
+Source: Plugins Reference L515–523.
+
+### Refactored — `init_plugin.py` reads the canonical template
+
+The script's embedded `PLUGIN_JSON_TEMPLATE` string had drifted from `templates/plugin.json.template` since v3.4.0 — it lacked `$schema`, lacked the commented `experimental.*` / `userConfig` / `channels` blocks, lacked `bin/` / `settings.json` notes, and lacked the array-form guidance. A user who invoked the script got a manifest that disagreed with what the docs and templates teach.
+
+Fix: `_render_plugin_json()` reads `templates/plugin.json.template`, strips the `//` documentation comments, parses the remaining JSON, substitutes the plugin name, and writes. The same source-of-truth file is rendered no matter where the user invokes `init_plugin.py` from.
+
+A related v3.5.0 miss is also patched: the embedded `HOOKS_TEMPLATE` now uses exec form (`"args": []`) on its three example command hooks, matching the canonical `templates/hooks/hooks.json.template`. This is a retroactive v3.5.0 fix; functional behavior of the scaffolded hooks is identical (exec form is semantically equivalent for these script invocations).
+
+Source: gap §2.1.
+
+### Added — Validator rules A02, A03, ST04, ST05, ST06
+
+`commands/validate.md` gains:
+
+- **A02 (info)** — Agent file under an `agents/` subfolder; emit a note that the scoped id includes the subfolder so the author can confirm the `name` field matches the label they expect users to type after the colons.
+- **A03 (warn)** — Agent file under an `agents/` subfolder missing the `name` frontmatter field. The agent loads with empty metadata and can't be invoked by scoped id.
+- **ST04 (info)** — Single-skill-at-root plugin (`SKILL.md` at plugin root, no `skills/` subdir) with a redundant `"skills": ["./"]` manifest field — the field is unnecessary as of v2.1.142+.
+- **ST05 (warn)** — Manifest references a folder that doesn't exist (typo catcher).
+- **ST06 (info)** — Manifest sets a "Replaces the default" field to a custom path AND the matching default folder still has files. Those files are silently ignored at runtime; `/doctor` flags this in v2.1.140+.
+
+The "Agents" validation section also gains an opener noting that plugin `agents/` is scanned **recursively** — older validator runs that only walked the top level missed subfolder agents.
+
+### Updated
+
+- `plugin.json` 3.5.0 → 3.6.0; description appended with v3.6.0 highlight.
+- Root `marketplace.json` `metadata.version` 1.14.40 → 1.14.41. Plugin entry version bumped + description tightened (now ~1200 chars, down from 1400+).
+
+### Notes
+
+- **`init_plugin.py` MARKETPLACE_JSON_TEMPLATE intentionally stays embedded.** The canonical `templates/marketplace.json.template` is a multi-plugin example (git-subdir / npm / pip sources) — not the right shape for a freshly-scaffolded single-plugin marketplace. Reading the canonical there would make the scaffold worse, not better. Roadmap §2.1 only called out the `plugin.json` divergence.
+- **Smoke test ran**: `init_plugin.py smoke-test --path /tmp --components skill,hook` — the rendered `plugin.json` contains `$schema`, the `repository` placeholder, and the keywords array, all from the canonical template. JSON parses; structure matches `templates/plugin.json.template` byte-for-byte after comment stripping.
+- **Ecosystem migration still deferred** to a `chore/ecosystem-layout-migration` follow-up PR. A02/A03/ST06 are most likely to fire against drupal-dev-framework (recursive `agents/` + several `agents` manifest entries) and brand-content-design (similar structure).
+- **Out of scope** (parked per roadmap): v3.6.1 metadata/tools (`displayName`, Task* family, `WaitForMcpServers`, $schema auto-fix); v3.6.2 skill guidance (effort.level skill examples, workspace-trust UI gate, listing budget framing); v3.7.0 cross-plugin session-remembrance helper.
+
 ## [3.5.0] - 2026-05-19
 
 **Theme: Hook Authoring Depth.** First release of the consolidated roadmap (2026-05-12). Catches up on the v2.1.139 → v2.1.144 hook revolution and ships paired enforcement rules so the same regressions can't reappear in other plugins.

--- a/plugin-creation-tools/CLAUDE.md
+++ b/plugin-creation-tools/CLAUDE.md
@@ -39,6 +39,10 @@ Every revision must keep these counts in sync between SKILL.md, `commands/valida
 - **Terminal sequence allowlist** (OSC `0`/`1`/`2`/`9`/`99`/`777` + BEL — anything else is rejected and the field is ignored).
 - **PreToolUse decision precedence** (`deny > defer > ask > allow`) and parallel-then-merge across all matching hooks.
 - Plugin component types (skills, commands, agents, hooks, mcpServers, lspServers, outputStyles, **`experimental.themes`**, **`experimental.monitors`** — themes and monitors are upstream-marked experimental and live under the `experimental.*` key; top-level still loads but `claude plugin validate` warns).
+- **Path-field replacement semantics** (`commands` / `agents` / `outputStyles` / `experimental.themes` / `experimental.monitors` **replace** the default; only `skills` **adds**; `hooks` / `mcpServers` / `lspServers` have their own merge rules). v2.1.140+ surfaces ignored defaults in `/doctor`, `claude plugin list`, and the `/plugin` detail view.
+- **Recursive `agents/` scanning + plugin-scoped subfolder ids** (subfolders join the scoped id with colons: `agents/review/security.md` → `my-plugin:review:security`). Project/user scopes do NOT join subfolders; this is plugin-only behavior.
+- **Single-skill-at-root auto-discovery** (v2.1.142+): `SKILL.md` at the plugin root + no `skills/` subdir + no `skills` field is auto-loaded as a single-skill plugin; the `"skills": ["./"]` field becomes redundant.
+- **Canonical templates source-of-truth**: `init_plugin.py` reads `templates/plugin.json.template` rather than embedding its own. Don't add new manifest fields in the script — add them to the template; the script will pick them up.
 - Reserved marketplace names list.
 - The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).
 

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -48,6 +48,28 @@ Log entry format:
 - [ ] CHANGELOG.md exists at plugin root
 - [ ] **Info** (not warning) if a `CLAUDE.md` is present at the plugin root: "Plugin-root `CLAUDE.md` is NOT loaded as project context. Instructions belong in a skill — put them in `skills/<name>/SKILL.md` so they reach Claude. The file is fine to keep as authoring reference (this plugin uses it that way)."
 
+#### ST04 — Redundant `skills: ["./"]` on a single-skill-at-root plugin (info)
+
+When a plugin has all three of: (a) `SKILL.md` at the plugin root, (b) no `skills/` subdirectory, AND (c) a manifest `skills` field set to exactly `["./"]` (or `"./"`), emit info:
+
+> "This plugin is auto-loaded as a single-skill plugin (v2.1.142+) when `SKILL.md` lives at the root and no `skills/` subdirectory exists. The `\"skills\": [\"./\"]` field is redundant — Claude Code discovers the root `SKILL.md` automatically. The field still works; you can remove it to declutter the manifest."
+
+#### ST05 — Manifest references a folder that doesn't exist (warn)
+
+For every path in `commands`, `agents`, `skills`, `outputStyles`, `experimental.themes`, `experimental.monitors`, resolve it against the plugin root and check the target exists. Missing target → warn:
+
+> "Plugin manifest references `<path>` which does not exist under the plugin root. Common cause: typo (`agents/` ↔ `agents`, `agnets/`, `commnads/`) or a folder that was renamed but not updated in `plugin.json`."
+
+Skip glob-style entries (`./commands/*.md`) — those are evaluated at load time and an empty match is not an error.
+
+#### ST06 — Manifest path overrides a populated default folder (info)
+
+For each "Replaces the default" field (`commands`, `agents`, `outputStyles`, `experimental.themes`, `experimental.monitors`), if the manifest sets a **custom** path that is NOT `./<default>/` or a sub-path of `./<default>/`, AND the default folder at `./<default>/` exists AND contains files matching the expected extension, emit info:
+
+> "Plugin manifest overrides `<field>` to `<custom-path>` but `<default-folder>/` is also populated. Those files will be **silently ignored** at runtime — the `<field>` field replaces the default for this component type (only `skills` adds). v2.1.140+ flags this in `/doctor`, `claude plugin list`, and the `/plugin` detail view. Either remove the default folder, or include it in the manifest array: `\"<field>\": [\"./<default>/\", \"<custom-path>\"]`."
+
+Heuristic exclusion: don't fire when the manifest path resolves into the default folder (e.g. `"commands": ["./commands/deploy.md"]`) — that's the explicit-address case upstream documents as not warning-worthy.
+
 ### plugin.json Schema Migration (soft-breaking — `experimental.*`)
 - [ ] **Warning** if top-level `themes` or `monitors` is set in `plugin.json`: "`themes` / `monitors` should live under `experimental.*`. `claude plugin validate` flags this and a future release will require the nested form." Offer an auto-migration diff that wraps both keys under an `experimental` object (preserve existing values, deduplicate if `experimental.themes` / `experimental.monitors` is already partially set).
 - [ ] **Warning** if `agents` is a bare string path: "The `agents` field is array-only. Wrap the path in an array: `\"agents\": [\"./agents/foo.md\"]`."
@@ -101,12 +123,31 @@ Log entry format:
 - [ ] `allowed-tools` field present
 - [ ] No inline code with backtick+exclamation or backtick+at-sign that could trigger execution
 
-### Agents (for each `agents/*.md`)
-- [ ] Valid YAML frontmatter — invalid frontmatter causes agent to load with no metadata at runtime
-- [ ] `name` field present
-- [ ] `description` field present (includes delegation triggers)
-- [ ] `tools` field present
-- [ ] `model` field present (haiku, sonnet, opus, or inherit)
+### Agents (for each `agents/**/*.md`)
+
+Plugin `agents/` directories are scanned **recursively** (Claude Code v2.x+). Walk every `.md` file under `agents/`, not just the top level.
+
+- [ ] **A01 (error)** — Valid YAML frontmatter. Invalid frontmatter causes agent to load with no metadata at runtime.
+- [ ] **(error)** — `name` field present.
+- [ ] **(error)** — `description` field present (includes delegation triggers).
+- [ ] **(warn)** — `tools` field present.
+- [ ] **(warn)** — `model` field present (haiku, sonnet, opus, or inherit).
+
+#### A02 — Subfolder agents and the scoped id (info)
+
+When an agent file sits under a subfolder of `agents/` (e.g. `agents/review/security.md`), the resulting plugin-scoped id includes the subfolder path — `<plugin>:review:security`, not `<plugin>:security`. If the agent's frontmatter `name` field differs in a way that suggests the author didn't realise the subfolder is part of the id, emit info:
+
+> "Agent `agents/<subfolder>/<file>.md` registers as `<plugin>:<subfolder>:<name>` (the subfolder joins the scoped id in plugins — unlike project/user scopes where the subfolder is purely organizational). Confirm the `name` field is the agent label you want users to invoke after the colons."
+
+Heuristic: only fire when a subfolder is present AND the frontmatter `name` doesn't naturally include the subfolder as a prefix.
+
+#### A03 — Subfolder agent missing `name` frontmatter (warn)
+
+When an agent file sits under an `agents/` subfolder AND its frontmatter is missing the `name` field, emit warn:
+
+> "Agent `agents/<subfolder>/<file>.md` has no `name` frontmatter — it loads with empty metadata at runtime and cannot be invoked by the scoped id. Add `name: <invocation-label>` to the frontmatter."
+
+Flat-layout agents missing `name` are already caught by the general A01-family check; A03 is the subfolder-aware variant that flags the scoped-id breakage explicitly.
 
 ### Themes (for each `themes/*.json`)
 - [ ] Valid JSON — invalid JSON is an **error** (theme will not load)

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -65,7 +65,7 @@ python scripts/init_plugin.py my-plugin --path ./plugins --components skill,comm
    ├── .claude-plugin/
    │   └── plugin.json
    ├── commands/        # if needed
-   ├── agents/          # if needed
+   ├── agents/          # if needed (recursively scanned — subfolders join the scoped id, e.g. agents/review/security.md → my-plugin:review:security)
    ├── skills/          # if needed
    │   └── skill-name/
    │       └── SKILL.md
@@ -73,6 +73,8 @@ python scripts/init_plugin.py my-plugin --path ./plugins --components skill,comm
    │   └── hooks.json
    └── .mcp.json        # if needed
    ```
+
+   **Single-skill minimum layout (v2.1.142+)**: if the plugin is exactly one skill and nothing else, put `SKILL.md` at the plugin root with no `skills/` subdirectory and no `skills` field — Claude Code auto-discovers it. See `references/08-configuration/plugin-json.md` § Important Path Rules item 4.
 
 2. Copy template from `templates/plugin.json.template`
 
@@ -301,7 +303,7 @@ Before creating a component, verify it's the right choice:
 | Cross-marketplace dependency rejected at install | Root marketplace's `marketplace.json` is missing `allowCrossMarketplaceDependenciesOn` | Add the target marketplace name to the root marketplace's `allowCrossMarketplaceDependenciesOn` array. Trust does not chain — only the **root** marketplace's allowlist is consulted. See `references/08-configuration/marketplace-json.md`. |
 | Version mismatch errors after release | `version` drifted between `plugin.json` and the marketplace entry | Bump both. The validator enforces this. Use `claude plugin tag` (run from inside the plugin folder) to create the `{plugin-name}--v{version}` git tag dependents resolve against. |
 | Frontmatter `hooks` / `mcpServers` ignored on a plugin agent | Plugin-packaged agents silently strip `hooks` / `mcpServers` / `permissionMode` for security | Move the hooks to `hooks/hooks.json` at the plugin root, or scope them via SKILL.md frontmatter. (For agents launched via `--agent` from project-local `.claude/agents/`, those fields fire as of v2.1.117+.) |
-| `--debug` shows the plugin loading but components missing | Custom `commands` / `skills` / `agents` paths in `plugin.json` replace defaults — they don't supplement | When you set a custom path for a component, the default directory is no longer scanned. Either remove the override or include the default path in the array. |
+| `--debug` shows the plugin loading but components missing | Custom `commands` / `agents` / `outputStyles` / `experimental.themes` / `experimental.monitors` paths in `plugin.json` **replace** defaults — they don't supplement. (`skills` is the only exception — it **adds** to the default `skills/` directory.) | When you set a custom path for a "Replaces the default" field, the default directory is no longer scanned. Either remove the override or include the default path in the array. **v2.1.140+ surfaces the ignored folder in `/doctor`, `claude plugin list`, and the `/plugin` detail view** — those tools name the folder being skipped, which is the fastest way to spot a misconfigured manifest. |
 
 For a symptom-first walkthrough of "what state is the runtime actually in," see the upstream **Debug Your Config** guide (`/context`, `/memory`, `/doctor`, `/hooks`, `/mcp`, `/skills`, `/permissions`, `/status`).
 

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/writing-agents.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/writing-agents.md
@@ -13,6 +13,46 @@ plugin-name/
     └── performance-analyst.md
 ```
 
+## Organizing Agents Into Subfolders
+
+Claude Code scans plugin `agents/` directories **recursively**, so a plugin with many agents can group them into topic subfolders:
+
+```
+my-plugin/
+└── agents/
+    ├── review/
+    │   ├── security.md
+    │   └── style.md
+    ├── research/
+    │   ├── api-finder.md
+    │   └── pattern-finder.md
+    └── code-reviewer.md
+```
+
+**Plugin agents — subfolder becomes part of the scoped id.** Unlike project (`.claude/agents/`) and user (`~/.claude/agents/`) scopes — where the subdirectory path is ignored and identity comes only from the frontmatter `name` field — **plugin** subfolders are joined into the [scoped identifier](#) with colons:
+
+| Plugin file path | Scoped id |
+|---|---|
+| `agents/code-reviewer.md` | `my-plugin:code-reviewer` |
+| `agents/review/security.md` | `my-plugin:review:security` |
+| `agents/research/api-finder.md` | `my-plugin:research:api-finder` |
+
+The scoped id is what users type in the picker (`@agent-my-plugin:review:security`) or pass to `--agent` (`claude --agent my-plugin:review:security`).
+
+**Identity rules**:
+
+- The agent's **invocation name** still comes from the `name` frontmatter field, exactly like flat-layout agents. Don't rely on the filename.
+- `name` must be **unique across the whole `agents/` tree**. Two files in different subfolders that declare the same `name` aren't disambiguated by the subfolder — Claude Code keeps one and discards the other without warning. Use the subfolder for **organization**, not for namespacing collisions away.
+- Project and user agents in subfolders have no scoped-id distinction (the subfolder is purely organisational). Don't carry the assumption over.
+
+**When to use subfolders**:
+
+- The plugin ships more than ~6–8 agents and they fall into clear topic clusters.
+- You want the scoped picker to read naturally (`my-plugin:review:security` is more discoverable than a flat `my-plugin:security-review`).
+- You want grouped agents to be obviously related at the file level.
+
+If your plugin only has 1–4 agents, keep them flat in `agents/` — the subfolder structure adds friction without payoff.
+
 ## Basic Structure
 
 ```markdown

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -254,9 +254,23 @@ The `lspServers` field configures Language Server Protocol servers for code inte
 
 ## Important Path Rules
 
-1. **Custom paths SUPPLEMENT default directories**
-   - If `commands/` exists, it's loaded automatically
-   - Custom paths add to (don't replace) defaults
+1. **Custom paths REPLACE the default for most fields — only `skills` adds.**
+
+   Whether a custom path replaces or extends the plugin's default directory depends on the field. This is the rule that surprises the most plugin authors, so memorize it:
+
+   | Behavior | Fields |
+   |---|---|
+   | **Replaces the default** — the default folder is no longer scanned | `commands`, `agents`, `outputStyles`, `experimental.themes`, `experimental.monitors` |
+   | **Adds to the default** — the default folder is always scanned, and listed paths are loaded alongside it | `skills` |
+   | **Own merge rules** — see each section below | `hooks`, `mcpServers`, `lspServers` |
+
+   For "Replaces the default" fields, to keep the default AND add more, list it explicitly:
+
+   ```json
+   { "commands": ["./commands/", "./extras/"] }
+   ```
+
+   **v2.1.140+ surfaces ignored defaults in tooling**: when a plugin sets a custom path for a "Replaces the default" field AND the matching default folder still exists with files, Claude Code flags the ignored folder in `/doctor`, `claude plugin list`, and the `/plugin` detail view. The plugin still loads using the manifest paths — the default folder's files are simply not scanned. No warning fires when the manifest key points **into** the default folder (e.g. `"commands": ["./commands/deploy.md"]`), because the folder is addressed explicitly.
 
 2. **All paths relative to plugin root**
    - Must start with `./`
@@ -265,6 +279,24 @@ The `lspServers` field configures Language Server Protocol servers for code inte
 3. **Use forward slashes**
    - Works across all platforms
    - Example: `./path/to/file.md`
+
+4. **Single-skill-at-root auto-discovery (v2.1.142+)**
+
+   A plugin with **all three** of:
+
+   - `SKILL.md` at the plugin root
+   - no `skills/` subdirectory
+   - no `skills` field in `plugin.json`
+
+   is **automatically** loaded as a single-skill plugin. You do **not** need `"skills": ["./"]` for this layout. The skill's invocation name comes from the frontmatter `name` field, with the directory basename as a fallback.
+
+   This is the minimum-overhead shape for plugins that ship exactly one skill and nothing else. Use it when:
+
+   - The plugin is a single skill — no commands, no agents, no hooks.
+   - You want users to discover the skill by the plugin name without an extra subdirectory hop.
+   - You don't anticipate adding more skills (if you do, migrate later to `skills/<name>/SKILL.md`).
+
+   Adding a manifest `skills` field on top of the root-`SKILL.md` layout is redundant; the validator flags it as info-level noise.
 
 ## Environment Variables and Path Substitution
 

--- a/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/10-distribution/packaging.md
@@ -31,8 +31,12 @@ plugin-name/
 │   └── plugin.json          # Required
 ├── commands/                 # Optional
 │   └── *.md
-├── agents/                   # Optional
-│   └── *.md
+├── agents/                   # Optional — scanned recursively; subfolders join the scoped id
+│   ├── *.md                  #   (e.g. agents/review/security.md → my-plugin:review:security)
+│   └── review/               # Subfolder organization for plugins with many agents
+│       └── security.md       #   — only plugin scope joins subfolders into the id;
+│                             #   project (.claude/agents/) and user (~/.claude/agents/)
+│                             #   scopes ignore the subfolder path.
 ├── skills/                   # Optional
 │   └── skill-name/
 │       └── SKILL.md
@@ -55,6 +59,21 @@ plugin-name/
 ├── CHANGELOG.md             # Recommended
 └── LICENSE                  # Recommended
 ```
+
+**Single-skill plugins (v2.1.142+) can use a flatter layout** — `SKILL.md` at the plugin root with no `skills/` subdirectory and no `skills` manifest field is auto-discovered as a single-skill plugin. Use this when the plugin ships exactly one skill and nothing else:
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json          # Required
+├── SKILL.md                 # Auto-loaded — no `skills/` subdir, no `skills` field needed
+├── references/              # Skill's progressive-disclosure references (optional)
+├── scripts/                 # Skill's bundled scripts (optional)
+├── README.md
+└── LICENSE
+```
+
+If you later add a command, agent, or second skill, migrate to the standard `skills/<name>/SKILL.md` layout — the flat layout is for the single-skill case only.
 
 ## Validation Script
 

--- a/plugin-creation-tools/skills/plugin-creation/scripts/init_plugin.py
+++ b/plugin-creation-tools/skills/plugin-creation/scripts/init_plugin.py
@@ -21,16 +21,48 @@ import json
 from pathlib import Path
 
 
-PLUGIN_JSON_TEMPLATE = """{
-  "name": "%s",
-  "version": "1.0.0",
-  "description": "Brief description of plugin purpose",
-  "author": {
-    "name": "Your Name"
-  },
-  "license": "MIT"
-}
-"""
+# Path to the canonical plugin.json template that the docs and scaffolds teach.
+# Resolved at runtime relative to this script's location, so the same source-
+# of-truth file is rendered no matter where the user invokes init_plugin.py
+# from.
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
+PLUGIN_JSON_TEMPLATE_PATH = TEMPLATE_DIR / "plugin.json.template"
+
+
+def _render_plugin_json(plugin_name):
+    """
+    Render the canonical templates/plugin.json.template for `plugin_name`.
+
+    The template file ships JSON-with-//-comments so it can document optional
+    fields inline. We strip the comment lines, parse the remainder as JSON,
+    and substitute the plugin name — guaranteeing the scaffold and the docs
+    teach the same shape (channels, bin/, settings.json notes, $schema, the
+    commented experimental.* / userConfig blocks, etc.).
+    """
+    raw = PLUGIN_JSON_TEMPLATE_PATH.read_text()
+
+    # Strip lines whose first non-whitespace token starts a // comment, and
+    # blank lines that follow such stripped blocks. We deliberately leave
+    # the multi-line commented-out JSON blocks (// "experimental": {...}) on
+    # the floor — those are documentation, not config.
+    cleaned_lines = []
+    for line in raw.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("//"):
+            continue
+        cleaned_lines.append(line)
+    cleaned = "\n".join(cleaned_lines)
+
+    # The template has trailing whitespace lines between commented blocks
+    # which are fine. Collapse the run of empty lines to a single one for
+    # readability of the rendered file.
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+
+    # Parse to make sure we still have valid JSON, then re-serialize so we
+    # control formatting (2-space indent, no trailing newline before `}`).
+    parsed = json.loads(cleaned)
+    parsed["name"] = plugin_name
+    return json.dumps(parsed, indent=2) + "\n"
 
 SKILL_TEMPLATE = """---
 name: %s
@@ -112,6 +144,7 @@ HOOKS_TEMPLATE = """{
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup-output.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -124,6 +157,7 @@ HOOKS_TEMPLATE = """{
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/example-hook.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -135,6 +169,7 @@ HOOKS_TEMPLATE = """{
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.sh",
+            "args": [],
             "timeout": 30
           }
         ]
@@ -144,6 +179,8 @@ HOOKS_TEMPLATE = """{
 }
 """
 # Note: 'http' hook type is NOT supported in hooks.json — http hooks only work in settings.json.
+# Note: command hooks above use exec form ("args": []) — preferred for any hook that references
+# a path placeholder like ${CLAUDE_PLUGIN_ROOT}. See references/06-hooks/writing-hooks.md.
 
 SETUP_OUTPUT_SCRIPT = """#!/bin/bash
 # SessionStart hook - Create output directories and set env vars
@@ -346,7 +383,7 @@ def init_plugin(plugin_name, path, components=None):
         claude_plugin_dir = plugin_dir / '.claude-plugin'
         claude_plugin_dir.mkdir()
         (claude_plugin_dir / 'plugin.json').write_text(
-            PLUGIN_JSON_TEMPLATE % plugin_name
+            _render_plugin_json(plugin_name)
         )
         print("Created .claude-plugin/plugin.json")
         (claude_plugin_dir / 'marketplace.json').write_text(


### PR DESCRIPTION
## Summary

Second release of the [consolidated 2026-05-12 roadmap](https://github.com/camoa/claude-skills/blob/main/plugin-creation-tools/CHANGELOG.md). Catches up on plugin-author-relevant layout features and kills one of the longest-standing divergences — `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding a truncated copy.

Scope per the roadmap (one release per PR):
- Recursive `agents/` subfolder scoping documentation
- Single-skill-at-root auto-discovery documentation (v2.1.142+)
- v2.1.140+ `/doctor` ignored-folder semantics
- `init_plugin.py` refactor to canonical template
- 5 paired validator rules
- One minor version bump (3.5.0 → 3.6.0)

## What changed

### Plugin doc fixes

- **`writing-agents.md`** gains "Organizing Agents Into Subfolders": recursive scan, plugin-specific scoped-id (`agents/review/security.md` → `my-plugin:review:security`), contrast with project/user scopes where subfolders are organisational only.
- **`plugin-json.md`** "Important Path Rules" item #1 rewritten — **the old text was actively wrong** ("Custom paths SUPPLEMENT default directories"). Correct rule: `commands`/`agents`/`outputStyles`/`experimental.themes`/`experimental.monitors` **replace** the default; only `skills` adds; `hooks`/`mcpServers`/`lspServers` have their own merge rules. New item #4 covers single-skill-at-root auto-discovery (v2.1.142+).
- **`packaging.md`** — layout diagram annotated with subfolder example; flat single-skill layout added alongside the standard one.
- **`SKILL.md`** — directory-structure block annotates `agents/` recursive scan; new single-skill mention; troubleshooting row mentions `/doctor`.

### `init_plugin.py` refactor

- New `_render_plugin_json()` reads `templates/plugin.json.template`, strips `//` documentation comments, parses, substitutes the plugin name, writes.
- Eliminates the v3.4.0+ divergence: scaffolded `plugin.json` now ships `$schema`, `repository`, `keywords`, and the commented `experimental.*` / `userConfig` / `channels` blocks from the canonical template.
- **Bonus**: embedded `HOOKS_TEMPLATE` patched to exec form (retroactive v3.5.0 fix — the v3.5.0 sweep missed this).
- `MARKETPLACE_JSON_TEMPLATE` intentionally stays embedded: the canonical template is a multi-plugin/multi-source example, wrong shape for a fresh single-plugin scaffold.

### Validator rules

| Rule | Severity | What it catches |
|---|---|---|
| **A02** | info | Subfolder agent — surface the scoped id so author confirms `name` matches what users will type after the colons |
| **A03** | warn | Subfolder agent missing `name` frontmatter — agent loads with empty metadata, can't be invoked by scoped id |
| **ST04** | info | Redundant `"skills": ["./"]` on a single-skill-at-root plugin (v2.1.142+ auto-discovers) |
| **ST05** | warn | Manifest references a folder that doesn't exist (typo catcher) |
| **ST06** | info | Manifest "Replaces the default" path leaves the matching default folder populated — those files are silently ignored at runtime; v2.1.140+ flags in `/doctor` / `claude plugin list` / `/plugin` |

The Agents validation section opener also rewrote to note plugin `agents/` is scanned **recursively** — old validator passes that only walked the top level missed subfolder agents.

### Metadata

- `plugin.json`: `3.5.0` → `3.6.0`; description appended.
- Root `marketplace.json`: `metadata.version` `1.14.40` → `1.14.41`; plugin entry description tightened ~1400 → ~1200 chars.
- `CHANGELOG.md`: full v3.6.0 entry.
- `CLAUDE.md` Drift to Watch list gains 4 new items.

## Validation

- ✅ Smoke-tested `init_plugin.py`: `/tmp/init_plugin_smoke/smoke-test/.claude-plugin/plugin.json` now inherits `$schema`, `repository`, and `keywords` from the canonical template.
- ✅ `claude plugin validate` (upstream): no new regressions. Pre-existing `CLAUDE.md root-info` warning and `SKILL.md frontmatter` parse error remain unchanged (the latter is caused by the protected `!\`backticks\`` dynamic-context injection — anti-pattern in CLAUDE.md).
- ✅ All JSON templates and example `hooks.json` files parse.
- ✅ All command/agent frontmatters parse with PyYAML.

## Validator rule hits against ecosystem plugins (paper-trace, dry-run)

Expected fires (not run; reserved for `chore/ecosystem-layout-migration`):

| Plugin | A02 | A03 | ST04 | ST05 | ST06 |
|---|---|---|---|---|---|
| drupal-dev-framework | likely (`agents/` subfolders exist) | possibly (some agents may lack `name`) | n/a | unknown | **likely** (custom `agents` paths + populated `agents/`) |
| brand-content-design | unknown | unknown | n/a | unknown | possibly |
| code-quality-tools | n/a (flat `agents/`) | n/a | n/a | unknown | possibly |
| design-system-converter | unknown | unknown | n/a | unknown | unknown |

## Notes

- The pre-v3.6.0 "SUPPLEMENT" misstatement in `plugin-json.md` is one to flag in code review — it was actively misleading authors before this PR. The fix cites upstream Plugins Reference §515-523 directly.
- **A03 is brittle by design** — it only fires when `name` is missing entirely. The validator can't tell when `name` is present but doesn't match what the subfolder-derived scoped id suggests the author intended. Documented as a limitation in the roadmap "Notes from v3.6.0" section.
- Ecosystem migration follow-up: `chore/ecosystem-layout-migration` PR will run validate against each plugin and surface real ST05/ST06 hits.

## Test plan

- [ ] `claude plugin validate` on this branch — no v3.6.0 regressions
- [ ] `python3 .../scripts/init_plugin.py demo --path /tmp/demo` — confirm scaffolded `plugin.json` matches canonical template shape
- [ ] `/plugin-creation-tools:validate` (self-apply) — exercise new A/ST rules manually
- [ ] Spot-check writing-agents.md scoped-id table against Subagents guide L181–183
- [ ] Spot-check the new "Important Path Rules" item #1 against Plugins Reference §515–523

🤖 Generated with [Claude Code](https://claude.com/claude-code)