### PR TITLE
drupal-dev-framework v4.9.0: Workflow integration & references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.49"
+    "version": "1.14.50"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow (Research → Architecture → Implementation) with enforced SOLID, TDD, DRY, and security gates. Ships 22 skills, 30 commands, and 7 agents covering epic/sub-task hierarchy, scope contracts, a Phase 4 /review gate, the Playbook System for opinionated best-practices, git-worktree parallel-task awareness, agent-team validation, and per-project session-remembrance hooks. Depends on dev-guides-navigator and code-quality-tools; see CHANGELOG.md for full version history.",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.0] - 2026-05-20
+
+### Workflow integration & references
+
+The final release of the 2026-05-20 modernization roadmap. Implements §6, §7a–§7e, §8, §10.4, and §10.7 of the 2026-05-08 improvement plan: session-ID-scoped session files, background-agent workflows, and the remaining reference docs.
+
+### Changed
+
+- **Session-context files are now session-ID-scoped (§7a).** `session-context-writer` and every session hook resolved the per-workspace session file as `md5($PWD).json`, so two Claude Code sessions in the same directory collided last-writer-wins. A new shared helper `scripts/session-paths.sh` (`ddf_session_file`) keys the file by `md5($PWD)` salted with `$CLAUDE_CODE_SESSION_ID` when set, falling back to the pre-v4.9.0 `md5($PWD)` scheme when absent (backward compatible).
+  - Helper sourced by 9 consumers: the `session-context-writer` skill, `session-start.sh`, `pre-compact.sh`, `post-compact.sh`, `stop-failure.sh`, `context-reminder.sh`, `loaded-context-summary.sh`, `phase-command-bypass-detect.sh`, `migrate-to-epic.sh`.
+  - `save-session.sh` (copied into the project by `/install-remembrance-hook`, so it cannot source the plugin helper) inlines the equivalent formula, with a keep-in-sync comment.
+  - Only the session-context JSON is session-salted. The within-session skip-emit caches (`<hash>.last-*.md5`) and `save-session.sh`'s cross-session `<hash>.last-saved` marker stay keyed by the workspace-only hash — the marker is cross-session by design; the caches self-heal.
+  - `session-context-writer` skill 1.4.0 → 1.5.0; `worktree-conventions.md` §10 reworded (doc v1.1 → v1.2).
+
+### Added
+
+- **`references/post-batch-aggregation.md` (§6).** Documents the opt-in `PostToolBatch` pattern for aggregating `/research-team` and `/validate:team` per-teammate outputs into one roll-up. The plugin does **not** ship the hook — plugin-scoped `PostToolBatch` fires on every conversation and has no matcher. Mirrors code-quality-tools' sibling reference.
+- **`commands/review.md` — "When to escalate" (§7b, §7d, §10.4).** `claude ultrareview` documented as an opt-in deeper cloud review after `/review`'s gates pass (explicit user opt-in, ~$5–20/run as usage credits, never automatic); plus a long-runs tip pairing `channelsEnabled` notifications and `/goal` with the gate-aggregating commands.
+- **`CONVENTIONS.md` — three sections (§7c, §7e, §8, §10.4, §10.7):**
+  - "Condition-checked autonomy with `/goal`" — `/goal` vs `/loop`, framework examples, background sessions / Agent View.
+  - "Security & auto-mode posture" — `--dangerously-skip-permissions` removes the framework's `.claude/`-write safety net; `defaultMode: "auto"` is silently ignored in project settings since v2.1.142, so `autoMode.hard_deny` only guards a user-enabled auto mode.
+  - "Documentation & observability notes" — link upstream pages directly (the `/en/common-workflows` hub was pruned); OTel `invocation_trigger` future-instrumentation footnote.
+- **Long-run tips** in `commands/research-team.md` (`channelsEnabled` notification) and `commands/validate-all.md` (`/goal` pairing).
+
+### Notes
+
+- No change to gate semantics, the `/worktree` flow, or agent behavior. §7a is the only code change and is backward compatible — the session-file path is byte-identical to the pre-v4.9.0 scheme when `CLAUDE_CODE_SESSION_ID` is unset.
+- §7a was scoped by the roadmap as a 2-file edit; in reality the `md5($PWD)` path was computed in ~10 places, so it shipped as a coordinated change behind one shared helper (surfaced and confirmed with the maintainer before implementation).
+
+Version: plugin.json + marketplace entry 4.8.0 → 4.9.0; marketplace metadata.version 1.14.49 → 1.14.50.
+
 ## [4.8.0] - 2026-05-20
 
 ### Effort-adaptive skills

--- a/drupal-dev-framework/CONVENTIONS.md
+++ b/drupal-dev-framework/CONVENTIONS.md
@@ -157,7 +157,7 @@ Merge-conflict path 1 aborts merge, prints conflict files, leaves worktree intac
 
 **`project_state.md` field:** `**Worktree By Default:** true` opts the project into worktree-always for `/implement`. Absent → false.
 
-**Conventions:** `references/worktree-conventions.md` v1.1 documents directory priority (`.worktrees/` > `worktrees/` > CLAUDE.md > ask), branch naming (`feature/<task>`), gitignore requirement, signal taxonomy, lifecycle paths, DDEV concerns, refusal cases, and (§11) how the command relates to Claude Code's native `--worktree` support.
+**Conventions:** `references/worktree-conventions.md` v1.2 documents directory priority (`.worktrees/` > `worktrees/` > CLAUDE.md > ask), branch naming (`feature/<task>`), gitignore requirement, signal taxonomy, lifecycle paths, DDEV concerns, refusal cases, and (§11) how the command relates to Claude Code's native `--worktree` support.
 
 **Reuses:** `superpowers:using-git-worktrees` skill's core patterns (directory priority, gitignore verify, auto-detect setup); extends with task-aware lifecycle + Drupal/DDEV awareness. Not a hard dependency; replicated in command body.
 
@@ -286,6 +286,16 @@ Users can poll deploy status or run periodic checks during long sessions:
 
 Session-scoped — stops when session exits. 3-day auto-expiry.
 
+## Condition-checked autonomy with `/goal` (v4.9.0+)
+
+`/loop` re-runs a prompt on a time interval; `/goal` re-runs the session **until a condition holds**. After each turn a small fast model checks the condition against what the transcript shows and either starts another turn or clears the goal. It fits framework phases with a verifiable end state.
+
+- `/review` writes `_review.json` and per-gate envelopes — a goal like `/goal every hard-block gate in <task>/validations/latest reports pass` runs review-fix loops unattended.
+- `/validate:all` (7 gates) is similar — `/goal every gate in the validation summary reports pass or skipped`.
+- The evaluator judges only what is **already in the transcript** — it does not run tools or read files. The command must surface gate results inline (both `/review` and `/validate:all` do). Each `/goal` turn bills tokens; keep conditions measurable and bound them (`… or stop after 20 turns`).
+
+Long `/review`, `/research-team`, and `/validate:team` runs can also be dispatched as **background sessions** — `claude --bg "<prompt>"`, `/background` (alias `/bg`) from inside a session, or from Agent View (`claude agents`). A background session keeps running with no terminal attached. This composes with the `channelsEnabled` push-notification tip: background-run + ping-on-done.
+
 ## Sandbox and DDEV
 
 If users enable Claude Code sandboxing (`/sandbox`), DDEV commands will fail because Docker socket access is restricted. Required configuration:
@@ -312,6 +322,18 @@ Recommend users create `.claude/rules/` files scoped to file types for Drupal-sp
 - `drupal-scss.md` with `paths: ["*.scss"]` — BEM, Bootstrap usage, mobile-first
 
 These load only when Claude works on matching files, keeping context lean.
+
+## Security & auto-mode posture (v4.9.0+)
+
+**`--dangerously-skip-permissions`.** The framework writes to `.claude/` constantly — `session_context.json`, the `_*.json` gate audits, task folders under `.claude/projects/`. Running Claude Code with `--dangerously-skip-permissions` removes the permission prompts on `.claude/`, `.git/`, and `.vscode/` writes that are the safety net for the framework's own state files. Use it only in throwaway or sandboxed environments, never on a production-adjacent checkout.
+
+**`autoMode.hard_deny` and project settings.** Since Claude Code v2.1.142, a project's `.claude/settings.json` (or `.claude/settings.local.json`) **cannot** set `defaultMode: "auto"` — it is silently ignored, so a repository cannot grant itself auto mode. Auto mode is enabled only from the user's own `~/.claude/settings.json`. A project may still ship an `autoMode.hard_deny` array (unconditional denials — e.g. `core/`, `vendor/`, `web/sites/default/settings.php`, `.ddev/`); that list applies as a guardrail **if** the user has turned auto mode on, but it cannot itself turn auto mode on.
+
+## Documentation & observability notes (v4.9.0+)
+
+**Upstream doc links.** When referencing Claude Code documentation, link the specific current page — `/en/permission-modes`, `/en/worktrees`, `/en/sub-agents` — not the former `/en/common-workflows` hub, which was pruned. Direct per-topic links are stable; the hub is gone.
+
+**OTel skill metrics.** The framework does not ship OpenTelemetry instrumentation. If it ever does, note that `claude_code.skill_activated` carries an `invocation_trigger` attribute distinguishing `user-slash` from `claude-proactive` and `nested-skill` — useful for measuring how often framework commands are user-invoked versus auto-triggered. Recorded here as a future-instrumentation footnote.
 
 ## General
 - Current state only — no historical narratives

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -249,10 +249,12 @@ Machine-readable contracts consumed by skills and commands. These pin schemas an
 | `team-manifest-schema.md` **(v3.14.0)** | `/validate:team` + 4 teammates | Minimum-context package v1.0 written by lead before team spawn; absolute-path invariant; `visual_fanout[]` presence rule; write-once contract; fallback behavior hints; gate enum excludes `visual-parity` (deferred to v2 Set B5) |
 | `playbook-schema.md` **(v3.15.0)** | `/playbook-capture`, `/playbook-review`, `scripts/playbook-read.sh` | Recommended local playbook structure v1.0: H3-per-play with What / Rationale / When it applies / Example fields; freeform fallback; defensive parser contract |
 | `playbook-conflict-schema.md` **(v3.15.0)** | `scripts/playbook-conflicts-write.sh`, `/playbook-active` | JSONL log line v1.0 for `<project>/.claude/playbook-conflicts.log`; per-conflict citation shape (local-vs-shipped + multi-set-contradiction types); append-only contract |
-| `worktree-conventions.md` **(v3.16.0; v1.1 in v4.7.0)** | `/worktree`, `/worktree-prune`, `/implement` (recommendation), `/complete` (lifecycle) | v1.1: directory priority, branch naming, gitignore requirement, detection signals (HIGH/MEDIUM-HIGH thresholds), 3-path lifecycle, DDEV `name:` warning, refusal cases. §11 (v4.7.0) maps the command to Claude Code's native worktree support — `claude --worktree`, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, `worktree.bgIsolation`. Reuses superpowers `using-git-worktrees` patterns + extends with task-aware lifecycle |
+| `worktree-conventions.md` **(v3.16.0; v1.2 in v4.9.0)** | `/worktree`, `/worktree-prune`, `/implement` (recommendation), `/complete` (lifecycle) | v1.2: directory priority, branch naming, gitignore requirement, detection signals (HIGH/MEDIUM-HIGH thresholds), 3-path lifecycle, DDEV `name:` warning, refusal cases. §11 (v4.7.0) maps the command to Claude Code's native worktree support — `claude --worktree`, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, `worktree.bgIsolation`. Reuses superpowers `using-git-worktrees` patterns + extends with task-aware lifecycle |
 | `gate-audit-schema.md` **(v4.0.0)** | `scripts/gate-audit-write.sh` + 7 hardened gates | Unified schema v1.0 for the 7 v4.0.0 audit file types (`pre-analysis`, `coverage-mapping`, `skill-review`, `plugin-validate`, `phase-command-bypass`, `dev-guides-load`, `playbook-load`); `gate_type` discriminator; per-gate `gate_specific` payloads; overwrite-on-fire lifecycle |
 | `gate-hardening-prompts.md` **(v4.0.0; v1.1 in v4.0.2)** | `commands/research.md`, `commands/complete.md`, `commands/audit-status.md` | Literal mandated wording v1.1 for the 5 user-prompt surfaces (`pre-analysis-decision`, `coverage-mapping-fail`, `skill-review-decision`, `plugin-validate-decision`, `phase-command-bypass-acknowledge`); framework refuses to paraphrase or pre-answer; bypass-reason free-text capture. v1.1 (additive) consolidates per-template defaults into a Templates index table; literal blocks byte-identical to v1.0 (verified by `tests/gate-prompts-literal.sh`) |
 | `<phase>-walkthrough.md` **(v4.0.2)** | Optional reference for phase commands | Tutorial-depth walkthrough of `/research`, `/design`, `/implement`, `/complete` — rationale, version history, worked examples. Loaded only when explicitly read; no hook or skill auto-loads |
+| `post-batch-aggregation.md` **(v4.9.0)** | Opt-in project pattern (not a shipped hook) | How a project can wire a `PostToolBatch` hook to roll up `/research-team` / `/validate:team` per-teammate output into one summary. Documents why the plugin doesn't ship it (plugin-scoped `PostToolBatch` has no matcher) — mirrors code-quality-tools |
+| `forked-subagents.md` **(v4.2.0)** | Capability evaluation reference | Fork-subagent eligibility for epic decomposition; what a standard non-fork subagent loads at startup; the v4.2.0 decision not to enable forks |
 
 ### Online Dev-Guides (60+ topics) — Required
 
@@ -316,7 +318,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.8.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.9.0**.
 
 ## License
 

--- a/drupal-dev-framework/commands/research-team.md
+++ b/drupal-dev-framework/commands/research-team.md
@@ -14,6 +14,8 @@ Research or investigate a task using an agent team with 3 competing perspectives
 /drupal-dev-framework:research-team <task-name>
 ```
 
+> **Tip — long runs.** A 3-teammate research team takes minutes. Enable `channelsEnabled` in user settings for a push notification when the run completes.
+
 ## What This Does
 
 Spawns a 3-teammate agent team for Phase 1 research. Detects whether the task is a **feature** (Build vs Use vs Extend debate) or a **bug** (competing hypothesis investigation). Each teammate writes their own findings file. The lead synthesizes a final output.

--- a/drupal-dev-framework/commands/review.md
+++ b/drupal-dev-framework/commands/review.md
@@ -109,6 +109,12 @@ Audit: {{audit_path}}
 
 `--team` invokes `/validate:team` directly; inner fallback (auto-falls-back to `/validate:all` when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS != "1"` or `TeamCreate` fails) handles unavailability. `_review.json gate_specific.mode` records actual: `"team"`, `"all"`, `"team-fallback-to-all"`.
 
+## When to escalate — `claude ultrareview`
+
+After `/review`'s gates pass, a high-stakes PR (production-adjacent, security-critical, or large) can get a deeper pass: `claude ultrareview <PR>` (or `/ultrareview`) runs a multi-agent reviewer fleet in a cloud sandbox that independently reproduces and verifies each finding. **Explicit user opt-in only** — never run it automatically from `/review`; it bills as usage credits (~$5–20/run beyond a small free-run allotment). The `code-quality-tools:ultrareview` skill wraps the same platform check; either entry point works.
+
+**Tip — long runs.** `/review`, `/research-team`, and `/validate:team` take minutes. Enable `channelsEnabled` in user settings for a push notification on completion. `/goal` pairs with `/review` for unattended green-until-done runs (e.g. `/goal every hard-block gate in <task>/validations/latest reports pass`) — see `CONVENTIONS.md` "Condition-checked autonomy with `/goal`".
+
 ## Pointers
 
 - Full walkthrough: `references/review-phase-walkthrough.md` (sibling `plumbing_docs_tests`)

--- a/drupal-dev-framework/commands/validate-all.md
+++ b/drupal-dev-framework/commands/validate-all.md
@@ -15,6 +15,8 @@ Run every validation gate sequentially against the current task. Aggregate the p
 /drupal-dev-framework:validate-all <task-name>  # run against a specific task
 ```
 
+> **Tip — unattended runs.** `/goal` pairs with `/validate:all` for green-until-done loops — e.g. `/goal every gate in the validation summary reports pass or skipped`. The evaluator judges only what the transcript shows, so the printed summary table (step 7) is what it reads. See `CONVENTIONS.md` "Condition-checked autonomy with `/goal`".
+
 ## What this does
 
 1. **Resolve task + project context** — same resolution as other `/validate:*` commands.

--- a/drupal-dev-framework/commands/worktree.md
+++ b/drupal-dev-framework/commands/worktree.md
@@ -18,7 +18,7 @@ Create a git worktree at `.worktrees/<task_name>/` on branch `feature/<task_name
 /drupal-dev-framework:worktree <task-name> --no-ddev-check              # skip DDEV name: warning
 ```
 
-See `references/worktree-conventions.md` v1.1 for the full convention — including §11, how this command relates to Claude Code's native `claude --worktree` flag, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, and `worktree.bgIsolation`.
+See `references/worktree-conventions.md` v1.2 for the full convention — including §11, how this command relates to Claude Code's native `claude --worktree` flag, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, and `worktree.bgIsolation`.
 
 ## What this does
 

--- a/drupal-dev-framework/hooks/context-reminder.sh
+++ b/drupal-dev-framework/hooks/context-reminder.sh
@@ -11,8 +11,10 @@
 
 set -eu
 
-WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-SESS="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+DDF_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+. "$DDF_DIR/scripts/session-paths.sh"
+WORKSPACE_HASH=$(ddf_workspace_hash)   # cache key (workspace-stable)
+SESS=$(ddf_session_file)
 
 # Fast gate — no session file means no active task in this workspace.
 [ -s "$SESS" ] || exit 0

--- a/drupal-dev-framework/hooks/loaded-context-summary.sh
+++ b/drupal-dev-framework/hooks/loaded-context-summary.sh
@@ -9,8 +9,10 @@
 set -euo pipefail
 
 # Read session_context for the current workspace
-WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-SESS_FILE="$HOME/.claude/drupal-dev-framework/sessions/$WORKSPACE_HASH.json"
+DDF_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+. "$DDF_DIR/scripts/session-paths.sh"
+WORKSPACE_HASH=$(ddf_workspace_hash)   # cache key (workspace-stable)
+SESS_FILE=$(ddf_session_file)
 
 [[ -s "$SESS_FILE" ]] || { jq -nc '{}'; exit 0; }
 

--- a/drupal-dev-framework/hooks/post-compact.sh
+++ b/drupal-dev-framework/hooks/post-compact.sh
@@ -2,8 +2,9 @@
 # Post-compact hook: Instruct Claude to reload project context after compaction
 # Reads per-workspace session file to find the active project
 
-WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+DDF_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+. "$DDF_DIR/scripts/session-paths.sh"
+SESSION_FILE=$(ddf_session_file)
 
 # Only output if a framework command was used in this workspace this session
 if [ ! -f "$SESSION_FILE" ]; then

--- a/drupal-dev-framework/hooks/pre-compact.sh
+++ b/drupal-dev-framework/hooks/pre-compact.sh
@@ -2,8 +2,9 @@
 # Pre-compact hook: Instruct Claude to preserve active project context
 # Reads per-workspace session file to find the active project
 
-WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+DDF_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+. "$DDF_DIR/scripts/session-paths.sh"
+SESSION_FILE=$(ddf_session_file)
 
 # Only output if a framework command was used in this workspace this session
 if [ ! -f "$SESSION_FILE" ]; then

--- a/drupal-dev-framework/hooks/session-start.sh
+++ b/drupal-dev-framework/hooks/session-start.sh
@@ -2,9 +2,10 @@
 # Session start hook for drupal-dev-framework
 # Checks required plugins and registered projects
 
-# Clear stale session context for THIS workspace only
-WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-rm -f "$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+# Clear stale session context for THIS session only
+DDF_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+. "$DDF_DIR/scripts/session-paths.sh"
+rm -f "$(ddf_session_file)"
 
 # Note: dev-guides-navigator presence is now enforced at install time via the
 # `dependencies` field in .claude-plugin/plugin.json. The former soft runtime

--- a/drupal-dev-framework/hooks/stop-failure.sh
+++ b/drupal-dev-framework/hooks/stop-failure.sh
@@ -11,8 +11,9 @@ TIMESTAMP=$(date -Iseconds)
 PROJECT_NAME=""
 TASK_NAME=""
 
-WORKSPACE_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-SESSION_FILE="$HOME/.claude/drupal-dev-framework/sessions/${WORKSPACE_HASH}.json"
+DDF_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+. "$DDF_DIR/scripts/session-paths.sh"
+SESSION_FILE=$(ddf_session_file)
 
 if [ -f "$SESSION_FILE" ]; then
   PROJECT_NAME=$(jq -r '.project // empty' "$SESSION_FILE" 2>/dev/null)

--- a/drupal-dev-framework/references/post-batch-aggregation.md
+++ b/drupal-dev-framework/references/post-batch-aggregation.md
@@ -1,0 +1,87 @@
+# PostToolBatch Aggregation Pattern
+
+> Status: documented optional pattern. **Not shipped as a default-on hook** by this plugin. Copy the snippets below into your project's `.claude/settings.json` (or a project-local hooks file) if you want batch-level aggregation of agent-team runs. Requires Claude Code v2.1.118+ (Hooks Reference).
+
+## What it is
+
+`PostToolBatch` fires once after a full batch of parallel tool calls resolves, **before the next model call**. There is no matcher — it fires on every batch. Compare to `PostToolUse`, which fires once per individual tool call (and so fires concurrently when Claude makes parallel calls).
+
+The framework's agent-team commands fan out across multiple teammates that each run tools and write their own output:
+
+- **`/research-team`** spawns a 3-teammate Phase-1 research team; each teammate writes its own findings file, then the lead synthesizes.
+- **`/validate:team`** spawns a 4-teammate validation team; each owns a subset of the v3.13.0 gates and writes its per-gate envelope.
+
+When those teammates' tool calls land as a parallel batch, `PostToolBatch` is the one place a handler sees the whole batch at once — so it can emit a single roll-up instead of reconstructing it from N per-tool events.
+
+## When to use
+
+- Rolling up `/research-team` per-teammate findings files into one "all three perspectives written" line once the batch settles.
+- Logging a single timestamped row per team run to a project log instead of one row per teammate.
+- Posting a single notification (Slack, etc.) on team-run completion rather than per-teammate fragments.
+
+## When not to use
+
+- Per-tool gating — that is `PreToolUse`.
+- Per-teammate error alerting where each failure should fire independently — that is `PostToolUse` / `PostToolUseFailure`.
+- Single-agent flows (`/research`, and `/validate:all` which runs gates sequentially) — there is no parallel batch to aggregate; standard per-step handling is simpler.
+
+## Worked example — team-run roll-up
+
+Project-local `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolBatch": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/team-batch-summary.sh",
+            "args": [],
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Aggregator `.claude/hooks/team-batch-summary.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Reads the PostToolBatch payload on stdin; summarizes teammate output writes.
+set -eu
+PAYLOAD=$(cat)
+echo "$PAYLOAD" | jq -r '
+  .tool_calls
+  | map(select(
+      (.tool_name == "Write")
+      and ((.tool_input.file_path // "") | test("research-team-|/validations/"))
+    ))
+  | select(length > 0)
+  | "drupal-dev-framework team batch — \(length) teammate output(s):",
+    (.[] | "  \(.tool_input.file_path)")
+'
+exit 0
+```
+
+`PostToolBatch` input carries `tool_calls[]`, each element with `tool_name`, `tool_input`, `tool_use_id`, and `tool_response` (Hooks Reference). The handler filters the batch to teammate output writes and emits one consolidated line; emit it as `additionalContext` JSON if you want Claude to see the roll-up before the next turn.
+
+## Why this plugin does not ship it by default
+
+- A plugin-scoped `PostToolBatch` hook fires on **every** batch in **every** Claude Code conversation while drupal-dev-framework is enabled — including conversations that never touch `/research-team` or `/validate:team`. That is pure noise for the common case.
+- `PostToolBatch` has **no matcher** (Hooks Reference) — there is no hook-layer way to scope it to "only during team runs." The handler script must filter the payload itself (the example does this with a `jq` test).
+- Until upstream adds a matcher or skill-scoping for `PostToolBatch`, the right home for this hook is the **user's project**, not the plugin. This mirrors code-quality-tools' decision for the same primitive.
+
+## Future avenue
+
+If `PostToolBatch` gains a matcher or skill-scoping, the framework can revisit shipping a default-on team-run aggregator scoped to `/research-team` and `/validate:team`. Track the Hooks Reference and re-evaluate.
+
+## Cross-references
+
+- `commands/research-team.md`, `commands/validate-team.md` — the team commands whose output a project-local aggregator would roll up.
+- `references/troubleshooting.md` — verifying a hook actually loads (`/hooks`).
+- code-quality-tools ships the sibling pattern at `skills/code-quality-audit/references/post-batch-aggregation.md`.

--- a/drupal-dev-framework/references/worktree-conventions.md
+++ b/drupal-dev-framework/references/worktree-conventions.md
@@ -1,4 +1,4 @@
-# Worktree Conventions v1.1
+# Worktree Conventions v1.2
 
 **Introduced:** drupal-dev-framework v3.16.0
 **Owner:** `commands/worktree.md`, `commands/worktree-prune.md`, `commands/implement.md` (recommendation), `commands/complete.md` (lifecycle)
@@ -131,7 +131,7 @@ The `/worktree` creation command refuses on:
 
 ## 10. Session-context interaction
 
-The existing `session-context-writer` skill (v1.4.0) writes to `~/.claude/drupal-dev-framework/sessions/<md5($PWD)>.json`. **No changes needed** — the worktree's distinct `$PWD` produces a distinct hash, which produces a distinct session-context file automatically.
+The `session-context-writer` skill (v1.5.0+) writes the session-context file through the shared `scripts/session-paths.sh` helper (`ddf_session_file`). The path is keyed by `md5($PWD)` and — when `CLAUDE_CODE_SESSION_ID` is set — additionally by the session ID. A worktree gets a distinct `$PWD` (`.worktrees/<task>/`), so its session-context file is already distinct from the main tree's; the session-ID salt (added v4.9.0, §7a of the improvement plan) additionally separates two sessions that share the **same** `$PWD` — two terminals in the main checkout, or a resumed session. Every session hook resolves the same path through the helper; the project-copied `save-session.sh` inlines an equivalent formula. When `CLAUDE_CODE_SESSION_ID` is absent the key is `md5($PWD)` exactly as before v4.9.0.
 
 `/worktree` pre-seeds the new session-context file with `task: null, taskPath: null, project: <name>, projectPath: <abs>` so the file exists for hooks; the user's first `/research` or `/implement` populates the task field.
 
@@ -242,7 +242,7 @@ task-completed), the native sweep is not.
 
 - **Major bumps** (`2.0`) are breaking: changes to directory priority semantics, branch-naming default, signal-strength thresholds, lifecycle path order.
 - **Minor bumps** (`1.1`) are additive: new optional signal types, new lifecycle paths, additional refusal cases, new flags, new documentation sections.
-- v1.0 committed for v3.16.0; v1.1 (additive — §11 native worktree support) for v4.7.0.
+- v1.0 committed for v3.16.0; v1.1 (additive — §11 native worktree support) for v4.7.0; v1.2 (§10 reworded for session-ID-salted session files) for v4.9.0.
 
 ## 13. Non-goals (deferred to v2)
 

--- a/drupal-dev-framework/scripts/migrate-to-epic.sh
+++ b/drupal-dev-framework/scripts/migrate-to-epic.sh
@@ -430,8 +430,8 @@ echo "  rollback at $TEMP_ROOT/.old-$TASK_NAME/ (delete manually after 24h)"
 # Step 7 — Session context hint (actual write delegated to caller)
 # ---------------------------------------------------------------------------
 echo "[7/8] Session context hint"
-SESS_HASH=$(printf %s "$PWD" | md5sum | cut -d' ' -f1)
-SESS_FILE="$HOME/.claude/drupal-dev-framework/sessions/${SESS_HASH}.json"
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/session-paths.sh"
+SESS_FILE=$(ddf_session_file)
 CASE="A"
 EPIC_FOR_CTX="{CURRENT_EPIC_OR_NULL}"
 NEW_TASK_PATH=""

--- a/drupal-dev-framework/scripts/phase-command-bypass-detect.sh
+++ b/drupal-dev-framework/scripts/phase-command-bypass-detect.sh
@@ -40,8 +40,8 @@ case "$ARTIFACT" in
 esac
 
 # Read session_context for current workspace
-WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
-SESS_FILE="$HOME/.claude/drupal-dev-framework/sessions/$WORKSPACE_HASH.json"
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/session-paths.sh"
+SESS_FILE=$(ddf_session_file)
 
 ACTIVE_PHASE="null"
 if [[ -f "$SESS_FILE" ]]; then

--- a/drupal-dev-framework/scripts/save-session.sh
+++ b/drupal-dev-framework/scripts/save-session.sh
@@ -10,9 +10,10 @@
 #     has reviewed in-flight state. Judgement first, then this script.
 #
 # What it does:
-#   1. Resolves the per-workspace session file (keyed by md5(cwd) — the same
-#      scheme session-context-writer uses). No file → no framework activity
-#      this session → exit 0 silently.
+#   1. Resolves the session file (keyed by md5(cwd), salted by
+#      CLAUDE_CODE_SESSION_ID when set — the same scheme session-context-writer
+#      uses via scripts/session-paths.sh). No file → no framework activity this
+#      session → exit 0 silently.
 #   2. Stamps `savedAt` (UTC ISO-8601) into that session file.
 #   3. Scans the active task folder for *.md changed since the last save. If
 #      any are found, prints ONE warning line to stderr. Silent otherwise
@@ -47,9 +48,20 @@ if [ ! -t 0 ]; then
 fi
 [ -n "$CWD" ] || CWD="$PWD"
 
+# Session key — kept in sync with scripts/session-paths.sh (ddf_session_file /
+# ddf_workspace_hash). save-session.sh is copied into the project by
+# /install-remembrance-hook and cannot source the plugin helper, so the formula
+# is inlined here. The session-context JSON is salted by CLAUDE_CODE_SESSION_ID
+# (when set) so concurrent same-directory sessions do not collide; the marker is
+# NOT salted — it is cross-session by design ("changed since the last persist").
 WORKSPACE_HASH=$(printf %s "$CWD" | md5sum | cut -d' ' -f1)
 SESS_DIR="$HOME/.claude/drupal-dev-framework/sessions"
-SESS_FILE="$SESS_DIR/${WORKSPACE_HASH}.json"
+if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+  SESS_KEY=$(printf %s "${WORKSPACE_HASH}::${CLAUDE_CODE_SESSION_ID}" | md5sum | cut -d' ' -f1)
+else
+  SESS_KEY="$WORKSPACE_HASH"
+fi
+SESS_FILE="$SESS_DIR/${SESS_KEY}.json"
 MARKER_FILE="$SESS_DIR/${WORKSPACE_HASH}.last-saved"
 
 # No session file, or unparseable JSON → no resolved framework context this

--- a/drupal-dev-framework/scripts/session-paths.sh
+++ b/drupal-dev-framework/scripts/session-paths.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# session-paths.sh — shared resolver for drupal-dev-framework session files.
+#
+# SOURCE this file (do not execute it). It defines:
+#
+#   ddf_workspace_hash [dir]   md5 of the workspace path (dir defaults to $PWD).
+#                              STABLE across sessions. Used for the cross-session
+#                              save-session marker and the within-session
+#                              skip-emit caches, whose keying must not change.
+#
+#   ddf_session_file  [dir]    Absolute path to the session-context JSON file.
+#                              Keyed by md5(workspace) AND, when
+#                              CLAUDE_CODE_SESSION_ID is set (every interactive
+#                              session and hook subprocess), the session ID — so
+#                              two Claude Code sessions running in the same
+#                              directory get distinct session-context files
+#                              instead of colliding last-writer-wins. Falls back
+#                              to the workspace-only key when the session ID is
+#                              absent, so the path is identical to the pre-v4.9.0
+#                              scheme in that case (backward compatible).
+#
+# Only the session-context JSON is session-salted. The skip-emit caches
+# (<hash>.last-*.md5) and save-session's cross-session marker (<hash>.last-saved)
+# stay keyed by ddf_workspace_hash — the marker is cross-session by design and
+# the caches self-heal, so neither needs per-session isolation.
+
+ddf_session_dir() {
+  printf '%s' "$HOME/.claude/drupal-dev-framework/sessions"
+}
+
+ddf_workspace_hash() {
+  printf %s "${1:-$PWD}" | md5sum | cut -d' ' -f1
+}
+
+ddf_session_file() {
+  local dir wh sid
+  dir="${1:-$PWD}"
+  wh=$(ddf_workspace_hash "$dir")
+  sid="${CLAUDE_CODE_SESSION_ID:-}"
+  if [ -n "$sid" ]; then
+    printf '%s/%s.json' "$(ddf_session_dir)" \
+      "$(printf %s "${wh}::${sid}" | md5sum | cut -d' ' -f1)"
+  else
+    printf '%s/%s.json' "$(ddf_session_dir)" "$wh"
+  fi
+}

--- a/drupal-dev-framework/skills/session-context-writer/SKILL.md
+++ b/drupal-dev-framework/skills/session-context-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: session-context-writer
 description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[], lastPhase, and currentEpic across writes.
 user-invocable: false
-version: 1.4.0
+version: 1.5.0
 model: haiku
 allowed-tools: Bash
 ---
@@ -39,11 +39,12 @@ You receive the resolved project and task values from the calling command. Write
 
 Run this bash command with the provided values. It merges the new core fields over any existing file, seeding `loadedGuides: []` and `lastPhase: null` only when the file is first created.
 
+The session file path is resolved by the shared `scripts/session-paths.sh` helper (`ddf_session_file`). The path is keyed by `md5($PWD)` and — when `CLAUDE_CODE_SESSION_ID` is set — additionally by the session ID, so two Claude Code sessions in the same directory get distinct session files instead of colliding. When the variable is absent the key is `md5($PWD)` exactly as before v4.9.0 (backward compatible).
+
 ```bash
-WORKSPACE_HASH=$(echo -n "$PWD" | md5sum | cut -d' ' -f1)
-SESS_DIR=~/.claude/drupal-dev-framework/sessions
-SESS_FILE=$SESS_DIR/${WORKSPACE_HASH}.json
-mkdir -p "$SESS_DIR"
+. "${CLAUDE_PLUGIN_ROOT}/scripts/session-paths.sh"
+SESS_FILE=$(ddf_session_file)
+mkdir -p "$(dirname "$SESS_FILE")"
 
 NEW_CORE=$(jq -n \
   --arg workspace "$PWD" \


### PR DESCRIPTION
The **final release** of the drupal-dev-framework modernization roadmap (2026-05-20). Implements §6, §7a–§7e, §8, §10.4, §10.7 of the 2026-05-08 improvement plan.

## Scope

§7a is the only code change and is backward compatible. Everything else is documentation. No change to gate semantics, the `/worktree` flow, or agent behavior.

## §7a — session-context files are session-ID-scoped

`session-context-writer` and the session hooks resolved the per-workspace session file as `md5($PWD).json`, so two Claude Code sessions in the same directory collided last-writer-wins.

- New shared helper **`scripts/session-paths.sh`** (`ddf_session_file` / `ddf_workspace_hash`) keys the session JSON by `md5($PWD)` salted with `$CLAUDE_CODE_SESSION_ID` when set; falls back to the **byte-identical pre-v4.9.0 scheme** when absent.
- **9 consumers** source the helper: `session-context-writer` skill, `session-start.sh`, `pre-compact.sh`, `post-compact.sh`, `stop-failure.sh`, `context-reminder.sh`, `loaded-context-summary.sh`, `phase-command-bypass-detect.sh`, `migrate-to-epic.sh`.
- `save-session.sh` (copied into the project, can't source the plugin helper) inlines the equivalent formula with a keep-in-sync comment.
- **Only the session JSON is salted.** Skip-emit caches and `save-session.sh`'s cross-session `.last-saved` marker stay workspace-keyed — the marker is cross-session by design.
- `session-context-writer` skill 1.4.0 → 1.5.0; `worktree-conventions.md` §10 reworded (doc v1.1 → v1.2).

> **Roadmap under-scope, surfaced & confirmed:** the plan scoped §7a as a 2-file edit; the `md5($PWD)` path was actually computed in ~10 places. Shipped as a coordinated change behind one shared helper, per the maintainer's decision to do §7a fully.

## §6 — `references/post-batch-aggregation.md` (new)

Opt-in `PostToolBatch` pattern to roll up `/research-team` and `/validate:team` per-teammate output. The plugin does **not** ship the hook — plugin-scoped `PostToolBatch` has no matcher and fires on every conversation. Mirrors code-quality-tools' sibling reference.

## §7b/§7d/§10.4 — command docs

- `commands/review.md` — "When to escalate": `claude ultrareview` as an opt-in deeper cloud review after `/review` passes (explicit user opt-in, ~$5–20/run as usage credits, never automatic); long-run tip pairing `channelsEnabled` + `/goal`.
- Long-run tips in `commands/research-team.md` (`channelsEnabled`) and `commands/validate-all.md` (`/goal`).

## §7c/§7e/§8/§10.7 — `CONVENTIONS.md` (three sections)

- **Condition-checked autonomy with `/goal`** — `/goal` vs `/loop`, framework examples, background sessions / Agent View.
- **Security & auto-mode posture** — `--dangerously-skip-permissions` removes the `.claude/`-write safety net; `defaultMode: "auto"` is silently ignored in project settings since v2.1.142.
- **Documentation & observability notes** — link upstream pages directly (the `/en/common-workflows` hub was pruned); OTel `invocation_trigger` future-instrumentation footnote.

**Version:** `plugin.json` + marketplace entry 4.8.0 → 4.9.0; marketplace `metadata.version` 1.14.49 → 1.14.50.

## Validation evidence

- `/plugin-creation-tools:validate` → **PASS** — zero errors, zero warnings.
- `claude plugin validate` → **`✔ Validation passed`** — clean.
- §7a smoke test: `bash -n` clean on all 10 modified scripts; verified the hook idiom, script idiom, and `save-session.sh`'s inline formula all resolve the **identical** salted path, and that the no-session-ID fallback is byte-identical to the pre-v4.9.0 `md5($PWD)` path.

## Roadmap status

This completes v4.6.0 → v4.9.0. All four modernization releases shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)