### PR TITLE
plugin-creation-tools v3.7.1: validator self-defects (gaps-2026-05-20)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.46"
+    "version": "1.14.47"
   },
   "plugins": [
     {
@@ -36,7 +36,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Authoritative quality gate + authoring guide for Claude Code plugins. Covers all 29 hook events, five handler types, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, parallel-then-merge precedence, recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, experimental.themes / experimental.monitors migration, $schema field, array-only agents, channels, bin/ auto-discovery, plugin-root settings.json (agent + subagentStatusLine), userConfig with type/title schema, skillOverrides, claude plugin prune + --plugin-url + --plugin-dir, Plugin Hints, workspace-trust gating, allowCrossMarketplaceDependenciesOn, forked subagents, Agent SDK, REVIEW.md v2, Routines auto-validate. v3.5.0 shipped Hook Authoring Depth + 7 paired validator rules (H05–H13) with opt-in `--fix`. v3.6.0 adds Layout & Discovery: 5 paired validator rules (A02 subfolder scoped-id awareness; A03 missing `name` on subfolder agents; ST04 redundant `skills: [\"./\"]` on auto-discovered single-skill plugins; ST05 manifest path doesn't exist; ST06 manifest override leaves a populated default folder ignored), `init_plugin.py` refactored to read the canonical `templates/plugin.json.template` (kills divergence). Auto-fix audit trail at `.claude-plugin/.validate-fixes.log`. v3.7.0 adds the cross-plugin session-remembrance pattern: `add-component remembrance-hooks` scaffolds the SessionStart+SessionEnd hook pair (no `PostCompact`), install command, `/save-session` command, and `save-session.sh` for any plugin that maintains per-project state; new R01–R05 validator rules enforce pattern conformance.",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "author": {
         "name": "camoa"
       },

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-creation-tools",
   "description": "Complete authoring guide for Claude Code plugins — skills, commands, agents, 29 hook events (with the `if` pre-spawn filter, the `mcp_tool` handler type, exec form via `args`, `systemMessage` / `terminalSequence` JSON output, the 10K-character output cap, and parallel-then-merge precedence), MCP servers, plugin dependencies, plugin themes, `userConfig` schema, cross-marketplace dependencies, permission modes, the Agent SDK, REVIEW.md v2, and Routines-based auto-validate. v3.5.0 added hook authoring depth + 7 paired validator rules (H05–H13). v3.6.0 adds layout & discovery: recursive `agents/` subfolder scoping (`my-plugin:review:security`), single-skill-at-root auto-discovery (v2.1.142+), v2.1.140+ `/doctor` ignored-folder semantics, and 5 paired validator rules (A02 / A03 / ST04 / ST05 / ST06). `init_plugin.py` now reads the canonical `templates/plugin.json.template` instead of embedding a divergent string.",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/.claude/rules/skill-conventions.md
+++ b/plugin-creation-tools/.claude/rules/skill-conventions.md
@@ -28,4 +28,4 @@ paths:
 - Current state only — no historical narratives, no version migration stories.
 
 ## Drift Watchlist
-The hook event count, hook handler types, plugin component types, reserved marketplace names, and skill-description budget numbers must stay in sync between SKILL.md, `commands/validate.md`, and the relevant references. See `../../CLAUDE.md` "Drift to Watch".
+The hook event count, hook handler types, plugin component types, reserved marketplace names, and skill-description budget numbers must stay in sync between SKILL.md, `commands/validate.md`, and the relevant references. See `../../CONTRIBUTING.md` "Drift to Watch".

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.1] - 2026-05-20
+
+**Theme: validator self-defects.** Bug-fix patch. drupal-dev-framework v4.6.0 used `/plugin-creation-tools:validate` v3.7.0 as its release gate and the tool surfaced eight defects in itself, recorded in `plugin-creation-tools-gaps-2026-05-20.md`. This release fixes all eight, plus a versioning-drift bug found while fixing them.
+
+All items are bug fixes — patch, not minor — even though FM01/FM02 are new rules: the validator's existing S01/A01 contract already *claimed* to check frontmatter validity; FM01 just makes that true.
+
+### Fixed — argument indexing (gaps A1)
+
+`commands/validate.md`, `create.md`, `add-component.md` all read `$1` as "the first argument". Claude Code's `$N` placeholders are **0-based** — `$0` is the first argument, `$1` the second (Slash Commands guide). Passing one argument left `$1` empty; passing `<path> --strict` made `$1` the flag. This is why a forked `/validate <plugin>` validated the wrong plugin or the whole marketplace.
+
+- `validate.md` Step 1 now parses `$ARGUMENTS`: first non-`--` token = plugin path, `--` tokens = flags. Resolves absolute paths directly; relative/bare names against cwd then marketplace siblings.
+- `create.md` parses `$ARGUMENTS` for the plugin name (the first non-flag token).
+- `add-component.md` now declares `arguments: component-type component-name` in frontmatter and uses the named placeholders `$component-type` / `$component-name` — the documented, index-free mechanism. All `$2` references replaced.
+
+`context: fork` commands **do** receive arguments — substitution happens before the fork (Slash Commands guide, "Run skills in a subagent"). A1 was never a harness limitation; it was this indexing bug.
+
+### Fixed — `--fix` is non-interactive (gaps A2)
+
+`validate.md` Step 5 told `--fix` to "ask the user to confirm" — impossible in a forked subagent (no user turn). `--fix` now applies directly + logs to `.claude-plugin/.validate-fixes.log` (reversible via `git`); passing `--fix` is the consent. New `--fix --dry-run` reports proposed migrations without writing. Both modes are non-interactive and work in fork context.
+
+### Fixed — frontmatter check now does a real YAML parse (gaps B1)
+
+New **FM-series** (Frontmatter Integrity), run against every component file:
+
+- **FM01 (error)** — the whole frontmatter block must pass a real `yaml.safe_load`. Lenient per-key extraction missed 3 error-class malformed files in DDF (`argument-hint: [x] [y]` flow-sequence-plus-trailing-content; an unquoted `:` in a `description`). A file whose frontmatter doesn't parse loads with **no metadata** at runtime — error-class.
+- **FM02 (info)** — a string-typed field (`argument-hint`, `description`, `name`, `compatibility`) that parses as a list/mapping instead of a string. Info, not error: the upstream guide's own `argument-hint` examples use the unquoted bracket form.
+
+S01 / A01 / the command frontmatter check now reference FM01 as the authoritative strict parse.
+
+### Fixed — this plugin's own flagship SKILL.md frontmatter was malformed
+
+Applying FM01 to plugin-creation-tools itself immediately caught a real defect in `skills/plugin-creation/SKILL.md` — the very skill the plugin is built around. Its `description` contained an unquoted `NOT for: using existing plugins` — the `: ` is YAML's mapping indicator, so the whole frontmatter block failed a standard YAML parse (`mapping values are not allowed here`). The same defect existed in the bundled `examples/full-featured-plugin/skills/code-helper/SKILL.md`.
+
+Both `description` values are now single-quoted. This was **mischaracterized for releases v3.5.0–v3.7.0**: each release's notes dismissed the `claude plugin validate` SKILL.md error as a harmless false positive caused by the `` !`ls …` `` dynamic-context injection. That was wrong — the `!` was a red herring; the cause was the unquoted colon, a genuine malformed-frontmatter bug of exactly the class gaps-doc B1 describes. A skill with unparseable frontmatter loads with **no metadata** at runtime.
+
+With this fix, **`claude plugin validate` passes clean** — the first fully-clean upstream validation of this plugin across the entire v3.5.0–v3.7.1 rollout. (The plugin-root `CLAUDE.md` warning is also gone, via the `CONTRIBUTING.md` rename below.)
+
+### Fixed — M14 / ST03 severity parity with upstream (gaps B2)
+
+Both were `info`; upstream `claude plugin validate` emits **warnings** for unknown manifest keys and a plugin-root `CLAUDE.md`. A plugin could pass `/plugin-creation-tools:validate` "clean" yet warn upstream. **M14 → warn**, **ST03 → warn**.
+
+### Fixed — H05 / H06 under-fire (gaps B3)
+
+v3.7.0's H05 was read as space-conditional ("exec form not needed since no spaces"). The Hooks Reference says exec form is preferred for *any* path-placeholder reference. H05/H06 rule text now explicitly states the check fires **regardless of whether the path contains spaces** — "no spaces" is not a pass condition.
+
+### Clarified — H08 scope (gaps B4)
+
+H08 fires only on broad matchers (`*`, `""`, `.*`, omitted). A **named-tool** matcher (`Write`, `Edit`, `Bash`) is intentionally "narrow enough" and not flagged. The rule note now says so explicitly.
+
+### Fixed — report formatting (gaps C1)
+
+`validate.md` Output Format: ruled-out checks must not be listed under the **Warnings** header with body text concluding they're clean (a gate counting Warnings entries would over-count). New "Checked — clean" bucket; header discipline spelled out — one finding goes in exactly one bucket, by actual severity.
+
+### Fixed — plugin-root `CLAUDE.md` relocated to `CONTRIBUTING.md`
+
+The plugin shipped its own maintainer doctrine in a plugin-root `CLAUDE.md` — the exact thing ST03 (now warn) flags. The plugin teaches "don't do this"; it must not do it. `CLAUDE.md` → **`CONTRIBUTING.md`** (`git mv`, history preserved). Inbound references updated: `.claude/rules/skill-conventions.md`, `hooks/pre-compact.sh`, `SKILL.md`. The plugin now validates clean against its own ST03.
+
+### Fixed — SKILL.md `version` drift
+
+`skills/plugin-creation/SKILL.md` frontmatter still said `version: 3.4.1` — never bumped across v3.5.0–v3.7.0 despite the versioning rule requiring it. Corrected to `3.7.1`. (The rule is in `CONTRIBUTING.md` § Versioning; this drift is itself evidence the SKILL.md version field is easy to forget — future releases must include it.)
+
+### Metadata
+
+- `plugin.json` 3.7.0 → 3.7.1; `skills/plugin-creation/SKILL.md` frontmatter 3.4.1 → 3.7.1.
+- Root `marketplace.json` `metadata.version` 1.14.46 → 1.14.47; plugin entry version bump.
+
+### Validation
+
+- `claude plugin validate` (upstream) now **passes clean** — zero errors, zero warnings. This is the first clean upstream run since the v3.5.0 cycle began; every prior release shipped with the malformed-SKILL.md error misreported as a false positive.
+- All 8 component frontmatter blocks parse via a real `yaml.safe_load` (the FM01 self-test).
+- jq / JSON syntax of all touched files verified.
+
+### Notes
+
+- **`context: fork` + arguments verified** against the cached Slash Commands guide ("Run skills in a subagent" — the `deep-research` example is a `context: fork` skill whose body uses `$ARGUMENTS`). The fork receives substituted arguments; A1 was an indexing bug, not a structural one.
+- **The 8th defect** (A3 — inconsistent fork cwd) is a harness behavior the plugin can't fix; mitigated by A1 — with an explicit path argument, cwd no longer matters. `validate.md` Step 1 documents "prefer an explicit path argument."
+- The gaps doc has been annotated with a "Resolved in v3.7.1" section.
+
 ## [3.7.0] - 2026-05-20
 
 **Theme: Cross-plugin pattern enforcement.** Fifth and final release of the consolidated 2026-05-12 roadmap. Extracts the session-remembrance pattern — pioneered by drupal-dev-framework v4.5.0 — into a scaffoldable, validatable shared pattern any plugin can adopt.

--- a/plugin-creation-tools/CONTRIBUTING.md
+++ b/plugin-creation-tools/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Plugin Creation Tools — Plugin Conventions
+# Contributing to Plugin Creation Tools
 
-This plugin teaches plugin authoring; it must hold itself to the same standards it teaches.
+Maintainer and contributor conventions for this plugin. It teaches plugin authoring, so it must hold itself to the same standards it teaches — including its own rule (ST03) that a plugin-root `CLAUDE.md` is not loaded as project context. That is why these conventions live in `CONTRIBUTING.md`, not `CLAUDE.md`. Path-scoped editing rules additionally live in `.claude/rules/`.
 
 ## Self-Application Rule
 
@@ -54,7 +54,10 @@ Every revision must keep these counts in sync between SKILL.md, `commands/valida
 - **Skill discovery** — project skills load from `.claude/skills/` in the starting dir AND every parent up to repo root; nested `.claude/skills/` load on demand (monorepo pattern).
 - **Session-remembrance pattern** — `add-component remembrance-hooks` scaffolds it; validator R01–R05 enforce conformance. Two rules are load-bearing and must never be "fixed" out of the templates: **no `PostCompact` hook** (stdout not injected into context) and **copy `save-session.sh` into the project** (`${CLAUDE_PLUGIN_ROOT}` doesn't resolve in project `settings.json`). The pattern is two hook events — `SessionStart` + `SessionEnd`. drupal-dev-framework v4.5.0 is the reference adopter.
 - Reserved marketplace names list.
-- The skill-description budget numbers (1% / 8,000-char fallback / 1,536-char per-entry cap / 500-line SKILL.md soft cap).
+- The skill-description budget numbers (`skillListingBudgetFraction` 1% default / 8,000-char fallback / `maxSkillDescriptionChars` 1,536-char per-entry cap) and the SKILL.md body model (S10: warn ≥ 250 lines, error ≥ 500).
+- **Frontmatter integrity** — FM01 does a real whole-block YAML parse of every component (error on failure); FM02 flags string-typed fields parsed as lists. The validator must never extract keys leniently.
+- **Argument indexing** — `$N` is 0-based (`$0` = first argument). Commands use named `arguments:` frontmatter or parse `$ARGUMENTS`; never bare `$1` for "the first argument".
+- **`--fix` is non-interactive** — `context: fork` commands have no user turn; `--fix` applies + logs, `--fix --dry-run` previews.
 
 ## Anti-Patterns Specific to This Plugin
 
@@ -67,8 +70,10 @@ Every revision must keep these counts in sync between SKILL.md, `commands/valida
 
 - `skills/plugin-creation/SKILL.md` — single large skill, progressive disclosure into `references/`.
 - `commands/create.md` — scaffold a new plugin.
-- `commands/add-component.md` — add a skill / command / agent / hook / MCP / theme.
+- `commands/add-component.md` — add a skill / command / agent / hook / MCP / theme / remembrance-hooks.
 - `commands/validate.md` — validate plugin structure and wiring.
 - `agents/plugin-structure-auditor.md` — Architecture / Cross-Component Consistency / Performance audit (read-only).
 - `agents/skill-quality-reviewer.md` — SKILL.md description-and-body review (read-only).
 - `hooks/hooks.json` — `PreCompact` only, instructs Claude to read plugin files on demand instead of dumping metadata.
+- `CONTRIBUTING.md` (this file) — maintainer conventions. NOT a plugin-root `CLAUDE.md` by design (ST03).
+- `.claude/rules/` — path-scoped editing rules (skill / command / agent conventions).

--- a/plugin-creation-tools/commands/add-component.md
+++ b/plugin-creation-tools/commands/add-component.md
@@ -2,6 +2,7 @@
 description: Add a skill, command, agent, hook, MCP server, theme, or remembrance-hooks pattern to an existing plugin. Use when user says "add skill", "add command", "add agent", "add hook", "add MCP", "add theme", "add remembrance hooks", "session remembrance", "new component", or wants to extend an existing plugin with additional functionality.
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 argument-hint: <component-type> <name>
+arguments: component-type component-name
 context: fork
 ---
 
@@ -11,8 +12,8 @@ Add a new component to an existing Claude Code plugin.
 
 ## Steps
 
-1. Parse arguments: `$1` = component type, `$2` = component name
-2. If missing arguments, ask user for component type and name
+1. Read the two named arguments: `$component-type` and `$component-name`. They come from the `arguments:` frontmatter, which maps the names to positions in order — `$component-type` is the first argument, `$component-name` the second. (Named arguments avoid the 0-based `$N` footgun: `$1` is the *second* positional, not the first.)
+2. If either is missing, ask the user for the component type and name
 3. Find the plugin root (look for `.claude-plugin/plugin.json` in current or parent directories)
 4. Validate the component name (hyphen-case, max 64 chars)
 5. Scaffold the component from templates
@@ -21,18 +22,18 @@ Add a new component to an existing Claude Code plugin.
 ## Component Types
 
 ### `skill`
-1. Create `skills/$2/SKILL.md` from `templates/skill/SKILL.md.template`
-2. Create `skills/$2/references/` directory
+1. Create `skills/$component-name/SKILL.md` from `templates/skill/SKILL.md.template`
+2. Create `skills/$component-name/references/` directory
 3. Remind: SKILL.md is instructions for Claude, not documentation
 4. Consider: `model:` field, dynamic context injection, `context: fork` for heavy ops
 
 ### `command`
-1. Create `commands/$2.md` from `templates/command/command.md.template`
+1. Create `commands/$component-name.md` from `templates/command/command.md.template`
 2. Remind: set `allowed-tools` to minimum needed
-3. Remind: use `$ARGUMENTS`, `$1`, `$2` for argument handling
+3. Remind: the scaffolded command can handle arguments via `$ARGUMENTS`, or declare named arguments in frontmatter (`arguments: foo bar` → `$foo` / `$bar`). Avoid bare `$1` / `$2` — `$N` is 0-based, so `$1` is the *second* argument.
 
 ### `agent`
-1. Create `agents/$2.md` from `templates/agent/agent.md.template`
+1. Create `agents/$component-name.md` from `templates/agent/agent.md.template`
 2. Remind: description must include delegation triggers ("Use proactively when...")
 3. Consider: `memory: project` for cross-session learning
 4. Consider: `model:` matched to task complexity (haiku for simple, opus for complex)
@@ -51,15 +52,15 @@ Add a new component to an existing Claude Code plugin.
 2. Guide user to configure server command and args
 
 ### `theme`
-1. Create `themes/$2.json` with `name`, `base`, `overrides` fields (see `references/08-configuration/themes.md`)
+1. Create `themes/$component-name.json` with `name`, `base`, `overrides` fields (see `references/08-configuration/themes.md`)
 2. Default `base` to `"dark"`; keep `overrides` sparse (only the tokens you actually change)
 3. If the user is using a non-default theme directory, write the path under **`experimental.themes`** in `plugin.json` (not the top level — the top-level form warns under `claude plugin validate` and a future release will require the nested form)
-4. Remind: theme appears in `/theme` once the plugin is enabled, persisted as `custom:<plugin-name>:$2` when the user selects it
+4. Remind: theme appears in `/theme` once the plugin is enabled, persisted as `custom:<plugin-name>:$component-name` when the user selects it
 5. Remind: users press `Ctrl+E` to copy the plugin theme into `~/.claude/themes/` for editing — your bundled file is read-only in the picker
 
 ### `remembrance-hooks`
 
-Scaffold the [session-remembrance pattern](../skills/plugin-creation/references/06-hooks/remembrance-hooks-pattern.md) — per-project `SessionStart` + `SessionEnd` hooks that survive compaction. `$2` is ignored (the component names are fixed). Read `references/06-hooks/remembrance-hooks-pattern.md` first so you can explain the design to the user.
+Scaffold the [session-remembrance pattern](../skills/plugin-creation/references/06-hooks/remembrance-hooks-pattern.md) — per-project `SessionStart` + `SessionEnd` hooks that survive compaction. `$component-name` is ignored (the component names are fixed). Read `references/06-hooks/remembrance-hooks-pattern.md` first so you can explain the design to the user.
 
 1. Confirm the plugin maintains **per-project state** worth remembering. If it's stateless (single command path, no project memory), say so and stop — the pattern adds nothing. A plugin used to build other plugins rather than maintain project state should not adopt it.
 2. Copy the four templates into the plugin, substituting `{plugin-name}` with the plugin's `name` from `plugin.json` throughout each file:
@@ -86,5 +87,5 @@ Scaffold the [session-remembrance pattern](../skills/plugin-creation/references/
 
 ## Arguments
 
-- `$1`: Component type (skill, command, agent, hook, mcp, theme, remembrance-hooks)
-- `$2`: Component name (hyphen-case) — ignored for `remembrance-hooks` (fixed component names)
+- `$component-type`: Component type (skill, command, agent, hook, mcp, theme, remembrance-hooks)
+- `$component-name`: Component name (hyphen-case) — ignored for `remembrance-hooks` (fixed component names)

--- a/plugin-creation-tools/commands/create.md
+++ b/plugin-creation-tools/commands/create.md
@@ -10,13 +10,13 @@ Create a new Claude Code plugin with any combination of components.
 
 ## Steps
 
-1. Parse arguments: `$1` = plugin name, remaining = component flags
+1. Parse `$ARGUMENTS`: the first non-`--` token is the plugin name; `--` tokens are component flags. (Claude Code's `$N` placeholders are **0-based** — `$0` is the first argument — so do not read `$1` for the plugin name; parse `$ARGUMENTS` for the first non-flag token, or use `$0`.)
 2. If no arguments, ask the user for plugin name and desired components
 3. Validate plugin name (lowercase, hyphens, max 64 chars)
 4. Ask user for target directory if not obvious from context
-5. Run the init script:
+5. Run the init script (substitute the parsed plugin name for `<plugin-name>`):
    ```
-   python3 ${CLAUDE_PLUGIN_ROOT}/skills/plugin-creation/scripts/init_plugin.py $1 --path <target> --components <list>
+   python3 ${CLAUDE_PLUGIN_ROOT}/skills/plugin-creation/scripts/init_plugin.py <plugin-name> --path <target> --components <list>
    ```
 6. After scaffolding, load the plugin-creation skill for guidance on completing each component
 7. Read `references/02-philosophy/core-philosophy.md` for design principles
@@ -45,5 +45,5 @@ After creating, guide the user to:
 
 ## Arguments
 
-- `$1`: Plugin name (hyphen-case, e.g., `my-tools`)
-- `$ARGUMENTS`: All arguments including component flags
+- **Plugin name**: first non-`--` token in `$ARGUMENTS` (equivalently `$0` — `$N` is 0-based). Hyphen-case, e.g. `my-tools`.
+- **Component flags**: the `--skill` / `--command` / `--agent` / `--hook` / `--mcp` tokens in `$ARGUMENTS`.

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -1,7 +1,7 @@
 ---
 description: Validate plugin structure, frontmatter, and best practices. Use when user says "validate plugin", "check plugin", "audit plugin", "verify plugin", "is my plugin correct", or before distributing/publishing a plugin.
 allowed-tools: Read, Glob, Grep
-argument-hint: "[plugin-path] [--fix] [--strict]"
+argument-hint: "[plugin-path] [--fix] [--dry-run] [--strict]"
 context: fork
 ---
 
@@ -11,21 +11,25 @@ Validate a plugin's structure and components against best practices.
 
 ## Steps
 
-1. Determine plugin path: use `$1` if provided, otherwise detect from current directory
-2. Parse flags: `--fix` enables auto-migration for rules tagged below; `--strict` promotes warnings to errors for CI gating
-3. Find `.claude-plugin/plugin.json` to confirm it's a plugin root
-4. Run all validation checks below
-5. If `--fix` is set, after the report ask the user to confirm before applying any auto-migration. Apply each fix atomically (write-tempfile-then-rename) and append an entry to `.claude-plugin/.validate-fixes.log`
-6. Report results as a structured checklist
+1. **Resolve the plugin path from `$ARGUMENTS`.** Parse `$ARGUMENTS` (the full argument string): the first token that does **not** start with `--` is the plugin path; tokens starting with `--` are flags. Do **not** read `$1` — Claude Code's `$N` placeholders are **0-based** (`$0` is the first argument, `$1` the second), so `$1` silently reads the wrong token. If no path token is present, fall back to detecting the plugin from the current directory.
+   - Absolute path → use directly.
+   - Relative path or bare plugin name → resolve against the current directory; if that misses and the cwd is inside a marketplace, resolve as a sibling plugin directory.
+   - This command is `context: fork`; argument substitution happens **before** the fork, so `$ARGUMENTS` is available in the forked run. The cwd of the fork is not reliable — always prefer an explicit path argument.
+2. Parse flags from the `--` tokens: `--fix` applies auto-migrations for rules tagged below; `--dry-run` (with `--fix`) reports the proposed migrations without writing; `--strict` promotes warnings to errors for CI gating.
+3. Find `.claude-plugin/plugin.json` to confirm it's a plugin root.
+4. Run all validation checks below.
+5. If `--fix` is set: apply each auto-fixable finding (unless `--dry-run`), atomically (write-tempfile-then-rename), and append an entry to `.claude-plugin/.validate-fixes.log`. With `--dry-run`, list the proposed changes instead of writing. **No interactive confirmation** — passing `--fix` is the consent; review the result via `git diff`.
+6. Report results as a structured checklist.
 
 ## Auto-fix (`--fix`)
 
-The validator gains an opt-in `--fix` flag that performs **only** mechanical, reversible migrations. Every fix:
+The validator has an opt-in `--fix` flag that performs **only** mechanical, reversible migrations. Every fix:
 
 - Is logged to `.claude-plugin/.validate-fixes.log` (append-only) with timestamp + rule ID + summary
 - Writes atomically (tempfile + rename), so a failure leaves the original intact
 - Is reversible via `git diff` / `git restore`
-- Requires user confirmation before any file is changed in this release
+
+`--fix` is **non-interactive** — it applies directly and relies on `git diff` for review. This is deliberate: the command runs `context: fork`, and a forked subagent has no interactive turn with the user, so a confirmation prompt could never fire. Passing the `--fix` flag is itself the consent. To preview without writing, run `--fix --dry-run` — it reports every proposed migration as a diff and changes nothing.
 
 Rules that ship with `--fix` (cumulative across releases): **H05**, **H06**, **H10** (v3.5.0); **M06**, **M07**, **M08**, **M09**, **M10**, **C01**, **C02** (v3.6.1). Future releases add more.
 
@@ -38,6 +42,32 @@ Log entry format:
 
 ## Validation Checks
 
+### Frontmatter Integrity (FM-series)
+
+Run these against **every** component file with a YAML frontmatter block — every `commands/*.md`, every `skills/**/SKILL.md`, every `agents/**/*.md`. These rules supersede the lenient per-key checks: a file can have a `description` key extractable by eye yet still fail a real parse.
+
+#### FM01 — Frontmatter block parses as YAML (error)
+
+Take the text **between** the opening `---` and closing `---` and run it through a real YAML parser (`yaml.safe_load` or equivalent) as a single document. If it raises, emit an **error**:
+
+> "Frontmatter of `<file>` fails YAML parsing: `<parser error>`. A file whose frontmatter block does not parse **loads with no metadata at runtime** — every frontmatter field (`description`, `allowed-tools`, `name`, …) is silently dropped. Fix the YAML."
+
+Do **not** extract individual keys leniently and call it valid — parse the whole block. Common real failures:
+
+- `argument-hint: [<task-name>] [--all]` — a YAML flow sequence (`[<task-name>]`) followed by more content (`[--all]`) on the same line is a syntax error for the whole value, and can break the block.
+- An unquoted `:` inside a value — `description: Do X: then Y` parses `X` as a nested mapping key. Quote the value.
+- A bare `%`, `@`, `` ` ``, or leading `[`/`{` in an unquoted scalar.
+
+The fix for almost all of these is to **quote the value**: `argument-hint: "[task-name] [--all]"`.
+
+#### FM02 — String-typed field parsed as a non-string (info)
+
+After a successful FM01 parse, check fields that are meant to be strings — `argument-hint`, `description`, `name`, `compatibility`. If the parsed value is a **list** or **mapping** instead of a string, emit info:
+
+> "`<field>` in `<file>` parses as a YAML `<list|mapping>`, not a string. Most commonly `argument-hint: [task-name]` → the list `[\"task-name\"]`. Quote it — `argument-hint: \"[task-name]\"` — so it's an unambiguous string."
+
+Info, not warn: the upstream Slash Commands guide's own `argument-hint` examples use the unquoted bracket form, so a single clean flow sequence is tolerated at runtime — but quoting removes the ambiguity and is the safer authoring habit.
+
 ### Plugin Structure
 - [ ] `.claude-plugin/plugin.json` exists and is valid JSON
 - [ ] `name` field present in plugin.json
@@ -46,7 +76,7 @@ Log entry format:
 - [ ] `description` present and not placeholder text
 - [ ] README.md exists at plugin root
 - [ ] CHANGELOG.md exists at plugin root
-- [ ] **ST03 (info)** — if a `CLAUDE.md` is present at the plugin root: "Plugin-root `CLAUDE.md` is NOT loaded as project context. Instructions belong in a skill — put them in `skills/<name>/SKILL.md` so they reach Claude. The file is fine to keep as authoring reference (this plugin uses it that way)."
+- [ ] **ST03 (warn)** — if a `CLAUDE.md` is present at the plugin root: "Plugin-root `CLAUDE.md` is NOT loaded as project context. Instructions belong in a skill — put them in `skills/<name>/SKILL.md` so they reach Claude; maintainer/contributor conventions belong in a `CONTRIBUTING.md` (a non-`CLAUDE.md` filename). Upstream `claude plugin validate` also warns on a plugin-root `CLAUDE.md` — this rule matches that severity so a plugin can't pass here yet warn upstream." (Raised from info to warn in v3.7.1 for upstream parity.)
 
 #### ST04 — Redundant `skills: ["./"]` on a single-skill-at-root plugin (info)
 
@@ -80,13 +110,13 @@ Heuristic exclusion: don't fire when the manifest path resolves into the default
 - [ ] **(info)** — `channels` declared in `plugin.json`: each entry must have a `server` field that matches a key in the plugin's `mcpServers` (or an externally-known MCP server name). Flag warning if `server` references an undeclared MCP server. Per-channel `userConfig` follows the top-level schema — apply the same legacy/required checks.
 - [ ] **(info)** — `bin/` directory present at the plugin root: confirm files are executable (warn on non-executable entries — they appear on `PATH` but fail to run). Auto-discovered, no manifest entry needed.
 
-#### M14 — Unknown top-level manifest keys (info)
+#### M14 — Unknown top-level manifest keys (warn)
 
-For each top-level key in `plugin.json` that is **not** in the documented schema (canonical list: `$schema`, `name`, `displayName`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`, `skills`, `hooks`, `mcpServers`, `lspServers`, `outputStyles`, `experimental`, `channels`, `userConfig`, `settings`, `dependencies`), emit info:
+For each top-level key in `plugin.json` that is **not** in the documented schema (canonical list: `$schema`, `name`, `displayName`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`, `skills`, `hooks`, `mcpServers`, `lspServers`, `outputStyles`, `experimental`, `channels`, `userConfig`, `settings`, `dependencies`), emit warn:
 
-> "Plugin manifest contains unknown top-level key `<name>`. Claude Code silently ignores keys not in the schema (forward-compatible). If this is intentional forward-compat or vendor-specific metadata, you can suppress this notice. Real-world example: `defaults`, `recommended` in drupal-dev-framework — both intentional, both load fine."
+> "Plugin manifest contains unknown top-level key `<name>`. Claude Code silently ignores keys not in the schema (forward-compatible), and upstream `claude plugin validate` warns on them. If this is intentional forward-compat or vendor-specific metadata, the warning is expected — keep it or move the data under a recognized key. Real-world example: `defaults`, `recommended` in drupal-dev-framework."
 
-Info only; never warn or error — surfacing for author confirmation, not enforcement.
+Severity is **warn** (raised from info in v3.7.1): upstream `claude plugin validate` warns on unknown keys, so this rule matches it — a plugin must not pass `/plugin-creation-tools:validate` "clean" while still warning upstream.
 
 #### M15 — Keywords cap (warn)
 
@@ -146,7 +176,7 @@ Info only — sometimes a plugin lives in the marketplace root on a feature bran
 
 ### Skills (for each skill in `skills/*/` — plus a root `SKILL.md` for single-skill plugins)
 
-- [ ] **S01 (error)** — `SKILL.md` exists with valid YAML frontmatter. Invalid frontmatter causes the skill to load with no metadata at runtime.
+- [ ] **S01 (error)** — `SKILL.md` exists, and its frontmatter passes the **FM01** strict YAML parse (see Frontmatter Integrity). Invalid frontmatter causes the skill to load with no metadata at runtime.
 - [ ] **S02 (error)** — Frontmatter has `name` (hyphen-case, max 64 chars).
 - [ ] **(error)** — `name` contains no reserved words (`anthropic`, `claude`).
 - [ ] **(warn)** — Description includes WHAT it does AND WHEN to use it (trigger conditions).
@@ -212,7 +242,7 @@ A `skills/<name>/` directory that itself contains a subdirectory with its own `S
 Info only — surfaces a layout that's usually unintended.
 
 ### Commands (for each `commands/*.md`)
-- [ ] Valid YAML frontmatter — invalid frontmatter causes command to load with no metadata at runtime
+- [ ] Frontmatter passes the **FM01** strict YAML parse (see Frontmatter Integrity) — invalid frontmatter causes the command to load with no metadata at runtime
 - [ ] `description` field present
 - [ ] `allowed-tools` field present
 - [ ] No inline code with backtick+exclamation or backtick+at-sign that could trigger execution
@@ -237,7 +267,7 @@ Info only — surfaces a layout that's usually unintended.
 
 Plugin `agents/` directories are scanned **recursively** (Claude Code v2.x+). Walk every `.md` file under `agents/`, not just the top level.
 
-- [ ] **A01 (error)** — Valid YAML frontmatter. Invalid frontmatter causes agent to load with no metadata at runtime.
+- [ ] **A01 (error)** — Frontmatter passes the **FM01** strict YAML parse (see Frontmatter Integrity). Invalid frontmatter causes the agent to load with no metadata at runtime.
 - [ ] **(error)** — `name` field present.
 - [ ] **(error)** — `description` field present (includes delegation triggers).
 - [ ] **(warn)** — `tools` field present.
@@ -286,9 +316,11 @@ Flat-layout agents missing `name` are already caught by the general A01-family c
 
 #### H05 — Exec form preferred for path placeholders (warn, `--fix`)
 
-For each command hook in `hooks.json` whose `command` string contains a path placeholder (`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_DATA}`) AND lacks an `args` field, emit:
+For each command hook in `hooks.json` whose `command` string contains a path placeholder (`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_DATA}`) AND lacks an `args` field, emit a warning.
 
-> "Hook `<event>` handler uses shell form with a path placeholder. Prefer exec form: add `\"args\": []` so the script path is passed as one argument with no quoting needed. See `references/06-hooks/writing-hooks.md` § Exec form vs shell form."
+**Fire regardless of whether the path contains spaces.** The Hooks Reference says exec form is preferred for *any* hook that references a path placeholder — "Set `args` whenever the hook references a [path placeholder]" — not only when the resolved path happens to contain spaces. A hook can `PASS` H05 only if it has no path placeholder, or already uses exec form (`args` present). "No spaces in the path" is **not** a pass condition — do not reason "exec form not needed since no spaces."
+
+> "Hook `<event>` handler uses shell form with a path placeholder. Prefer exec form: add `\"args\": []` so the script path is passed as one argument with no quoting needed — this is the recommended shape for every placeholder reference, independent of spaces. See `references/06-hooks/writing-hooks.md` § Exec form vs shell form."
 
 **`--fix`**: Insert `"args": []` as a sibling to `command` in the hook handler. Do **not** auto-migrate when the command string contains shell metacharacters (`|`, `&&`, `||`, `;`, `>`, `<`, `` ` ``, `$(`, glob `*`/`?` outside placeholder, `~`) — those need shell form. In that case, emit the warning but skip the fix and note "shell form required for this command".
 
@@ -299,6 +331,8 @@ In each `hooks.json` command-string value (and only in command-string values —
 > "Use `${VAR}` (curly-brace form) instead of bare `$VAR` inside JSON command strings — the curly form is the canonical placeholder syntax and is unambiguous to the placeholder resolver."
 
 **`--fix`**: Literal rewrite of `$CLAUDE_<NAME>` → `${CLAUDE_<NAME>}` inside JSON string values in `hooks.json` only. Skip script files (`.sh`, `.py`, etc.) entirely.
+
+H06 fires on **any** bare-dollar placeholder in a command string — like H05 it is not conditioned on spaces or any other property of the resolved path.
 
 #### H07 — Placeholder quoting (warn)
 
@@ -311,6 +345,8 @@ Hook handlers on tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`,
 > "Consider adding an `if` field to this handler to pre-filter tool calls cheaply — broad-matcher hooks spawn a process on every call. See `references/06-hooks/writing-hooks.md` § The if Field."
 
 This is intentionally **info**, not warn — some authors deliberately spawn on every call (logging, analytics). Don't punish them.
+
+**Scope — what counts as a "broad" matcher.** H08 fires only on `*`, `""`, an omitted matcher, or `.*`. A **named-tool** matcher — `Write`, `Edit`, `Bash`, `Write|Edit` — is considered narrow enough and does **not** trip H08, even with no `if` field. Rationale: the matcher already scopes the hook to specific tool(s); an `if` would narrow it further (to specific arguments) but the spawn-on-every-call cost is bounded to one tool's frequency, which is an acceptable, common design. If you want argument-level filtering on a named-tool hook, `if` is still available — H08 just doesn't *demand* it there.
 
 #### H09 — `if` on non-tool events (warn)
 
@@ -429,17 +465,30 @@ The `SessionEnd` hook entry the install command emits must set an explicit `time
 ## Plugin Validation: {name} v{version}
 
 ### Errors (must fix)
-- ...
+- {rule-id} {file}: {what's wrong}
 
 ### Warnings (should fix)
-- ...
+- {rule-id} {file}: {what's wrong}
 
 ### Info
+- {rule-id} {file}: {note}
+
+### Checked — clean
 - {n} skills, {n} commands, {n} agents, hooks: {yes/no}, MCP: {yes/no}
+- {rule-ids that were evaluated and found nothing}
 
 ### Result: PASS / FAIL
 ```
 
+**Header discipline (one finding, one correct bucket):**
+
+- Place an entry under **Errors** / **Warnings** / **Info** strictly by its actual emitted severity. A rule that was evaluated and produced **no finding** is not a warning — it does not appear under Warnings at all.
+- Do **not** list a ruled-out check under Warnings with body text that concludes it's clean (e.g. "S04 — no actual hits", "S10 — below the 250-line line"). A consumer or gate that counts entries under the Warnings header would over-count. Ruled-out checks go under **Checked — clean**, or are simply omitted.
+- The `### Result` line is `PASS` only when Errors is empty (and, under `--strict`, Warnings is empty too).
+
 ## Arguments
 
-- `$1`: Path to plugin directory (optional, defaults to current directory)
+- **Plugin path** (optional): the first non-`--` token in `$ARGUMENTS`. Resolve per Step 1. Defaults to current-directory detection when absent. Do not read `$1` — `$N` is 0-based; the path is `$0` if you index positionally, but parsing `$ARGUMENTS` for the first non-flag token is the robust approach.
+- `--fix`: apply auto-migrations for `--fix`-tagged rules (non-interactive; see Auto-fix section).
+- `--dry-run`: with `--fix`, report proposed migrations without writing.
+- `--strict`: promote warnings to errors (CI gating).

--- a/plugin-creation-tools/hooks/pre-compact.sh
+++ b/plugin-creation-tools/hooks/pre-compact.sh
@@ -26,6 +26,6 @@ echo ""
 echo "To restore context after compaction:"
 echo "1. Read \`$PLUGIN_JSON\` for plugin metadata"
 echo "2. List \`$PLUGIN_DIR/skills/\`, \`$PLUGIN_DIR/commands/\`, \`$PLUGIN_DIR/agents/\` for components"
-if [ -f "$PLUGIN_DIR/CLAUDE.md" ]; then
-  echo "3. Read \`$PLUGIN_DIR/CLAUDE.md\` for plugin conventions"
+if [ -f "$PLUGIN_DIR/CONTRIBUTING.md" ]; then
+  echo "3. Read \`$PLUGIN_DIR/CONTRIBUTING.md\` for plugin conventions"
 fi

--- a/plugin-creation-tools/skills/plugin-creation/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plugin-creation
-version: 3.4.1
-description: Use when creating Claude Code plugins - covers skills, commands, agents, hooks, MCP servers, and plugin configuration. Use when user says "create plugin", "make a skill", "add command", "add hooks", "skill authoring", "SKILL.md", "plugin components", "package reusable behavior", "distribute skills", "scaffold plugin", "plugin structure", "write a skill description". NOT for: using existing plugins, installing plugins, plugin marketplace browsing. !`ls .claude-plugin/ 2>/dev/null`
+version: 3.7.1
+description: 'Use when creating Claude Code plugins - covers skills, commands, agents, hooks, MCP servers, and plugin configuration. Use when user says "create plugin", "make a skill", "add command", "add hooks", "skill authoring", "SKILL.md", "plugin components", "package reusable behavior", "distribute skills", "scaffold plugin", "plugin structure", "write a skill description". NOT for: using existing plugins, installing plugins, plugin marketplace browsing. !`ls .claude-plugin/ 2>/dev/null`'
 user-invocable: false
 ---
 
@@ -37,7 +37,7 @@ Create complete Claude Code plugins with any combination of components.
 
 When creating any plugin, also consider:
 - `.claude/rules/` with modular project rules (path-scoped if needed for different component directories)
-- `CLAUDE.md` at plugin root **for authoring reference only** — it is NOT loaded as project context when the plugin is installed. To ship instructions Claude reads at runtime, put them in a skill (`skills/<name>/SKILL.md`). The validator emits an info notice when a plugin-root `CLAUDE.md` is present so you don't mistake it for runtime context.
+- Maintainer/contributor conventions belong in a `CONTRIBUTING.md` at the plugin root — **not** a `CLAUDE.md`. A plugin-root `CLAUDE.md` is NOT loaded as project context when the plugin is installed; both `claude plugin validate` and this validator (rule **ST03**, warn) flag one. To ship instructions Claude reads at runtime, put them in a skill (`skills/<name>/SKILL.md`); for path-scoped editing rules use `.claude/rules/`.
 - README.md and CHANGELOG.md at plugin root (for humans — never inside skill directories)
 
 ## Documentation Principles

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/skills/code-helper/SKILL.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/skills/code-helper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-helper
-description: Assists with code quality tasks. Use when reviewing code, checking for issues, or improving code quality. NOT for: writing new features from scratch.
+description: 'Assists with code quality tasks. Use when reviewing code, checking for issues, or improving code quality. NOT for: writing new features from scratch.'
 model: sonnet
 hooks:
   PreToolUse:


### PR DESCRIPTION
## Summary

drupal-dev-framework v4.6.0 used `/plugin-creation-tools:validate` v3.7.0 as its release gate, and the tool surfaced **eight defects in itself** — recorded in `plugin-creation-tools-gaps-2026-05-20.md`. This patch fixes all eight, plus two bugs found while fixing them. Every item is a bug fix → **patch** (v3.7.0 → v3.7.1).

**Headline:** `claude plugin validate` (upstream) now **passes clean** — the first fully-clean upstream validation across the entire v3.5.0–v3.7.1 rollout.

## The gaps and their fixes

| Gap | Sev | Fix |
|---|---|---|
| **A1** — forked `/validate` ignores the `[plugin-path]` arg | HIGH | Root cause was a **0-based index bug**, not a harness limit. `$N` is 0-based (`$0` = first arg); `validate.md`/`create.md`/`add-component.md` read `$1`. Verified against the Slash Commands guide that `context: fork` commands *do* receive substituted args. `validate.md`+`create.md` now parse `$ARGUMENTS`; `add-component.md` uses named `arguments:` frontmatter. |
| **A2** — `--fix` unusable via the Skill tool | HIGH | Dropped the interactive confirmation (impossible in a fork). `--fix` applies + logs to `.validate-fixes.log` (reversible via git); new `--fix --dry-run` previews. |
| **A3** — inconsistent fork cwd | MED | Harness behavior; mitigated by A1 — explicit path arg makes cwd irrelevant. Documented in Step 1. |
| **B1** — frontmatter check wasn't a real YAML parse | HIGH | New **FM01 (error)** — whole-block `yaml.safe_load` of every component; **FM02 (info)** — string field parsed as list/mapping. |
| **B2** — M14/ST03 softer than upstream | MED | **M14 → warn, ST03 → warn** for upstream parity. |
| **B3** — H05/H06 under-fire | LOW-MED | Rule text now fires for *any* path-placeholder reference, explicitly regardless of spaces. |
| **B4** — H08 on named-tool matcher | LOW | Note clarifies named-tool matchers (`Write`/`Edit`/`Bash`) are intentionally not flagged. |
| **C1** — non-findings under "Warnings" header | LOW | New "Checked — clean" bucket; header discipline spelled out. |

## Found while fixing

- **FM01 immediately caught a real defect in this plugin's own flagship `SKILL.md`.** Its `description` had an unquoted `NOT for: …` — the `: ` is YAML's mapping indicator, so the frontmatter block failed a standard parse and loaded with **no metadata**. Same in the bundled `code-helper` example. Both `description`s single-quoted.
  - **Correction to the record:** v3.5.0–v3.7.0 each dismissed the `claude plugin validate` SKILL.md error as a harmless `` !`ls …` `` false positive. **That was wrong** — the `!` was a red herring; the cause was the unquoted colon, a genuine malformed-frontmatter bug. With it fixed, upstream validation passes clean.
- **Plugin-root `CLAUDE.md` → `CONTRIBUTING.md`.** The plugin shipped its maintainer doctrine in a plugin-root `CLAUDE.md` — exactly what the now-`warn` ST03 flags. `git mv` (history preserved); inbound refs updated (`.claude/rules/skill-conventions.md`, `hooks/pre-compact.sh`, `SKILL.md`).
- **`SKILL.md` `version` drift** — frontmatter stuck at `3.4.1` since before v3.5.0 despite the versioning rule. Corrected to `3.7.1`.

## Validation

- ✅ `claude plugin validate` — **`✔ Validation passed`**, 0 errors, 0 warnings. First clean run of the rollout.
- ✅ All 8 component frontmatter blocks parse via real `yaml.safe_load` (the FM01 self-test).
- ✅ `--fix` argument/flag parsing traced; `context: fork` + `$ARGUMENTS` behavior verified against the cached Slash Commands guide.

## Metadata

- `plugin.json` `3.7.0` → `3.7.1`; `skills/plugin-creation/SKILL.md` frontmatter `3.4.1` → `3.7.1`.
- Root `marketplace.json` `metadata.version` `1.14.46` → `1.14.47`; plugin entry bump.
- Gaps doc annotated with a "Resolved in v3.7.1" section.

## Test plan

- [ ] `claude plugin validate` on this branch → passes clean
- [ ] `/plugin-creation-tools:validate <abs-path-to-some-plugin>` via the Skill tool → targets the named plugin (not the marketplace, not itself)
- [ ] `/plugin-creation-tools:validate --fix --dry-run` → lists proposed changes, writes nothing
- [ ] Re-run `/plugin-creation-tools:validate` against drupal-dev-framework → FM01 catches the 3 malformed-frontmatter files the gaps doc cites; M14/ST03 now warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)