### PR TITLE
drupal-dev-framework v4.7.0: Worktree & subagent modernization

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.47"
+    "version": "1.14.48"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow (Research → Architecture → Implementation) with enforced SOLID, TDD, DRY, and security gates. Ships 22 skills, 30 commands, and 7 agents covering epic/sub-task hierarchy, scope contracts, a Phase 4 /review gate, the Playbook System for opinionated best-practices, git-worktree parallel-task awareness, agent-team validation, and per-project session-remembrance hooks. Depends on dev-guides-navigator and code-quality-tools; see CHANGELOG.md for full version history.",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.0] - 2026-05-20
+
+### Worktree & subagent modernization
+
+Brings the `/worktree` command and the subagent references up to parity with
+Claude Code's dedicated Worktrees guide and the current Subagents content.
+Documentation only — no change to the `/worktree` command flow or any agent.
+Implements §1, §2, §10.2, §10.3 of the 2026-05-08 improvement plan.
+
+### Added
+
+- **`references/worktree-conventions.md` §11 — "Claude Code's native worktree
+  support"** (doc bumped v1.0 → v1.1). New section mapping the framework's
+  task-scoped `/worktree` to Claude Code's native worktree features:
+  - the `claude --worktree` / `-w` CLI flag as a second, session-scoped entry
+    point (`.claude/worktrees/<name>/` on branch `worktree-<name>`);
+  - PR-based worktrees — `claude --worktree "#1234"` → `.claude/worktrees/pr-1234`
+    — and how they pair with Phase 4 `/review`;
+  - `.worktreeinclude` for copying gitignored files (`.env`,
+    `settings.local.php`) into native worktrees;
+  - `worktree.baseRef` (`fresh`/`head`) and why `/worktree` keeps its own
+    `--base` flag defaulting to HEAD rather than reading the setting;
+  - `worktree.bgIsolation` (v2.1.143) and the distinction between the
+    framework's `.worktrees/<task>/` and Claude Code's `.claude/worktrees/`;
+  - cleanup boundaries — `/worktree-prune` scans only `.worktrees/`/`worktrees/`;
+    `cleanupPeriodDays` auto-sweep and Agent View manage native worktrees;
+  - a brief `WorktreeCreate`/`WorktreeRemove` note (non-git VCS; n/a for Drupal).
+
+### Changed
+
+- **`commands/worktree.md`** — "Related" section links the upstream Worktrees
+  guide and conventions §11; Step 6 notes the HEAD default matches the
+  `worktree.baseRef: "head"` semantic (cross-reference, no behavior change).
+- **`references/forked-subagents.md`** — Status line clarifies
+  `CLAUDE_CODE_FORK_SUBAGENT=1` is honored in non-interactive / SDK / `claude -p`
+  flows, not only interactive sessions; "What it is" now states what a standard
+  non-fork subagent loads at startup (CLAUDE.md + memory + git status +
+  preloaded `skills`, but not the parent conversation, prior skill invocations,
+  or already-read files — the cost forks amortize); the bulk-epic-review pattern
+  notes `/propose-epics` re-invocations are SDK-eligible fork candidates; the
+  upstream reference adds the "What loads at startup" anchor. The v4.2.0
+  decision not to enable forks is unchanged.
+
+### Notes
+
+- No behavior change. `/worktree` does not begin reading the `worktree.baseRef`
+  setting — it keeps its `--base` flag and HEAD default (§11.4 explains the
+  reconciliation). The 7 agent files are untouched.
+
 ## [4.6.0] - 2026-05-20
 
 ### Validator hygiene & hook form

--- a/drupal-dev-framework/CONVENTIONS.md
+++ b/drupal-dev-framework/CONVENTIONS.md
@@ -157,7 +157,7 @@ Merge-conflict path 1 aborts merge, prints conflict files, leaves worktree intac
 
 **`project_state.md` field:** `**Worktree By Default:** true` opts the project into worktree-always for `/implement`. Absent → false.
 
-**Conventions:** `references/worktree-conventions.md` v1.0 documents directory priority (`.worktrees/` > `worktrees/` > CLAUDE.md > ask), branch naming (`feature/<task>`), gitignore requirement, signal taxonomy, lifecycle paths, DDEV concerns, refusal cases.
+**Conventions:** `references/worktree-conventions.md` v1.1 documents directory priority (`.worktrees/` > `worktrees/` > CLAUDE.md > ask), branch naming (`feature/<task>`), gitignore requirement, signal taxonomy, lifecycle paths, DDEV concerns, refusal cases, and (§11) how the command relates to Claude Code's native `--worktree` support.
 
 **Reuses:** `superpowers:using-git-worktrees` skill's core patterns (directory priority, gitignore verify, auto-detect setup); extends with task-aware lifecycle + Drupal/DDEV awareness. Not a hard dependency; replicated in command body.
 

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -220,7 +220,7 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `team-manifest-schema.md` **(v3.14.0)** | `/validate:team` + 4 teammates | Minimum-context package v1.0 written by lead before team spawn; absolute-path invariant; `visual_fanout[]` presence rule; write-once contract; fallback behavior hints; gate enum excludes `visual-parity` (deferred to v2 Set B5) |
 | `playbook-schema.md` **(v3.15.0)** | `/playbook-capture`, `/playbook-review`, `scripts/playbook-read.sh` | Recommended local playbook structure v1.0: H3-per-play with What / Rationale / When it applies / Example fields; freeform fallback; defensive parser contract |
 | `playbook-conflict-schema.md` **(v3.15.0)** | `scripts/playbook-conflicts-write.sh`, `/playbook-active` | JSONL log line v1.0 for `<project>/.claude/playbook-conflicts.log`; per-conflict citation shape (local-vs-shipped + multi-set-contradiction types); append-only contract |
-| `worktree-conventions.md` **(v3.16.0)** | `/worktree`, `/worktree-prune`, `/implement` (recommendation), `/complete` (lifecycle) | v1.0: directory priority, branch naming, gitignore requirement, detection signals (HIGH/MEDIUM-HIGH thresholds), 3-path lifecycle, DDEV `name:` warning, refusal cases. Reuses superpowers `using-git-worktrees` patterns + extends with task-aware lifecycle |
+| `worktree-conventions.md` **(v3.16.0; v1.1 in v4.7.0)** | `/worktree`, `/worktree-prune`, `/implement` (recommendation), `/complete` (lifecycle) | v1.1: directory priority, branch naming, gitignore requirement, detection signals (HIGH/MEDIUM-HIGH thresholds), 3-path lifecycle, DDEV `name:` warning, refusal cases. §11 (v4.7.0) maps the command to Claude Code's native worktree support — `claude --worktree`, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, `worktree.bgIsolation`. Reuses superpowers `using-git-worktrees` patterns + extends with task-aware lifecycle |
 | `gate-audit-schema.md` **(v4.0.0)** | `scripts/gate-audit-write.sh` + 7 hardened gates | Unified schema v1.0 for the 7 v4.0.0 audit file types (`pre-analysis`, `coverage-mapping`, `skill-review`, `plugin-validate`, `phase-command-bypass`, `dev-guides-load`, `playbook-load`); `gate_type` discriminator; per-gate `gate_specific` payloads; overwrite-on-fire lifecycle |
 | `gate-hardening-prompts.md` **(v4.0.0; v1.1 in v4.0.2)** | `commands/research.md`, `commands/complete.md`, `commands/audit-status.md` | Literal mandated wording v1.1 for the 5 user-prompt surfaces (`pre-analysis-decision`, `coverage-mapping-fail`, `skill-review-decision`, `plugin-validate-decision`, `phase-command-bypass-acknowledge`); framework refuses to paraphrase or pre-answer; bypass-reason free-text capture. v1.1 (additive) consolidates per-template defaults into a Templates index table; literal blocks byte-identical to v1.0 (verified by `tests/gate-prompts-literal.sh`) |
 | `<phase>-walkthrough.md` **(v4.0.2)** | Optional reference for phase commands | Tutorial-depth walkthrough of `/research`, `/design`, `/implement`, `/complete` — rationale, version history, worked examples. Loaded only when explicitly read; no hook or skill auto-loads |
@@ -287,7 +287,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.6.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.7.0**.
 
 ## License
 

--- a/drupal-dev-framework/commands/worktree.md
+++ b/drupal-dev-framework/commands/worktree.md
@@ -18,7 +18,7 @@ Create a git worktree at `.worktrees/<task_name>/` on branch `feature/<task_name
 /drupal-dev-framework:worktree <task-name> --no-ddev-check              # skip DDEV name: warning
 ```
 
-See `references/worktree-conventions.md` v1.0 for the full convention.
+See `references/worktree-conventions.md` v1.1 for the full convention — including §11, how this command relates to Claude Code's native `claude --worktree` flag, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, and `worktree.bgIsolation`.
 
 ## What this does
 
@@ -73,6 +73,8 @@ If `--no-ddev-check` was passed, skip this step entirely.
 Determine BASE:
 - `--base <ref>` flag → use it
 - Default → `git rev-parse HEAD` (current commit)
+
+The HEAD default matches the `worktree.baseRef: "head"` semantic — Drupal task work often sits on uncommitted local patches a `"fresh"` base would drop. This command does not read the `worktree.baseRef` setting (that setting governs Claude Code's native `--worktree`); pass `--base origin/main` for a clean base. See `references/worktree-conventions.md` §11.4.
 
 Determine BRANCH:
 - `--branch <name>` flag → use it
@@ -160,5 +162,6 @@ Or run /worktree-prune later to clean up when done.
 - `/drupal-dev-framework:worktree-prune` — cleanup
 - `/drupal-dev-framework:implement` — invokes worktree recommendation pre-step
 - `/drupal-dev-framework:complete` — invokes worktree merge prompt at task end
-- `references/worktree-conventions.md` — full conventions
+- `references/worktree-conventions.md` — full conventions; §11 covers Claude Code's native worktree support
 - `superpowers:using-git-worktrees` — generic creation pattern (drupal-dev-framework adds task-aware lifecycle)
+- Claude Code's native worktree support — `https://code.claude.com/docs/en/worktrees` (the `claude --worktree` / `-w` CLI flag, PR-based worktrees, `.worktreeinclude`). The framework's `/worktree` and the native flag are complementary entry points — see `references/worktree-conventions.md` §11.

--- a/drupal-dev-framework/references/forked-subagents.md
+++ b/drupal-dev-framework/references/forked-subagents.md
@@ -1,10 +1,12 @@
 # Forked Subagents (experimental)
 
-> Status: experimental upstream feature. Requires Claude Code v2.1.117+ and explicit opt-in via `CLAUDE_CODE_FORK_SUBAGENT=1`. **Not enabled by default.** Documented here as a future avenue for epic decomposition; v4.2.0 does not change framework behavior.
+> Status: experimental upstream feature. Requires Claude Code v2.1.117+ and explicit opt-in via `CLAUDE_CODE_FORK_SUBAGENT=1` — honored in interactive sessions **and** in non-interactive / SDK / `claude -p` flows. **Not enabled by default.** Documented here as a future avenue for epic decomposition; neither v4.2.0 nor the v4.7.0 doc refresh changes framework behavior.
 
 ## What it is
 
-A *fork* is a subagent that inherits the **entire conversation history** instead of starting fresh — same system prompt, tools, model, messages. Standard subagents start with a clean context. Forks are useful when re-explaining context would be too costly.
+A *fork* is a subagent that inherits the **entire conversation history** instead of starting fresh — same system prompt, tools, model, messages.
+
+A standard (non-fork) subagent starts with a fresh, isolated context. Per the Subagents guide ("What loads at startup"), that initial context is the agent's own system prompt, the full CLAUDE.md + memory hierarchy, a git-status snapshot, and the full content of any skill named in its `skills` frontmatter — but **not** the parent's conversation history, the skills already invoked, or the files Claude has already read. That last gap is the concrete cost a fork amortizes. Forks are useful when re-explaining context would be too costly.
 
 When `CLAUDE_CODE_FORK_SUBAGENT=1` is set:
 
@@ -19,7 +21,7 @@ Epic decomposition (`/migrate-to-epic`, `/propose-epics`) and parallel sub-task 
 
 Concrete patterns where forks could help:
 
-- **Bulk epic review** — `/propose-epics` calls `analysis-agent` per task; with forks, each per-task assessment inherits the project research already loaded (`project_state.md`, `_playbook-load.json`, dev-guides) instead of starting fresh.
+- **Bulk epic review** — `/propose-epics` calls `analysis-agent` per task; with forks, each per-task assessment inherits the project research already loaded (`project_state.md`, `_playbook-load.json`, dev-guides) instead of starting fresh. `/propose-epics` can run non-interactively, and `CLAUDE_CODE_FORK_SUBAGENT=1` is honored in SDK / `claude -p` flows — so these re-invocations are eligible fork candidates regardless of how `/propose-epics` is launched.
 - **Parallel sub-task scoping** — when a newly-promoted epic has 3–5 children needing scope assessment, fork once per child from the loaded epic context.
 - **Cross-cutting validation** — `/validate:team` already isolates per-gate context for honest validation; forks invert that for cases where shared context is *desired* (e.g., comparing two architecture options against the same loaded research).
 
@@ -40,4 +42,4 @@ If (1) is yes and (2) is no, fork. Otherwise stay with standard subagent.
 
 ## Upstream reference
 
-`https://docs.claude.com/en/docs/claude-code/sub-agents` (Subagents guide; "Fork the current conversation" section).
+Subagents guide — `https://code.claude.com/docs/en/sub-agents`, sections "Fork the current conversation" and "What loads at startup" (`#what-loads-at-startup`).

--- a/drupal-dev-framework/references/worktree-conventions.md
+++ b/drupal-dev-framework/references/worktree-conventions.md
@@ -1,4 +1,4 @@
-# Worktree Conventions v1.0
+# Worktree Conventions v1.1
 
 **Introduced:** drupal-dev-framework v3.16.0
 **Owner:** `commands/worktree.md`, `commands/worktree-prune.md`, `commands/implement.md` (recommendation), `commands/complete.md` (lifecycle)
@@ -135,13 +135,116 @@ The existing `session-context-writer` skill (v1.4.0) writes to `~/.claude/drupal
 
 `/worktree` pre-seeds the new session-context file with `task: null, taskPath: null, project: <name>, projectPath: <abs>` so the file exists for hooks; the user's first `/research` or `/implement` populates the task field.
 
-## 11. Versioning policy
+## 11. Claude Code's native worktree support
+
+Claude Code ships its own git-worktree features, separate from this framework's
+`/worktree` command. The two coexist; this section maps the relationship so a
+user running framework work inside native worktrees is not surprised.
+
+### 11.1 Two entry points
+
+| Entry point | Creates | Branch | Owned by |
+|---|---|---|---|
+| `/drupal-dev-framework:worktree <task>` | `.worktrees/<task>/` | `feature/<task>` | this framework |
+| `claude --worktree <name>` (or `-w`) | `.claude/worktrees/<name>/` | `worktree-<name>` | Claude Code |
+
+The framework's `/worktree` is task-scoped: it resolves the task folder, runs
+Drupal/DDEV-aware setup, and pre-seeds session-context (§2, §10). The native
+`--worktree` flag is session-scoped — it starts a whole Claude Code session in a
+fresh worktree. Mid-session, asking Claude to "work in a worktree" triggers the
+`EnterWorktree` tool, which creates one the same way. Native `--worktree`
+requires the workspace-trust dialog to have been accepted (run `claude` once in
+the directory first).
+
+### 11.2 Reviewing a PR in a worktree
+
+`claude --worktree "#1234"` (or a full GitHub pull-request URL) fetches
+`pull/1234/head` and creates a worktree at `.claude/worktrees/pr-1234`. This
+pairs naturally with Phase 4 `/review`: open the PR in its own checkout, run
+`/review` there, and the main working tree stays untouched. The framework does
+not wrap this — it is a native CLI entry point, used directly.
+
+### 11.3 Copying gitignored files — `.worktreeinclude`
+
+A native worktree is a fresh checkout, so gitignored files (`.env`,
+`settings.local.php`, parts of `.ddev/`) are absent. A `.worktreeinclude` file
+at the project root — `.gitignore` syntax — lists gitignored files to copy into
+each new native worktree. Only files that both match a pattern AND are
+gitignored are copied, so tracked files are never duplicated. A typical Drupal
+entry:
+
+```text
+.env
+web/sites/default/settings.local.php
+```
+
+`.worktreeinclude` applies to `--worktree`, `EnterWorktree`, and subagent
+worktrees. It is NOT processed when a `WorktreeCreate` hook is configured
+(§11.6). The framework's own `/worktree` runs explicit setup (`commands/worktree.md`
+Step 7) rather than relying on `.worktreeinclude`.
+
+### 11.4 Base ref — `worktree.baseRef` vs the framework's HEAD default
+
+The `worktree.baseRef` setting governs which ref *native* worktrees branch from:
+
+- `"fresh"` (default) — branches from `origin/<default-branch>`, a clean tree
+  matching the remote.
+- `"head"` — branches from local `HEAD`, carrying unpushed commits and
+  feature-branch state.
+
+It applies to `--worktree`, the `EnterWorktree` tool, and subagent isolation.
+
+The framework's `/worktree` command does **not** read `worktree.baseRef`. It has
+its own `--base <ref>` flag and defaults `BASE` to `git rev-parse HEAD` — i.e.
+the `"head"` semantic. This is deliberate: Drupal task work frequently sits on
+uncommitted local patches and feature-branch state that a `"fresh"` base would
+drop. Users who want a clean base pass `--base origin/main` explicitly.
+
+### 11.5 Background-session isolation — `worktree.bgIsolation`
+
+`worktree.bgIsolation` (v2.1.143+) controls how *background* sessions
+(`claude --bg`, `/background`, Agent View) isolate their edits:
+
+- `"worktree"` (default) — `Edit`/`Write` in the main checkout are blocked until
+  the background session calls `EnterWorktree`, so background work lands in a
+  `.claude/worktrees/` worktree.
+- `"none"` — background jobs edit the working copy directly.
+
+This is a background-session mechanism, finer-grained than and independent of
+the framework's `/worktree`. A user who runs framework work in background
+sessions will accumulate native worktrees under `.claude/worktrees/` — see §11.7.
+
+### 11.6 Non-git VCS — `WorktreeCreate` / `WorktreeRemove`
+
+`WorktreeCreate` / `WorktreeRemove` hooks let non-git VCSs (SVN, Perforce,
+Mercurial) supply custom worktree creation and cleanup. Drupal projects are git
+in practice, so the framework neither ships nor needs these hooks — noted only
+so the relationship is complete.
+
+### 11.7 Cleanup boundaries
+
+`/worktree-prune` scans only `.worktrees/` and `worktrees/` — the framework's own
+layout. It does **not** see `.claude/worktrees/` (native `--worktree` sessions,
+PR worktrees, background isolation). Native worktrees are managed by:
+
+- Agent View (`Ctrl+X` to delete a background-session worktree),
+- `git worktree remove` / `git worktree prune`, and
+- the `cleanupPeriodDays` auto-sweep, which removes *orphaned subagent*
+  worktrees older than the cutoff that have no uncommitted changes, untracked
+  files, or unpushed commits. Worktrees created with `--worktree` are never
+  swept.
+
+The `cleanupPeriodDays` auto-sweep complements `/worktree-prune`; it does not
+replace it — the framework's prune is task-aware (checks branch-merged and
+task-completed), the native sweep is not.
+
+## 12. Versioning policy
 
 - **Major bumps** (`2.0`) are breaking: changes to directory priority semantics, branch-naming default, signal-strength thresholds, lifecycle path order.
-- **Minor bumps** (`1.1`) are additive: new optional signal types, new lifecycle paths, additional refusal cases, new flags.
-- v1.0 is committed for v3.16.0.
+- **Minor bumps** (`1.1`) are additive: new optional signal types, new lifecycle paths, additional refusal cases, new flags, new documentation sections.
+- v1.0 committed for v3.16.0; v1.1 (additive — §11 native worktree support) for v4.7.0.
 
-## 12. Non-goals (deferred to v2)
+## 13. Non-goals (deferred to v2)
 
 - Configurable detection-window beyond 2 hours
 - Detection signals on `/research` and `/design`


### PR DESCRIPTION
Second release of the drupal-dev-framework modernization roadmap (2026-05-20). Brings the `/worktree` command and subagent references up to parity with Claude Code's dedicated Worktrees guide and current Subagents content.

## Scope

Documentation only — **no change** to the `/worktree` command flow or any of the 7 agent files. Implements §1, §2, §10.2, §10.3 of the 2026-05-08 improvement plan.

## Changes

**`references/worktree-conventions.md` — new §11 "Claude Code's native worktree support"** (doc v1.0 → v1.1, additive)
- `claude --worktree` / `-w` CLI flag documented as a second, session-scoped entry point alongside the framework's task-scoped `/worktree`.
- PR-based worktrees (`claude --worktree "#1234"` → `.claude/worktrees/pr-1234`) and how they pair with Phase 4 `/review`.
- `.worktreeinclude` for copying gitignored files (`.env`, `settings.local.php`) into native worktrees.
- `worktree.baseRef` (`fresh`/`head`) — **reconciled, not switched**: `/worktree` keeps its own `--base` flag defaulting to HEAD (the `"head"` semantic, deliberate for Drupal patch-on-HEAD work) and does not read the setting.
- `worktree.bgIsolation` (v2.1.143) and the `.worktrees/<task>/` vs `.claude/worktrees/` distinction.
- Cleanup boundaries — `/worktree-prune` scans only `.worktrees/`/`worktrees/`; `cleanupPeriodDays` auto-sweep + Agent View manage native worktrees.
- Brief `WorktreeCreate`/`WorktreeRemove` note (non-git VCS; n/a for Drupal).

**`commands/worktree.md`**
- "Related" section links the upstream Worktrees guide and conventions §11.
- Step 6 cross-references the `worktree.baseRef: "head"` semantic. Command flow (10 steps) unchanged.

**`references/forked-subagents.md`** (§1 + §10.2)
- Status line clarifies `CLAUDE_CODE_FORK_SUBAGENT=1` is honored in non-interactive / SDK / `claude -p` flows, not only interactive sessions.
- "What it is" now documents what a standard non-fork subagent loads at startup (CLAUDE.md + memory + git status + preloaded `skills`, but **not** parent conversation, prior skill invocations, or already-read files — the cost forks amortize).
- Bulk-epic-review pattern notes `/propose-epics` re-invocations are SDK-eligible fork candidates.
- Upstream reference adds the "What loads at startup" anchor. The v4.2.0 decision not to enable forks is unchanged.

**Version:** `plugin.json` + marketplace entry 4.6.0 → 4.7.0; marketplace `metadata.version` 1.14.47 → 1.14.48.

## Validation evidence

- `/plugin-creation-tools:validate` → **PASS** — zero errors, zero warnings. (All 67 frontmatter blocks parse as valid YAML — confirms the v4.6.0 fixes hold.)
- `claude plugin validate` → **`✔ Validation passed`** — clean.
- `/worktree` command spec re-checked: frontmatter valid, all 10 steps intact, no flow change.

## Notes

- Every worktree/subagent claim is grounded in the cached upstream guides (Worktrees, Worktree Isolation, Subagents, Settings), not training data.
- One pre-existing info item left untouched (out of scope): `commands/validate-guides.md` declares the experimental `Agent` tool in `allowed-tools` — a candidate for a future release, not a v4.7.0 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)