### PR TITLE
code-quality-tools v3.6.0: References & loose ends

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.53"
+    "version": "1.14.54"
   },
   "plugins": [
     {
@@ -101,7 +101,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-05-20
+
+### References & loose ends
+
+Final release of the modernization roadmap — the LOW-priority gaps and ride-along capability items from the 2026-05-12 deep dives. All doc-currency edits; no behavior change to scripts, hooks, or audit logic.
+
+### Changed
+
+- **Hook exec form** — the skill-scoped `FileChanged` hook (`SKILL.md` frontmatter) and the worked-example snippet in `references/post-batch-aggregation.md` migrated to exec form (`"args": []`), completing deep-dive item 2.1 begun in v3.5.0 (`PreCompact`).
+- **`references/post-batch-aggregation.md`** — the `if`-Bash footnote refreshed against the current Hooks Reference: the rule matches each subcommand after leading `VAR=value` assignments are stripped, and the hook always runs when the command is too complex to parse. Semantics verified unchanged; stale date attribution dropped.
+- **`references/scheduled-sweeps.md`** — new "Autonomous & headless runs" section: the built-in **Proactive** output style suits `/goal`-driven loops (mirrors auto mode without changing permission mode; the plugin ships no output style of its own); and a `--dangerously-skip-permissions` advisory — it activates `bypassPermissions`, which skips all prompts including writes to `.git`/`.claude`/`.vscode`/`.idea`/`.husky` (root/home removals still circuit-break), disableable via `permissions.disableBypassPermissionsMode`.
+- **`commands/audit.md`, `commands/security.md`** — "run in the background" notes: `claude --bg`, monitor with `claude agents`, pull output with `claude logs <id>`.
+- **`commands/security-debate.md`, `commands/architecture-debate.md`** — "Teammate model & monitoring" note: `teammateDefaultModel` is the global lever (per-spawn `Model:` overrides it); watch teammates with `claude agents` / `/tasks`; do not background a whole debate (`claude --bg`) — the worktree-of-worktrees + permission-auto-deny interaction is untested, run debates in the foreground.
+- **`commands/ultrareview.md`, `commands/review.md`** — See-also entry for `claude --from-pr <number>` (resumes the Claude Code session linked to a PR; distinct from `/ultrareview <PR>`, which clones a PR fresh).
+- **`README.md`** — note that plugin command/skill visibility is managed via `/plugin`; plugin skills are not affected by the `skillOverrides` setting, and slash commands are not skills.
+- **`CONVENTIONS.md`** — Skills checklist gains the `maxSkillDescriptionChars` (1,536 default) cap; Agent Frontmatter Limitations gains the Subagents-guide detail (`name` → `agent_type` for hooks; `permissionMode`/`hooks` ignored for plugin subagents; "what loads at startup"); the `/loop` section gains a `/goal` condition-checked-loop pointer.
+
+### Not done (intentional)
+
+- `agentProgressSummaries` (capability item 4) — not documented in any cached Claude Code guide; dropped rather than guessed. `teammateDefaultModel` (a confirmed setting) and Agent View monitoring cover the same need.
+- `SKILL.md` body trim — at 303 lines it trips the validator's S10 hub-skill nudge (an accepted carve-out, not a defect; shipped at 286–303 since v3.3.0). Trimming is outside the roadmap's scope for this release; left as an optional future follow-up.
+
+Marketplace metadata bumped 1.14.53 → 1.14.54. This completes the v3.3.0 → v3.6.0 modernization roadmap.
+
 ## [3.5.0] - 2026-05-20
 
 ### Adaptive depth & autonomous remediation

--- a/code-quality-tools/CONVENTIONS.md
+++ b/code-quality-tools/CONVENTIONS.md
@@ -14,6 +14,7 @@
 - Description must be pushy — include "Use proactively" and enforcement where appropriate
 - Body uses imperative voice — instructions, not documentation
 - Under 500 lines per SKILL.md
+- Keep the `description` (plus any `when_to_use`) within `maxSkillDescriptionChars` — default 1,536 — since text past the cap is truncated in the skill listing Claude sees each turn; put the key trigger phrases first
 
 ## Commands
 - Frontmatter must include: description, allowed-tools
@@ -25,6 +26,8 @@
 
 ## Agent Frontmatter Limitations
 Agent spawn prompts in this plugin document `effort`, `model`, `maxTurns`, and `isolation` as intent markers inside Markdown. These are NOT evaluated as YAML frontmatter — they are instructions to Claude on how to configure the spawned agent. The actual agent launch mechanism (TeamCreate/TaskCreate) is what enforces model routing and isolation. Do not add `hooks`, `mcpServers`, or `permissionMode` to agent spawn prompt blocks — those fields are not processed in the agent spawning context and will be silently ignored.
+
+Per the Subagents guide: a subagent's `name` frontmatter is the value hooks receive as `agent_type`, and `permissionMode` / `hooks` are specifically ignored for *plugin* subagents. See that guide's "what loads at startup" section for the full list of what reaches a spawned agent.
 
 ## Hooks
 
@@ -74,6 +77,8 @@ Users can run quality checks on a schedule during long coding sessions using Cla
 Session-scoped — checks stop when the session exits. 3-day auto-expiry prevents forgotten loops. Up to 50 concurrent tasks.
 
 For CI-based recurring checks, use GitHub Actions or GitLab CI instead of `/loop`.
+
+For a **condition-checked** loop — run until a stated end state holds rather than on a clock — use `/goal` instead of `/loop`. `commands/audit.md` and `commands/tdd.md` document worked `/goal` patterns (audit-until-clean, TDD GREEN phase). Like `/loop`, `/goal` is session-scoped and not a CI primitive.
 
 ## Online Dev-Guides
 For Drupal-specific patterns when explaining violations or suggesting fixes, fetch the guide index:

--- a/code-quality-tools/README.md
+++ b/code-quality-tools/README.md
@@ -94,6 +94,8 @@ These spawn 3-agent teams that analyze from competing perspectives, cross-challe
 
 Each agent runs in an isolated worktree with scoped tool access and cost-controlled turns.
 
+> To control which of this plugin's commands and skills are available, use `/plugin` — plugin skills are not affected by the `skillOverrides` setting, and slash commands are not skills, so neither can be muted that way.
+
 ## How It Works
 
 ### Conversational Use

--- a/code-quality-tools/commands/architecture-debate.md
+++ b/code-quality-tools/commands/architecture-debate.md
@@ -77,6 +77,8 @@ Spawn 3 teammates using the prompt templates below. After spawning:
 1. Tell the user: "Team spawned. Teammates are debating — I'll synthesize when they finish."
 2. Do NOT perform analysis yourself — wait for all teammates to complete.
 
+**Teammate model & monitoring.** Each spawn prompt pins `**Model:** sonnet` — explicit per-spawn values are intentional. To change the team's default model globally without editing these prompts, set `teammateDefaultModel` in settings (a per-spawn `Model:` still overrides it). Watch teammate progress with `claude agents` or `/tasks`. Do **not** dispatch the whole debate as a background session (`claude --bg`): the teammates already run in worktree isolation, so a backgrounded debate is a worktree-of-worktrees plus permission-auto-deny scenario that is untested — run debates in the foreground.
+
 ### Step 6 — Synthesize
 
 When all teammates finish:

--- a/code-quality-tools/commands/audit.md
+++ b/code-quality-tools/commands/audit.md
@@ -132,6 +132,8 @@ For recurring sweeps (daily, weekly, hourly security watch), pick a surface base
 
 Surface comparison and decision tree: `${CLAUDE_PLUGIN_ROOT}/skills/code-quality-audit/references/scheduled-sweeps.md`.
 
+**Run it without blocking.** A full audit is a ~10-minute run. `claude --bg "/code-quality:audit"` dispatches it as a background session that keeps running with no terminal attached while you keep working — monitor it with `claude agents` (the agent-view TUI) and pull results in a script with `claude logs <id>`. This is on-demand-async; the scheduled surfaces above are clock-driven.
+
 ## Wire to CI
 
 For CI-triggered pre-merge audits (fire from GitHub Actions / GitLab CI on PR labels or merge-ready signal), use a Cloud Routine with an API trigger. Full `curl` + workflow snippets + bearer-token lifecycle in `${CLAUDE_PLUGIN_ROOT}/skills/code-quality-audit/references/premerge-gate-routine.md`.

--- a/code-quality-tools/commands/review.md
+++ b/code-quality-tools/commands/review.md
@@ -197,3 +197,4 @@ To gate merges on Code Review findings, parse the **Claude Code Review** check r
 - `/code-quality:generate-review-md` — generate a v2 REVIEW.md tailored to the project
 - `/code-quality:ultrareview` — cloud multi-agent deep review for pre-merge (slower, more rigorous, paid after free quota)
 - `@claude review once` — GitHub PR comment that triggers one managed Code Review without subscribing the PR to future push-triggered reviews. Requires the managed Code Review service enabled on the repository. Useful for long-running PRs with frequent rebases.
+- `claude --from-pr <number>` — resumes the Claude Code session linked to a PR (linked automatically when Claude opened it). Use it to act on review findings in the original session's context.

--- a/code-quality-tools/commands/security-debate.md
+++ b/code-quality-tools/commands/security-debate.md
@@ -87,6 +87,8 @@ Spawn 3 teammates using the prompt templates below. After spawning:
 2. If running inside tmux, teammates appear in split panes (visible output). Otherwise they run in-process (background).
 3. Do NOT perform analysis yourself — wait for all teammates to complete before proceeding.
 
+**Teammate model & monitoring.** Each spawn prompt pins `**Model:** sonnet` — explicit per-spawn values are intentional. To change the team's default model globally without editing these prompts, set `teammateDefaultModel` in settings (a per-spawn `Model:` still overrides it). Watch teammate progress with `claude agents` or `/tasks`. Do **not** dispatch the whole debate as a background session (`claude --bg`): the teammates already run in worktree isolation, so a backgrounded debate is a worktree-of-worktrees plus permission-auto-deny scenario that is untested — run debates in the foreground.
+
 ### Step 6 — Synthesize
 
 When all teammates finish:

--- a/code-quality-tools/commands/security.md
+++ b/code-quality-tools/commands/security.md
@@ -96,6 +96,10 @@ To customize, create `.code-quality.json`:
 }
 ```
 
+## Run in the background
+
+To run a security scan without blocking your session, dispatch it as a background session: `claude --bg "/code-quality:security"`. It keeps running with no terminal attached — monitor it with `claude agents` and pull results with `claude logs <id>`.
+
 ## Error Handling
 
 Common issues:

--- a/code-quality-tools/commands/ultrareview.md
+++ b/code-quality-tools/commands/ultrareview.md
@@ -174,3 +174,4 @@ A run that fails or is stopped **still consumes** one of the three free Pro/Max 
 - `/code-quality:audit` — full local audit (all tools, no rubric)
 - `/code-quality:generate-review-md` — tune managed Code Review (separate from ultrareview)
 - `skills/code-quality-audit/references/scheduled-sweeps.md` — scheduling reviews across local and cloud surfaces
+- `claude --from-pr <number>` — resumes the Claude Code session linked to a PR (linked automatically when Claude opened it). Use it to pick up review or fix work on a PR; distinct from `/ultrareview <PR>`, which clones a PR fresh to review it.

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -11,6 +11,7 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/lint-changed.sh"
+          args: []
           timeout: 30
   PermissionDenied:
     - matcher: "Read|Grep|Glob"

--- a/code-quality-tools/skills/code-quality-audit/references/post-batch-aggregation.md
+++ b/code-quality-tools/skills/code-quality-audit/references/post-batch-aggregation.md
@@ -34,6 +34,7 @@ Project-local `.claude/hooks.json`:
           {
             "type": "command",
             "command": "${HOME}/.claude/scripts/quality-batch-summary.sh",
+            "args": [],
             "timeout": 10
           }
         ]
@@ -79,4 +80,4 @@ If `PostToolBatch` gains skill-scoping (matching this plugin's existing skill-sc
 
 - `references/troubleshooting.md` — `Debug Your Config` cross-link for verifying the hook actually loads (`/hooks` slash command).
 - Skill-scoped vs plugin-scoped hooks — see `CONVENTIONS.md` in plugin root.
-- `if`-Bash subcommand semantics: `Bash(rm *)` matches `FOO=bar rm file` and `npm test && rm file` (per Hooks Reference 2026-04-25 clarification). There is no `&&`/`||` in `if` — register separate handlers for compound conditions.
+- `if`-Bash subcommand semantics: the rule is matched against each subcommand after leading `VAR=value` assignments are stripped, so `Bash(rm *)` matches `FOO=bar rm file` and `npm test && rm file` (per the Hooks Reference). The hook also always runs when the command is too complex to parse. There is no `&&`/`||` or list syntax in `if` — register a separate handler per condition.

--- a/code-quality-tools/skills/code-quality-audit/references/scheduled-sweeps.md
+++ b/code-quality-tools/skills/code-quality-audit/references/scheduled-sweeps.md
@@ -65,6 +65,11 @@ Not for: production quality automation — restart the session and the loop is g
 
 **`/loop` vs `/goal`:** `/loop` re-runs a prompt on a fixed **time interval** and stops only when you stop it. `/goal` re-runs after every turn and stops when a fresh evaluator model confirms a **completion condition** from the transcript — use it for "audit until clean" / "fix until tests pass" loops (see `commands/audit.md` and `commands/tdd.md`). Neither is a CI primitive: both keep the current session running.
 
+## Autonomous & headless runs
+
+- **Proactive output style.** A `/goal`-driven audit-remediation loop (see `commands/audit.md`) or a TDD GREEN loop runs more smoothly under the built-in **Proactive** output style — it makes Claude execute immediately and prefer action over planning, the same guidance as auto mode but *without* changing your permission mode (you still see permission prompts). Switch via `/config` → Output style. Do **not** use it for interactive review where you want Claude to pause and ask. This plugin does not ship an output style — only the built-in is referenced.
+- **`--dangerously-skip-permissions`.** Running an unattended audit with this flag activates `bypassPermissions` mode, which skips *all* permission prompts — including writes to `.git`, `.claude`, `.vscode`, `.idea`, and `.husky` (root- and home-directory removals still circuit-break). Audits are read-heavy but the linters and `git`-aware scanners do touch the tree; only use this flag in an isolated environment (container/VM). To forbid it organization-wide, set `permissions.disableBypassPermissionsMode` to `"disable"` in managed settings.
+
 ## See Also
 
 - `desktop-sweep-template.md` — full Desktop Scheduled Task template (primary)


### PR DESCRIPTION
## Release v3.6.0 — References & loose ends

**Final release** of the [code-quality-tools modernization roadmap](https://github.com/camoa/claude-skills) (v3.3.0 → v3.6.0). The LOW-priority gaps and ride-along capability items from the 2026-05-12 deep dives. All doc-currency edits — no behavior change to scripts, hooks, or audit logic.

### Changed (11 files)

- **Hook exec form** — the skill-scoped `FileChanged` hook (`SKILL.md`) and the `post-batch-aggregation.md` worked-example snippet migrated to exec form (`"args": []`), completing deep-dive item 2.1 (`PreCompact` was done in v3.5.0).
- **`post-batch-aggregation.md`** — `if`-Bash footnote refreshed against the current Hooks Reference: rule matches each subcommand after leading `VAR=value` is stripped, and always runs when the command is too complex to parse. Semantics verified unchanged; stale date attribution dropped.
- **`scheduled-sweeps.md`** — new "Autonomous & headless runs" section: the built-in **Proactive** output style for `/goal`-driven loops (mirrors auto mode without changing permission mode); `--dangerously-skip-permissions` advisory (activates `bypassPermissions` → skips writes to `.git`/`.claude`/`.vscode`/`.idea`/`.husky`; root/home removals still circuit-break; disableable via `disableBypassPermissionsMode`).
- **`audit.md` / `security.md`** — "run in the background" notes (`claude --bg`, `claude agents`, `claude logs <id>`).
- **`security-debate.md` / `architecture-debate.md`** — "Teammate model & monitoring" note: `teammateDefaultModel` is the global model lever (per-spawn `Model:` overrides it); watch teammates with `claude agents` / `/tasks`; don't background a whole debate (untested worktree-of-worktrees + permission-auto-deny).
- **`ultrareview.md` / `review.md`** — See-also entry for `claude --from-pr <number>` (resumes the session linked to a PR — accurately distinguished from `/ultrareview <PR>`, which clones a PR fresh).
- **`README.md`** — plugin command/skill visibility is a `/plugin` concern; plugin skills aren't affected by `skillOverrides`, and commands aren't skills.
- **`CONVENTIONS.md`** — Skills checklist gains the `maxSkillDescriptionChars` (1,536) cap; Agent Frontmatter Limitations gains the Subagents-guide detail (`name` → `agent_type`; "what loads at startup"); the `/loop` section gains a `/goal` condition-checked-loop pointer.

### Not done (intentional, surfaced)

- **`agentProgressSummaries`** (capability item 4) — **dropped**: not documented in any cached Claude Code guide. The capability deep dive called it an SDK option; it could not be grounded for interactive debate commands, so it was not guessed. `teammateDefaultModel` (a confirmed setting) + Agent View monitoring cover the same need.
- **`SKILL.md` body trim** — at 303 lines it trips the validator's S10 hub-skill nudge, an **accepted carve-out, not a defect** (the skill has shipped at 286–303 lines since v3.3.0). A trim is outside this roadmap's scope; left as an optional standalone follow-up (noted in the roadmap).

### Validation evidence

- `/plugin-creation-tools:validate` → **PASS** — 0 errors, 0 warnings (the `FileChanged` exec-form migration also cleared the H05 nudge; S10 not flagged this run).
- `claude plugin validate ./code-quality-tools` → **✔ Validation passed**

### Metadata

`plugin.json` 3.5.0 → 3.6.0 · `marketplace.json` entry 3.5.0 → 3.6.0 · marketplace `metadata.version` 1.14.53 → 1.14.54 · `CHANGELOG.md` `[3.6.0]` entry · roadmap checked off.

### Roadmap complete

This is the **fourth and final** release. code-quality-tools is now current through Claude Code v2.1.144: validator hygiene + ultrareview CLI (v3.3.0), LSP code intelligence (v3.4.0), adaptive depth & autonomous remediation (v3.5.0), references & loose ends (v3.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)