### PR TITLE
code-quality-tools v3.4.0: LSP code intelligence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.51"
+    "version": "1.14.52"
   },
   "plugins": [
     {
@@ -100,8 +100,8 @@
     {
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
-      "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.3.0",
+      "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
+      "version": "3.4.0",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
-  "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.3.0",
+  "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
+  "version": "3.4.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-05-20
+
+### LSP code intelligence
+
+Marquee release of the modernization roadmap: the SOLID, DRY, and review commands can now use Claude Code's built-in **LSP tool** for language-server semantics instead of grep heuristics — converting the plugin's biggest documented weakness (grep blindness on inherited, interface-wired, and config-wired relationships) into a strength, while reducing token cost (no more full-file reads as the default). Ships **recommended-not-required**: every command degrades cleanly to the existing full-file-read Type-B pass when no code-intelligence plugin is present.
+
+### Added
+
+- **`skills/code-quality-audit/references/code-intelligence.md`** — new reference: what the LSP tool provides (definitions, references, find-implementations, call-hierarchy, list-symbols, automatic post-edit diagnostics), how to enable it (`php-lsp`→`intelephense`, `typescript-lsp`→`typescript-language-server`, installed from the official marketplace), per-command leverage, and the honest caveats — LSP availability varies by language/environment, Drupal `.module`/`.inc`/`.theme` files carry non-`.php` extensions that `intelephense` may not index by default (the grep-free full-read pass stays the guaranteed floor there), plus large-project memory and monorepo false-positive notes.
+
+### Changed
+
+- **`commands/solid.md`, `commands/dry.md`, `commands/review.md`** — each gains an "LSP Code Intelligence (recommended)" section: `solid` uses `find-implementations` for genuine Liskov/ISP checks, `find-references` for Dependency Inversion, and `call-hierarchy` for Single Responsibility fan-in/fan-out; `dry` uses `find-references` to catch semantic duplication that textual clone detectors (PHPCPD/jscpd) miss; `review` uses `call-hierarchy` and reference resolution to ground the *Separation of concerns* and *Testability* rubric categories in evidence. Each block instructs an explicit fall-back to the full-file-read pass when no LSP plugin is installed.
+- **`commands/setup.md`** — new "Code Intelligence Plugins (recommended)" section with the plugin/binary install table; code intelligence added to the Tool Categories list.
+- **`skills/code-quality-audit/SKILL.md`** — the reading-strategy note now points at the LSP tool for inherited/wired relationship questions; `references/code-intelligence.md` added to the References list. Skill `version` 3.0.0 → 3.4.0.
+- **`README.md`** — optional code-intelligence install note added under First-Time Setup.
+- **`plugin.json` / `marketplace.json` descriptions** — added "optional LSP code-intelligence" to the capability summary (still under the 600-char cap).
+
+The `LSP` tool is **not** added to any command or skill `allowed-tools` — it requires no permission and is inert without a code-intelligence plugin, so listing it would imply a hard dependency that does not exist. Shipping `lspServers` in the plugin manifest is intentionally out of scope (a future consideration, not a currency item). `architecture-debate.md` is unchanged this release. No behavior change to scripts, hooks, or audit logic.
+
+Marketplace metadata bumped 1.14.51 → 1.14.52.
+
 ## [3.3.0] - 2026-05-20
 
 ### Validator hygiene & the ultrareview CLI gap

--- a/code-quality-tools/README.md
+++ b/code-quality-tools/README.md
@@ -65,6 +65,8 @@ npm install --save-dev \
 
 **System tools (both):** [Semgrep](https://semgrep.dev/docs/getting-started/), [Trivy](https://trivy.dev/latest/getting-started/installation/), [Gitleaks](https://github.com/gitleaks/gitleaks#installing)
 
+**Code intelligence (optional, recommended):** install a code-intelligence plugin — `php-lsp` (Drupal) or `typescript-lsp` (Next.js) — plus its language-server binary to make `/code-quality:solid`, `:dry`, and `:review` resolve inherited and config-wired relationships semantically via Claude Code's LSP tool. Recommended, not required: the commands fall back to full-file reads when no LSP plugin is present. See `skills/code-quality-audit/references/code-intelligence.md`.
+
 ### 3. Run Commands
 
 | Command | Purpose | When to Use |

--- a/code-quality-tools/commands/dry.md
+++ b/code-quality-tools/commands/dry.md
@@ -10,6 +10,12 @@ Find duplicated code blocks that violate the DRY (Don't Repeat Yourself) princip
 
 > **Reading strategy:** This is **Type B** work — duplicate detection often reveals near-duplicates that need full-file context to assess intent. Do NOT grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
 
+## LSP Code Intelligence (recommended)
+
+PHPCPD and jscpd detect **textual** clones. If a code-intelligence plugin is installed (`php-lsp` for Drupal, `typescript-lsp` for Next.js), also use the **LSP tool**'s `find-references` to catch **semantic** duplication the copy-paste detectors miss — e.g. the same service resolved inline at 14 call sites is a DRY/DIP violation even though the surrounding text differs at every site.
+
+The LSP tool needs no permission and is inert when no plugin is installed — fall back to the copy-paste detectors and full-file reads when it is unavailable. See `skills/code-quality-audit/references/code-intelligence.md`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/commands/review.md
+++ b/code-quality-tools/commands/review.md
@@ -10,6 +10,10 @@ Structured code review with rubric-based scoring. Produces a graded assessment w
 
 > **Reading strategy:** This is **Type B** work — read full source and config files; do NOT grep-first. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
 
+## LSP Code Intelligence (recommended)
+
+If a code-intelligence plugin is installed (`php-lsp` for Drupal, `typescript-lsp` for Next.js), use the **LSP tool** to ground the rubric's *Separation of concerns* and *Testability* categories in evidence rather than impression: `call-hierarchy` shows whether a controller/form method reaches into a data layer N levels deep; `find-references` and definition resolution show how dependencies are actually wired. The tool needs no permission and is inert when no plugin is installed — fall back to full-file reads when it is unavailable. See `skills/code-quality-audit/references/code-intelligence.md`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/commands/setup.md
+++ b/code-quality-tools/commands/setup.md
@@ -54,6 +54,10 @@ Detection → Tool Selection → Threshold Config → Installation → Git Hooks
 - Drupal: Drupal Coder, Rector
 - Next.js: Prettier (optional)
 
+**Code Intelligence (recommended):**
+- Drupal: `php-lsp` plugin + `intelephense` binary
+- Next.js: `typescript-lsp` plugin + `typescript-language-server` binary
+
 ## Installation Modes
 
 ### Quick Install (Recommended)
@@ -93,6 +97,23 @@ Plus: Semgrep, Trivy, Gitleaks (system-level)
 
 ### Custom Install
 Select specific tools and configure thresholds individually.
+
+## Code Intelligence Plugins (recommended)
+
+The `/code-quality:solid`, `/code-quality:dry`, and `/code-quality:review` commands go deeper when Claude Code's built-in **LSP tool** is active — it resolves references, interface implementations, and call hierarchies that grep cannot see, and it reports type errors automatically after every edit. The tool is inactive until a code-intelligence plugin **and** its language-server binary are installed:
+
+| Project | Plugin | Server binary |
+|---------|--------|---------------|
+| Drupal / PHP | `php-lsp` | `intelephense` |
+| Next.js / TypeScript | `typescript-lsp` | `typescript-language-server` |
+
+```bash
+/plugin install php-lsp@claude-plugins-official        # or typescript-lsp@claude-plugins-official
+```
+
+Then install the language-server binary so it is on `$PATH` (see each plugin's README for the exact package). If `/plugin` shows `Executable not found in $PATH`, the binary is missing.
+
+This is **recommended, not required** — every command falls back to full-file reads when no LSP plugin is present. Analysis-depth gains and the Drupal `.module`/`.inc`/`.theme` indexing caveat: `skills/code-quality-audit/references/code-intelligence.md`.
 
 ## Threshold Configuration
 

--- a/code-quality-tools/commands/solid.md
+++ b/code-quality-tools/commands/solid.md
@@ -10,6 +10,16 @@ Analyze code architecture and adherence to SOLID principles.
 
 > **Reading strategy:** This is **Type B** work — read full class hierarchies, interfaces, and service definitions; do NOT grep-first. SOLID violations span inherited methods that grep cannot see. See `https://camoa.github.io/dev-guides/development/reading-strategy/`.
 
+## LSP Code Intelligence (recommended)
+
+If a code-intelligence plugin is installed (`php-lsp` for Drupal, `typescript-lsp` for Next.js), prefer the **LSP tool** over grep for the relationship questions SOLID depends on:
+
+- **Liskov / Interface Segregation** — `find-implementations` on an interface enumerates every subtype; check each override for contract compatibility. This is the exact check grep cannot do.
+- **Dependency Inversion** — `find-references` on a concrete class shows whether high-level modules depend on it directly instead of on an abstraction.
+- **Single Responsibility** — `call-hierarchy` gives real fan-in/fan-out instead of inferring "reasons to change" from file size.
+
+The LSP tool needs no permission and is inert when no plugin is installed — **fall back to the full-file-read Type-B pass above** in that case. Setup and the Drupal `.module`/`.inc`/`.theme` indexing caveat: `skills/code-quality-audit/references/code-intelligence.md`.
+
 ## Usage
 
 ```

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-quality-audit
 description: Use when checking code quality, running security audits, testing coverage, finding SOLID/DRY violations, or setting up quality tools. Use when user says "audit this code", "check security", "run PHPStan", "code quality", "find violations", "SOLID check", "DRY check", "test coverage", "lint this", "security review", "is this production ready", "check for vulnerabilities", "code review", "grade this code", "watch mode lint", "deep review", "ultrareview", "schedule quality sweep". Supports Drupal (PHPStan, PHPMD, Psalm, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Use proactively before deployment or after significant code changes.
-version: 3.0.0
+version: 3.4.0
 model: sonnet
 allowed-tools: Read, Bash, Grep, Glob
 user-invocable: false
@@ -24,7 +24,7 @@ hooks:
 
 Run quality and security audits for **Drupal** and **Next.js** projects with consistent tooling and reporting.
 
-> **Reading strategy:** Audit, review, security, SOLID, and DRY commands are **Type B** work (audit / review / architecture analysis) — agents must read full source and config files. Do NOT grep-first these flows. Inherited methods, annotations, and config-wired classes are invisible to a grep-first pass. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`.
+> **Reading strategy:** Audit, review, security, SOLID, and DRY commands are **Type B** work (audit / review / architecture analysis) — agents must read full source and config files. Do NOT grep-first these flows. Inherited methods, annotations, and config-wired classes are invisible to a grep-first pass. See `https://camoa.github.io/dev-guides/development/reading-strategy/` via `dev-guides-navigator`. When a code-intelligence plugin is installed, the **LSP tool** resolves those inherited and config-wired relationships semantically — prefer it for SOLID/DRY/review relationship questions, and fall back to the full-read pass when it is unavailable. See `references/code-intelligence.md`.
 
 ## Quick Commands
 
@@ -267,6 +267,7 @@ All reports must follow `schemas/audit-report.schema.json`:
 - `references/composer-scripts.md` - Ready-to-use composer scripts
 - `references/scope-targeting.md` - Target specific modules/components
 - `references/post-batch-aggregation.md` - Optional `PostToolBatch` aggregation pattern (Claude Code 2.1.118+); not shipped by default
+- `references/code-intelligence.md` - Optional LSP-tool code intelligence for deeper SOLID/DRY/review analysis (recommended-not-required)
 
 ### Operations
 - `references/operations/drupal-setup.md` - Drupal setup operations

--- a/code-quality-tools/skills/code-quality-audit/references/code-intelligence.md
+++ b/code-quality-tools/skills/code-quality-audit/references/code-intelligence.md
@@ -1,0 +1,70 @@
+# Code Intelligence (LSP tool)
+
+The SOLID, DRY, and review commands run deeper and cheaper when Claude Code's built-in **LSP tool** is active. This file explains what it adds, how to enable it, and where it does *not* reach — so the commands can degrade cleanly when it is absent.
+
+## Recommended, not required
+
+The LSP tool needs **no permission** and is **inert when no code-intelligence plugin is installed**. Every command in this plugin keeps its grep-free, full-file-read **Type-B** pass as the guaranteed floor. Installing an LSP plugin makes the analysis sharper and reduces token cost; skipping it changes nothing about correctness.
+
+Do **not** add `LSP` to any skill or command `allowed-tools` — it requires no permission grant, and listing it would imply a hard dependency that does not exist.
+
+## What the LSP tool provides
+
+Once a language server is running, Claude can (per the Tools Reference, §"LSP tool behavior"):
+
+- Jump to a symbol's definition
+- Find all references to a symbol
+- Get type information at a position
+- List symbols in a file or workspace
+- Find implementations of an interface
+- Trace call hierarchies
+- Receive **automatic type errors and warnings after every file edit** — no separate build/lint step
+
+These give semantic navigation that grep cannot: grep matches text, the language server resolves *meaning* (inheritance, interface implementation, wired dependencies).
+
+## Enabling it
+
+The LSP tool stays inactive until you install a code-intelligence plugin **and** its language-server binary (the plugin bundles the LSP configuration; the binary is installed separately).
+
+| Project | Plugin | Server binary |
+|---------|--------|---------------|
+| Drupal / PHP | `php-lsp` | `intelephense` |
+| Next.js / TypeScript | `typescript-lsp` | `typescript-language-server` |
+
+```bash
+# Install the plugin from the official marketplace
+/plugin install php-lsp@claude-plugins-official
+# …or
+/plugin install typescript-lsp@claude-plugins-official
+```
+
+Then install the server binary so it is on `$PATH` (see each plugin's own README for the exact package). If `/plugin` shows `Executable not found in $PATH` in its Errors tab, the binary is missing.
+
+Verify it is active: `/plugin` lists the loaded LSP servers; a "diagnostics found" indicator appears after edits (press **Ctrl+O** to view inline).
+
+## What each command gains
+
+### `/code-quality:solid`
+
+SOLID's hardest checks are exactly the ones grep cannot do:
+
+- **Liskov / Interface Segregation** — `find-implementations` on an interface enumerates *every* subtype; each override can then be checked for contract compatibility. A real check, not a heuristic.
+- **Dependency Inversion** — `find-references` on a concrete class shows whether high-level modules depend on it directly instead of on an abstraction.
+- **Single Responsibility** — `call-hierarchy` gives real fan-in/fan-out, instead of inferring "reasons to change" from file size.
+
+### `/code-quality:dry`
+
+PHPCPD and jscpd find **textual** clones. `find-references` finds **semantic** duplication they miss entirely — e.g. the same service resolved inline at 14 call sites is a DRY/DIP violation even though the surrounding text differs at every site.
+
+### `/code-quality:review`
+
+The rubric's *Separation of concerns* and *Testability* categories otherwise rest on the reviewer's impression. `call-hierarchy` shows whether a controller/form method reaches into a data layer N levels deep; `find-references` and definition resolution show how dependencies are actually wired — evidence instead of impression.
+
+## Caveats — keep the full-read floor
+
+- **Availability varies by language and environment** (Discover Plugins guide). When in doubt, fall back to the Type-B full-file read.
+- **Drupal `.module` / `.inc` / `.theme` files** are PHP but carry non-`.php` extensions. `intelephense` may not index them by default. For those files, the grep-free full-read pass remains the guaranteed path — do not assume LSP coverage.
+- **Large projects** — language servers can consume significant memory. If a project is heavy, disabling the plugin and relying on built-in search is a valid trade-off.
+- **Monorepos** — a language server may report false-positive unresolved-import diagnostics for internal packages when the workspace is not configured for it; these do not affect edit correctness.
+
+When the LSP tool is unavailable or a file falls outside its index, the command MUST fall back to reading full class hierarchies, interfaces, and service definitions — the behavior documented in each command's "Reading strategy" note.


### PR DESCRIPTION
## Release v3.4.0 — LSP code intelligence

Second release of the [code-quality-tools modernization roadmap](https://github.com/camoa/claude-skills) — the **marquee** release. Replaces grep-based heuristics with language-server semantics in the analysis commands.

### What changed

The SOLID, DRY, and review commands carried a long-standing warning that "SOLID violations span inherited methods grep cannot see," mitigated by a costly "read every full file" instruction. Claude Code's built-in **LSP tool** replaces that workaround — it resolves inherited, interface-wired, and config-wired relationships semantically.

**Ships recommended-not-required.** Every command degrades cleanly to the existing full-file-read Type-B pass when no code-intelligence plugin is installed. `LSP` is **not** added to any `allowed-tools` — it requires no permission and is inert without a plugin, so listing it would imply a hard dependency that does not exist (confirmed against Tools Reference: `LSP` permission-required = No).

### Added

- **`skills/code-quality-audit/references/code-intelligence.md`** — what the LSP tool provides (definitions, references, find-implementations, call-hierarchy, list-symbols, auto post-edit diagnostics); enabling it (`php-lsp`→`intelephense`, `typescript-lsp`→`typescript-language-server`, installed via `<name>@claude-plugins-official`); per-command leverage; and honest caveats — LSP availability varies by language/environment, Drupal `.module`/`.inc`/`.theme` files carry non-`.php` extensions `intelephense` may not index by default (full-read pass stays the floor there), plus large-project memory and monorepo false-positive notes.

### Changed

- **`commands/solid.md`** — `find-implementations` for genuine Liskov/ISP checks, `find-references` for Dependency Inversion, `call-hierarchy` for Single Responsibility fan-in/fan-out
- **`commands/dry.md`** — `find-references` catches *semantic* duplication that textual clone detectors (PHPCPD/jscpd) miss
- **`commands/review.md`** — `call-hierarchy` / reference resolution ground the *Separation of concerns* and *Testability* rubric categories in evidence
- Each block instructs an explicit fall-back to full-file reads when no LSP plugin is present
- **`commands/setup.md`** — new "Code Intelligence Plugins (recommended)" section + Tool Categories line
- **`skills/code-quality-audit/SKILL.md`** — reading-strategy note points at the LSP tool; `code-intelligence.md` added to References; skill `version` 3.0.0 → 3.4.0
- **`README.md`** — optional code-intelligence install note
- **`plugin.json` / `marketplace.json`** descriptions — "optional LSP code-intelligence" clause added (514 chars, under the 600 cap)

### Out of scope (deliberate)

- No `lspServers` shipped in the plugin manifest (deep-dive 4.2 marks it a future consideration, not a currency item)
- `architecture-debate.md` untouched (roadmap v3.4.0 names only solid/dry/review)

### Validation evidence

- `/plugin-creation-tools:validate` → **PASS** — 0 errors, 0 warnings (two non-blocking info notes: a pre-existing cosmetic permission bit on `tdd-workflow.sh` unrelated to this release; SKILL.md 287 lines, accepted hub-skill length)
- `claude plugin validate ./code-quality-tools` → **✔ Validation passed**
- The roadmap's runtime LSP smoke test (solid/dry on a Drupal module with/without `php-lsp`) requires `php-lsp` + `intelephense` installed — not available in the build environment. This release is instruction-only (no executable code changed) with explicit graceful-degradation language in every touched command.

### Metadata

`plugin.json` 3.3.0 → 3.4.0 · `marketplace.json` entry 3.3.0 → 3.4.0 · marketplace `metadata.version` 1.14.51 → 1.14.52 · `CHANGELOG.md` `[3.4.0]` entry added.

### Next

v3.5.0 — adaptive depth & autonomous remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)