### PR TITLE
code-quality-tools v3.5.0: Adaptive depth & autonomous remediation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.52"
+    "version": "1.14.53"
   },
   "plugins": [
     {
@@ -101,7 +101,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-05-20
+
+### Adaptive depth & autonomous remediation
+
+Third release of the modernization roadmap. Three additive items — effort-scaled audit depth, `/goal`-driven autonomous loops, and a `Setup`-hook CI-bootstrap reference. No behavior change to scripts, hooks, or audit logic.
+
+### Added
+
+- **Adaptive audit depth (`${CLAUDE_EFFORT}`)** — `skills/code-quality-audit/SKILL.md` gains an "Adaptive Audit Depth" section that scales the audit to the session effort level: `low` → fast lint only, `medium` → lint + coverage + SOLID/DRY, `high` → full audit (the effective default), `xhigh`/`max` → full audit + a `/code-quality:security-debate` offer. An unset/unrecognized level falls back to `high` — depth never silently drops because the level could not be read. `commands/audit.md` carries a prose "Adaptive Depth" pointer to the ladder. **Pilot scope (v3.5.0):** wired into the audit flow only — `lint-changed.sh` and per-command effort gates are deliberately left for a later "broaden" cycle once the pilot is observed. *Grounding note:* the cached Skills guide documents `${CLAUDE_EFFORT}` strictly as a **skill-content** string substitution; it is therefore placed in `SKILL.md` (skill content), and `audit.md` uses a plain-prose behavioral instruction rather than the literal token, which the guides do not support inside slash-command bodies.
+- **`/goal` autonomous loops** — `commands/tdd.md` gains a "Drive the GREEN phase with `/goal`" subsection (worked condition, transcript-checkable end-state rule, trust/`disableAllHooks`/`allowManagedHooksOnly` requirements); `commands/audit.md` gains an "Autonomous remediation with `/goal`" subsection (fix-verify-fix loop paired with `--json` as the proof step). Both state plainly that `/goal` is an interactive / headless-`-p` convenience and **not** a CI gate — the CI primitives remain `audit --json` and `claude ultrareview --json`.
+- **`skills/code-quality-audit/references/setup-hook-pattern.md`** — new reference documenting the `Setup` hook event (fires on `--init-only` / `--init -p` / `--maintenance -p`; `init`/`maintenance` matcher; `trigger` field; cannot block; `command`/`mcp_tool` handlers only) as the one-time CI tool-bootstrap pattern. Exec form (`args` array). Opt-in, **not shipped** — honest about the Hooks Reference caveat that `Setup` never fires on a normal launch (first-use detection stays the fallback) and that `${CLAUDE_PLUGIN_ROOT}` resolves only in plugin-shipped hooks, not a project's own `settings.json`. Corrects the capability-analysis `args: ["--ci"]` example — `install-tools.sh` takes no positional arguments (it is env-var driven).
+
+### Changed
+
+- **`skills/code-quality-audit/references/scheduled-sweeps.md`** — the `/loop` section now distinguishes `/loop` (time-interval re-run) from `/goal` (condition-checked re-run); neither is a CI primitive.
+- **`skills/code-quality-audit/SKILL.md`** — `setup-hook-pattern.md` added to the References list; skill `version` 3.4.0 → 3.5.0.
+- **`hooks/hooks.json`** — the `PreCompact` command hook migrated to exec form (`"args": []`), the Hooks Reference's preferred form for any hook referencing a `${CLAUDE_PLUGIN_ROOT}` path placeholder. Surfaced as a validator H05 warning; fixed here to keep the release gate clean. (The skill-scoped `FileChanged` hook and the `post-batch-aggregation.md` example snippet — the rest of deep-dive item 2.1 — remain queued for v3.6.0.)
+
+Marketplace metadata bumped 1.14.52 → 1.14.53.
+
 ## [3.4.0] - 2026-05-20
 
 ### LSP code intelligence

--- a/code-quality-tools/commands/audit.md
+++ b/code-quality-tools/commands/audit.md
@@ -51,6 +51,10 @@ Full schema + field definitions: `${CLAUDE_PLUGIN_ROOT}/skills/code-quality-audi
 3. Generates reports in `.reports/` directory
 4. Displays summary in chat
 
+## Adaptive Depth
+
+Audit depth scales with the session's effort level — at `low`, run a fast lint pass; at `medium`, lint + coverage + SOLID/DRY; at `high` (the effective default), the full audit; at `xhigh`/`max`, the full audit followed by an offer to run `/code-quality:security-debate`. An unset or unrecognized level falls back to the full audit — depth never silently drops below `high` because the level could not be read. The full ladder lives in the `code-quality-audit` skill's "Adaptive Audit Depth" section. (Pilot, v3.5.0 — wired into the audit flow only.)
+
 ## Detection & Execution
 
 Use `${CLAUDE_PLUGIN_ROOT}` (Claude Code exposes this) to reach the scripts regardless of the user's current working directory:
@@ -133,6 +137,20 @@ Surface comparison and decision tree: `${CLAUDE_PLUGIN_ROOT}/skills/code-quality
 For CI-triggered pre-merge audits (fire from GitHub Actions / GitLab CI on PR labels or merge-ready signal), use a Cloud Routine with an API trigger. Full `curl` + workflow snippets + bearer-token lifecycle in `${CLAUDE_PLUGIN_ROOT}/skills/code-quality-audit/references/premerge-gate-routine.md`.
 
 Two complementary gates: run the cheap local `/code-quality:audit --json` on every push; reserve the verified-findings cloud review for release branches via the headless `claude ultrareview --json` subcommand (exit-code contract + gating snippet in `commands/ultrareview.md` → "CI / Headless Mode").
+
+## Autonomous remediation with `/goal`
+
+After an audit produces a findings list, the built-in `/goal` command turns fix-verify-fix into an autonomous loop — Claude keeps working turn after turn until a fresh evaluator model confirms the condition from the transcript:
+
+```
+/goal every critical and high finding in .reports/audit-synthesis.md is resolved,
+verified by re-running /code-quality:audit --json and confirming zero findings
+with severity high or critical — or stop after 15 turns
+```
+
+The condition must name a **transcript-checkable end state** — the evaluator does not run tools itself, it reads what Claude surfaced. Pair it with `--json` so the proof is a machine-checkable document, not a prose claim. Bound the loop with an explicit `stop after N turns` clause.
+
+`/goal` requires an accepted workspace-trust dialog and is unavailable when `disableAllHooks` or `allowManagedHooksOnly` is set. It is an interactive / headless-`-p` convenience — **not** a CI gate. For CI, use the non-interactive gates instead: `/code-quality:audit --json` per push and `claude ultrareview --json` on release branches.
 
 ## Related Commands
 

--- a/code-quality-tools/commands/tdd.md
+++ b/code-quality-tools/commands/tdd.md
@@ -90,6 +90,21 @@ TDD workflow tracks coverage incrementally:
 4. **Commit when green** - Only commit passing code
 5. **Keep tests fast** - Under 1 second for unit tests
 
+## Drive the GREEN phase with `/goal`
+
+The RED-GREEN cycle is iterative by nature — a good fit for the built-in `/goal` command, which keeps the session working turn after turn until a fresh evaluator model confirms a completion condition from the transcript.
+
+Once a failing test exists (RED), set a goal for the GREEN phase:
+
+```
+/goal all tests in tests/Unit pass and phpstan exits 0, verified by running
+the suite — and no test file is modified — or stop after 12 turns
+```
+
+Write the condition as a **transcript-checkable end state**: the evaluator does not run tools, it reads what Claude has surfaced, so name the proof (`npm test exits 0`, `the PHPUnit run reports 0 failures`) — not "the feature works". Add constraints that must hold (`no test file is modified`) and an explicit `stop after N turns` bound.
+
+`/goal` requires an accepted workspace-trust dialog and is unavailable when `disableAllHooks` or `allowManagedHooksOnly` is set; in those cases it reports why rather than failing silently. It is a session-scoped interactive / headless-`-p` convenience.
+
 ## Error Handling
 
 Common issues:

--- a/code-quality-tools/hooks/hooks.json
+++ b/code-quality-tools/hooks/hooks.json
@@ -6,6 +6,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.sh",
+            "args": [],
             "timeout": 10
           }
         ]

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-quality-audit
 description: Use when checking code quality, running security audits, testing coverage, finding SOLID/DRY violations, or setting up quality tools. Use when user says "audit this code", "check security", "run PHPStan", "code quality", "find violations", "SOLID check", "DRY check", "test coverage", "lint this", "security review", "is this production ready", "check for vulnerabilities", "code review", "grade this code", "watch mode lint", "deep review", "ultrareview", "schedule quality sweep". Supports Drupal (PHPStan, PHPMD, Psalm, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Use proactively before deployment or after significant code changes.
-version: 3.4.0
+version: 3.5.0
 model: sonnet
 allowed-tools: Read, Bash, Grep, Glob
 user-invocable: false
@@ -151,6 +151,21 @@ Read `decision-guides/quality-audit-checklist.md` for detailed guidance.
 | Pre-merge | Full audit | ~10min |
 | Weekly | Full audit + HTML reports | ~15min |
 
+## Adaptive Audit Depth (`${CLAUDE_EFFORT}`)
+
+When this skill drives an audit, scale depth to the session's effort level. The `${CLAUDE_EFFORT}` substitution resolves to the current level:
+
+| `${CLAUDE_EFFORT}` | Audit depth |
+|---|---|
+| `low` | Fast lint only — coding-standards pass; skip security, SOLID, DRY, coverage |
+| `medium` | Lint + coverage + SOLID + DRY; skip the deep security battery |
+| `high` | Full audit — all 22 operations (the effective default) |
+| `xhigh` / `max` | Full audit, then offer `/code-quality:security-debate` for a 3-agent review of the security findings |
+
+Treat an unset or unrecognized value as `high` (full audit) — never silently skip coverage or security because the level could not be read.
+
+This is a **pilot** (v3.5.0): adaptive depth is wired into the audit flow only. The `FileChanged` watch-mode dispatcher and per-command effort gates are intentionally not yet effort-aware — they will be revisited once this pilot has been observed in real use.
+
 ## Scope Targeting
 
 To audit specific modules or components instead of the entire project:
@@ -268,6 +283,7 @@ All reports must follow `schemas/audit-report.schema.json`:
 - `references/scope-targeting.md` - Target specific modules/components
 - `references/post-batch-aggregation.md` - Optional `PostToolBatch` aggregation pattern (Claude Code 2.1.118+); not shipped by default
 - `references/code-intelligence.md` - Optional LSP-tool code intelligence for deeper SOLID/DRY/review analysis (recommended-not-required)
+- `references/setup-hook-pattern.md` - Optional `Setup`-hook pattern for one-time CI tool bootstrap on `claude --init -p`; not shipped by default
 
 ### Operations
 - `references/operations/drupal-setup.md` - Drupal setup operations

--- a/code-quality-tools/skills/code-quality-audit/references/scheduled-sweeps.md
+++ b/code-quality-tools/skills/code-quality-audit/references/scheduled-sweeps.md
@@ -63,6 +63,8 @@ Best for:
 
 Not for: production quality automation — restart the session and the loop is gone.
 
+**`/loop` vs `/goal`:** `/loop` re-runs a prompt on a fixed **time interval** and stops only when you stop it. `/goal` re-runs after every turn and stops when a fresh evaluator model confirms a **completion condition** from the transcript — use it for "audit until clean" / "fix until tests pass" loops (see `commands/audit.md` and `commands/tdd.md`). Neither is a CI primitive: both keep the current session running.
+
 ## See Also
 
 - `desktop-sweep-template.md` — full Desktop Scheduled Task template (primary)

--- a/code-quality-tools/skills/code-quality-audit/references/setup-hook-pattern.md
+++ b/code-quality-tools/skills/code-quality-audit/references/setup-hook-pattern.md
@@ -1,0 +1,70 @@
+# Setup-hook pattern — one-time CI tool bootstrap
+
+The quality tools this plugin drives (PHPStan, PHPMD, Psalm, Semgrep, Trivy, Gitleaks, ESLint, …) must be installed before an audit can run. In CI, that install should happen **once** during pipeline initialization, not on every audit. Claude Code's **`Setup` hook event** is the canonical place for it.
+
+This is an **opt-in pattern** — the plugin does **not** ship a `Setup` hook. You add it to your own project, exactly as with the `StopFailure` alerting pattern in `CONVENTIONS.md`.
+
+## When the `Setup` event fires
+
+`Setup` does **not** fire on a normal `claude` launch. It fires only when you start Claude Code explicitly for initialization or maintenance:
+
+| Matcher       | Fires on                                   |
+| :------------ | :------------------------------------------ |
+| `init`        | `claude --init-only` or `claude -p --init`  |
+| `maintenance` | `claude -p --maintenance`                   |
+
+`--init` and `--maintenance` fire `Setup` **only when combined with `-p`** (print mode); in an interactive session those flags do not. `claude --init-only` runs `Setup` hooks plus `startup`-matcher `SessionStart` hooks, then exits without starting a conversation — ideal as a dedicated CI step.
+
+`Setup` hooks receive a `trigger` field (`"init"` or `"maintenance"`), have access to `CLAUDE_ENV_FILE`, and support only `command` and `mcp_tool` handler types. They **cannot block** — on a non-zero exit, execution continues (stderr reaches the user only on exit code 2, or under `--verbose`).
+
+> **`Setup` alone does not guarantee tooling is present.** Because it never fires on a normal launch, a developer who skips the init step has no tools. Keep the audit scripts' existing "tool not found → run `/code-quality:setup`" guidance as the fallback. `Setup` optimizes the CI path; it does not replace first-use detection.
+
+## CI pipeline step
+
+Run the dedicated init once, early in the pipeline:
+
+```bash
+claude --init-only          # fires Setup hooks, then exits
+# … later steps run /code-quality:audit etc. with tools already installed
+```
+
+## Wiring the hook
+
+Add the hook to your **project's** `.claude/settings.json` (or `.claude/hooks.json`). Use **exec form** (`args` array) — the preferred form per the Hooks Reference:
+
+```json
+{
+  "hooks": {
+    "Setup": [
+      {
+        "matcher": "init",
+        "hooks": [
+          { "type": "command", "command": "composer", "args": ["install", "--dev"] }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If your quality tools are declared as dev dependencies in `composer.json` / `package.json` (recommended), the hook is just `composer install --dev` or `npm ci` — the dependency manifest is the source of truth and the hook only triggers it.
+
+To invoke this plugin's installer directly instead, point at `install-tools.sh`:
+
+```json
+{ "type": "command",
+  "command": "<path-to-installed-plugin>/skills/code-quality-audit/scripts/core/install-tools.sh",
+  "args": [] }
+```
+
+Notes on `install-tools.sh`:
+
+- It takes **no positional arguments** — it is driven by environment variables (`PROJECT_TYPE`, `REPORT_DIR`, `DDEV_AVAILABLE`). Set them in the hook environment or let it auto-detect from `.reports/environment.json`.
+- For Drupal it requires a running DDEV container and exits non-zero if DDEV is absent. A `Setup` hook cannot block, so a failed install will not stop the session — have the pipeline verify tool availability after `--init-only` and fail there if needed.
+- `${CLAUDE_PLUGIN_ROOT}` resolves **only inside plugin-shipped hooks**. A hook in your project's own `settings.json` must use a real path (or a CI variable) instead.
+
+## Related
+
+- `CONVENTIONS.md` → "StopFailure Hook (CI pipelines)" — the sibling opt-in CI hook pattern
+- `commands/setup.md` — the interactive `/code-quality:setup` wizard (the local, first-time counterpart to this CI pattern)
+- `references/premerge-gate-routine.md` — running the audit itself in CI once tools are installed


### PR DESCRIPTION
## Release v3.5.0 — Adaptive depth & autonomous remediation

Third release of the [code-quality-tools modernization roadmap](https://github.com/camoa/claude-skills). Three additive items plus one validator-surfaced hook-form fix. No behavior change to scripts, hooks, or audit logic.

### 1. Effort-adaptive audit depth (pilot)

`skills/code-quality-audit/SKILL.md` gains an "Adaptive Audit Depth" section keyed on `${CLAUDE_EFFORT}`:

| `${CLAUDE_EFFORT}` | Depth |
|---|---|
| `low` | fast lint only |
| `medium` | lint + coverage + SOLID/DRY |
| `high` | full audit (effective default) |
| `xhigh` / `max` | full audit + `/code-quality:security-debate` offer |

Unknown/unset → full audit (never silently drops). `commands/audit.md` carries a prose pointer.

**Grounding discrepancy surfaced & resolved:** the gap deep dive called for `${CLAUDE_EFFORT}` gates *in `commands/audit.md`*, but the cached **Skills guide** documents `${CLAUDE_EFFORT}` strictly as a **skill-content** string substitution — no cached guide supports it in a slash-command body. So the substituting token lives in `SKILL.md`; `audit.md` uses a plain-prose behavioral instruction instead. **Pilot scope** — audit flow only; `lint-changed.sh` effort-parsing and per-command (`review.md`) gates are deferred to a later "broaden" cycle.

### 2. `/goal` autonomous loops

- `commands/tdd.md` — "Drive the GREEN phase with `/goal`": worked condition, the transcript-checkable end-state rule, and the requirements (workspace trust accepted; unavailable under `disableAllHooks` / `allowManagedHooksOnly`)
- `commands/audit.md` — "Autonomous remediation with `/goal`": fix-verify-fix loop paired with `--json` as the proof step
- `references/scheduled-sweeps.md` — distinguishes `/loop` (time-interval) from `/goal` (condition-checked)
- Both command sections state plainly: `/goal` is an interactive / headless-`-p` convenience, **not** a CI gate (CI primitives remain `audit --json` and `claude ultrareview --json`)

### 3. `Setup`-hook reference doc

New `skills/code-quality-audit/references/setup-hook-pattern.md` — documents the `Setup` hook event (fires on `--init-only` / `--init -p` / `--maintenance -p`; `init`/`maintenance` matcher; `trigger` field; cannot block; `command`/`mcp_tool` handlers only) as the one-time CI tool-bootstrap pattern. Exec form (`args` array). **Opt-in, not shipped** — honest about the Hooks Reference caveat that `Setup` never fires on a normal launch (first-use detection stays the fallback) and that `${CLAUDE_PLUGIN_ROOT}` resolves only in plugin-shipped hooks. Corrects the capability analysis's `args: ["--ci"]` — `install-tools.sh` verified to take **no positional args** (it is env-var driven).

### 4. Validator H05 fix

`hooks/hooks.json` — the `PreCompact` hook migrated to exec form (`"args": []`), the Hooks Reference's preferred form for path-placeholder hooks. The validator surfaced this as an H05 warning; fixed here per the v3.3.0 precedent (validator-flagged warning → fixed in the current release, since zero-warnings is the gate). The rest of deep-dive item 2.1 (the skill-scoped `FileChanged` hook + `post-batch-aggregation.md` snippet) remains queued for v3.6.0.

### Validation evidence

- `/plugin-creation-tools:validate` → **Result: PASS**, 0 errors. The run listed **S10** (SKILL.md 303 lines) under "Warnings" but explicitly characterizes it as *"an accepted-finding-style nudge, not a defect ... the same accepted hub-skill carve-out ... no action strictly required."* This is the identical finding the v3.3.0 (286 lines) and v3.4.0 (287 lines) runs classified as **Info** and shipped. The `${CLAUDE_EFFORT}` ladder must live in SKILL.md (substitution only works in skill content); trimming 53+ lines to chase the 250 threshold would be out-of-scope restructuring. Flagged in the roadmap notes as a natural v3.6.0 ("references & loose ends") candidate.
- `claude plugin validate ./code-quality-tools` → **✔ Validation passed**

### Metadata

`plugin.json` 3.4.0 → 3.5.0 · `marketplace.json` entry 3.4.0 → 3.5.0 · marketplace `metadata.version` 1.14.52 → 1.14.53 · skill `version` 3.4.0 → 3.5.0 · `CHANGELOG.md` `[3.5.0]` entry · roadmap checked off.

### Next

v3.6.0 — references & loose ends (the 11 LOW gaps + ride-along items; includes the remainder of hook exec-form migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)