### PR TITLE
code-quality-tools v3.6.1: replace abandoned sebastian/phpcpd

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.54"
+    "version": "1.14.55"
   },
   "plugins": [
     {
@@ -101,7 +101,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] - 2026-05-20
+
+### Fixed
+
+- **`README.md` and `commands/setup.md` no longer install the abandoned `sebastian/phpcpd`.** Both manual-install / Quick Install blocks listed `sebastian/phpcpd`, which is marked **abandoned** on Packagist (Sebastian Bergmann archived phpcpd) — so following the README or running `/code-quality:setup` Quick Install produced a Composer deprecation warning. Switched both to the maintained community fork `systemsdk/phpcpd`, which the plugin's own `scripts/core/install-tools.sh`, `scripts/drupal/dry-check.sh`, CI template, and `references/dry-detection.md` already use. The fork is a drop-in replacement — same `vendor/bin/phpcpd` binary and CLI flags — so no script or command logic changed.
+
+Marketplace metadata bumped 1.14.54 → 1.14.55.
+
 ## [3.6.0] - 2026-05-20
 
 ### References & loose ends

--- a/code-quality-tools/README.md
+++ b/code-quality-tools/README.md
@@ -42,7 +42,7 @@ Or install manually:
 ddev composer require --dev \
   phpstan/phpstan \
   phpmd/phpmd \
-  sebastian/phpcpd \
+  systemsdk/phpcpd \
   vimeo/psalm \
   drupal/coder \
   drupal/security_review \

--- a/code-quality-tools/commands/setup.md
+++ b/code-quality-tools/commands/setup.md
@@ -68,7 +68,7 @@ Installs all recommended tools with default thresholds.
 ddev composer require --dev \
   phpstan/phpstan \
   phpmd/phpmd \
-  sebastian/phpcpd \
+  systemsdk/phpcpd \
   vimeo/psalm \
   drupal/coder \
   rector/rector \


### PR DESCRIPTION
## Patch v3.6.1 — drop the abandoned `sebastian/phpcpd`

### Problem

`README.md` (manual-install block) and `commands/setup.md` (Quick Install block) listed **`sebastian/phpcpd`** in their `composer require --dev` commands. That package is marked **abandoned** on Packagist — Sebastian Bergmann archived phpcpd — so following the README or running `/code-quality:setup` Quick Install produced a Composer deprecation/abandoned warning.

The plugin had already migrated everywhere else: `scripts/core/install-tools.sh`, `scripts/drupal/dry-check.sh`, `templates/ci/github-drupal.yml`, `resources.md`, `tool-comparison.md`, `drupal-setup.md`, and `references/dry-detection.md` all use the maintained fork `systemsdk/phpcpd` — `dry-detection.md` even states *"Original `sebastian/phpcpd` is abandoned."* Only these two user-facing docs were missed, so they contradicted the plugin's own installer.

### Fix

Two one-word changes — `sebastian/phpcpd` → `systemsdk/phpcpd` in `README.md` and `commands/setup.md`. `systemsdk/phpcpd` is a drop-in replacement (same `vendor/bin/phpcpd` binary, same CLI flags), which is why no script or command logic changed. The whole plugin now consistently installs the maintained fork.

The rest of the Composer toolchain was reviewed — `phpstan/phpstan`, `phpmd/phpmd`, `vimeo/psalm`, `drupal/coder`, `rector/rector` / `palantirnet/drupal-rector`, `phpro/grumphp`, `roave/security-advisories`, `drupal/security_review` — all actively maintained, none abandoned.

### Validation

- `/plugin-creation-tools:validate` → **PASS**, 0 errors (the two warnings are pre-existing accepted hub-skill nudges on `SKILL.md`, untouched by this patch)
- `claude plugin validate ./code-quality-tools` → **✔ Validation passed**

### Metadata

`plugin.json` 3.6.0 → 3.6.1 · `marketplace.json` entry 3.6.0 → 3.6.1 · marketplace `metadata.version` 1.14.54 → 1.14.55 · `CHANGELOG.md` `[3.6.1]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)