### PR TITLE
plugin-creation-tools v3.6.2: Skill & Authoring Guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.42"
+    "version": "1.14.43"
   },
   "plugins": [
     {
@@ -36,7 +36,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Authoritative quality gate + authoring guide for Claude Code plugins. Covers all 29 hook events, five handler types, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, parallel-then-merge precedence, recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, experimental.themes / experimental.monitors migration, $schema field, array-only agents, channels, bin/ auto-discovery, plugin-root settings.json (agent + subagentStatusLine), userConfig with type/title schema, skillOverrides, claude plugin prune + --plugin-url + --plugin-dir, Plugin Hints, workspace-trust gating, allowCrossMarketplaceDependenciesOn, forked subagents, Agent SDK, REVIEW.md v2, Routines auto-validate. v3.5.0 shipped Hook Authoring Depth + 7 paired validator rules (H05–H13) with opt-in `--fix`. v3.6.0 adds Layout & Discovery: 5 paired validator rules (A02 subfolder scoped-id awareness; A03 missing `name` on subfolder agents; ST04 redundant `skills: [\"./\"]` on auto-discovered single-skill plugins; ST05 manifest path doesn't exist; ST06 manifest override leaves a populated default folder ignored), `init_plugin.py` refactored to read the canonical `templates/plugin.json.template` (kills divergence). Auto-fix audit trail at `.claude-plugin/.validate-fixes.log`.",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter, the `mcp_tool` handler type, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, and parallel-then-merge precedence), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate. v3.5.0 added hook authoring depth + 7 paired validator rules (H05–H13). v3.6.0 adds layout & discovery: recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, and 5 paired validator rules (A02 / A03 / ST04 / ST05 / ST06). `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding a divergent string.",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2] - 2026-05-19
+
+**Theme: Skill & Authoring Guidance.** Fourth release of the consolidated 2026-05-12 roadmap — the last before the conditional v3.7.0. Sharpens skill-body authoring guidance, documents skill discovery semantics, fixes a stale description-cap number, and ships six skill-quality validator rules with explicit S-IDs.
+
+Snapshot baseline: Claude Code v2.1.144. No upstream-version bump from v3.6.1.
+
+### Added — `${CLAUDE_EFFORT}` adaptive-skill worked example
+
+- `references/03-skills/writing-skillmd.md`: new "Adaptive skills with `${CLAUDE_EFFORT}`" subsection — a worked SKILL.md body fragment that branches verbosity on the effort level (terse at `low`/`medium`, full checklist at `high`+). The substitution was already in the variables table; this adds the missing how-to.
+
+### Added — Skill discovery semantics
+
+- `references/03-skills/writing-skillmd.md`: new "Where Skills Live & How They're Discovered" section — a table covering plugin skills (incl. single-skill-at-root), project skills (`.claude/skills/` loads from the starting dir **and every parent up to repo root**), nested project skills (loaded **on demand** when Claude touches a subdirectory's files — the monorepo pattern), and user skills. Plus explicit monorepo guidance: repo-wide skills at the root, package-specific skills in each package's `.claude/skills/`.
+
+### Fixed — Stale description cap (1024 → 1536)
+
+The plugin claimed a flat "Max 1024 chars" for skill `description` in three places. The Claude Code **runtime** cap is `maxSkillDescriptionChars`, default **1,536** — text past it is silently truncated from the listing Claude sees. 1,024 is the stricter agentskills.io **portability** recommendation, a different thing.
+
+- `references/03-skills/writing-skillmd.md`: frontmatter table row rewritten to distinguish the two caps; completion-checklist line updated.
+- `references/quick-reference.md`: size-guidelines table updated — description max is now the 1,536 runtime cap (~1,024 for portability); SKILL.md body target/maximum updated to the warn-250 / error-500 model.
+- `references/03-skills/anthropic-skill-standards.md`: left at 1,024 — that file documents the agentskills.io standard, where 1,024 is correct.
+
+### Updated — Line-count guidance
+
+- `references/03-skills/writing-skillmd.md` "Line Count Target": was a flat "under 500 lines"; now "target under 250, hard ceiling 500" matching the validator's warn-250 / error-500 model, with an explicit note that mature 250–400-line skills are fine.
+
+### Added — Validator rules S04 / S05 / S10 / S11 / S12 / S13 (+ S-ID renumbering, ST03 tag)
+
+`commands/validate.md` Skills section renumbered with explicit S-IDs. New/changed rules:
+
+- **S04 (warn)** — Description has no trigger phrase ("Use when …") and no three-part WHAT/WHEN/NOT-FOR structure. Routing-critical; promoted to error under `--strict`.
+- **S05 (warn)** — Description exceeds `maxSkillDescriptionChars` (default 1,536; read from settings if set). Replaces the stale flat "max 1024" check.
+- **S10 (warn ≥ 250 / error ≥ 500)** — SKILL.md body length. Replaces the flat "under 500 lines" check with the two-threshold model. Configurable via `--max-skill-lines`.
+- **S11 (info)** — Body > 150 lines — conciseness nudge below the S10 warn threshold.
+- **S12 (warn)** — Project-scoped skill (`.claude/skills/`) declares `allowed-tools` but the body has no workspace-trust note. Targets the reader who decides whether to trust a repo. Plugin-shipped skills exempt.
+- **S13 (info)** — Nested skill directory (`skills/<name>/` containing a subdirectory with its own `SKILL.md`) — Claude Code discovers these recursively; usually unintended.
+- The existing plugin-root `CLAUDE.md` info rule is tagged **ST03** for cross-release ID consistency.
+
+### Updated
+
+- `plugin.json` 3.6.1 → 3.6.2.
+- Root `marketplace.json` `metadata.version` 1.14.42 → 1.14.43; plugin entry version bump.
+- `CLAUDE.md` Drift to Watch list: parent-directory skill discovery + the warn-250/error-500 line model added.
+
+### Notes
+
+- **S04 ships as warn, not error** — the roadmap's v3.6.2 task list says "S04 (error)", but enforcement-design §3/§13 reasons that a day-one hard error on missing trigger phrases would fail existing skills across the ecosystem. Soft-nudge adoption wins: warn by default, error under `--strict`. The roadmap's "Notes from v3.6.2" records this deliberate deviation.
+- **S10 thresholds (250/500)** follow enforcement-design §3/§13, not the roadmap's looser ">500" phrasing — §13 explicitly picks 250-warn/500-error to leave headroom for mature skills.
+- **This plugin's own `plugin-creation` SKILL.md is 334 lines** — it trips S10's new ≥250 warn. This is an **accepted self-finding**: it's a deliberately large hub skill with heavy progressive disclosure into `references/`. Not fixed; documented here and in the rule text. (The plugin's self-application gate in CLAUDE.md is "clean or all-warnings" — a warn is within bounds.)
+- **Ecosystem migration** for the S-rules deferred to `chore/ecosystem-skill-migration`. Expected: S10 warn fires on several mature skills across DDF / brand-content-design (the enforcement-design sample already noted `memory-manager` and `visual-content` near 400 lines).
+- **Out of scope** — v3.7.0 (cross-plugin session-remembrance helper) remains conditional on drupal-dev-framework shipping `/install-remembrance-hook` first.
+
 ## [3.6.1] - 2026-05-19
 
 **Theme: Metadata & Tool Catalogue.** Third release of the consolidated 2026-05-12 roadmap. Brings the agent-tools catalogue and manifest-schema guidance current with v2.1.142+ tool churn, documents the skill listing budget, and ships seven new validator rules + extends `--fix` coverage to seven manifest/command auto-fixes.

--- a/plugin-creation-tools/CLAUDE.md
+++ b/plugin-creation-tools/CLAUDE.md
@@ -49,6 +49,9 @@ Every revision must keep these counts in sync between SKILL.md, `commands/valida
 - **License hygiene** — prefer SPDX identifiers; `"proprietary"` only with private repository; validator M16 surfaces non-SPDX at info.
 - **Keywords cap** — soft cap 25; validator M15 warns past this (marketplace UI truncation + per-tag budget pressure).
 - **Marketplace per-plugin description cap** — soft cap 600 chars; validator X02 warns past this. Verbose history goes in CHANGELOG.md.
+- **Skill body line model** — target < 250 lines; validator S10 warns ≥ 250, errors ≥ 500. This plugin's own `plugin-creation` SKILL.md (~334 lines) trips the warn — an accepted self-finding (large hub skill, heavy progressive disclosure).
+- **Skill description caps** — runtime cap `maxSkillDescriptionChars` 1,536 (validator S05); agentskills.io portability target ~1,024. Don't conflate the two — 1,024 is a recommendation, 1,536 is the hard truncation point.
+- **Skill discovery** — project skills load from `.claude/skills/` in the starting dir AND every parent up to repo root; nested `.claude/skills/` load on demand (monorepo pattern).
 - Reserved marketplace names list.
 - The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).
 

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -46,7 +46,7 @@ Log entry format:
 - [ ] `description` present and not placeholder text
 - [ ] README.md exists at plugin root
 - [ ] CHANGELOG.md exists at plugin root
-- [ ] **Info** (not warning) if a `CLAUDE.md` is present at the plugin root: "Plugin-root `CLAUDE.md` is NOT loaded as project context. Instructions belong in a skill — put them in `skills/<name>/SKILL.md` so they reach Claude. The file is fine to keep as authoring reference (this plugin uses it that way)."
+- [ ] **ST03 (info)** — if a `CLAUDE.md` is present at the plugin root: "Plugin-root `CLAUDE.md` is NOT loaded as project context. Instructions belong in a skill — put them in `skills/<name>/SKILL.md` so they reach Claude. The file is fine to keep as authoring reference (this plugin uses it that way)."
 
 #### ST04 — Redundant `skills: ["./"]` on a single-skill-at-root plugin (info)
 
@@ -144,22 +144,72 @@ Info only — sometimes a plugin lives in the marketplace root on a feature bran
 - [ ] Pre-release ranges are only matched when the range opts in with a pre-release suffix (e.g. `^2.0.0-0`)
 - [ ] Use official error names when reporting: `range-conflict`, `dependency-version-unsatisfied`, `no-matching-tag` (align with `claude plugin list` output)
 
-### Skills (for each skill in `skills/*/`)
-- [ ] `SKILL.md` exists with valid YAML frontmatter — invalid frontmatter causes skill to load with no metadata at runtime
-- [ ] Frontmatter has `name` (hyphen-case, max 64 chars)
-- [ ] Frontmatter has `description` (starts with "Use when" or three-part structure, max 1024 chars)
-- [ ] Description includes WHAT it does AND WHEN to use it (trigger conditions)
-- [ ] Description uses third person (no "you")
-- [ ] No XML angle brackets (< >) in frontmatter (security restriction)
-- [ ] `compatibility` field valid if present (1-500 chars)
-- [ ] Body is instructions, not documentation (imperative voice)
-- [ ] Body under 500 lines
-- [ ] Body includes examples section with user scenarios (warning if missing)
-- [ ] Body includes troubleshooting/error handling section (warning if missing)
-- [ ] Referenced files in `references/` exist
-- [ ] Referenced scripts in `scripts/` exist
-- [ ] No README.md inside skill directories (belongs at plugin root)
-- [ ] **Info** when `allowed-tools` is present on a project-scoped skill (path matches `.claude/skills/`): "`.claude/skills/*` skills with `allowed-tools` only take effect after the workspace trust dialog is accepted. Review the skill carefully before trusting a repository — a skill can grant itself broad tool access this way." (Plugin-shipped skills are not subject to this — their trust is established at install time.)
+### Skills (for each skill in `skills/*/` — plus a root `SKILL.md` for single-skill plugins)
+
+- [ ] **S01 (error)** — `SKILL.md` exists with valid YAML frontmatter. Invalid frontmatter causes the skill to load with no metadata at runtime.
+- [ ] **S02 (error)** — Frontmatter has `name` (hyphen-case, max 64 chars).
+- [ ] **(error)** — `name` contains no reserved words (`anthropic`, `claude`).
+- [ ] **(warn)** — Description includes WHAT it does AND WHEN to use it (trigger conditions).
+- [ ] **(warn)** — Description uses third person (no "you").
+- [ ] **(error)** — No XML angle brackets (`<` `>`) in any frontmatter value (security restriction — prompt-injection vector).
+- [ ] **(warn)** — `compatibility` field valid if present (1–500 chars).
+- [ ] **(warn)** — Body is instructions, not documentation (imperative voice).
+- [ ] **(warn)** — Body includes an examples section with user scenarios.
+- [ ] **(warn)** — Body includes a troubleshooting / error-handling section.
+- [ ] **(error)** — Referenced files in `references/` exist.
+- [ ] **(error)** — Referenced scripts in `scripts/` exist.
+- [ ] **(warn)** — No `README.md` inside skill directories (belongs at plugin root).
+
+#### S04 — Description trigger phrase (warn)
+
+The `description` must give Claude a routing signal — either it opens with a trigger phrase ("Use when …") OR it follows the three-part WHAT / WHEN / NOT-FOR structure. A description that only says WHAT the skill does, with no WHEN, leaves Claude unable to route to it. Emit warn:
+
+> "Skill `<name>` description has no trigger phrase. Start with 'Use when …' or include an explicit WHEN/NOT-FOR boundary so Claude can route to the skill. A WHAT-only description is loaded into context but rarely matched."
+
+Severity is **warn**, promoted to error under `--strict`. (Routing-critical, but making it a hard error would fail existing skills on day one — soft-nudge adoption.)
+
+#### S05 — Description length cap (warn)
+
+The combined `description` + `when_to_use` text is capped at `maxSkillDescriptionChars` (default **1,536**; read the actual value from settings if the validated environment sets it). Past the cap, text is silently truncated from the listing Claude sees. Emit warn when the description exceeds the cap:
+
+> "Skill `<name>` description is `<n>` characters, over the `maxSkillDescriptionChars` cap (`<cap>`). Text past the cap is silently dropped from the skill listing. Trim to the cap — put the key trigger phrase first so it survives truncation."
+
+(This replaces the old flat "max 1024 chars" check — 1,024 was stale; 1,536 is the runtime cap. ~1,024 remains a stricter agentskills.io portability target, not a validator error.)
+
+#### S10 — Body length (warn ≥ 250, error ≥ 500)
+
+Count the SKILL.md body lines (excluding frontmatter). Warn at **≥ 250 lines**, error at **≥ 500 lines**:
+
+> warn: "Skill `<name>` body is `<n>` lines. Consider extracting detail into `references/` — every body line is loaded into context on invocation. Mature skills legitimately reach 250–400 lines, so this is a nudge, not a defect."
+> error: "Skill `<name>` body is `<n>` lines, over the 500-line ceiling. Extract detail into `references/` and keep only the essential workflow in SKILL.md."
+
+Configurable via `--max-skill-lines`. Note: this plugin's own `plugin-creation` SKILL.md exceeds 250 lines — an accepted finding (it's a deliberately large hub skill with heavy progressive disclosure).
+
+#### S11 — Body conciseness threshold (info)
+
+Body exceeds **150 lines** — info-level conciseness nudge below the S10 warn threshold:
+
+> "Skill `<name>` body is `<n>` lines. Skills that load frequently benefit from staying under ~150 lines. If this skill is invoked often, consider whether more detail can move to `references/`."
+
+Info only — many legitimate skills sit in the 150–250 band.
+
+#### S12 — Project-scoped skill `allowed-tools` without a workspace-trust note (warn)
+
+When a **project-scoped** skill (path matches `.claude/skills/`) declares `allowed-tools` AND the skill **body** contains no note explaining the workspace-trust gating, emit warn:
+
+> "Project-scoped skill `<name>` declares `allowed-tools` but the body doesn't document the workspace-trust gating. `allowed-tools` on a `.claude/skills/` skill only takes effect after the user accepts the workspace trust dialog — and grants the skill prompt-free tool access. Add a note so a user reviewing the skill before trusting the repo understands what they're granting."
+
+(Plugin-shipped skills are exempt — trust is established at install time. This rule targets skills checked into a project repo, where the reader IS the person deciding whether to trust.)
+
+The validator additionally emits its own **info** note on every project-scoped `allowed-tools` skill (unchanged behavior): "`.claude/skills/*` skills with `allowed-tools` only take effect after the workspace trust dialog is accepted. Review the skill carefully before trusting a repository."
+
+#### S13 — Nested skill directory (info)
+
+A `skills/<name>/` directory that itself contains a subdirectory with its own `SKILL.md`. Claude Code recursively discovers nested skill directories, which may not be the author's intent (e.g. a `references/` folder accidentally named such that it looks like a skill). Emit info:
+
+> "Skill directory `skills/<name>/` contains a nested subdirectory `<sub>/` with its own `SKILL.md`. Claude Code discovers nested skill directories recursively — if `<sub>` is meant to be a separate skill, give it a top-level `skills/` entry; if it's reference material, it shouldn't contain a `SKILL.md`."
+
+Info only — surfaces a layout that's usually unintended.
 
 ### Commands (for each `commands/*.md`)
 - [ ] Valid YAML frontmatter — invalid frontmatter causes command to load with no metadata at runtime

--- a/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/03-skills/writing-skillmd.md
@@ -102,10 +102,12 @@ description: Use when [triggers] - [what it does]
 
 ## Line Count Target
 
-**Keep SKILL.md under 500 lines.** If approaching this limit:
+**Target SKILL.md under 250 lines; treat 500 as a hard ceiling.** The validator warns at ≥ 250 lines and errors at ≥ 500. Mature skills legitimately reach 250–400 lines — the warn is a nudge to consider extraction, not a defect. If approaching 500:
 1. Move detailed content to `references/`
 2. Link from SKILL.md: "See references/topic.md for..."
 3. Keep only essential workflow in SKILL.md
+
+Every line of SKILL.md body is loaded into context when the skill is invoked — extraction to `references/` is the progressive-disclosure mechanism that keeps the invocation cost low.
 
 ## Frontmatter Requirements
 
@@ -121,7 +123,7 @@ context: fork
 | Field | Required | Constraints |
 |-------|----------|-------------|
 | `name` | Yes | Lowercase, numbers, hyphens only. Max 64 chars. No "anthropic" or "claude". |
-| `description` | Yes | Max 1024 chars. Must include WHAT and WHEN. Third person only. |
+| `description` | Yes | Must include WHAT and WHEN. Third person only. **Two caps apply:** the Claude Code runtime truncates the combined `description` + `when_to_use` text at `maxSkillDescriptionChars` (default **1,536**, configurable in settings); the agentskills.io portability standard recommends a stricter **~1,024**. Target 1,024 for portable skills; 1,536 is the hard runtime limit past which text is silently dropped from the listing Claude sees. |
 | `model` | No | Override model for this skill. Values: `haiku`, `sonnet`, `opus`. Use for cost optimization -- `haiku` for simple/repetitive tasks, `opus` for complex reasoning. |
 | `allowed-tools` | No | Grants permission for the listed tools while the skill is active (does not restrict — every tool remains callable, but listed tools skip the permission prompt). Syntax: `"Bash(python:*) Bash(npm:*) WebFetch"`. **Workspace-trust gating:** for skills checked into a project at `.claude/skills/`, `allowed-tools` only takes effect *after* the workspace trust dialog is accepted (same gate as permission rules in `.claude/settings.json`). Review project skills before trusting a repo — a hostile skill can grant itself broad tool access this way. Plugin-shipped skills are not subject to this gate (trust is established at install time). |
 | `context` | No | Set to `fork` to run skill in an isolated context (own context window). Use for heavy operations that would pollute the main context. |
@@ -209,6 +211,26 @@ Look up issue $0 and summarize it.
 Store results in ${CLAUDE_SKILL_DIR}/output/.
 ```
 
+### Adaptive skills with `${CLAUDE_EFFORT}`
+
+`${CLAUDE_EFFORT}` lets a skill scale its own thoroughness to the user's effort dial. Branch the instructions on the substituted value so a `low`-effort turn gets a terse path and a `high`/`max` turn gets the full checklist:
+
+```markdown
+## Review the change
+
+The current effort level is `${CLAUDE_EFFORT}`.
+
+- At **low** / **medium**: run the linter, report pass/fail, stop.
+- At **high** / **xhigh** / **max**: run the linter, then trace each
+  changed function for edge cases, check test coverage, and write a
+  findings summary.
+
+Match your depth to the effort level above — don't over-investigate a
+`low` turn or under-investigate a `max` turn.
+```
+
+`${CLAUDE_EFFORT}` is substituted as a literal string before Claude reads the body, so the branch reads as plain instructions. Use it for skills where the right amount of work genuinely varies — audits, reviews, research. A skill whose work is fixed (format a file, rename a symbol) doesn't need it.
+
 ## Context Budget
 
 Each skill consumes context when loaded. The budget defaults to **2% of the context window** with a **16,000-character fallback** if the window size is unknown. This includes the SKILL.md content and any dynamically injected output.
@@ -216,6 +238,19 @@ Each skill consumes context when loaded. The budget defaults to **2% of the cont
 - Run `/context` to check current context usage and remaining budget
 - Override the default budget with the `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable (value in characters)
 - Keep skills concise to leave room for conversation context
+
+## Where Skills Live & How They're Discovered
+
+Skills load from several locations, and the discovery rules matter when you advise teams on layout:
+
+| Source | Discovery |
+|--------|-----------|
+| **Plugin skills** (`skills/<name>/SKILL.md` in a plugin) | Loaded when the plugin is enabled. Plus the single-skill-at-root layout — root `SKILL.md`, no `skills/` subdir — auto-discovered (v2.1.142+). |
+| **Project skills** (`.claude/skills/`) | Loaded from the starting directory **and every parent directory up to the repository root**. Starting Claude in a subdirectory still picks up skills defined at the repo root. |
+| **Nested project skills** (`.claude/skills/` deeper in the tree) | Loaded **on demand**: when Claude works with a file under a subdirectory, it also discovers skills from that subdirectory's `.claude/skills/`. Editing `packages/frontend/file.ts` picks up `packages/frontend/.claude/skills/`. This is the monorepo pattern — each package ships its own skills. |
+| **User skills** (`~/.claude/skills/`) | Available in every project. |
+
+**Monorepo guidance**: in a monorepo, put repo-wide skills in the root `.claude/skills/` and package-specific skills in each package's `.claude/skills/`. The package skills only enter context when Claude touches that package's files, keeping the listing budget lean for unrelated work.
 
 ## Hot-Reload
 
@@ -450,7 +485,7 @@ Build at least 3 test scenarios before finalizing:
 - [ ] Name is lowercase, hyphens only
 - [ ] Description is third person
 - [ ] Description includes WHAT and WHEN
-- [ ] Description under 1024 chars
+- [ ] Description under the 1,536-char runtime cap (`maxSkillDescriptionChars`); ~1,024 for agentskills.io portability
 
 ### References
 - [ ] All references one level deep

--- a/plugin-creation-tools/skills/plugin-creation/references/quick-reference.md
+++ b/plugin-creation-tools/skills/plugin-creation/references/quick-reference.md
@@ -172,8 +172,8 @@ Use when [triggers] - [what it does, third person]
 
 | Component | Target | Maximum |
 |-----------|--------|---------|
-| Skill description | 200-500 chars | 1024 chars |
-| SKILL.md body | <500 lines | - |
+| Skill description | 200-500 chars | 1,536 chars runtime cap (`maxSkillDescriptionChars`); ~1,024 for agentskills.io portability |
+| SKILL.md body | <250 lines | warn ≥250, error ≥500 |
 | Reference files | <1000 lines | - |
 | Command description | 50-100 chars | - |
 | Agent description | 100-200 chars | - |


### PR DESCRIPTION
## Summary

Fourth release of the [consolidated 2026-05-12 roadmap](https://github.com/camoa/claude-skills/blob/main/plugin-creation-tools/CHANGELOG.md) — the last unconditional release before v3.7.0 (which is gated on drupal-dev-framework adopting the session-remembrance pattern first).

Scope per the roadmap (one release per PR):
- `${CLAUDE_EFFORT}` adaptive-skill worked example
- Skill discovery semantics (parent-dir + monorepo)
- Stale description-cap fix (1024 → 1536)
- 6 skill-quality validator rules with explicit S-IDs
- One patch version bump (3.6.1 → 3.6.2)

## What changed

### Plugin doc updates

- **`writing-skillmd.md`** — new "Adaptive skills with `${CLAUDE_EFFORT}`" worked example; new "Where Skills Live & How They're Discovered" section (plugin / project parent-dir / nested-project on-demand monorepo / user); "Line Count Target" reworked to the warn-250 / error-500 model.
- **Stale description cap fixed** — the plugin claimed a flat "Max 1024 chars" for skill `description`. The Claude Code **runtime** cap is `maxSkillDescriptionChars`, default **1,536**; 1,024 is the stricter agentskills.io **portability** recommendation. `writing-skillmd.md` + `quick-reference.md` now distinguish the two. `anthropic-skill-standards.md` keeps 1,024 (it documents the agentskills.io standard).

### Validator rules (Skills section renumbered with S-IDs)

| Rule | Severity | What it catches |
|---|---|---|
| **S04** | warn | Description has no trigger phrase / WHEN boundary (routing-critical; → error under `--strict`) |
| **S05** | warn | Description over `maxSkillDescriptionChars` (default 1,536) — replaces the stale flat "1024" check |
| **S10** | warn ≥250 / error ≥500 | SKILL.md body length — two-threshold model replacing flat "under 500" |
| **S11** | info | Body > 150 lines — conciseness nudge |
| **S12** | warn | Project-scoped skill declares `allowed-tools` but body has no workspace-trust note |
| **S13** | info | Nested skill directory (recursively discovered, usually unintended) |

The existing plugin-root `CLAUDE.md` info rule is tagged **ST03** for cross-release ID consistency.

### Metadata

- `plugin.json` `3.6.1` → `3.6.2`.
- Root `marketplace.json` `metadata.version` `1.14.42` → `1.14.43`.
- `CHANGELOG.md` full v3.6.2 entry; `CLAUDE.md` Drift list gains 3 items.

## Validation

- ✅ `claude plugin validate` (upstream): no new regressions. Pre-existing CLAUDE.md info-warning + SKILL.md frontmatter parse error remain (protected `!\`backticks\`` injection).
- ⚠️ **Accepted self-finding**: this plugin's own `plugin-creation/SKILL.md` (~334 lines) trips the new S10 ≥250 warn. It's a deliberate large hub skill with heavy progressive disclosure; the self-application gate is "clean or all-warnings" so a warn is in-bounds. Documented in the rule text + CHANGELOG, not fixed.
- ✅ All command frontmatters parse with PyYAML.

## Roadmap-vs-enforcement-design reconciliations (flagged for review)

- **S04 ships as warn, not the roadmap's "error".** Enforcement-design §13 reasons a day-one hard error on missing trigger phrases would fail existing skills ecosystem-wide. Soft-nudge adoption wins: warn by default, error under `--strict`. Recorded in the roadmap "Notes from v3.6.2".
- **S10 thresholds (250/500)** follow enforcement-design §3/§13, not the roadmap's looser ">500".

## Ecosystem rule-fire forecast (paper-trace)

Reserved for `chore/ecosystem-skill-migration`:

| Plugin | S04 | S10 warn | S12 |
|---|---|---|---|
| drupal-dev-framework | unknown | likely (`memory-manager` ~400 lines per enforcement-design sample) | n/a (plugin skills exempt) |
| brand-content-design | unknown | likely (`visual-content` near 400) | n/a |
| code-quality-tools | unknown | unknown | n/a |

S12 only fires on project-scoped (`.claude/skills/`) skills — plugin-shipped skills are exempt, so the ecosystem plugins won't trip it.

## Test plan

- [ ] `claude plugin validate` on this branch — no v3.6.2 regressions
- [ ] `/plugin-creation-tools:validate` self-apply — confirm S10 warns on `plugin-creation/SKILL.md` (~334 lines) and nothing errors
- [ ] Spot-check the skill-discovery section against Skills guide L102
- [ ] Spot-check the `${CLAUDE_EFFORT}` example against Skills guide L220
- [ ] Confirm the 1,536 cap against Skills guide L753 + Settings L214

🤖 Generated with [Claude Code](https://claude.com/claude-code)