### PR TITLE
plugin-creation-tools v3.6.1: Metadata & Tool Catalogue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.41"
+    "version": "1.14.42"
   },
   "plugins": [
     {
@@ -36,7 +36,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Authoritative quality gate + authoring guide for Claude Code plugins. Covers all 29 hook events, five handler types, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, parallel-then-merge precedence, recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, experimental.themes / experimental.monitors migration, $schema field, array-only agents, channels, bin/ auto-discovery, plugin-root settings.json (agent + subagentStatusLine), userConfig with type/title schema, skillOverrides, claude plugin prune + --plugin-url + --plugin-dir, Plugin Hints, workspace-trust gating, allowCrossMarketplaceDependenciesOn, forked subagents, Agent SDK, REVIEW.md v2, Routines auto-validate. v3.5.0 shipped Hook Authoring Depth + 7 paired validator rules (H05–H13) with opt-in `--fix`. v3.6.0 adds Layout & Discovery: 5 paired validator rules (A02 subfolder scoped-id awareness; A03 missing `name` on subfolder agents; ST04 redundant `skills: [\"./\"]` on auto-discovered single-skill plugins; ST05 manifest path doesn't exist; ST06 manifest override leaves a populated default folder ignored), `init_plugin.py` refactored to read the canonical `templates/plugin.json.template` (kills divergence). Auto-fix audit trail at `.claude-plugin/.validate-fixes.log`.",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter, the `mcp_tool` handler type, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, and parallel-then-merge precedence), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate. v3.5.0 added hook authoring depth + 7 paired validator rules (H05–H13). v3.6.0 adds layout & discovery: recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, and 5 paired validator rules (A02 / A03 / ST04 / ST05 / ST06). `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding a divergent string.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] - 2026-05-19
+
+**Theme: Metadata & Tool Catalogue.** Third release of the consolidated 2026-05-12 roadmap. Brings the agent-tools catalogue and manifest-schema guidance current with v2.1.142+ tool churn, documents the skill listing budget, and ships seven new validator rules + extends `--fix` coverage to seven manifest/command auto-fixes.
+
+Snapshot baseline: Claude Code v2.1.144. No upstream-version bump from v3.6.0.
+
+### Added — Tool catalogue updates
+
+- `references/05-agents/agent-tools.md`:
+  - **`TaskStop`** row added under Agent and Task Operations (kills a running background task by ID).
+  - **`TodoWrite` deprecation callout**: disabled by default as of v2.1.142; pointer to `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate`; mention of the `CLAUDE_CODE_ENABLE_TASKS=0` escape hatch; warning that new content should not reference it (the validator's C01 flags it).
+  - **`EnterWorktree` / `ExitWorktree`** rows added (with the "not available to subagents" caveat).
+  - **`WaitForMcpServers`** row added (v2.1.142+; only appears when `ToolSearch` is disabled).
+  - New **Code Intelligence & Background Work** subsection covers **`LSP`** (code intelligence on edited files; not available to subagents) and **`Monitor`** (background command with per-line feedback; same permission rules as `Bash`; not available on Bedrock/Vertex/Foundry).
+
+### Added — `displayName` manifest field (v2.1.143+)
+
+- `templates/plugin.json.template`: commented optional `displayName` block added at the bottom of the metadata section.
+- `references/08-configuration/plugin-json.md`: new `displayName` row in the metadata fields table. Note: human-readable; may contain spaces and any casing; not used for namespacing or lookup; falls back to `name`.
+
+### Added — Skill listing budget guidance
+
+- `references/08-configuration/settings.md`: new "Skill listing budget" subsection documents `maxSkillDescriptionChars` (default 1,536) and `skillListingBudgetFraction` (default 0.01 = 1%) — both v2.1.105+. Explains why the budget exists (every line is recurring token cost), how `/doctor` surfaces truncation, and three plugin-author-relevant implications.
+- New `defaultMode: "auto"` security-change subsection: setting it in project/local settings is silently ignored as of v2.1.142 — repositories can't grant themselves auto mode.
+- `references/03-skills/description-patterns.md` gets a one-paragraph budget callout linking to settings.md.
+
+### Updated — License, keywords, repository guidance
+
+`references/08-configuration/plugin-json.md` metadata-fields table:
+
+- `license` row clarified: prefer SPDX identifiers (`MIT`, `Apache-2.0`, etc.); `"proprietary"` acceptable when paired with a private repository; non-SPDX values are surfaced by the validator at info level so the author confirms intent.
+- `keywords` row gets a soft cap of 25 (marketplace UI truncation + budget pressure).
+
+### Added — Validator rules M06 / M07 / M08 / M09 / M10 (with `--fix`) + M14 / M15 / M16 / C01 / C02 / X02 / X03
+
+`commands/validate.md` gains:
+
+- **M06 (info, `--fix`)** — Missing `$schema`. Auto-fix inserts the SchemaStore URL as the first key.
+- **M07 (warn, `--fix`)** — Top-level `themes` → `experimental.themes`. Auto-fix wraps under `experimental` with merge semantics (arrays concatenated and deduped; string + array coerced to array).
+- **M08 (warn, `--fix`)** — Top-level `monitors` → `experimental.monitors`. Same merge semantics as M07.
+- **M09 (warn, `--fix`)** — `agents` as string → array. Auto-fix wraps in `[...]`.
+- **M10 (info, `--fix`)** — `commands` / `skills` as string → array. Auto-fix wraps in `[...]`.
+- **M14 (info)** — Unknown top-level manifest keys (forward-compat catcher). Real-world example: drupal-dev-framework's `defaults` + `recommended`.
+- **M15 (warn)** — `keywords` array > 25 entries. Real ecosystem hit: brand-content-design ships 29.
+- **M16 (info)** — `license` not a recognized SPDX identifier and not `"proprietary"` + private repo. Real ecosystem hit: design-system-converter ships `"license": "proprietary"`.
+- **C01 (warn, `--fix`)** — `TodoWrite` referenced in command/skill/agent body or examples. Auto-fix performs literal text replacement in safe contexts (lists of tools) and flags ambiguous contexts (TodoWrite-specific argument shapes) for human review.
+- **C02 (warn, `--fix`)** — `/extra-usage` referenced (renamed to `/usage-credits`). Auto-fix performs literal rename. Source: Built-in Commands guide L127.
+- **X02 (warn)** — Marketplace per-plugin `description` > 600 characters. Real ecosystem hit: drupal-dev-framework was ~3,500 chars before v3.5.0/v3.6.0 trim. No auto-fix — trimming is a content decision.
+- **X03 (info)** — Marketplace root contains a plugin subdirectory not listed in `marketplace.json`. Surfaces feature-branch state for confirmation.
+
+### Updated
+
+- `plugin.json` 3.6.0 → 3.6.1; description unchanged (already covers H05–H13 and the layout/discovery items; the v3.6.1 additions slot under "metadata & tool catalogue" which is implied by the existing list).
+- Root `marketplace.json` `metadata.version` 1.14.41 → 1.14.42; plugin entry version bump.
+- `commands/validate.md` `--fix` rule list now: H05, H06, H10 (v3.5.0); M06, M07, M08, M09, M10, C01, C02 (v3.6.1).
+
+### Notes
+
+- **C02 verified against cached guides** — Built-in Commands guide L127 explicitly documents `/usage-credits` as the rename target ("Previously `/extra-usage`"). Auto-fix is a safe literal rename.
+- **M14 stays info, not warn.** Surfacing unknown keys is forward-compat reassurance, not a quality issue. Drupal-dev-framework's `defaults` / `recommended` keys are intentional and the validator says so.
+- **M15 keyword cap set at 25, not 30.** brand-content-design ships 29 keywords; the rule fires once. The enforcement-design note about possibly raising to 30 is parked — if more ecosystem plugins push past 25, revisit. For now, 25 is the cap a careful author should target.
+- **X02 deliberately stays warn, not error.** Existing plugins may need a content-rewrite cycle. Authors opt into hard enforcement via `--strict`.
+- **Ecosystem migration** for v3.6.1 paired rules deferred to `chore/ecosystem-metadata-migration` per the no-half-measures + real-smoke-tests memos. Expected hits: M06 (3/3 sampled plugins); M14 (DDF); M15 (brand-content-design); M16 (design-system-converter); X02 (DDF, pre-trim — already addressed in v3.5.0/v3.6.0 cycles).
+
 ## [3.6.0] - 2026-05-19
 
 **Theme: Layout & Discovery.** Second release of the consolidated 2026-05-12 roadmap. Catches up on plugin-author-relevant layout features (recursive `agents/` subfolder scoping, single-skill-at-root auto-discovery) and kills one of the longest-standing divergences — `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding its own truncated copy.

--- a/plugin-creation-tools/CLAUDE.md
+++ b/plugin-creation-tools/CLAUDE.md
@@ -43,6 +43,12 @@ Every revision must keep these counts in sync between SKILL.md, `commands/valida
 - **Recursive `agents/` scanning + plugin-scoped subfolder ids** (subfolders join the scoped id with colons: `agents/review/security.md` → `my-plugin:review:security`). Project/user scopes do NOT join subfolders; this is plugin-only behavior.
 - **Single-skill-at-root auto-discovery** (v2.1.142+): `SKILL.md` at the plugin root + no `skills/` subdir + no `skills` field is auto-loaded as a single-skill plugin; the `"skills": ["./"]` field becomes redundant.
 - **Canonical templates source-of-truth**: `init_plugin.py` reads `templates/plugin.json.template` rather than embedding its own. Don't add new manifest fields in the script — add them to the template; the script will pick them up.
+- **TodoWrite is disabled by default v2.1.142+** — new content uses `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate` / `TaskStop`. Validator rule C01 flags `TodoWrite` references.
+- **Skill listing budget**: per-skill cap `maxSkillDescriptionChars` (default 1,536); aggregate cap `skillListingBudgetFraction` (default 0.01 = 1%); descriptions for least-used skills collapse to bare names when the listing overflows. `/doctor` shows truncation count.
+- **`displayName` manifest field** (v2.1.143+) — optional, human-readable, falls back to `name`. Not used for namespacing/lookup.
+- **License hygiene** — prefer SPDX identifiers; `"proprietary"` only with private repository; validator M16 surfaces non-SPDX at info.
+- **Keywords cap** — soft cap 25; validator M15 warns past this (marketplace UI truncation + per-tag budget pressure).
+- **Marketplace per-plugin description cap** — soft cap 600 chars; validator X02 warns past this. Verbose history goes in CHANGELOG.md.
 - Reserved marketplace names list.
 - The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).
 

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -27,7 +27,7 @@ The validator gains an opt-in `--fix` flag that performs **only** mechanical, re
 - Is reversible via `git diff` / `git restore`
 - Requires user confirmation before any file is changed in this release
 
-Rules that ship with `--fix` in v3.5.0: **H05**, **H06**, **H10**. Other auto-fixable rules (M07/M08/M09/M10, C05/C06, etc.) land in later releases.
+Rules that ship with `--fix` (cumulative across releases): **H05**, **H06**, **H10** (v3.5.0); **M06**, **M07**, **M08**, **M09**, **M10**, **C01**, **C02** (v3.6.1). Future releases add more.
 
 Log entry format:
 
@@ -70,13 +70,39 @@ For each "Replaces the default" field (`commands`, `agents`, `outputStyles`, `ex
 
 Heuristic exclusion: don't fire when the manifest path resolves into the default folder (e.g. `"commands": ["./commands/deploy.md"]`) — that's the explicit-address case upstream documents as not warning-worthy.
 
-### plugin.json Schema Migration (soft-breaking — `experimental.*`)
-- [ ] **Warning** if top-level `themes` or `monitors` is set in `plugin.json`: "`themes` / `monitors` should live under `experimental.*`. `claude plugin validate` flags this and a future release will require the nested form." Offer an auto-migration diff that wraps both keys under an `experimental` object (preserve existing values, deduplicate if `experimental.themes` / `experimental.monitors` is already partially set).
-- [ ] **Warning** if `agents` is a bare string path: "The `agents` field is array-only. Wrap the path in an array: `\"agents\": [\"./agents/foo.md\"]`."
-- [ ] **Info** (not warning) if `commands` or `skills` is a bare string path: "The array form is preferred — `\"commands\": [\"./cmd.md\"]`. The string form still loads but is being phased out."
-- [ ] **Info** if `$schema` is missing: "Consider adding `\"$schema\": \"https://json.schemastore.org/claude-code-plugin-manifest.json\"` for editor autocomplete. Claude Code ignores the field at load time."
-- [ ] **Info** when `channels` is declared in `plugin.json`: each entry must have a `server` field that matches a key in the plugin's `mcpServers` (or an externally-known MCP server name). Flag a warning if `server` references an undeclared MCP server. Per-channel `userConfig` follows the same schema as the top-level `userConfig` — apply the same legacy/required checks.
-- [ ] **Info** when a `bin/` directory is present at the plugin root: confirm files are executable (warn on non-executable entries — they will appear on `PATH` but fail to run). Auto-discovered, no manifest entry needed.
+### plugin.json Schema Migration (M-series)
+
+- [ ] **M06 (info, `--fix`)** — `$schema` field missing. Auto-fix inserts `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` as the first key. Ignored by Claude Code at load time — purely for editor autocomplete.
+- [ ] **M07 (warn, `--fix`)** — Top-level `themes` should live under `experimental.themes`. Auto-fix wraps the key under an `experimental` object. **Merge semantics**: if `experimental.themes` already exists, combine the two values (arrays concatenated and deduped; mixed string + array coerced to an array). Preserve existing keys order. Upstream `claude plugin validate` also warns; we add the migration.
+- [ ] **M08 (warn, `--fix`)** — Top-level `monitors` → `experimental.monitors`. Same merge semantics as M07.
+- [ ] **M09 (warn, `--fix`)** — `agents` is a bare string path. Auto-fix wraps in `[...]`: `"agents": "./agents/foo.md"` → `"agents": ["./agents/foo.md"]`.
+- [ ] **M10 (info, `--fix`)** — `commands` or `skills` is a bare string path. Auto-fix wraps in `[...]`. The string form still loads but is being phased out.
+- [ ] **(info)** — `channels` declared in `plugin.json`: each entry must have a `server` field that matches a key in the plugin's `mcpServers` (or an externally-known MCP server name). Flag warning if `server` references an undeclared MCP server. Per-channel `userConfig` follows the top-level schema — apply the same legacy/required checks.
+- [ ] **(info)** — `bin/` directory present at the plugin root: confirm files are executable (warn on non-executable entries — they appear on `PATH` but fail to run). Auto-discovered, no manifest entry needed.
+
+#### M14 — Unknown top-level manifest keys (info)
+
+For each top-level key in `plugin.json` that is **not** in the documented schema (canonical list: `$schema`, `name`, `displayName`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`, `skills`, `hooks`, `mcpServers`, `lspServers`, `outputStyles`, `experimental`, `channels`, `userConfig`, `settings`, `dependencies`), emit info:
+
+> "Plugin manifest contains unknown top-level key `<name>`. Claude Code silently ignores keys not in the schema (forward-compatible). If this is intentional forward-compat or vendor-specific metadata, you can suppress this notice. Real-world example: `defaults`, `recommended` in drupal-dev-framework — both intentional, both load fine."
+
+Info only; never warn or error — surfacing for author confirmation, not enforcement.
+
+#### M15 — Keywords cap (warn)
+
+`keywords` array has more than **25** entries:
+
+> "Plugin manifest declares `<n>` keywords (cap: 25). Marketplace UIs typically truncate long keyword lists, and budget pressure on each keyword decreases the chance any single tag drives a match. Trim to your most distinctive 20–25 entries."
+
+This is the proposed cap from enforcement design — brand-content-design v3.3.1 ships 29 keywords as a real-world ecosystem hit.
+
+#### M16 — License is non-SPDX (info)
+
+`license` value is not a recognized SPDX identifier AND not the literal `"proprietary"`. Common SPDX values: `MIT`, `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `GPL-3.0-or-later`, `LGPL-3.0-or-later`, `MPL-2.0`, `CC-BY-4.0`, `CC0-1.0`, `Unlicense`, `ISC`. Info:
+
+> "Plugin manifest uses `<license-value>`, which is not a recognized SPDX identifier. Use an SPDX value when possible (https://spdx.org/licenses/) so marketplace UIs and license-scanners interpret it correctly. `\"proprietary\"` is acceptable when the repository is private and the value reflects company policy — the validator only surfaces this so you confirm intent."
+
+Info only — palcera/design-system-converter ships `"license": "proprietary"` intentionally.
 
 ### Plugin settings.json (if present at plugin root)
 - [ ] Valid JSON.
@@ -91,6 +117,24 @@ Heuristic exclusion: don't fire when the manifest path resolves into the default
 - [ ] No `..` path traversal in source paths (error if found)
 - [ ] No duplicate plugin names within the plugins array (error if found)
 - [ ] Each plugin's `version` in the marketplace entry matches the `version` in its `.claude-plugin/plugin.json` (error if drifted — reference `feedback_marketplace_json`)
+
+#### X02 — Marketplace per-plugin description >600 chars (warn)
+
+For each entry in the `plugins` array, if the `description` field exceeds 600 characters, emit warn:
+
+> "Marketplace entry for `<plugin-name>` has a `<n>`-character description (cap: 600). Marketplace UIs typically truncate at this length, so the long form is invisible to users browsing the catalog. Move the verbose history into the plugin's CHANGELOG.md and keep the marketplace description to a one-paragraph elevator pitch plus the latest release highlight."
+
+Real ecosystem hit: drupal-dev-framework v4.3.0 shipped a ~3,500-character description (multi-version changelog dump) before the v3.5.0 cycle trimmed it.
+
+**No auto-fix** — trimming a description is a content decision. The validator surfaces the issue and points at CHANGELOG.md as the destination.
+
+#### X03 — Marketplace entry missing for a plugin directory (info)
+
+When validating a marketplace root (a directory containing `.claude-plugin/marketplace.json` and subdirectories that look like plugins — each has its own `.claude-plugin/plugin.json`), for each subdirectory NOT referenced by an entry in the marketplace `plugins` array, emit info:
+
+> "Plugin directory `./<dir>/` has its own `plugin.json` but is not listed in `marketplace.json`. Add it to the `plugins` array to make it installable through this marketplace, or move it out of the marketplace root if it's an in-progress branch."
+
+Info only — sometimes a plugin lives in the marketplace root on a feature branch before it's added to `plugins`.
 
 ### Plugin Dependencies (if `dependencies` is declared in `plugin.json`)
 - [ ] `dependencies` is an array
@@ -122,6 +166,22 @@ Heuristic exclusion: don't fire when the manifest path resolves into the default
 - [ ] `description` field present
 - [ ] `allowed-tools` field present
 - [ ] No inline code with backtick+exclamation or backtick+at-sign that could trigger execution
+
+#### C01 — `TodoWrite` referenced in command/skill body or examples (warn, `--fix`)
+
+`TodoWrite` is disabled by default as of Claude Code v2.1.142 (replaced by the `Task*` family). For each command file, skill body, agent file, or referenced reference doc, grep for the literal token `TodoWrite`. Each hit emits warn:
+
+> "References `TodoWrite`, which is disabled by default as of Claude Code v2.1.142. Use `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate` instead. To re-enable `TodoWrite` for users on a managed environment, set `CLAUDE_CODE_ENABLE_TASKS=0`."
+
+**`--fix`**: literal text replacement of `TodoWrite` → `TaskCreate` in non-ambiguous contexts. The auto-fix flags **ambiguous** cases for human review rather than silently transforming them:
+
+- A sentence like "use `TodoWrite` to track session todos" → ambiguous (which Task* operation? Create? Update?). Flag, don't fix.
+- A list like "Available tools: Read, Write, TodoWrite, Bash" → safe to rewrite to `TaskCreate, TaskUpdate, TaskList, TaskGet` (the canonical replacement set). Auto-fix.
+- A code example using TodoWrite-specific arguments (e.g. `TodoWrite({ todos: [...] })`) → ambiguous; the Task* family has a different argument shape. Flag, don't fix.
+
+#### C02 — `/extra-usage` reference (warn, `--fix`)
+
+`/extra-usage` was renamed to `/usage-credits`. Literal references in command bodies, skill descriptions, agent prompts, and reference docs should be updated. Auto-fix performs the literal rename. Source: Built-in Commands guide L127 ("Previously `/extra-usage`").
 
 ### Agents (for each `agents/**/*.md`)
 

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/description-patterns.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/description-patterns.md
@@ -2,6 +2,8 @@
 
 The description field is the most critical part of a skill - it determines whether Claude loads your skill.
 
+> **Listing budget matters per-skill AND in aggregate.** Each description is capped at `maxSkillDescriptionChars` (default 1,536). Across all installed skills, the total listing is capped at `skillListingBudgetFraction` of the model's context window (default 1%). When the aggregate overflows, descriptions for the least-used skills are collapsed to bare names — losing the trigger phrasing Claude uses to route. Write descriptions tight enough to survive both caps. See `references/08-configuration/settings.md` § Skill listing budget for the tunable settings.
+
 ## The Formula
 
 Two valid structures (per Anthropic's official guide):

--- a/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/05-agents/agent-tools.md
@@ -59,8 +59,11 @@ Use `disallowedTools` when it is easier to exclude a few tools than to list all 
 | TaskUpdate | Update an existing task | Medium |
 | TaskList | List active tasks | Low |
 | TaskGet | Get task details and output | Low |
+| TaskStop | Kill a running background task by ID | Medium |
 | Skill | Invoke a preloaded skill | Low |
 | AskUserQuestion | Prompt the user for input | Low |
+
+> **`TodoWrite` is disabled by default as of Claude Code v2.1.142.** It used to manage the session task checklist; that role has moved to `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate`. To re-enable `TodoWrite`, set `CLAUDE_CODE_ENABLE_TASKS=0` in the environment. **Don't reference `TodoWrite` in new skills, commands, or agent prompts** — the validator's C01 rule flags it.
 
 ### Planning and Discovery
 
@@ -68,9 +71,19 @@ Use `disallowedTools` when it is easier to exclude a few tools than to list all 
 |------|---------|------------|
 | EnterPlanMode | Switch agent to read-only planning | Low |
 | ExitPlanMode | Leave planning mode | Low |
+| EnterWorktree | Create an isolated git worktree and switch into it (or switch into an existing worktree with `path`). **Not available to subagents.** | Medium |
+| ExitWorktree | Exit a worktree session and return to the original directory. **Not available to subagents.** | Low |
 | ToolSearch | Discover and load deferred tools | Low |
+| WaitForMcpServers | **v2.1.142+** Wait for MCP servers still connecting in the background so a request can use their tools without restarting the session. Only appears when [tool search](https://docs.anthropic.com/en/mcp#scale-with-mcp-tool-search) is **disabled** — `ToolSearch` handles the wait when enabled. | Low |
 | ListMcpResourcesTool | List available MCP resources | Low |
 | ReadMcpResourceTool | Read a specific MCP resource | Low |
+
+### Code Intelligence & Background Work
+
+| Tool | Purpose | Risk Level |
+|------|---------|------------|
+| LSP | Code intelligence via language servers: jump to definitions, find references, report type errors and warnings on edited files. **Not available to subagents.** | Low |
+| Monitor | Run a command in the background and feed each output line back to Claude — react to log entries, file changes, or polled status mid-conversation. Same permission rules as `Bash`. **Not available on Amazon Bedrock, Vertex AI, or Foundry**, nor when `DISABLE_TELEMETRY` / `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` is set. Available to subagents. | Medium |
 
 ## MCP Tool Access
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/plugin-json.md
@@ -62,11 +62,12 @@ The `name` field is the **only required field**.
 | `$schema` | string | JSON Schema URL for editor autocomplete and validation (e.g., `"https://json.schemastore.org/claude-code-plugin-manifest.json"`). Ignored by Claude Code at load time — purely a developer-ergonomics hint. |
 | version | string | Semantic version (e.g., "2.1.0") |
 | description | string | Brief explanation of plugin purpose |
+| `displayName` | string | **v2.1.143+** Human-readable name shown in the `/plugin` picker and other UI surfaces. Falls back to `name` when omitted. Unlike `name`, may contain spaces and any casing. Not used for namespacing or lookup. |
 | author | object/string | Author information |
 | homepage | string | Documentation URL |
 | repository | string | Source code URL |
-| license | string | SPDX identifier (MIT, Apache-2.0, etc.) |
-| keywords | array | Discovery tags |
+| license | string | SPDX identifier (`MIT`, `Apache-2.0`, `BSD-3-Clause`, `GPL-3.0-or-later`, etc.). Use `"proprietary"` only when the repository is private and the value reflects company policy. The validator surfaces non-SPDX values as info-level so you can confirm intent. |
+| keywords | array | Discovery tags. Keep to ≤ 25 entries — marketplace UIs truncate longer lists and the budget pressure isn't worth squeezing in another niche tag. |
 
 ### Author Object
 

--- a/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/08-configuration/settings.md
@@ -194,6 +194,34 @@ Set these environment variables in `.claude/settings.json`:
 | `MYPLUGIN_FEATURE_X` | `false` | Enable experimental feature X |
 ```
 
+### Skill listing budget (`maxSkillDescriptionChars`, `skillListingBudgetFraction`)
+
+Both settings shipped in Claude Code v2.1.105. Together they control how much of Claude's context is spent on skill descriptions each turn — relevant to plugin authors because **every line in the skill listing is a recurring token cost** on every model call.
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `maxSkillDescriptionChars` | `1536` | Per-skill character cap on the combined `description` + `when_to_use` text. Text past this is truncated. Raise to keep long descriptions intact at the cost of more context per turn; lower to fit more skills under the listing budget. |
+| `skillListingBudgetFraction` | `0.01` (1%) | Fraction of the model's context window reserved for the skill listing. When the listing exceeds this budget, descriptions for the **least-used** skills are collapsed to bare names (Claude can still invoke them but won't see why). |
+
+`/doctor` shows the current truncation count and which skills are affected — surface this in your plugin's README so users on small-context models know they can raise the budget.
+
+```json
+{
+  "maxSkillDescriptionChars": 2048,
+  "skillListingBudgetFraction": 0.02
+}
+```
+
+**Why this matters for plugin authors**:
+
+- If your plugin ships > 10 skills, you're contributing meaningfully to the user's listing budget. Keep each description tight and avoid duplicating WHEN-to-use phrasing.
+- If a user installs your plugin alongside 5 other large plugins, their listing may overflow and your least-used skill drops to name-only — losing the trigger phrasing Claude uses to route. Write descriptions that survive `name-only` (descriptive skill names matter more than they look).
+- Authors shipping niche skills (`framework-debug-foo`) can suggest the user raise `skillListingBudgetFraction` to `0.02`–`0.03` in the plugin README's "Recommended settings" section.
+
+### `defaultMode: "auto"` is ignored in project/local settings (v2.1.142+)
+
+As of Claude Code v2.1.142, setting `defaultMode: "auto"` in `.claude/settings.json` or `.claude/settings.local.json` is **silently ignored** — a repository cannot grant itself auto mode. To use auto mode, set it in `~/.claude/settings.json` (user scope) or pass `--permission-mode auto` on the CLI. Plugin authors should not document `defaultMode: "auto"` as a project-settings recommendation; it won't take effect.
+
 ### skillOverrides
 
 Per-skill visibility control without editing the skill's own SKILL.md. Useful for:

--- a/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/plugin.json.template
@@ -11,6 +11,11 @@
   "repository": "https://github.com/username/repo",
   "keywords": ["keyword1", "keyword2"]
 
+  // Optional: human-readable name shown in the /plugin picker and other UI
+  // surfaces (v2.1.143+). Falls back to "name" when omitted. May contain
+  // spaces and any casing. Not used for namespacing or lookup.
+  // "displayName": "Plugin Name"
+
   // Optional: experimental components have a manifest schema that may change
   // between releases while they stabilize. Top-level "themes" / "monitors"
   // still load but `claude plugin validate` emits a warning, and a future


### PR DESCRIPTION
## Summary

Third release of the [consolidated 2026-05-12 roadmap](https://github.com/camoa/claude-skills/blob/main/plugin-creation-tools/CHANGELOG.md). Brings the agent-tools catalogue and manifest-schema guidance current with Claude Code v2.1.142+ tool churn, documents the skill listing budget, and ships seven new validator rules plus extends `--fix` coverage to seven manifest/command auto-fixes.

Scope per the roadmap (one release per PR):
- Tool catalogue updates (TaskStop, EnterWorktree, ExitWorktree, WaitForMcpServers, LSP, Monitor; TodoWrite deprecation callout)
- `displayName` manifest field (v2.1.143+)
- Skill listing budget guidance + `defaultMode: "auto"` security change
- 7 paired validator rules + `--fix` extensions
- One patch version bump (3.6.0 → 3.6.1)

## What changed

### Plugin doc updates

- **`agent-tools.md`** — six new rows (TaskStop, EnterWorktree, ExitWorktree, WaitForMcpServers, LSP, Monitor) with subagent-availability caveats; `TodoWrite` deprecation callout (disabled by default v2.1.142+, escape hatch `CLAUDE_CODE_ENABLE_TASKS=0`, warning that new content should not reference it).
- **`plugin-json.md`** — `displayName` row added (v2.1.143+); `license` guidance expanded (SPDX preferred; `"proprietary"` only with private repo); `keywords` soft cap of 25.
- **`templates/plugin.json.template`** — optional `displayName` block.
- **`settings.md`** — new "Skill listing budget" subsection (`maxSkillDescriptionChars` 1,536 / `skillListingBudgetFraction` 0.01 = 1%); new `defaultMode: "auto"` security note (ignored in project/local scope as of v2.1.142).
- **`description-patterns.md`** — one-paragraph listing-budget callout linking to settings.md.

### Validator rules

| Rule | Severity | `--fix` | What it catches |
|---|---|---|---|
| **M06** | info | yes | Missing `$schema` — inserts SchemaStore URL |
| **M07** | warn | yes | Top-level `themes` → `experimental.themes` (merge: arrays concat + dedup) |
| **M08** | warn | yes | Top-level `monitors` → `experimental.monitors` (same merge) |
| **M09** | warn | yes | `agents` string → array |
| **M10** | info | yes | `commands` / `skills` string → array |
| **M14** | info | — | Unknown top-level manifest keys (forward-compat) |
| **M15** | warn | — | `keywords` array > 25 entries |
| **M16** | info | — | Non-SPDX `license` (and not `"proprietary"` + private repo) |
| **C01** | warn | yes | `TodoWrite` referenced — literal rewrite in safe contexts; flag ambiguous ones |
| **C02** | warn | yes | `/extra-usage` → `/usage-credits` literal rename (verified against Built-in Commands L127) |
| **X02** | warn | — | Marketplace per-plugin `description` > 600 chars |
| **X03** | info | — | Plugin dir in marketplace root not listed in `marketplace.json` |

**Cumulative `--fix` coverage**: H05, H06, H10 (v3.5.0); M06, M07, M08, M09, M10, C01, C02 (v3.6.1).

### Metadata

- `plugin.json` `3.6.0` → `3.6.1`.
- Root `marketplace.json` `metadata.version` `1.14.41` → `1.14.42`.
- `CHANGELOG.md` full v3.6.1 entry.
- `CLAUDE.md` Drift to Watch list gains 7 new items.

## Validation

- ✅ `claude plugin validate` (upstream): no new regressions. Pre-existing CLAUDE.md info-warning + SKILL.md frontmatter parse error remain (the latter is the protected `!\`backticks\`` dynamic-context injection — CLAUDE.md anti-pattern).
- ✅ `init_plugin.py` smoke-tested — scaffolded plugin.json structure unchanged (displayName remains optional/commented in the canonical template).
- ✅ C02 rename verified: Built-in Commands guide L127 explicitly says "Previously `/extra-usage`" for `/usage-credits`.
- ✅ All command/agent frontmatters parse with PyYAML.

## Ecosystem rule-fire forecast (paper-trace)

Expected hits (not run; reserved for `chore/ecosystem-metadata-migration`):

| Plugin | M06 | M14 | M15 | M16 | X02 |
|---|---|---|---|---|---|
| drupal-dev-framework | likely | likely (`defaults`, `recommended`) | unknown | unknown | already trimmed in v3.5.0/v3.6.0 |
| brand-content-design | likely | unknown | **yes** (29 keywords) | unknown | clean |
| code-quality-tools | likely | unknown | unknown | unknown | unknown |
| design-system-converter (palcera) | likely | unknown | unknown | **yes** (`"license": "proprietary"`) | clean |

## Notes

- **M14 keyword list is the canonical source-of-truth** for plugin.json top-level keys. When upstream adds new manifest fields, update this list **first** to avoid M14 false positives.
- **M15 keyword cap at 25**, not 30. brand-content-design at 29 is a real fire; we accept that one fire rather than raise the cap and lose signal.
- **M07/M08 auto-fix merge semantics matter** — when a plugin has BOTH top-level + `experimental.*` set, concatenate and dedup rather than overwrite. Documented in the roadmap notes.
- **C01 auto-fix flags ambiguous contexts** — `TodoWrite` in a sentence about session todos gets flagged for human review; `TodoWrite` in a "Available tools: …" list gets the literal rewrite.
- **X02 stays warn-not-error** to give existing plugins a content-rewrite cycle.

## Test plan

- [ ] `claude plugin validate` on this branch — no v3.6.1 regressions
- [ ] `/plugin-creation-tools:validate` self-apply — exercise M14/M15/M16 + C01/C02 manually
- [ ] Smoke `init_plugin.py` — confirm rendered plugin.json shape unchanged
- [ ] Spot-check the agent-tools.md new rows against Tools Reference §23–50
- [ ] Spot-check the listing-budget subsection against Settings L214/L232 + Skills guide L748–765

🤖 Generated with [Claude Code](https://claude.com/claude-code)