### PR TITLE
feat(drupal-ai-contrib): new plugin — AI-assisted Drupal contribution quality

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": ""
   },
   "metadata": {
-    "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.14.60"
+    "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
+    "version": "1.15.0"
   },
   "plugins": [
     {
@@ -95,6 +95,30 @@
         "migration",
         "forms",
         "dynamic-content"
+      ]
+    },
+    {
+      "name": "drupal-ai-contrib",
+      "source": "./drupal-ai-contrib",
+      "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline), a local drupalci-parity gate set plus AI-policy and eval gates inside verify, 3 read-only agents (fresh-context review, external-fact verification, live AI-policy checking), and a PostToolUse re-verification ledger. A quality layer outside drupal-dev-framework; cites the camoa/dev-guides contribution guides as its knowledge layer.",
+      "version": "0.1.0",
+      "author": {
+        "name": "camoa"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/camoa/claude-skills",
+      "keywords": [
+        "drupal",
+        "contribution",
+        "drupalci",
+        "gitlab-ci",
+        "ai-policy",
+        "code-quality",
+        "merge-request",
+        "phpcs",
+        "phpstan",
+        "phpunit",
+        "evidence-over-assertion"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ I wrote more about this methodology in [My Journey with AI Tools](https://adrupa
 /plugin install code-quality-tools@camoa-skills
 /plugin install drupal-htmx@camoa-skills
 /plugin install code-paper-test@camoa-skills
+/plugin install drupal-ai-contrib@camoa-skills
 ```
 
 ## Using these plugins outside Claude Code
@@ -170,6 +171,26 @@ Systematically test code, skills, commands, and configs through mental execution
 Tests code AND non-code artifacts: skills, commands, agents, YAML configs. Auto-detects skill files and switches to instruction tracing mode.
 
 See [code-paper-test/README.md](code-paper-test/README.md) for full documentation.
+
+### drupal-ai-contrib (v0.1.0)
+
+AI-assisted Drupal contribution quality — **evidence over assertion**: every gate passes only on a produced, captured artifact, never on an AI assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline.
+
+```bash
+/drupal-ai-contrib:setup     # Onboard + environment-match a contribution workspace
+/drupal-ai-contrib:verify    # Local drupalci-parity + AI-policy + eval gates
+```
+
+| Component | Contents |
+|-----------|----------|
+| Commands | 6 (`/setup`, `/issue`, `/verify`, `/review`, `/submit`, `/pipeline`) — the detect-driven contribution arc |
+| Skills | 8 (`drupal-ai-contrib` umbrella/router, 6 worker skills, `contribution-guardrails` discipline) |
+| Agents | 3 read-only (`fresh-context-reviewer`, `external-fact-verifier`, `ai-policy-checker`) |
+| Hooks | PostToolUse (re-verification ledger), SessionStart (contribution-workspace reminder) |
+
+The drupalci-parity gate set (`composer`/`phpcs`/`phpstan`/`phpunit`/`cspell`/`eslint`/`stylelint`) mirrors each enabled `gitlab_templates` job at its real strictness. Cites the `camoa/dev-guides` contribution guides by slug via `dev-guides-navigator`; a contribution is run as a `drupal-dev-framework` task.
+
+See [drupal-ai-contrib/README.md](drupal-ai-contrib/README.md) for full documentation.
 
 ## Plugin Conventions
 

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "drupal-ai-contrib",
+  "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
+  "version": "0.1.0",
+  "author": {
+    "name": "camoa"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/camoa/claude-skills",
+  "keywords": [
+    "drupal",
+    "contribution",
+    "drupalci",
+    "gitlab-ci",
+    "ai-policy",
+    "code-quality",
+    "merge-request",
+    "phpcs",
+    "phpstan",
+    "phpunit",
+    "evidence-over-assertion"
+  ]
+}

--- a/drupal-ai-contrib/.claude/rules/agent-conventions.md
+++ b/drupal-ai-contrib/.claude/rules/agent-conventions.md
@@ -1,0 +1,21 @@
+---
+globs: agents/**
+---
+
+# Agent Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — includes delegation triggers ("Use proactively when...")
+- `version` — semver
+- `model` — haiku, sonnet, or opus matched to task complexity
+
+## Tool Restriction
+- The agent tool allowlist field is `tools` — NOT `allowed-tools` (silently ignored
+  on agents, leaving the agent with all tools).
+- All three agents are read-only — also declare `disallowedTools: Edit, Write`.
+
+## Body
+- Imperative voice: "Verify...", "Review...", "Fetch...".
+- Fresh context, no session narrative — an agent must not inherit the builder's claims.
+- Return findings to the caller as a structured verdict; never modify files.

--- a/drupal-ai-contrib/.claude/rules/command-conventions.md
+++ b/drupal-ai-contrib/.claude/rules/command-conventions.md
@@ -1,0 +1,18 @@
+---
+globs: commands/**
+---
+
+# Command Conventions
+
+## Required Frontmatter
+- `description` — clear action description with literal trigger phrases
+- `allowed-tools` — minimum the backing worker skill needs
+
+## Optional Frontmatter
+- `argument-hint` — when the command accepts arguments
+
+## Body
+- Thin entry point: validate arguments, invoke the backing worker skill via the Skill
+  tool, present the result. No procedure logic in the command body.
+- Include error handling for missing prerequisites — point the contributor at the
+  gap, never refuse to run (the arc is detect-driven, not a forced sequence).

--- a/drupal-ai-contrib/.claude/rules/skill-conventions.md
+++ b/drupal-ai-contrib/.claude/rules/skill-conventions.md
@@ -1,0 +1,21 @@
+---
+globs: skills/**
+---
+
+# Skill Conventions
+
+## Required Frontmatter
+- `name` — lowercase, hyphens only
+- `description` — starts with "Use when...", includes literal trigger phrases
+- `version` — semver
+
+## Optional Frontmatter
+- `model` — matched to complexity (sonnet for balanced tasks)
+- `user-invocable: false` — umbrella + the six worker skills (invoked by command or
+  routed to by the umbrella, never from the `/` menu)
+
+## Body
+- Imperative voice — instructions for Claude, not documentation
+- Under 500 lines per SKILL.md; push detail into `references/`
+- Cite dev-guides by slug; never embed guide content or fetch dev-guides URLs directly
+- Every gate passes on a captured artifact, never on an assertion

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-05-21
+
+Initial release — AI-assisted Drupal contribution quality, built per the
+`drupal_contrib_workflow` epic architecture. Core principle: **evidence over assertion**
+— every gate passes only on a produced, captured artifact, never on an AI assertion.
+
+### Added
+
+- **6 commands** — the detect-driven contribution arc: `setup`, `issue`, `verify`,
+  `review`, `submit`, `pipeline`. Thin entry points, each backed by a worker skill.
+- **8 skills** — the `drupal-ai-contrib` umbrella & router (supplies the dev-guides
+  knowledge layer); six worker skills, one per command; and `contribution-guardrails`,
+  the cross-cutting development discipline (no-guessing rule, verification-gate
+  artifact contracts). The umbrella and the six workers are `user-invocable: false`.
+- **3 read-only agents** — `fresh-context-reviewer` (honest review with no build
+  narrative), `external-fact-verifier` (verify an external fact against source or a
+  live probe), `ai-policy-checker` (live-fetch the AI-policy + eval state,
+  maturity-tagged). All carry `disallowedTools: Edit, Write`.
+- **2 hooks** — a `PostToolUse` re-verification ledger (`hooks/reverify-mark.sh` +
+  `scripts/reverify-list.sh`) so `verify` re-fires the gate for any path edited after
+  it passed; and a context-aware `SessionStart` reminder that speaks only inside a
+  contribution workspace.
+- **The drupalci-parity gate set** inside `verify` — `composer` / `phpcs` / `phpstan` /
+  `phpunit` / `cspell` / `eslint` / `stylelint`, environment-matched to the CI-target
+  core, mirroring each enabled `gitlab_templates` job at its real strictness and
+  reporting its real blocking status; plus the AI-policy gate (every contribution) and
+  the best-effort eval gate.
+- **The contribution knowledge layer** — worker skills cite the `camoa/dev-guides`
+  contribution guides (`drupal/contributing/`, `drupal/contributing-with-ai/`) by slug,
+  loaded via `dev-guides-navigator`.

--- a/drupal-ai-contrib/CONVENTIONS.md
+++ b/drupal-ai-contrib/CONVENTIONS.md
@@ -50,3 +50,28 @@ Both are fetched live, never hard-coded — they move fast.
 - Delegate, don't reinvent: `drupal-dev-framework` (phase lifecycle), `code-quality-tools`
   (philosophy/standards review), `code-paper-test` (paper testing), `drupalorg-cli`
   (issue/MR/CI). The plugin owns orchestration + evidence-gating + the contribution arc.
+
+## Enforcement model & known limitations
+
+Be honest about what this plugin can and cannot enforce — the plugin preaches evidence
+over assertion, so it must apply that candor to itself.
+
+- **Enforcement is instruction-level, plus one hook.** A Claude Code plugin is skills
+  (instructions) — there is no runtime engine that *compels* the model to run `phpcs`,
+  dispatch an agent, or paste a captured artifact. The gate contracts in
+  `contribution-verify` and `contribution-guardrails` are followed because the
+  instructions are explicit and strongly worded, not because a supervisor blocks a
+  skipped step. The **`PostToolUse` re-verification hook is the one piece of genuine
+  runtime enforcement.** When wording a gate, make the *artifact* the thing reported —
+  "paste the `phpcs` output", not "confirm phpcs passes" — so a skipped step is visible
+  in the transcript.
+- **Re-verification covers `Edit`/`Write` only.** The ledger hook does not see files
+  written through the `Bash` tool (shell redirects, `sed -i`) or other write-capable
+  tools. This never causes a false green — `contribution-verify` re-runs the full gate
+  set every run; the ledger only adds *extra* re-runs after a gate passed mid-session.
+  A `Bash`-written change is simply caught by the next full `verify`.
+- **Live-fetched governance is authoritative over inline text.** Any AI-policy
+  threshold quoted inline in a skill (e.g. the "significant portion" examples) is
+  *illustrative*. The binding state is whatever the `ai-policy-checker` agent fetches
+  live for the contribution. If a source is unreachable, the AI-policy gate is UNRUN,
+  never silently passed.

--- a/drupal-ai-contrib/CONVENTIONS.md
+++ b/drupal-ai-contrib/CONVENTIONS.md
@@ -1,0 +1,52 @@
+# drupal-ai-contrib — Plugin Conventions
+
+Maintainer/contributor conventions for this plugin. Not loaded as end-user context.
+
+## Core principle
+
+**Evidence over assertion.** Every gate passes only on a produced artifact — a
+command's output, a file diff, a live API response, a real pipeline result. Never on
+the model stating "done", "passes", or "should work". This invariant governs every
+component; the plugin eats its own dog food.
+
+## Commands
+- Thin entry points. Each command validates its arguments, then invokes its backing
+  worker skill via the Skill tool and presents the result. No procedure logic in the
+  command body.
+- Frontmatter must include: `description` (with literal trigger phrases), `allowed-tools`.
+- Use `argument-hint` when the command accepts arguments.
+- Restrict `allowed-tools` to the minimum the backing worker skill needs.
+
+## Skills
+- Frontmatter must include: `name`, `description`, `version`.
+- The umbrella skill (`drupal-ai-contrib`) and the six worker skills are
+  `user-invocable: false` — invoked by their command or routed to by the umbrella.
+- `contribution-guardrails` is user-invocable — a contributor may pull it up directly.
+- Body uses imperative voice — instructions for Claude, not documentation.
+- Under 500 lines per SKILL.md; push detail into `references/`.
+
+## Agents
+- Frontmatter must include: `name`, `description`, `version`, `model`.
+- The agent tool allowlist field is `tools` (NOT `allowed-tools` — silently ignored on
+  agents). Read-only agents also carry `disallowedTools: Edit, Write`.
+- All three agents are read-only — they return findings, never modify files.
+
+## Hooks
+- Command hooks use exec form (`"args": []`).
+
+## The knowledge layer — dev-guides
+The plugin's technical how-to comes from the `camoa/dev-guides` contribution guides,
+accessed via the `dev-guides-navigator` skill (caching + disambiguation). Worker skills
+cite guides by slug; they do NOT embed or duplicate guide content, and never fetch
+`llms.txt` or dev-guides URLs directly. See `skills/drupal-ai-contrib/references/dev-guides-index.md`.
+
+## The governance layer — ai_best_practices
+AI-policy + compliance + evals anchor on `ai_best_practices` (the canonical Drupal AI
+source of truth) and the adopted *Policy on the use of AI when contributing to Drupal*.
+Both are fetched live, never hard-coded — they move fast.
+
+## General
+- Current truth only — no historical narratives in skill/command bodies.
+- Delegate, don't reinvent: `drupal-dev-framework` (phase lifecycle), `code-quality-tools`
+  (philosophy/standards review), `code-paper-test` (paper testing), `drupalorg-cli`
+  (issue/MR/CI). The plugin owns orchestration + evidence-gating + the contribution arc.

--- a/drupal-ai-contrib/README.md
+++ b/drupal-ai-contrib/README.md
@@ -7,11 +7,31 @@ AI-assisted Drupal contribution **quality** — *evidence over assertion*.
 ## Why this exists
 
 Drupal is openly concerned about the *quality* of AI-assisted contributions: AI makes
-contributing cheap but makes *reviewing* expensive. This plugin's purpose is not "help
-someone contribute" — it is to make AI a **trusted, good-practice** way to contribute:
-AI-assisted code that passes drupalci, survives maintainer review on the first or
-second round, follows Drupal + PHP best practices, and follows the Code of Conduct and
-the adopted AI-contribution policy.
+contributing cheap but makes *reviewing* expensive. A contribution that looks finished
+but fails drupalci, drifts from the coding standards, or hides undisclosed AI authorship
+does not save the project time — it spends a maintainer's time.
+
+This plugin exists to make AI a **trusted, good-practice** way to contribute:
+AI-assisted code that passes drupalci, survives maintainer review on the first or second
+round, follows Drupal + PHP best practices, and follows the Code of Conduct and the
+adopted AI-contribution policy.
+
+## What you get
+
+Running the plugin's gates *before* you push means:
+
+- **Your MR is not bounced by drupalci.** The same `phpcs` / `phpstan` / `phpunit` /
+  `cspell` jobs CI runs are mirrored locally at CI strictness — environment-matched to
+  the CI-target core — so failures surface on your machine, not in the pipeline.
+- **You do not burn maintainer goodwill.** A fresh-context agent reviews the diff
+  against scope, standards, and security, so the obvious findings are caught before a
+  human reviewer ever sees them.
+- **You do not risk a disclosure violation.** Significant AI use must be disclosed under
+  the adopted policy; undisclosed use is sanctionable (education → temporary ban →
+  permanent ban). The plugin assesses the threshold and prepares the disclosure where
+  the policy requires it.
+- **You ship exactly what was asked.** Over-delivery is review burden a maintainer did
+  not ask for — scope discipline is a gate here, not a suggestion.
 
 ## Core principle — evidence over assertion
 
@@ -20,6 +40,27 @@ live API response, a real pipeline result. **Never** on the model stating "done"
 "passes", or "should work". The plugin's job is to *produce, capture, and check* that
 artifact. It applies the same discipline to its own output.
 
+## Built on the Drupal AI standards
+
+This plugin does **not** invent its own rules. AI governance for Drupal contributions is
+an actively evolving standard, developed in the **`ai_best_practices`** drupal.org
+project — the canonical source of truth for the adopted *Policy on the use of AI when
+contributing to Drupal* and the contribution **eval suite** (`evals/evals.json`).
+
+Because that standard is still being created, the plugin **tracks it live** rather than
+freezing a snapshot that goes stale:
+
+- The `ai-policy-checker` agent fetches the current policy and eval state on **every
+  contribution**, and tags each fact **SETTLED / DRAFT / DISCUSSION** so you know what
+  is binding versus still in debate.
+- The eval gate runs `ai_best_practices`' `evals/evals.json` when available and degrades
+  gracefully when it changes — it never hard-pins a schema.
+- No policy text is hard-coded in this plugin. As `ai_best_practices` evolves, the
+  plugin follows it without needing a release.
+
+The plugin is the **implementation layer** for those standards inside your editor;
+`ai_best_practices` remains the authority.
+
 ## Installation
 
 ```bash
@@ -27,11 +68,59 @@ artifact. It applies the same discipline to its own output.
 /plugin install drupal-ai-contrib@camoa-skills
 ```
 
+**Companions & tools** — `dev-guides-navigator` (companion — supplies the contribution
+how-to guides; install it alongside), `drupalorg-cli` (issue / MR / pipeline
+operations), DDEV (the local environment), and a drupal.org account with GitLab access.
+`setup` detects what is missing and points you at it; nothing is a hard prerequisite.
+
 ## The contribution arc
 
 Six stages — **detect-driven, not a forced sequence**. Each command checks the state it
 needs and runs regardless of whether earlier commands ran; a command that finds a real
-gap points at `setup` for *that gap only*. `setup` is the on-ramp, never a prerequisite.
+gap points at `setup` for *that gap only*. `setup` is the on-ramp, never a prerequisite
+— a contributor with a ready environment can enter at `issue`, or even at `verify` with
+work already underway.
+
+1. **`setup`** — onboard + environment-match the workspace, so local gate results
+   actually match CI.
+2. **`issue`** — work the issue lifecycle; review prior work *first*, so the
+   contribution is not a duplicate.
+3. **`verify`** — run the drupalci-parity gates locally at CI strictness, so CI does not
+   bounce the MR.
+4. **`review`** — honest fresh-context review, so the obvious findings are caught before
+   a maintainer sees them.
+5. **`submit`** — open the MR with the AI disclosure the policy requires, so the
+   submission is compliant.
+6. **`pipeline`** — confirm the *real* GitLab pipeline — the authoritative final gate;
+   local green is not "done".
+
+## Walkthrough — contribute a fix to an existing module
+
+```bash
+# 1. Onboard: detect the workflow, match the environment to CI's target core.
+/drupal-ai-contrib:setup
+
+# 2. Claim the issue (numeric drupal.org / GitLab issue ID); reviews prior work first.
+/drupal-ai-contrib:issue 3456789
+
+#    ...develop the fix. contribution-guardrails applies during development —
+#    evidence over assertion, no guessing external facts.
+
+# 3. Verify locally — the drupalci-parity gates at CI strictness, on captured artifacts.
+/drupal-ai-contrib:verify
+
+# 4. Honest review — a fresh-context agent checks scope, standards, security, disclosure.
+/drupal-ai-contrib:review
+
+# 5. Open / update the merge request, with the AI disclosure the policy requires.
+/drupal-ai-contrib:submit 3456789
+
+# 6. Confirm the real GitLab pipeline — the authoritative final gate.
+/drupal-ai-contrib:pipeline
+```
+
+You can also enter without a command — *"I want to contribute a fix to the Pathauto
+module"* routes to the right stage.
 
 ## Commands
 
@@ -65,7 +154,8 @@ All three are read-only — `disallowedTools: Edit, Write`.
 ## Hooks
 
 - **`PostToolUse`** (`Edit|Write`) — re-verification ledger: records every edited
-  contribution file so `verify` re-fires the gate for any path changed after it passed.
+  contribution file so `verify` re-fires the gate for any path changed after it passed,
+  and so `submit` / `review` can flag a green `verify` invalidated by later edits.
 - **`SessionStart`** — a one-line reminder, emitted only in a contribution workspace,
   that AI-policy + eval guidance must be re-confirmed per contribution.
 

--- a/drupal-ai-contrib/README.md
+++ b/drupal-ai-contrib/README.md
@@ -1,0 +1,89 @@
+# drupal-ai-contrib
+
+AI-assisted Drupal contribution **quality** — *evidence over assertion*.
+
+> **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
+
+## Why this exists
+
+Drupal is openly concerned about the *quality* of AI-assisted contributions: AI makes
+contributing cheap but makes *reviewing* expensive. This plugin's purpose is not "help
+someone contribute" — it is to make AI a **trusted, good-practice** way to contribute:
+AI-assisted code that passes drupalci, survives maintainer review on the first or
+second round, follows Drupal + PHP best practices, and follows the Code of Conduct and
+the adopted AI-contribution policy.
+
+## Core principle — evidence over assertion
+
+Every gate passes **only on a produced artifact** — a command's output, a file diff, a
+live API response, a real pipeline result. **Never** on the model stating "done",
+"passes", or "should work". The plugin's job is to *produce, capture, and check* that
+artifact. It applies the same discipline to its own output.
+
+## Installation
+
+```bash
+/plugin marketplace add camoa/claude-skills
+/plugin install drupal-ai-contrib@camoa-skills
+```
+
+## The contribution arc
+
+Six stages — **detect-driven, not a forced sequence**. Each command checks the state it
+needs and runs regardless of whether earlier commands ran; a command that finds a real
+gap points at `setup` for *that gap only*. `setup` is the on-ramp, never a prerequisite.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/drupal-ai-contrib:setup` | Onboard + environment-match a contribution workspace — DDEV with the workflow-matched add-on, CI gate config, the Drupal AI skills. Idempotent. |
+| `/drupal-ai-contrib:issue` | Work the issue lifecycle — review prior work first, then create / comment / claim, with three-way issue-fork handling. |
+| `/drupal-ai-contrib:verify` | The centerpiece — the local drupalci-parity gate set at CI strictness + the AI-policy gate + the eval gate, every gate on a captured artifact. |
+| `/drupal-ai-contrib:review` | Honest fresh-context review against scope, standards, security, and the AI policy. |
+| `/drupal-ai-contrib:submit` | Create / update the merge request and the AI-disclosure comment at the policy threshold. |
+| `/drupal-ai-contrib:pipeline` | Fetch the real GitLab MR pipeline and gate on it — the authoritative final check. |
+
+## Agents
+
+| Agent | Model | Role |
+|-------|-------|------|
+| `fresh-context-reviewer` | sonnet | Read-only (`tools: Read, Grep, Glob, Bash`); reviews a diff with no build narrative. |
+| `external-fact-verifier` | sonnet | Read-only (`tools: WebFetch, WebSearch, Read, Bash`); verifies an external fact against source or a live probe. |
+| `ai-policy-checker` | sonnet | Read-only (`tools: WebFetch, WebSearch, Read`); live-fetches the AI-policy + eval state, maturity-tagged. |
+
+All three are read-only — `disallowedTools: Edit, Write`.
+
+## Skills
+
+- **`drupal-ai-contrib`** — umbrella & router; supplies the contribution knowledge layer.
+- Six worker skills — one per command (`contribution-setup` / `-issue` / `-verify` /
+  `-review` / `-submit` / `-pipeline`), each backing its command.
+- **`contribution-guardrails`** — the cross-cutting development discipline: evidence
+  over assertion, the no-guessing rule, the verification-gate artifact contracts.
+
+## Hooks
+
+- **`PostToolUse`** (`Edit|Write`) — re-verification ledger: records every edited
+  contribution file so `verify` re-fires the gate for any path changed after it passed.
+- **`SessionStart`** — a one-line reminder, emitted only in a contribution workspace,
+  that AI-policy + eval guidance must be re-confirmed per contribution.
+
+## The knowledge layer — dev-guides
+
+Technical how-to comes from the `camoa/dev-guides` contribution guides
+(`drupal/contributing/` and `drupal/contributing-with-ai/`), loaded via the
+`dev-guides-navigator` skill. Worker skills cite guides by slug; they never embed guide
+content or fetch dev-guides URLs directly.
+
+## Relationship to drupal-dev-framework
+
+A contribution **is** a `drupal-dev-framework` (DDF) task. DDF owns the phase lifecycle
+and its phase gates. `drupal-ai-contrib` is a separate layer **outside** DDF — it adds
+contribution-quality commands and gates on top, without forking or modifying DDF.
+
+## Interop — delegate, never reinvent
+
+`code-quality-tools` (philosophy / standards review) · `code-paper-test` (paper
+testing) · `drupalorg-cli` (issue / MR / pipeline CLI) · `drupal_devkit` (Drupal AI
+skill install) · `ai_best_practices` (the canonical AI policy + evals).

--- a/drupal-ai-contrib/agents/ai-policy-checker.md
+++ b/drupal-ai-contrib/agents/ai-policy-checker.md
@@ -1,0 +1,78 @@
+---
+name: ai-policy-checker
+description: "Live-fetches the current state of the Drupal AI-contribution policy, ai_best_practices, and the eval landscape, and returns a SETTLED / DRAFT / DISCUSSION-tagged summary. Use proactively per contribution — the AI-policy and eval landscape is the fastest-moving area and must be re-confirmed each time, never assumed from memory."
+capabilities: ["policy fetch", "best-practices fetch", "eval-landscape check", "maturity tagging"]
+version: 0.1.0
+model: sonnet
+tools: WebFetch, WebSearch, Read
+disallowedTools: Edit, Write
+---
+
+# AI-Policy Checker
+
+## Role
+
+Reporter of the **current** Drupal AI-contribution governance state. You run with
+**fresh context every time** — which is exactly what "re-confirm per contribution"
+requires. You never report policy from model memory; you fetch it live and tag each
+fact by maturity so the caller knows what is binding versus still moving.
+
+## Capabilities
+
+- Policy fetch — the adopted *Policy on the use of AI when contributing to Drupal*,
+  including its concrete rules and the disclosure threshold.
+- Best-practices fetch — the `ai_best_practices` drupal.org project's current status.
+- Eval-landscape check — `evals/evals.json` maturity, the broader eval registry state.
+- Maturity tagging — label each fact SETTLED / DRAFT / DISCUSSION.
+
+## When to Use
+
+- Inside `contribution-verify`'s AI-policy gate — every contribution
+- Inside `contribution-submit` — to set the disclosure threshold correctly
+- NOT for: applying the policy to a diff (that is `fresh-context-reviewer`)
+- NOT for: verifying technical external facts (that is `external-fact-verifier`)
+
+## Process
+
+1. **Fetch the adopted policy** — its concrete rules: full contributor responsibility
+   ("the AI wrote it" is not a defense); dependencies/logic/security must be verified;
+   disclosure required for significant AI use (whole functions/classes/scaffolding/
+   extensive docblocks — single-line autocomplete exempt) in the `AI-Generated: Yes (...)`
+   format; sole responsibility for copyright/GPL; the unacceptable-practices list;
+   education → temp ban → permanent ban enforcement; no core/contrib distinction.
+2. **Fetch `ai_best_practices`** — its current project status and whether its
+   `evals/evals.json` is usable.
+3. **Check the eval landscape** — eval registry maturity; note that `promptfoo` is
+   discontinued and must not be adopted.
+4. **Tag every fact** — SETTLED (adopted/binding), DRAFT (pilot/schema unstable),
+   DISCUSSION (under governance debate, not binding).
+5. **Return the tagged summary** — never modify files.
+
+## Decision Criteria
+
+- Report what the live sources say **today** — do not reconcile against prior memory.
+- The adopted policy's concrete rules are SETTLED; an issue still under debate is
+  DISCUSSION even if a direction seems likely.
+- If a source is unreachable, say so and tag the affected facts as unconfirmed — do not
+  fill the gap from memory.
+- Note the policy document's "last updated" date so the caller can judge freshness.
+
+## Output
+
+Return to the caller:
+- the **disclosure threshold** and format, as currently published (tagged)
+- the **policy rules** relevant to gating a contribution (each tagged)
+- `ai_best_practices` **status** and eval usability (tagged)
+- the **last-updated date** of the policy document
+- any source that could not be reached
+
+## Examples
+
+### Example 1: verify's AI-policy gate
+`contribution-verify` dispatches this agent. It returns: disclosure threshold SETTLED,
+the policy last updated on a given date, `evals.json` DRAFT. → `verify` records the
+disclosure decision against the SETTLED threshold and runs evals best-effort.
+
+### Example 2: a governance issue in flux
+A drupal.org issue proposes changing the disclosure format. → Reported as DISCUSSION,
+not binding; the caller keeps applying the current SETTLED format.

--- a/drupal-ai-contrib/agents/external-fact-verifier.md
+++ b/drupal-ai-contrib/agents/external-fact-verifier.md
@@ -1,0 +1,77 @@
+---
+name: external-fact-verifier
+description: "Verifies a single external-fact claim — an SDK symbol, API header/parameter, beta-feature slug, or library-version behavior — against vendor source or a live probe, and returns verified or unverified with evidence. Use proactively whenever AI-assisted Drupal contribution code relies on an external fact recalled from model memory or a changelog line. An unverified external fact is a blocker."
+capabilities: ["source verification", "live probe", "version-behavior check"]
+version: 0.1.0
+model: sonnet
+tools: WebFetch, WebSearch, Read, Bash
+disallowedTools: Edit, Write
+---
+
+# External-Fact Verifier
+
+## Role
+
+Verifier of external facts for Drupal contribution work. Given **one claim** about
+something outside the codebase — an SDK symbol, an API header or parameter, a
+beta-feature slug, a library-version behavior — establish whether it is true against
+**vendor source or a live probe**. Model memory and changelog lines are leads, never
+facts; you do not trust them and neither does the caller.
+
+## Capabilities
+
+- Source verification — confirm a symbol/parameter against vendor docs or the library's
+  actual source (composer/vendor tree, GitHub, official reference).
+- Live probe — confirm behavior by running a minimal, safe check (a CLI `--help`, a
+  reflection check, a read-only API call against documented endpoints).
+- Version-behavior check — confirm a behavior holds for the specific version the
+  project pins, not "a recent version".
+
+## When to Use
+
+- Before AI-assisted code commits to an external symbol, parameter, or behavior
+- When a claim traces only to model memory or a changelog line
+- NOT for: verifying the project's own internal code (read it directly)
+- NOT for: running the drupalci gates (that is `contribution-verify`)
+
+## Process
+
+1. **Restate the claim precisely** — the exact symbol/parameter/behavior and the exact
+   version it must hold for.
+2. **Pick the authority** — vendor source first (the installed `vendor/` tree, the
+   library's tagged source, official reference docs). A live probe second.
+3. **Check it** — read the source or run the minimal probe. Pin to the project's
+   version.
+4. **Decide** — `verified` only if the authority confirms it for the right version;
+   otherwise `unverified`. There is no "probably".
+5. **Return the verdict with its evidence** — never modify files.
+
+## Decision Criteria
+
+- `verified` requires a citable authority: a source file + line, a doc URL, or captured
+  probe output.
+- A claim that is true for a *different* version than the project pins is `unverified`
+  for this contribution.
+- If the authority cannot be reached, return `unverified` (not "assume true") and say
+  what was unreachable.
+- A changelog line alone is never sufficient — it is a lead to chase to source.
+
+## Output
+
+Return to the caller:
+- **verdict**: `verified` / `unverified`
+- the **claim** as restated, with the version it was checked against
+- the **evidence**: source `file:line`, doc URL, or captured probe output
+- if `unverified`: what is missing or what contradicts the claim
+
+## Examples
+
+### Example 1: SDK method from memory
+Claim: `Client::stream()` exists in the pinned SDK version. → Read the installed
+`vendor/` source; the method is `Client::streamResponse()`. → `unverified`; report the
+correct symbol.
+
+### Example 2: API parameter
+Claim: the endpoint accepts a `max_tokens` query parameter. → Fetch the vendor's
+versioned API reference; the parameter is body-only, not a query parameter. →
+`unverified` with the doc URL.

--- a/drupal-ai-contrib/agents/fresh-context-reviewer.md
+++ b/drupal-ai-contrib/agents/fresh-context-reviewer.md
@@ -1,0 +1,76 @@
+---
+name: fresh-context-reviewer
+description: "Reviews a Drupal contribution diff honestly with no session narrative — checks scope adherence, Drupal + PHP coding standards, security, and AI-policy disclosure. Use proactively when a contribution needs honest validation before submission; dispatched by the contribution-review skill. A builder cannot objectively review its own work."
+capabilities: ["scope review", "standards review", "security review", "AI-policy review"]
+version: 0.1.0
+model: sonnet
+tools: Read, Grep, Glob, Bash
+disallowedTools: Edit, Write
+---
+
+# Fresh-Context Reviewer
+
+## Role
+
+Honest reviewer of AI-assisted Drupal contributions. You arrive with **no session
+narrative** — none of the story of why each choice was made. You see only the diff, the
+scope contract, and the issue. That is deliberate: a builder cannot objectively review
+its own work, and the builder's intent is not evidence of correctness.
+
+## Capabilities
+
+- Scope review — does the diff deliver exactly the contract, nothing beyond it?
+- Standards review — Drupal coding standards, Drupal + PHP best practices.
+- Security review — AI-specific risks (injection, missing access checks, unsafe
+  unserialization, secrets, over-broad permissions).
+- AI-policy review — is AI use above the "significant portion" threshold disclosed?
+
+## When to Use
+
+- Before a contribution is submitted, dispatched by `contribution-review`
+- When a change is large or security-critical and needs perspective diversity
+- NOT for: running the drupalci-parity gates (that is `contribution-verify`)
+- NOT for: SOLID/DRY philosophy review (that is `code-quality-tools`)
+
+## Process
+
+1. **Read the inputs as given** — the diff, the scope contract (goal / expected result
+   / success criteria / non-goals), the issue. Do not request or use the build
+   narrative.
+2. **Scope** — map each hunk of the diff to a contract item. Any hunk that maps to
+   nothing — or to a non-goal — is an over-delivery **finding**: it is review burden
+   the maintainer did not ask for.
+3. **Standards** — check Drupal coding standards and Drupal/PHP best practices on the
+   changed lines. Cite `file:line`.
+4. **Security** — inspect the changed lines for the AI-specific risk patterns. Cite
+   `file:line`.
+5. **AI policy** — assess whether AI generated a significant portion (whole functions/
+   classes/scaffolding/extensive docblocks) and whether that is disclosed.
+6. **Return a structured verdict** — never modify files.
+
+## Decision Criteria
+
+- A finding needs a concrete location (`file:line`) and a concrete fix — not a vague concern.
+- Severity: **blocker** (must fix before submit), **should-fix**, **suggestion**.
+- An honest "not ready" is the correct verdict when the work is not ready. Do not
+  soften a finding because the change is well-intentioned.
+- If you cannot assess something (missing context, missing contract), say so — do not guess.
+
+## Output
+
+Return to the caller:
+- a one-line **verdict**: READY FOR SUBMIT / NOT READY
+- **findings** grouped by severity, each with `file:line` and a concrete fix
+- what was **checked clean**
+- anything **unassessable** and why
+
+## Examples
+
+### Example 1: over-delivery
+The diff refactors an unrelated helper class. It maps to no contract item and the
+contract's non-goals say "no refactors". → Blocker finding: out-of-scope work.
+
+### Example 2: undisclosed AI generation
+A whole new service class was added; the issue has no AI-disclosure checkbox and the MR
+description has no `AI-Generated: Yes (...)` comment. → Blocker finding: disclosure
+required above the significant-portion threshold.

--- a/drupal-ai-contrib/commands/issue.md
+++ b/drupal-ai-contrib/commands/issue.md
@@ -20,10 +20,11 @@ duplicate.
 
 ## Steps
 
-1. If `$1` is present and is not `create`, it is an issue ID — **reject it unless it
-   matches `^[0-9]+$`** (drupal.org / GitLab issue IDs are numeric). A non-matching,
-   non-`create` argument is an error: ask for a valid issue ID, do not pass it on. If
-   `$1` is `create` or absent, treat it as create / interactive.
+1. If `$1` is present and is not `create` (case-insensitive — `create`, `Create`,
+   `CREATE` all count), it is an issue ID — **reject it unless it matches `^[0-9]+$`**
+   (drupal.org / GitLab issue IDs are numeric). A non-matching, non-`create` argument
+   is an error: ask for a valid issue ID, do not pass it on. If `$1` is `create` or
+   absent, treat it as create / interactive.
 2. Invoke the `drupal-ai-contrib:contribution-issue` skill via the Skill tool, passing
    `$1`.
 3. Present the skill's result: the issue and its system + status, the prior-work

--- a/drupal-ai-contrib/commands/issue.md
+++ b/drupal-ai-contrib/commands/issue.md
@@ -1,0 +1,34 @@
+---
+description: "Work the Drupal issue lifecycle — review prior work first, then create / comment on / claim an issue and check out its fork + branch with three-way fork handling. Use when user says 'Drupal issue', 'claim an issue', 'create an issue', 'check out issue fork', 'drupal-ai-contrib issue'. Wraps drupalorg-cli."
+allowed-tools: Read, Bash, Glob, Grep, Skill, WebFetch, AskUserQuestion
+argument-hint: "[issue-id|action]"
+---
+
+# Issue — Drupal Issue Lifecycle
+
+Thin entry point. Reviews prior work first so the contribution is meaningful, not
+duplicate.
+
+## Usage
+
+`/drupal-ai-contrib:issue [issue-id|action]`
+
+## Parameters
+
+- `$1` — an issue ID (e.g. `3456789`), or an action (`create`). Optional — if absent,
+  the worker skill asks what the contributor wants to do.
+
+## Steps
+
+1. If `$1` is an issue ID, validate it against the expected numeric pattern. If it is
+   `create` or absent, treat it as create / interactive.
+2. Invoke the `drupal-ai-contrib:contribution-issue` skill via the Skill tool, passing
+   `$1`.
+3. Present the skill's result: the issue and its system + status, the prior-work
+   finding, and the fork/branch state and action taken.
+
+## Notes
+
+The worker skill reviews existing comments, status, and MRs **before** acting, and
+handles the issue-fork three ways — your fork (checkout), someone else's (surface,
+coordinate, never clobber), or none (create the branch).

--- a/drupal-ai-contrib/commands/issue.md
+++ b/drupal-ai-contrib/commands/issue.md
@@ -20,8 +20,10 @@ duplicate.
 
 ## Steps
 
-1. If `$1` is an issue ID, validate it against the expected numeric pattern. If it is
-   `create` or absent, treat it as create / interactive.
+1. If `$1` is present and is not `create`, it is an issue ID — **reject it unless it
+   matches `^[0-9]+$`** (drupal.org / GitLab issue IDs are numeric). A non-matching,
+   non-`create` argument is an error: ask for a valid issue ID, do not pass it on. If
+   `$1` is `create` or absent, treat it as create / interactive.
 2. Invoke the `drupal-ai-contrib:contribution-issue` skill via the Skill tool, passing
    `$1`.
 3. Present the skill's result: the issue and its system + status, the prior-work

--- a/drupal-ai-contrib/commands/pipeline.md
+++ b/drupal-ai-contrib/commands/pipeline.md
@@ -21,8 +21,10 @@ real pipeline is green.
 ## Steps
 
 1. If `$1` is given, validate it: an issue ID must match `^[0-9]+$`; an MR URL must
-   match `^https://[^ ]+/-/merge_requests/[0-9]+$`. Reject anything else — ask for a
-   valid issue ID or MR URL rather than passing a malformed value on.
+   match `^https://[A-Za-z0-9._/-]+/-/merge_requests/[0-9]+$` (the host/path segment
+   admits only URL-safe characters — no spaces, shell metacharacters, or control
+   characters). Reject anything else — ask for a valid issue ID or MR URL rather than
+   passing a malformed value on.
 2. Invoke the `drupal-ai-contrib:contribution-pipeline` skill via the Skill tool,
    passing `$1`.
 3. Present the skill's per-job report: name, status, blocking vs. `allow_failure` vs.

--- a/drupal-ai-contrib/commands/pipeline.md
+++ b/drupal-ai-contrib/commands/pipeline.md
@@ -20,7 +20,9 @@ real pipeline is green.
 
 ## Steps
 
-1. If `$1` is given, validate the MR URL / issue ID against expected patterns.
+1. If `$1` is given, validate it: an issue ID must match `^[0-9]+$`; an MR URL must
+   match `^https://[^ ]+/-/merge_requests/[0-9]+$`. Reject anything else — ask for a
+   valid issue ID or MR URL rather than passing a malformed value on.
 2. Invoke the `drupal-ai-contrib:contribution-pipeline` skill via the Skill tool,
    passing `$1`.
 3. Present the skill's per-job report: name, status, blocking vs. `allow_failure` vs.

--- a/drupal-ai-contrib/commands/pipeline.md
+++ b/drupal-ai-contrib/commands/pipeline.md
@@ -1,0 +1,34 @@
+---
+description: "Fetch the real GitLab merge-request pipeline for a Drupal contribution and gate on it — the authoritative final check. Use when user says 'check the pipeline', 'real CI status', 'is the contribution done', 'drupalci pipeline', 'drupal-ai-contrib pipeline'."
+allowed-tools: Read, Bash, Glob, Grep, Skill, WebFetch
+argument-hint: "[mr-url|issue-id]"
+---
+
+# Pipeline — Confirm the Real drupalci Pipeline
+
+Thin entry point. The authoritative final gate — a contribution is not done until the
+real pipeline is green.
+
+## Usage
+
+`/drupal-ai-contrib:pipeline [mr-url|issue-id]`
+
+## Parameters
+
+- `$1` — an MR URL or issue ID (optional). If absent, the worker skill resolves the MR
+  from the current issue-fork branch.
+
+## Steps
+
+1. If `$1` is given, validate the MR URL / issue ID against expected patterns.
+2. Invoke the `drupal-ai-contrib:contribution-pipeline` skill via the Skill tool,
+   passing `$1`.
+3. Present the skill's per-job report: name, status, blocking vs. `allow_failure` vs.
+   manual, the job-log link; and the plain verdict — is the contribution done, or what
+   remains.
+
+## Notes
+
+The worker skill reads the pipeline honestly — a green pipeline can hide a red
+`allow_failure` job or un-run manual opt-in variants; those are surfaced, never implied
+as coverage.

--- a/drupal-ai-contrib/commands/review.md
+++ b/drupal-ai-contrib/commands/review.md
@@ -1,0 +1,32 @@
+---
+description: "Run honest fresh-context review of a Drupal contribution — isolated reviewer agents with no session narrative check the work against scope, standards, security, and the AI policy. Use when user says 'review Drupal contribution', 'honest review', 'fresh-eyes review', 'pre-submission review', 'drupal-ai-contrib review'."
+allowed-tools: Read, Glob, Grep, Skill, Task, Bash
+argument-hint: "[project-path]"
+---
+
+# Review — Honest Fresh-Context Review
+
+Thin entry point. A builder cannot objectively review its own work.
+
+## Usage
+
+`/drupal-ai-contrib:review [project-path]`
+
+## Parameters
+
+- `$1` — project path (optional). Defaults to the current directory.
+
+## Steps
+
+1. Resolve the project path and confirm there is a contribution diff to review (an
+   issue-fork branch vs. its target). If none, report it and stop.
+2. Invoke the `drupal-ai-contrib:contribution-review` skill via the Skill tool, passing
+   the resolved path.
+3. Present the skill's findings report: per-finding severity (blocker / should-fix /
+   suggestion), file:line location, and concrete fix; and the plain verdict — ready for
+   `submit`, or another development pass needed.
+
+## Notes
+
+The worker skill dispatches the `fresh-context-reviewer` agent (no build narrative) and
+delegates the SOLID / DRY philosophy review to `code-quality-tools`.

--- a/drupal-ai-contrib/commands/setup.md
+++ b/drupal-ai-contrib/commands/setup.md
@@ -1,0 +1,32 @@
+---
+description: "Onboard and environment-match a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config, and the Drupal AI skills. Use when user says 'set up Drupal contribution', 'contribution environment', 'scaffold a contrib module', 'drupal-ai-contrib setup'. Idempotent — does only what is missing."
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, AskUserQuestion
+argument-hint: "[project-path]"
+---
+
+# Setup — Drupal Contribution Environment
+
+Thin entry point. Onboarding is optional, idempotent, and never a gate.
+
+## Usage
+
+`/drupal-ai-contrib:setup [project-path]`
+
+## Parameters
+
+- `$1` — project path (optional). Defaults to the current directory.
+
+## Steps
+
+1. Resolve the project path (`$1` or the current directory). If it is not a directory,
+   ask the contributor for the path.
+2. Invoke the `drupal-ai-contrib:contribution-setup` skill via the Skill tool, passing
+   the resolved path.
+3. Present the skill's result: the detected workflow and issue system, environment
+   status, the resolved gate set, AI-skill status, and the environment-match result.
+
+## Notes
+
+`contribution-setup` writes scaffolding files only with explicit confirmation and only
+within the target project. A contributor with a ready environment can skip straight to
+`/drupal-ai-contrib:issue`.

--- a/drupal-ai-contrib/commands/submit.md
+++ b/drupal-ai-contrib/commands/submit.md
@@ -1,0 +1,32 @@
+---
+description: "Create or update a Drupal merge request and generate the AI-disclosure comment at the policy threshold. Use when user says 'submit Drupal contribution', 'open a merge request', 'update the MR', 'submit patch', 'drupal-ai-contrib submit'. Wraps drupalorg-cli."
+allowed-tools: Read, Bash, Glob, Grep, Skill, Task, WebFetch
+argument-hint: "[issue-id]"
+---
+
+# Submit — Create / Update the Merge Request
+
+Thin entry point. Prepares the policy-required AI disclosure with the MR.
+
+## Usage
+
+`/drupal-ai-contrib:submit [issue-id]`
+
+## Parameters
+
+- `$1` — the issue ID (optional). If absent, the worker skill resolves it from the
+  current issue-fork branch.
+
+## Steps
+
+1. If `$1` is given, validate it against the expected numeric pattern.
+2. Invoke the `drupal-ai-contrib:contribution-submit` skill via the Skill tool, passing
+   `$1`.
+3. Present the skill's result: the MR URL, target branch, the AI-disclosure decision
+   and where it was placed, the issue status set, and the next step (`pipeline`).
+
+## Notes
+
+The worker skill surfaces — but does not silently block on — unmet preconditions
+(`verify` not green, `review` not run). It fetches the current AI-contribution policy
+live via the `ai-policy-checker` agent to decide the disclosure threshold.

--- a/drupal-ai-contrib/commands/submit.md
+++ b/drupal-ai-contrib/commands/submit.md
@@ -1,6 +1,6 @@
 ---
 description: "Create or update a Drupal merge request and generate the AI-disclosure comment at the policy threshold. Use when user says 'submit Drupal contribution', 'open a merge request', 'update the MR', 'submit patch', 'drupal-ai-contrib submit'. Wraps drupalorg-cli."
-allowed-tools: Read, Bash, Glob, Grep, Skill, Task, WebFetch
+allowed-tools: Read, Bash, Glob, Grep, Skill, Task
 argument-hint: "[issue-id]"
 ---
 

--- a/drupal-ai-contrib/commands/submit.md
+++ b/drupal-ai-contrib/commands/submit.md
@@ -19,7 +19,8 @@ Thin entry point. Prepares the policy-required AI disclosure with the MR.
 
 ## Steps
 
-1. If `$1` is given, validate it against the expected numeric pattern.
+1. If `$1` is given, **reject it unless it matches `^[0-9]+$`** (issue IDs are
+   numeric) — ask for a valid issue ID rather than passing a malformed value on.
 2. Invoke the `drupal-ai-contrib:contribution-submit` skill via the Skill tool, passing
    `$1`.
 3. Present the skill's result: the MR URL, target branch, the AI-disclosure decision

--- a/drupal-ai-contrib/commands/verify.md
+++ b/drupal-ai-contrib/commands/verify.md
@@ -1,6 +1,6 @@
 ---
 description: "Run the local verification inner loop for a Drupal contribution — the drupalci-parity gate set at CI strictness, the AI-policy gate, and the eval gate, every gate passing only on a captured artifact. Use when user says 'verify Drupal contribution', 'run the gates', 'check before submitting', 'drupalci parity', 'drupal-ai-contrib verify'."
-allowed-tools: Read, Bash, Glob, Grep, Skill, Task, WebFetch
+allowed-tools: Read, Bash, Glob, Grep, Skill, Task
 argument-hint: "[project-path]"
 ---
 

--- a/drupal-ai-contrib/commands/verify.md
+++ b/drupal-ai-contrib/commands/verify.md
@@ -1,0 +1,34 @@
+---
+description: "Run the local verification inner loop for a Drupal contribution — the drupalci-parity gate set at CI strictness, the AI-policy gate, and the eval gate, every gate passing only on a captured artifact. Use when user says 'verify Drupal contribution', 'run the gates', 'check before submitting', 'drupalci parity', 'drupal-ai-contrib verify'."
+allowed-tools: Read, Bash, Glob, Grep, Skill, Task, WebFetch
+argument-hint: "[project-path]"
+---
+
+# Verify — Local drupalci-Parity + AI-Policy + Eval Gates
+
+Thin entry point. The centerpiece: evidence over assertion — never a bare "passes".
+
+## Usage
+
+`/drupal-ai-contrib:verify [project-path]`
+
+## Parameters
+
+- `$1` — project path (optional). Defaults to the current directory.
+
+## Steps
+
+1. Resolve the project path. If no `.gitlab-ci.yml` is found, report the gap and point
+   the contributor at `/drupal-ai-contrib:setup` for that gap only — do not refuse to run.
+2. Invoke the `drupal-ai-contrib:contribution-verify` skill via the Skill tool, passing
+   the resolved path.
+3. Present the skill's per-gate report: each gate's actual blocking status, PASS / FAIL
+   / UNRUN, and the captured artifact. Opt-in variants are listed UNRUN. State the
+   environment-match status.
+
+## Notes
+
+The worker skill environment-matches first (installs the CI-target core), mirrors each
+enabled drupalci job locally at CI strictness, runs the AI-policy gate (every
+contribution) and the eval gate (best-effort), and re-fires any gate whose path was
+edited after it last passed.

--- a/drupal-ai-contrib/hooks/hooks.json
+++ b/drupal-ai-contrib/hooks/hooks.json
@@ -1,0 +1,31 @@
+{
+  "description": "drupal-ai-contrib — re-verification ledger (pillar 5) and a per-contribution AI-policy reminder",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/reverify-mark.sh",
+            "args": [],
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-reminder.sh",
+            "args": [],
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/drupal-ai-contrib/hooks/reverify-mark.sh
+++ b/drupal-ai-contrib/hooks/reverify-mark.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# drupal-ai-contrib — re-verification ledger (architecture pillar 5).
+#
+# PostToolUse(Edit|Write) hook: record every edited contribution source file so that
+# `contribution-verify` can re-fire the gate for any path changed after its gate last
+# passed. Reads the PostToolUse event JSON from stdin; degrades silently on any error
+# (a logging hook must never disrupt the session).
+set -u
+
+input="$(cat 2>/dev/null || true)"
+[ -n "$input" ] || exit 0
+
+# Extract the edited file path from the event JSON.
+fp=""
+if command -v python3 >/dev/null 2>&1; then
+  fp="$(printf '%s' "$input" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_input", {}).get("file_path", ""))
+except Exception:
+    pass
+' 2>/dev/null || true)"
+fi
+[ -n "$fp" ] || exit 0
+
+# Track only contribution-relevant source files; ignore everything else.
+case "$fp" in
+  *.php|*.module|*.inc|*.install|*.theme|*.profile|*.engine|*.yml|*.yaml|*.twig|*.js|*.css) ;;
+  *) exit 0 ;;
+esac
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+data="${CLAUDE_PLUGIN_DATA:-${TMPDIR:-/tmp}}"
+key="$(printf '%s' "$proj" | cksum | cut -d' ' -f1)"
+ledger_dir="$data/reverify"
+
+mkdir -p "$ledger_dir" 2>/dev/null || exit 0
+stamp="$(date -u +%FT%TZ 2>/dev/null || date 2>/dev/null || echo unknown)"
+printf '%s\t%s\n' "$stamp" "$fp" >> "$ledger_dir/$key.log" 2>/dev/null || true
+exit 0

--- a/drupal-ai-contrib/hooks/reverify-mark.sh
+++ b/drupal-ai-contrib/hooks/reverify-mark.sh
@@ -5,12 +5,19 @@
 # `contribution-verify` can re-fire the gate for any path changed after its gate last
 # passed. Reads the PostToolUse event JSON from stdin; degrades silently on any error
 # (a logging hook must never disrupt the session).
+#
+# Coverage limit: this hook observes the Edit and Write tools only. A file changed via
+# the Bash tool (shell redirects, `sed -i`) is NOT recorded — see CONVENTIONS.md
+# "Known limitations". `contribution-verify` re-runs the full gate set regardless, so
+# the ledger only adds *extra* re-runs; a missed entry never produces a false green.
 set -u
 
 input="$(cat 2>/dev/null || true)"
 [ -n "$input" ] || exit 0
 
-# Extract the edited file path from the event JSON.
+# Extract the edited file path from the event JSON. Try python3, then jq, then a
+# grep/sed fallback — so the hook still records when python3 is absent rather than
+# silently disabling re-verification.
 fp=""
 if command -v python3 >/dev/null 2>&1; then
   fp="$(printf '%s' "$input" | python3 -c '
@@ -22,6 +29,21 @@ except Exception:
     pass
 ' 2>/dev/null || true)"
 fi
+if [ -z "$fp" ] && command -v jq >/dev/null 2>&1; then
+  fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+fi
+if [ -z "$fp" ]; then
+  # Last-resort parse: the first "file_path": "..." value via grep/sed.
+  fp="$(printf '%s' "$input" \
+    | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -n1 \
+    | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//; s/"$//' 2>/dev/null || true)"
+fi
+[ -n "$fp" ] || exit 0
+
+# Strip control characters (newline, tab, CR) — a crafted path must not inject extra
+# tab-delimited rows into the ledger.
+fp="$(printf '%s' "$fp" | tr -d '[:cntrl:]')"
 [ -n "$fp" ] || exit 0
 
 # Track only contribution-relevant source files; ignore everything else.

--- a/drupal-ai-contrib/hooks/reverify-mark.sh
+++ b/drupal-ai-contrib/hooks/reverify-mark.sh
@@ -46,9 +46,13 @@ fi
 fp="$(printf '%s' "$fp" | tr -d '[:cntrl:]')"
 [ -n "$fp" ] || exit 0
 
-# Track only contribution-relevant source files; ignore everything else.
+# Track contribution-relevant source files and the gate-config files that change what
+# a gate does (composer.json, phpcs.xml.dist, phpstan.neon, phpunit.xml.dist, cspell
+# wordlist); ignore everything else.
 case "$fp" in
   *.php|*.module|*.inc|*.install|*.theme|*.profile|*.engine|*.yml|*.yaml|*.twig|*.js|*.css) ;;
+  */composer.json|composer.json|*.dist|*.neon) ;;
+  */.cspell-project-words.txt|.cspell-project-words.txt) ;;
   *) exit 0 ;;
 esac
 

--- a/drupal-ai-contrib/hooks/session-reminder.sh
+++ b/drupal-ai-contrib/hooks/session-reminder.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 # drupal-ai-contrib — SessionStart reminder.
 #
-# Speaks one line only when the working directory looks like a Drupal contribution
+# Speaks one line only when the working directory looks like a *Drupal* contribution
 # workspace; silent (exit 0) otherwise, so non-contribution sessions are not disturbed.
 set -u
 
 proj="${CLAUDE_PROJECT_DIR:-$PWD}"
 is_contrib=0
 
-[ -f "$proj/.gitlab-ci.yml" ] && is_contrib=1
+# A bare .gitlab-ci.yml is not Drupal-specific — require a Drupal signal in it.
+if [ -f "$proj/.gitlab-ci.yml" ] && \
+   grep -qi 'gitlab_templates\|drupal' "$proj/.gitlab-ci.yml" 2>/dev/null; then
+  is_contrib=1
+fi
 [ -d "$proj/.drupal-ai-contrib" ] && is_contrib=1
 for f in "$proj"/*.info.yml; do
   [ -e "$f" ] && is_contrib=1

--- a/drupal-ai-contrib/hooks/session-reminder.sh
+++ b/drupal-ai-contrib/hooks/session-reminder.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# drupal-ai-contrib — SessionStart reminder.
+#
+# Speaks one line only when the working directory looks like a Drupal contribution
+# workspace; silent (exit 0) otherwise, so non-contribution sessions are not disturbed.
+set -u
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+is_contrib=0
+
+[ -f "$proj/.gitlab-ci.yml" ] && is_contrib=1
+[ -d "$proj/.drupal-ai-contrib" ] && is_contrib=1
+for f in "$proj"/*.info.yml; do
+  [ -e "$f" ] && is_contrib=1
+  break
+done
+
+if [ "$is_contrib" -eq 1 ]; then
+  echo "drupal-ai-contrib: re-confirm the AI-contribution policy and eval guidance for this contribution — they move fast and verify's AI-policy gate fetches them live. Evidence over assertion: every gate passes on a captured artifact, never on a claim."
+fi
+exit 0

--- a/drupal-ai-contrib/hooks/session-reminder.sh
+++ b/drupal-ai-contrib/hooks/session-reminder.sh
@@ -13,6 +13,9 @@ if [ -f "$proj/.gitlab-ci.yml" ] && \
    grep -qi 'gitlab_templates\|drupal' "$proj/.gitlab-ci.yml" 2>/dev/null; then
   is_contrib=1
 fi
+# Optional opt-in marker: a contributor may `mkdir .drupal-ai-contrib` to force the
+# reminder on (e.g. early in a contribution, before .gitlab-ci.yml or *.info.yml exist).
+# The plugin never creates this directory itself.
 [ -d "$proj/.drupal-ai-contrib" ] && is_contrib=1
 for f in "$proj"/*.info.yml; do
   [ -e "$f" ] && is_contrib=1

--- a/drupal-ai-contrib/scripts/reverify-list.sh
+++ b/drupal-ai-contrib/scripts/reverify-list.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# drupal-ai-contrib — re-verification ledger reader.
+#
+# Prints the unique contribution paths edited since the last verify — the stale-gate
+# set that `contribution-verify` must re-fire (architecture pillar 5). The ledger is
+# written by the PostToolUse hook hooks/reverify-mark.sh.
+#
+#   reverify-list.sh           print stale paths, one per line
+#   reverify-list.sh --clear   print stale paths, then clear the ledger
+#
+# Prints nothing and exits 0 when there is no ledger (no stale gates).
+set -u
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+data="${CLAUDE_PLUGIN_DATA:-${TMPDIR:-/tmp}}"
+key="$(printf '%s' "$proj" | cksum | cut -d' ' -f1)"
+ledger="$data/reverify/$key.log"
+
+[ -f "$ledger" ] || exit 0
+
+cut -f2 "$ledger" 2>/dev/null | sort -u
+
+if [ "${1:-}" = "--clear" ]; then
+  : > "$ledger" 2>/dev/null || true
+fi
+exit 0

--- a/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: contribution-guardrails
+description: "Enforces the development discipline for AI-assisted Drupal contributions — evidence over assertion, the no-guessing rule for external facts, the verification-gate artifact contracts, and re-verification on post-gate change. Use PROACTIVELY during any development between claiming an issue and verifying it. Use when user says 'guardrails', 'evidence over assertion', 'no guessing', 'verify this fact', 'is this actually tested', or whenever AI-assisted code is being written for a Drupal contribution. MUST apply before claiming any gate passed."
+version: 0.1.0
+model: sonnet
+---
+
+# Contribution Guardrails
+
+The cross-cutting discipline for AI-assisted Drupal contribution development. The
+recurring failure this prevents: AI claiming correctness it never verified. Drupal
+treats this as an existential review-cost problem — AI makes contributing cheap but
+makes *reviewing* expensive.
+
+## When to Use
+
+- During any development between `/drupal-ai-contrib:issue` and `/drupal-ai-contrib:verify`
+- Before stating that anything "passes", "works", "is done", or "is secure"
+- When about to use an SDK symbol, API parameter, or version-specific behavior
+- NOT for: running the gates themselves (that is `contribution-verify`)
+
+## Rule 1 — Evidence over assertion
+
+A gate passes **only on a produced artifact**. Never on the model stating a verdict.
+
+For each gate, *produce → capture → check the artifact*:
+
+| Gate | Pass artifact |
+|------|---------------|
+| Research | Cited findings — each claim traced to a source (dev-guide slug, vendor doc, source file) |
+| Implementation | TDD evidence — a failing test, then the same test passing (red → green) |
+| Static analysis | Clean **captured** `phpcs` / `phpstan` output — the actual command output, pasted |
+| Test | The core `phpunit.xml.dist` run with **zero** failures, warnings, deprecations |
+| Live behavior | Real API / command output — captured, not described |
+| Review | A fresh-context agent's verdict (`fresh-context-reviewer`) |
+| Completion | A green **real** drupalci pipeline (`contribution-pipeline`) |
+
+If you cannot show the artifact, the gate has **not** passed — say so plainly.
+
+## Rule 2 — No guessing external facts
+
+Any external fact — an SDK symbol, an API header or parameter, a beta-feature slug, a
+library-version behavior — is **verified against vendor source or a live probe**.
+
+- Model memory and changelog lines are **leads, never facts**.
+- An unverified external fact is a **blocker** — not a caveat, not a "should".
+- Hand the claim to the `drupal-ai-contrib:external-fact-verifier` agent (Task tool);
+  act only on a `verified` result.
+
+## Rule 3 — Re-verification on post-gate change
+
+Any code edited **after** its gate passed re-fires that gate for the touched path.
+Features added after a green test run are the classic escape hatch for unverified code.
+The `PostToolUse` re-verification hook marks a changed path's gate **stale**; `verify`
+re-runs every stale gate. Never treat a pre-edit green as still valid.
+
+## Rule 4 — Proportionality, justified not assumed
+
+Full gates for features. A light path is allowed for trivial changes — but "trivial"
+must be **explicitly justified and recorded** (what makes it trivial, in writing),
+never assumed. An unrecorded "this is trivial" is the bypass that hides unverified work.
+
+## Rule 5 — Scope discipline
+
+Deliver exactly the agreed scope contract — goal / expected result / success criteria /
+non-goals. AI over-delivers, and every extra line is review burden a maintainer did not
+ask for. Out-of-scope work is a guardrail violation, not a bonus.
+
+## Anti-patterns this skill blocks
+
+- Guessing an API/SDK fact from model memory instead of verifying against source.
+- Reporting "tests pass locally" without disclosing local tool versions vs. CI's.
+- Dismissing a warning as "noise" without tracing it to its source.
+- Entering design or implementation without consulting the relevant dev-guides.
+- Delivering beyond the agreed scope contract.
+- Marking a task done on local-green before the real drupalci pipeline is green.
+- Undisclosed AI use above the policy's "significant portion" threshold.
+
+## Examples
+
+### Example 1: an unverified "passes"
+**User says:** "The phpcs job should pass now."
+**Actions:**
+1. "Should" is an assertion, not an artifact (Rule 1).
+2. Require the captured `phpcs` output; if it has not been run, run it and capture it.
+**Result:** The gate's verdict is the pasted command output, not a prediction.
+
+### Example 2: an SDK symbol from memory
+**User says:** "Use the `Client::stream()` method from the SDK."
+**Actions:**
+1. `Client::stream()` is an external fact recalled from memory (Rule 2).
+2. Hand the claim to the `drupal-ai-contrib:external-fact-verifier` agent — verify
+   against vendor source.
+**Result:** Code uses the symbol only after a `verified` result; otherwise it is blocked.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| Asked to call something "trivial" to skip gates | Allowed only if the justification is written down (Rule 4). No record → full gates. |
+| A warning is dismissed as "noise" | Trace it to its source before dismissing — undismissed by default. |
+| Builder explains why the work is fine | Explanation is narrative, not evidence. Require the artifact. |
+| Extra work delivered beyond scope | Flag as a Rule 5 violation; it is review burden, not a bonus. |
+
+## Knowledge layer
+
+Load via `dev-guides-navigator`: `drupal/contributing-with-ai/evidence-over-assertion`,
+`drupal/contributing-with-ai/supervised-ai-workflow`,
+`drupal/contributing-with-ai/human-review-requirements`.

--- a/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
@@ -3,6 +3,7 @@ name: contribution-guardrails
 description: "Enforces the development discipline for AI-assisted Drupal contributions — evidence over assertion, the no-guessing rule for external facts, the verification-gate artifact contracts, and re-verification on post-gate change. Use PROACTIVELY during any development between claiming an issue and verifying it. Use when user says 'guardrails', 'evidence over assertion', 'no guessing', 'verify this fact', 'is this actually tested', or whenever AI-assisted code is being written for a Drupal contribution. MUST apply before claiming any gate passed."
 version: 0.1.0
 model: sonnet
+user-invocable: true
 ---
 
 # Contribution Guardrails

--- a/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
@@ -4,6 +4,7 @@ description: "Enforces the development discipline for AI-assisted Drupal contrib
 version: 0.1.0
 model: sonnet
 user-invocable: true
+allowed-tools: Read, Grep, Glob, Task
 ---
 
 # Contribution Guardrails

--- a/drupal-ai-contrib/skills/contribution-issue/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-issue/SKILL.md
@@ -57,10 +57,11 @@ the most recent development branch (`main` for core; per-project for contrib).
 ### 5. Wrap drupalorg-cli — safely
 
 All issue/fork operations wrap `mglaman/drupalorg-cli`. Use **fixed, validated
-subcommands**. Validate issue IDs and project names against their expected patterns
-before passing them to the CLI; never interpolate unsanitized input into a shell
-command. drupal.org / GitLab credentials are the contributor's own — never store or
-transmit them.
+subcommands**. Before passing any identifier to the CLI, validate it against an
+explicit pattern — issue IDs must match `^[0-9]+$`, project machine-names must match
+`^[a-z][a-z0-9_]*$` — and **reject anything that does not match** rather than shelling
+out with it. Never interpolate unsanitized input into a shell command. drupal.org /
+GitLab credentials are the contributor's own — never store or transmit them.
 
 ### 6. Report
 

--- a/drupal-ai-contrib/skills/contribution-issue/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-issue/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: contribution-issue
+description: "Works the Drupal issue lifecycle — reviews prior work on an issue first, then creates / comments on / claims it, and checks out the issue fork + branch with three-way fork handling. Use when the user runs /drupal-ai-contrib:issue or asks to find, create, claim, or check out a Drupal issue or issue fork. Wraps drupalorg-cli."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Contribution Issue (worker skill)
+
+Works the Drupal issue lifecycle so the contribution is **meaningful, not duplicate**.
+
+Backs `/drupal-ai-contrib:issue`. Load the knowledge layer via `dev-guides-navigator`:
+`drupal/contributing/drupal-issue-lifecycle`,
+`drupal/contributing/issue-forks-merge-requests`,
+`drupal/contributing/contribution-etiquette-rtbc-credit`,
+`drupal/contributing-with-ai/issue-creation`.
+
+## Procedure
+
+### 1. Review prior work FIRST — before anything else
+
+For an existing issue, review what has already happened:
+- Read existing comments, the issue status, and any open merge requests.
+- Determine whether the contribution would **duplicate** work in progress.
+- If someone is actively on it, surface that — coordinate, do not compete.
+
+A contribution that re-does existing work wastes maintainer review time. This review
+is mandatory; it is not optional context-gathering.
+
+### 2. Detect the issue system
+
+drupal.org classic queue vs. GitLab — detect by following the project's Issues link.
+The status taxonomy differs (classic statuses vs. GitLab `state::*` scoped labels);
+handle dual-mode per the issue-lifecycle dev-guide.
+
+### 3. Act — create, comment, or claim
+
+- **Create** an issue — a clear summary, steps to reproduce, the proposed resolution.
+- **Comment** on an issue — shape: thank → what works → feedback → next step.
+- **Claim** an issue — set the appropriate status; then proceed to fork checkout (§4).
+
+### 4. Fork checkout — three-way handling
+
+When claiming an issue, handle the issue-fork state in **three ways** — never clobber
+existing work:
+
+| State | Action |
+|-------|--------|
+| **Your existing fork** | `issue:checkout` — check out your fork's issue branch |
+| **Someone else's fork/branch** | **Surface it. Do not clobber.** Coordinate via an issue comment before proceeding — their work may be ahead of yours |
+| **No fork yet** | `issue:branch` — create the issue fork + branch |
+
+Branch naming **must include the issue number** (per the issue-forks dev-guide). Target
+the most recent development branch (`main` for core; per-project for contrib).
+
+### 5. Wrap drupalorg-cli — safely
+
+All issue/fork operations wrap `mglaman/drupalorg-cli`. Use **fixed, validated
+subcommands**. Validate issue IDs and project names against their expected patterns
+before passing them to the CLI; never interpolate unsanitized input into a shell
+command. drupal.org / GitLab credentials are the contributor's own — never store or
+transmit them.
+
+### 6. Report
+
+Summarize: the issue, its system + status, the prior-work finding, the fork/branch
+state and what was done. Point the contributor at the development phase, then `verify`.
+
+## Examples
+
+### Example 1: claiming an issue someone else already forked
+**Trigger:** `/drupal-ai-contrib:issue 3456789`
+**Actions:**
+1. Review comments, status, MRs — find an existing issue fork by another contributor.
+2. Surface it; do **not** create a competing branch. Suggest a coordinating comment.
+**Result:** No clobbered work; the contributor decides whether to build on or wait.
+
+### Example 2: a fresh issue, no prior work
+**Trigger:** `/drupal-ai-contrib:issue 3456789`
+**Actions:**
+1. Review confirms no prior MR or fork.
+2. Claim the issue, `issue:branch` to create the fork + issue-number branch.
+**Result:** A clean issue branch checked out, ready for development.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| Issue ID is non-numeric / malformed | Reject before calling `drupalorg-cli`; ask for a valid ID. |
+| `drupalorg-cli` not installed | Report how to install `mglaman/drupalorg-cli`; do not fabricate fork state. |
+| Project uses GitLab, not the classic queue | Use the `state::*` scoped-label taxonomy per the issue-lifecycle dev-guide. |
+| Prior work fully resolves the issue | Surface it — the contribution may be unnecessary; let the contributor decide. |

--- a/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: contribution-pipeline
+description: "Fetches the real GitLab merge-request pipeline for a Drupal contribution and gates on it — the authoritative final check. Use when the user runs /drupal-ai-contrib:pipeline or asks to check the real pipeline, the CI status, or whether a Drupal contribution is done. A contribution is not complete until the real drupalci pipeline is green."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Contribution Pipeline (worker skill)
+
+The authoritative final gate. Local verification (`contribution-verify`) is the fast
+inner loop; **the real GitLab MR pipeline is the truth**. A contribution is **not done**
+until the real drupalci pipeline is green.
+
+Backs `/drupal-ai-contrib:pipeline`. Load the knowledge layer via `dev-guides-navigator`:
+`drupal/contributing/drupalci-pipeline-gitlab-templates`,
+`drupal/contributing/reproducing-drupalci-failures-locally`.
+
+## Procedure
+
+### 1. Resolve the MR and project
+
+Identify the GitLab project and merge-request for the current issue fork (from `submit`
+state, or ask). Validate the project path and MR number against expected patterns
+before any API call.
+
+### 2. Fetch the pipeline — via the GitLab API
+
+Fetch the MR's latest pipeline and its jobs from the GitLab API. This is the produced
+artifact — the actual pipeline result, not a prediction. Credentials are the
+contributor's own; never store or transmit them.
+
+### 3. Read the pipeline honestly
+
+A pipeline reported "passed" can still hide problems. Inspect **every job**:
+- **`allow_failure` jobs** — a red `allow_failure` job does not fail the pipeline but
+  is still a real failure. Surface it.
+- **Manual / opt-in jobs** — `gitlab_templates` v1.15.0+ moved opt-in variant jobs
+  (`OPT_IN_TEST_PREVIOUS_MAJOR`, `_PREVIOUS_MINOR`, `_NEXT_MINOR`, `_MAX_PHP`) to
+  manual trigger. An un-run manual job is **not coverage**. Report it explicitly as
+  not run — never imply a green pipeline means those variants passed.
+
+### 4. Gate
+
+The contribution is **done** only when: every blocking job is green, every
+`allow_failure` job's real status is surfaced, and every relevant manual variant is
+either triggered-and-green or explicitly recorded as a deliberate non-goal.
+
+If a job failed, diagnose it against the reproduction dev-guide and route the
+contributor back to development → `verify`. Do not mark the work complete on local
+green alone.
+
+### 5. Report
+
+Summarize per job: name, status, blocking vs. `allow_failure` vs. manual, and the link
+to the job log. State plainly: is the contribution done, or what remains. The verdict
+is the pipeline's — never assert "should pass".
+
+## Examples
+
+### Example 1: a green pipeline hiding a red allow_failure job
+**Trigger:** `/drupal-ai-contrib:pipeline`
+**Actions:**
+1. Fetch the MR pipeline — overall status "passed".
+2. Inspect every job — `phpstan` is red but `allow_failure: true`.
+**Result:** Reported: pipeline green, but `phpstan` failed (non-blocking) — surfaced, not hidden.
+
+### Example 2: un-run manual variant
+**Trigger:** `/drupal-ai-contrib:pipeline`
+**Actions:**
+1. All blocking jobs green; the `PREVIOUS_MAJOR` variant is a manual job, never triggered.
+**Result:** Reported as UNRUN — not implied coverage; the contributor decides whether to trigger it.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| No MR found for the branch | Report it; point at `/drupal-ai-contrib:submit` to create the MR first. |
+| GitLab API unreachable / unauthenticated | Report the failure; never substitute a local-green result for the real pipeline. |
+| Pipeline still running | Report in-progress; the gate is not satisfied until jobs finish. |
+| A blocking job failed | Diagnose against the reproduction dev-guide; route back to development → `verify`. |

--- a/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
@@ -21,8 +21,9 @@ Backs `/drupal-ai-contrib:pipeline`. Load the knowledge layer via `dev-guides-na
 ### 1. Resolve the MR and project
 
 Identify the GitLab project and merge-request for the current issue fork (from `submit`
-state, or ask). Validate the project path and MR number against expected patterns
-before any API call.
+state, or ask). Before any API call, validate against an explicit pattern — the MR
+number must match `^[0-9]+$`, the project path `^[A-Za-z0-9_./-]+$` — and reject
+anything that does not match rather than calling the API with it.
 
 ### 2. Fetch the pipeline — via the GitLab API
 

--- a/drupal-ai-contrib/skills/contribution-review/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-review/SKILL.md
@@ -24,7 +24,10 @@ Backs `/drupal-ai-contrib:review`. Load the knowledge layer via `dev-guides-navi
 
 Gather, without editorializing:
 - the **scope contract** — goal / expected result / success criteria / non-goals
-- the **diff** under review (the issue-fork branch vs. its target)
+- the **diff** under review — produce it explicitly with
+  `git diff <target-branch>...<issue-fork-branch>` (the three-dot form shows only the
+  contribution's own changes). The reviewer agent must receive a real, non-empty diff;
+  if `git diff` returns nothing, there is nothing to review — report that and stop.
 - the issue and its acceptance criteria
 
 ### 2. Dispatch the fresh-context reviewer

--- a/drupal-ai-contrib/skills/contribution-review/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-review/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: contribution-review
+description: "Runs honest fresh-context review of a Drupal contribution — dispatches isolated reviewer agents with no session narrative to check the work against scope, coding standards, security, and the AI policy. Use when the user runs /drupal-ai-contrib:review or asks for an honest review, a fresh-eyes review, or a pre-submission review of a Drupal contribution. A builder cannot objectively review its own work."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Contribution Review (worker skill)
+
+Honest validation. A builder carries a session narrative — the story of why each
+choice was made — and cannot objectively review its own work. This skill dispatches
+**fresh-context agents** that have none of that narrative.
+
+Backs `/drupal-ai-contrib:review`. Load the knowledge layer via `dev-guides-navigator`:
+`drupal/contributing-with-ai/ai-code-review-checklist`,
+`drupal/contributing-with-ai/human-review-requirements`,
+`drupal/contributing-with-ai/security-considerations`,
+`drupal/contributing-with-ai/issue-review-guidelines`.
+
+## Procedure
+
+### 1. Establish the review inputs
+
+Gather, without editorializing:
+- the **scope contract** — goal / expected result / success criteria / non-goals
+- the **diff** under review (the issue-fork branch vs. its target)
+- the issue and its acceptance criteria
+
+### 2. Dispatch the fresh-context reviewer
+
+Use the Task tool to invoke the `drupal-ai-contrib:fresh-context-reviewer` agent. Pass
+it the diff, the scope contract, and the issue — but **not** the build narrative. The
+agent reviews against:
+- **Scope** — does the change deliver exactly the contract, nothing beyond it?
+  Over-delivery is a finding (it is review burden the maintainer did not ask for).
+- **Standards** — Drupal coding standards, Drupal + PHP best practices.
+- **Security** — AI-specific risks (see the security-considerations dev-guide).
+- **AI policy** — is AI use above the "significant portion" threshold disclosed?
+
+For a large or security-critical change, dispatch multiple reviewer agents for
+perspective diversity, or delegate to `code-paper-test` for line-by-line paper testing.
+
+### 3. Delegate the philosophy review
+
+Hand the SOLID / DRY / architecture review to `code-quality-tools`. This skill owns the
+*honest-validation* concern; `code-quality-tools` owns the philosophy review. Do not
+re-implement it here.
+
+### 4. Synthesize — honest verdicts only
+
+Collect the agents' verdicts. Report findings by severity (blocker / should-fix /
+suggestion), each tied to a **file:line** and a concrete fix. The verdict is the
+agent's — never soften it because the builder explained the intent. If reviewers
+disagree, surface the disagreement; do not paper over it.
+
+### 5. Report
+
+A findings report: per-finding severity, location, fix. State plainly whether the
+contribution is ready for `submit` or needs another development pass. An honest "not
+ready" is the correct output when the work is not ready.
+
+## Examples
+
+### Example 1: over-delivery caught
+**Trigger:** `/drupal-ai-contrib:review`
+**Actions:**
+1. The `fresh-context-reviewer` agent compares the diff to the scope contract.
+2. It finds a refactor of an unrelated class — outside the contract's non-goals.
+**Result:** Logged as a blocker — review burden the maintainer did not ask for.
+
+### Example 2: a security-critical change
+**Trigger:** `/drupal-ai-contrib:review` on a diff touching access control.
+**Actions:**
+1. Dispatch multiple reviewer agents for perspective diversity.
+2. Delegate line-by-line paper testing to `code-paper-test`.
+**Result:** A synthesized findings report; reviewer disagreement surfaced, not hidden.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| No diff to review | Report it and stop — there is nothing to review. |
+| No scope contract exists | Surface the gap — scope review needs a contract; ask for one or note it unassessable. |
+| Builder pushes back on a finding | The agent's verdict stands — do not soften it because intent was explained. |
+| Reviewer agents disagree | Surface the disagreement in the report; do not paper over it. |

--- a/drupal-ai-contrib/skills/contribution-review/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-review/SKILL.md
@@ -29,6 +29,9 @@ Gather, without editorializing:
   contribution's own changes). The reviewer agent must receive a real, non-empty diff;
   if `git diff` returns nothing, there is nothing to review — report that and stop.
 - the issue and its acceptance criteria
+- the **verify-staleness state** — run `${CLAUDE_PLUGIN_ROOT}/scripts/reverify-list.sh`;
+  if it prints any path, note in the report that those files changed since `verify`
+  last passed, so reviewers know the gate evidence may not cover the current diff.
 
 ### 2. Dispatch the fresh-context reviewer
 

--- a/drupal-ai-contrib/skills/contribution-setup/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-setup/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: contribution-setup
+description: "Stands up and environment-matches a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config (new-module scaffold or existing-module discovery), and the Drupal AI skills. Use when the user runs /drupal-ai-contrib:setup or asks to set up a Drupal contribution environment. Idempotent and detect-driven — does only what is missing; never a gate, never a prerequisite."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Contribution Setup (worker skill)
+
+Onboarding for a Drupal contribution. **Optional, idempotent, not a gate.** Detect what
+already exists and do only what is missing — a contributor who arrives with a ready
+environment can skip straight to `issue`.
+
+Backs `/drupal-ai-contrib:setup`. Load the knowledge layer via `dev-guides-navigator`:
+`drupal/contributing/ddev-contribution-environment`,
+`drupal/contributing/contrib-project-scaffolding`,
+`drupal/contributing/three-contribution-workflows-compared`,
+`drupal/contributing-with-ai/ai-toolchain-for-contribution`.
+
+## Procedure
+
+### 1. Detect the workflow and issue system
+
+Determine — by inspecting the working directory and asking the contributor only what
+cannot be inferred:
+
+- **Workflow** — core / your own contrib / someone else's contrib (the three workflows
+  differ in authority, CI ownership, who merges). See the workflows dev-guide.
+- **Issue system** — drupal.org classic queue vs. GitLab. Detect by following the
+  project's Issues link; do not assume.
+
+### 2. Detect the environment
+
+Check for an existing DDEV project (`.ddev/config.yaml`) and the add-on in use.
+If a working contribution environment already exists, report it and stop — nothing to do.
+
+If none exists, stand up **DDEV** with the **workflow-matched add-on**:
+
+| Workflow | Add-on |
+|----------|--------|
+| Single contrib module/theme | `ddev-drupal-contrib` (module repo *is* the project root; `web/` + `vendor/` generated & gitignored) |
+| Multi-module suite | `ddev-drupal-suite` |
+| Drupal core | `ddev-drupal-core-dev` |
+
+### 3. Resolve the gate config — two modes
+
+**Existing module** — discover gates by parsing `.gitlab-ci.yml`:
+- Read the `gitlab_templates` `include` and `ref`, the `variables:` block
+  (`_TARGET_CORE`, `_TARGET_PHP`, `_GITLAB_TEMPLATES_REF`, `_PHPUNIT_CONCURRENT`,
+  `SKIP_*`, `OPT_IN_TEST_*`).
+- Record the discovered gate set; `verify` will mirror exactly these.
+
+**New module / maintainer setup** — scaffold the correct config (writes — see §Writes).
+Generate, version-resolved per the target core, from the scaffolding dev-guide:
+- `.gitlab-ci.yml` — the `gitlab_templates` include + a `variables:` block
+- `phpcs.xml.dist` — `Drupal` + `DrupalPractice`, scoped to `src` + `tests`
+- `phpstan.neon` — `phpstan-drupal` extension, the project's level
+- `phpunit.xml.dist` — the **major-version-correct schema** (D11 → PHPUnit 11 schema,
+  `<source>` block, `failOnWarning`; D10 → PHPUnit 9.x schema + `DrupalListener`) —
+  copy from the target core, never hand-write the version
+- `.cspell-project-words.txt`
+- `drupal/core-dev` (+ `drupal/coder`, `phpstan/phpstan`, `mglaman/phpstan-drupal`) in
+  `require-dev`, constrained to the target major
+
+### 4. Ensure the Drupal AI skills
+
+Ensure `ai_best_practices` and `ai_skills` are installed via `drupal_devkit` (the
+cross-harness skill installer). If `drupal_devkit` is absent, report how to obtain it;
+do not block.
+
+### 5. Environment-match
+
+Install the **CI-target core version** + `drupal/core-dev` so `phpunit` / `phpstan`
+resolve to the same releases CI uses (the local DDEV default usually will not match).
+This is the mechanism that makes `verify`'s gates trustworthy — see `contribution-verify`.
+
+### 6. Report
+
+Summarize: workflow, issue system, environment status, the resolved gate set, AI-skill
+status, the environment-match result. Point the contributor at `issue` (or, if work is
+underway, `verify`).
+
+## Writes — explicit confirmation only
+
+`setup` writes files **only** with explicit user confirmation and **only** within the
+target project. Show the contributor each file to be written before writing it. Never
+write outside the project directory.
+
+## Detect-driven
+
+Every step checks first and does only what is missing. Re-running `setup` on a ready
+environment is a no-op that simply reports state.
+
+## Examples
+
+### Example 1: existing module, environment ready
+**Trigger:** `/drupal-ai-contrib:setup` in a contrib module that already has DDEV.
+**Actions:**
+1. Detect the workflow (someone else's contrib) and the GitLab issue system.
+2. DDEV already present → report it, do not re-create.
+3. Parse `.gitlab-ci.yml`, record the discovered gate set; environment-match the core.
+**Result:** No files written; the contributor is told to proceed to `issue`.
+
+### Example 2: new module, maintainer setup
+**Trigger:** `/drupal-ai-contrib:setup` in a fresh contrib module with no CI config.
+**Actions:**
+1. Stand up DDEV with `ddev-drupal-contrib`.
+2. Show each scaffold file (`.gitlab-ci.yml`, `phpcs.xml.dist`, `phpstan.neon`,
+   `phpunit.xml.dist`, `.cspell-project-words.txt`) and write only on confirmation.
+**Result:** A CI-ready module the maintainer owns.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| `drupal_devkit` not installed | Report how to obtain it; do not block setup. |
+| Workflow cannot be inferred | Ask the contributor — never assume core vs. contrib. |
+| `.gitlab-ci.yml` exists but uses a non-`gitlab_templates` setup | Record what is there; `verify` mirrors the discovered jobs as-is. |
+| Contributor declines a scaffold write | Skip that file; report which gates remain unconfigured. |

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -39,6 +39,7 @@ open as draft while work continues; mark ready when the issue moves to Needs rev
 
 Determine whether AI generated a **significant portion** — whole functions, classes,
 architectural scaffolding, or extensive docblocks. Single-line autocomplete is exempt.
+(These examples are illustrative — the live policy fetched below is authoritative.)
 
 - If **yes**: prepare the disclosure in **both** places the policy requires — the issue
   **disclosure checkboxes** (AI Assisted Code / AI Generated Code / Vibe Coded, as
@@ -56,9 +57,11 @@ contributor as the responsible author — "the AI wrote it" is never a defense.
 
 ### 4. Create or update the MR — via drupalorg-cli
 
-Wrap `mglaman/drupalorg-cli` with **fixed, validated subcommands**. Validate issue IDs
-and project names against expected patterns; never interpolate unsanitized input.
-Credentials are the contributor's own — never stored or transmitted.
+Wrap `mglaman/drupalorg-cli` with **fixed, validated subcommands**. Before any
+shell-out, validate identifiers against an explicit pattern — issue IDs `^[0-9]+$`,
+project machine-names `^[a-z][a-z0-9_]*$` — and reject non-matching values; never
+interpolate unsanitized input. Credentials are the contributor's own — never stored or
+transmitted.
 
 The MR description states: what the change does, the issue it resolves, the AI
 disclosure (§2), and how it was verified (cite the captured `verify` artifacts).

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: contribution-submit
+description: "Creates or updates a Drupal merge request and generates the AI-disclosure comment at the policy threshold. Use when the user runs /drupal-ai-contrib:submit or asks to submit, open, or update a Drupal merge request or patch. Wraps drupalorg-cli; surfaces status and RTBC guidance."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Contribution Submit (worker skill)
+
+Creates or updates the merge request and prepares the required AI disclosure.
+
+Backs `/drupal-ai-contrib:submit`. Load the knowledge layer via `dev-guides-navigator`:
+`drupal/contributing-with-ai/merge-request-workflow`,
+`drupal/contributing/issue-forks-merge-requests`,
+`drupal/contributing-with-ai/commit-messages`,
+`drupal/contributing-with-ai/disclosure-checkboxes`,
+`drupal/contributing/contribution-etiquette-rtbc-credit`.
+
+## Preconditions — point, never refuse
+
+`submit` runs whatever the prior state. But before creating the MR, check and surface:
+- Has `verify` been run, with its gates green? If not, say so — submitting unverified
+  work is exactly the drive-by behavior the AI policy lists as unacceptable.
+- Has `review` been run? Surface it if not.
+
+If a precondition is unmet, **report it and let the contributor decide** — do not
+silently block. The contributor may have evidence from another path.
+
+## Procedure
+
+### 1. Confirm the branch and target
+
+The issue-fork branch (issue-number in the name) and the **target branch** — the most
+recent development branch (`main` for core; per-project for contrib). Draft vs. ready:
+open as draft while work continues; mark ready when the issue moves to Needs review.
+
+### 2. The AI-disclosure decision — policy-driven
+
+Determine whether AI generated a **significant portion** — whole functions, classes,
+architectural scaffolding, or extensive docblocks. Single-line autocomplete is exempt.
+
+- If **yes**: prepare the disclosure in **both** places the policy requires — the issue
+  **disclosure checkboxes** (AI Assisted Code / AI Generated Code / Vibe Coded, as
+  applicable) **and** the MR description, including the `AI-Generated: Yes (...)`
+  comment in the policy's format.
+- If **no**: record that the threshold was assessed and not crossed.
+
+Fetch the **current** policy state via the `drupal-ai-contrib:ai-policy-checker` agent
+(Task tool) — do not rely on hard-coded thresholds; the policy moves.
+
+### 3. Commit messages
+
+Attribute AI involvement in commit messages per the commit-messages dev-guide. Keep the
+contributor as the responsible author — "the AI wrote it" is never a defense.
+
+### 4. Create or update the MR — via drupalorg-cli
+
+Wrap `mglaman/drupalorg-cli` with **fixed, validated subcommands**. Validate issue IDs
+and project names against expected patterns; never interpolate unsanitized input.
+Credentials are the contributor's own — never stored or transmitted.
+
+The MR description states: what the change does, the issue it resolves, the AI
+disclosure (§2), and how it was verified (cite the captured `verify` artifacts).
+
+### 5. Status & RTBC guidance — dual-mode
+
+Set the issue status correctly (Needs review when the MR is ready). Surface RTBC
+discipline: RTBC asserts the **full checklist** (tests pass, phpcs clean, threads
+resolved, gates passed for core) — never just a code read, never self-RTBC. drupal.org
+classic queue and GitLab `state::*` labels differ — handle the project's actual system.
+
+### 6. Report
+
+Summarize: the MR URL, target branch, the disclosure decision and where it was placed,
+the issue status set, and the next step (`pipeline` — the real pipeline is the
+authoritative final gate).
+
+## No overclaiming
+
+Never imply Drupal "endorses AI contributions", never guarantee MR acceptance, never
+make GPL or provenance guarantees. The contributor is fully responsible for the
+submission, including copyright and licensing.
+
+## Examples
+
+### Example 1: significant AI portion → disclosure required
+**Trigger:** `/drupal-ai-contrib:submit 3456789`
+**Actions:**
+1. Assess: AI generated a whole service class → over the "significant portion" threshold.
+2. Prepare the issue disclosure checkboxes **and** the `AI-Generated: Yes (...)` comment
+   in the MR description; fetch the current policy via `drupal-ai-contrib:ai-policy-checker`.
+**Result:** The MR opens with disclosure in both required places.
+
+### Example 2: submitting before verify
+**Trigger:** `/drupal-ai-contrib:submit` with no green `verify` run.
+**Actions:**
+1. Surface that `verify` has not produced green gates.
+2. Report it plainly; let the contributor decide whether to proceed.
+**Result:** No silent block — but the drive-by risk is named.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| `verify` / `review` not run | Surface it; report, do not refuse — the contributor decides. |
+| `drupalorg-cli` not installed | Report how to install it; do not fabricate an MR URL. |
+| Disclosure threshold ambiguous | Fetch the live policy via `drupal-ai-contrib:ai-policy-checker`; when still unclear, disclose. |
+| Project uses GitLab `state::*` labels | Set the GitLab scoped label, not a classic-queue status. |

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -23,6 +23,10 @@ Backs `/drupal-ai-contrib:submit`. Load the knowledge layer via `dev-guides-navi
 - Has `verify` been run, with its gates green? If not, say so — submitting unverified
   work is exactly the drive-by behavior the AI policy lists as unacceptable.
 - Has `review` been run? Surface it if not.
+- **Is the green `verify` still valid?** Run `${CLAUDE_PLUGIN_ROOT}/scripts/reverify-list.sh`.
+  If it prints any path, those files were edited **after** `verify` last passed — the
+  green is stale. Surface the stale paths and recommend re-running `verify` before
+  submitting. A pre-edit green is not evidence for the current code (guardrails Rule 3).
 
 If a precondition is unmet, **report it and let the contributor decide** — do not
 silently block. The contributor may have evidence from another path.

--- a/drupal-ai-contrib/skills/contribution-verify/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-verify/SKILL.md
@@ -90,6 +90,10 @@ never pin its schema, never adopt `promptfoo`. When guidance fails in practice, 
 an expert correction (correction → fix → eval passes; agent-agnostic JSONL) and offer
 to file it upstream.
 
+When **3 or more** captured corrections cluster on the **same subsystem**, surface a
+recommendation to propose a dedicated skill section or eval suite for it — a recurring
+failure cluster is a signal the guidance itself has a gap, not just one bad output.
+
 ### 6. Re-verification
 
 Any path edited after its gate last passed is **stale**. The `PostToolUse`

--- a/drupal-ai-contrib/skills/contribution-verify/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-verify/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: contribution-verify
+description: "Runs the local verification inner loop for a Drupal contribution — the drupalci-parity gate set at CI strictness, the AI-policy gate, and the eval gate, every gate passing only on a captured artifact. Use when the user runs /drupal-ai-contrib:verify or asks to verify, check, or locally test a Drupal contribution before submitting. This is the centerpiece — evidence over assertion, never a bare 'passes'."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Contribution Verify (worker skill)
+
+The fast inner loop. Mirrors the **real drupalci jobs** locally at their **real
+strictness**, plus the AI-policy and eval gates. Every gate passes **only on a produced
+artifact** — a captured command output, a diff, a real result. **Never** report a bare
+"passes".
+
+Backs `/drupal-ai-contrib:verify`. Load the knowledge layer via `dev-guides-navigator`:
+`drupal/contributing/drupalci-pipeline-gitlab-templates`,
+`drupal/contributing/drupal-coding-standards-ci-parity`,
+`drupal/contributing/reproducing-drupalci-failures-locally`,
+`drupal/contributing-with-ai/coding-standards`,
+`drupal/contributing-with-ai/testing-ai-code`,
+`drupal/contributing-with-ai/drupal-ai-policy`,
+`drupal/contributing-with-ai/ai-best-practices-and-evals`.
+
+## Procedure
+
+### 1. Environment match — before any gate
+
+Read from `.gitlab-ci.yml`: `_TARGET_CORE`, `_TARGET_PHP`, `_GITLAB_TEMPLATES_REF`,
+`_PHPUNIT_CONCURRENT`, `SKIP_*`, `OPT_IN_TEST_*`. Install the **target core version** +
+`drupal/core-dev` so `phpunit` / `phpstan` resolve to the releases CI uses. Versions
+are **resolved, never baked in**. If the environment is not matched, say so — local
+green on mismatched versions is not evidence.
+
+### 2. Parse the enabled gate set
+
+`.gitlab-ci.yml` `include`s the `gitlab_templates` files. Determine which jobs are
+enabled and each job's **actual blocking status** (`allow_failure`, `SKIP_*`). Report
+each gate's real blocking status — not a uniform pass/fail.
+
+### 3. Run the drupalci-parity gate set
+
+Run each enabled job locally at CI strictness; capture each one's output as the artifact:
+
+| Gate | How to run at CI strictness |
+|------|------------------------------|
+| `composer` | `composer validate` + install with the project's constraints |
+| `phpcs` | `phpcs` against the project's `phpcs.xml.dist` (`Drupal` + `DrupalPractice`); `drupal/coder` ^8.3.x. **Blocking by default.** |
+| `phpstan` | `phpstan analyse` with the project's `phpstan.neon` (`phpstan-drupal`). **`allow_failure: true` by default** — report it, flagged non-blocking. |
+| `phpunit` | Run with the **core config**: `vendor/bin/phpunit -c web/core/phpunit.xml.dist --webroot=web`, switching to `core/scripts/run-tests.sh` when `_PHPUNIT_CONCURRENT: 1`. The core `phpunit.xml.dist` carries `failOnWarning` / `failOnPhpunitWarning` — that is what fails on warnings. Pass = zero failures, zero warnings, zero deprecations. |
+| `cspell` | `cspell` with the project's `.cspell-project-words.txt` loaded |
+| `eslint` / `stylelint` | only when JS/CSS present and not `SKIP_ESLINT` / `SKIP_STYLELINT` |
+
+**Opt-in variants** — `OPT_IN_TEST_PREVIOUS_MAJOR` / `_PREVIOUS_MINOR` / `_NEXT_MINOR` /
+`_MAX_PHP`. `gitlab_templates` v1.15.0+ moved these to **manual trigger** — they do not
+auto-run. Report opt-in variants **explicitly as unrun**; never imply coverage. Defer
+locally-impossible combinations to `contribution-pipeline`.
+
+**Parity, not philosophy.** These gates assert "does the drupalci job pass". Delegate
+the philosophy / standards review (SOLID, DRY) to `code-quality-tools` — parity gates
+stay here and are authoritative for "code correctly done".
+
+### 4. The AI-policy gate — every contribution
+
+Runs every time. Dispatch the `drupal-ai-contrib:ai-policy-checker` agent (Task tool)
+to fetch the **current** state of the adopted *Policy on the use of AI when
+contributing to Drupal* and `ai_best_practices` — never hard-code policy text. The
+gate's pass artifact is:
+- a **disclosure decision recorded** — does AI use cross the "significant portion"
+  threshold (whole functions / classes / scaffolding / extensive docblocks; single-line
+  autocomplete is exempt)? If yes, the `AI-Generated: Yes (...)` disclosure is prepared.
+- the **verification checklist confirmed for this contribution** — dependencies, logic,
+  and security verified (not assumed); full contributor responsibility acknowledged.
+- the policy state fetched **live** and attached.
+
+### 5. The eval gate — best-effort
+
+`ai_best_practices` ships `evals/evals.json` (offline grader — PHP lint / phpcs / diff /
+security-pattern / report-structure checks). Run the eval set locally as a quality gate
+**if available**; degrade silently if not. Never hard-depend on the eval registry,
+never pin its schema, never adopt `promptfoo`. When guidance fails in practice, capture
+an expert correction (correction → fix → eval passes; agent-agnostic JSONL) and offer
+to file it upstream.
+
+### 6. Re-verification
+
+Any path edited after its gate last passed is **stale**. The `PostToolUse`
+re-verification hook records every edited contribution file in a ledger. Read the stale
+set by running `${CLAUDE_PLUGIN_ROOT}/scripts/reverify-list.sh` — it prints one path per
+line (nothing if no gate is stale). Re-run the gate for **every** stale path before
+reporting; a pre-edit green is not valid. After all gates report green, clear the
+ledger: `${CLAUDE_PLUGIN_ROOT}/scripts/reverify-list.sh --clear`.
+
+### 7. Report — evidence, never assertion
+
+For each gate report: the gate, its **actual blocking status**, PASS / FAIL / UNRUN,
+and the **captured artifact** (the command output). Never report a verdict without its
+artifact. List opt-in variants as UNRUN. State the environment-match status. If a gate
+cannot be run locally, say so and defer it to `contribution-pipeline` — do not imply it
+passed.
+
+## Examples
+
+### Example 1: a clean inner-loop run
+**Trigger:** `/drupal-ai-contrib:verify`
+**Actions:**
+1. Environment-match the target core; parse the enabled gate set.
+2. Run `composer`, `phpcs`, `phpstan`, `phpunit`, `cspell`; run the AI-policy + eval gates.
+3. Report each with its captured output and real blocking status.
+**Result:** Every gate's verdict is backed by a pasted artifact; opt-in variants UNRUN.
+
+### Example 2: a warning surfaced by the core config
+**Trigger:** `/drupal-ai-contrib:verify` after adding a deprecated API call.
+**Actions:**
+1. `phpunit` runs with the core `phpunit.xml.dist` (`failOnWarning`).
+2. The deprecation fails the gate — capture the output, do not dismiss it as noise.
+**Result:** FAIL reported with the deprecation trace; routed back to development.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| No `.gitlab-ci.yml` found | Report the gap; point at `/drupal-ai-contrib:setup` for that gap only — do not refuse. |
+| Local core version ≠ `_TARGET_CORE` | Environment-match first; a green on mismatched versions is not evidence. |
+| `evals.json` absent or schema changed | Degrade silently — the eval gate is best-effort, never a hard dependency. |
+| A gate cannot run locally (e.g. `_MAX_PHP`) | Report UNRUN and defer to `contribution-pipeline`; never imply it passed. |
+| `phpstan` reports errors | It is `allow_failure: true` by default — report FAIL flagged non-blocking, per the project's config. |

--- a/drupal-ai-contrib/skills/contribution-verify/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-verify/SKILL.md
@@ -17,9 +17,11 @@ Backs `/drupal-ai-contrib:verify`. Load the knowledge layer via `dev-guides-navi
 `drupal/contributing/drupalci-pipeline-gitlab-templates`,
 `drupal/contributing/drupal-coding-standards-ci-parity`,
 `drupal/contributing/reproducing-drupalci-failures-locally`,
+`drupal/contributing/contrib-project-scaffolding`,
 `drupal/contributing-with-ai/coding-standards`,
 `drupal/contributing-with-ai/testing-ai-code`,
 `drupal/contributing-with-ai/drupal-ai-policy`,
+`drupal/contributing-with-ai/disclosure-checkboxes`,
 `drupal/contributing-with-ai/ai-best-practices-and-evals`.
 
 ## Procedure
@@ -67,11 +69,17 @@ to fetch the **current** state of the adopted *Policy on the use of AI when
 contributing to Drupal* and `ai_best_practices` — never hard-code policy text. The
 gate's pass artifact is:
 - a **disclosure decision recorded** — does AI use cross the "significant portion"
-  threshold (whole functions / classes / scaffolding / extensive docblocks; single-line
-  autocomplete is exempt)? If yes, the `AI-Generated: Yes (...)` disclosure is prepared.
+  threshold (illustrative examples: whole functions / classes / scaffolding / extensive
+  docblocks; single-line autocomplete exempt — the live policy the agent returns is
+  authoritative over these examples)? If yes, the `AI-Generated: Yes (...)` disclosure
+  is prepared.
 - the **verification checklist confirmed for this contribution** — dependencies, logic,
   and security verified (not assumed); full contributor responsibility acknowledged.
 - the policy state fetched **live** and attached.
+
+If the `ai-policy-checker` agent reports a policy source **unreachable**, the AI-policy
+gate is **UNRUN** — report it as UNRUN, never as passed. The contribution cannot clear
+this gate on an unconfirmed policy state.
 
 ### 5. The eval gate — best-effort
 

--- a/drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md
+++ b/drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: drupal-ai-contrib
+description: "Routes Drupal contribution work to the right contribution-quality stage and supplies the contribution knowledge layer. Use when user says 'contribute to Drupal', 'Drupal contribution', 'submit a Drupal patch', 'Drupal merge request', 'fix a Drupal core issue', 'contribute a module', 'AI-assisted Drupal contribution', or works a drupal.org / GitLab Drupal issue. Use PROACTIVELY whenever AI-assisted code is headed for a Drupal contribution — drupalci and maintainer review are unforgiving."
+version: 0.1.0
+model: sonnet
+user-invocable: false
+---
+
+# Drupal AI Contribution — Umbrella & Router
+
+Make AI a trusted, good-practice way to contribute to Drupal: AI-assisted code that
+passes drupalci, survives maintainer review on the first or second round, follows
+Drupal + PHP best practices, and follows the Code of Conduct and the adopted
+AI-contribution policy.
+
+This skill **routes** a contribution request to the right stage and supplies the
+**knowledge layer**. It does not run the stages itself — each stage is a worker skill.
+
+## Core principle — evidence over assertion
+
+Every gate passes **only on a produced artifact**: a command's output, a file diff, a
+live API response, a real pipeline result. Never on the model stating "done", "passes",
+or "should work". The cross-cutting discipline lives in the `contribution-guardrails`
+skill — invoke it during any development between `issue` and `verify`.
+
+## The contribution arc — detect-driven, not a forced sequence
+
+Six stages. Each checks the state it needs and runs regardless of whether earlier
+stages ran. A contributor can enter at `issue` (environment ready) or even at `verify`
+(work underway). A stage that finds a real gap points at `setup` for *that gap only*;
+it never refuses to run. `setup` is the on-ramp, never a prerequisite.
+
+| Stage | Command | Worker skill |
+|-------|---------|--------------|
+| 1. Onboard the environment | `/drupal-ai-contrib:setup` | `contribution-setup` |
+| 2. Work the issue | `/drupal-ai-contrib:issue` | `contribution-issue` |
+| 3. Verify locally (the inner loop) | `/drupal-ai-contrib:verify` | `contribution-verify` |
+| 4. Honest review | `/drupal-ai-contrib:review` | `contribution-review` |
+| 5. Submit the MR | `/drupal-ai-contrib:submit` | `contribution-submit` |
+| 6. Confirm the real pipeline | `/drupal-ai-contrib:pipeline` | `contribution-pipeline` |
+
+## Routing
+
+When a contribution request arrives without a specific command, route it:
+
+| The contributor wants to… | Route to |
+|---------------------------|----------|
+| Stand up a DDEV environment, scaffold CI config, install Drupal AI skills | `contribution-setup` |
+| Find / create / claim an issue, check out an issue fork + branch | `contribution-issue` |
+| Run the local drupalci-parity / AI-policy / eval gates | `contribution-verify` |
+| Get an honest, fresh-context review of the work | `contribution-review` |
+| Create or update the merge request, write the AI-disclosure comment | `contribution-submit` |
+| Check the authoritative real GitLab MR pipeline | `contribution-pipeline` |
+| Develop code safely between `issue` and `verify` | `contribution-guardrails` |
+
+Ambiguous request → ask which stage; do not guess.
+
+## The knowledge layer — dev-guides
+
+Technical how-to (writing the code correctly, the contribution mechanics, coding
+standards, the drupalci pipeline) comes from the `camoa/dev-guides` contribution
+guides, **not** from this plugin. Load them via the `dev-guides-navigator` skill —
+never fetch `llms.txt` or dev-guides URLs directly.
+
+`references/dev-guides-index.md` maps each contribution stage to the dev-guide slugs to
+load. Worker skills cite those slugs. A guide that is not yet authored simply will not
+resolve — the navigator degrades gracefully; never block on a missing guide.
+
+## The governance layer — ai_best_practices
+
+AI-policy + compliance + evals anchor on `ai_best_practices` (the canonical Drupal AI
+source of truth) and the adopted *Policy on the use of AI when contributing to Drupal*.
+Both are fetched **live** per contribution by the `ai-policy-checker` agent — never
+hard-coded, never assumed; this is the fastest-moving area.
+
+## Relationship to drupal-dev-framework
+
+A contribution **is** a `drupal-dev-framework` (DDF) task. DDF owns the phase lifecycle
+(research → architecture → implement → review → complete) and its phase gates. This
+plugin is a separate layer **outside** DDF — it adds contribution-quality commands and
+gates on top. It does not fork or modify DDF. Run the contribution as a DDF task and
+use this plugin's commands alongside it.
+
+## Interop — delegate, never reinvent
+
+| Need | Delegate to |
+|------|-------------|
+| Phase lifecycle + phase gates | `drupal-dev-framework` |
+| Philosophy / standards review (SOLID, DRY) | `code-quality-tools` |
+| Paper-testing before submission | `code-paper-test` |
+| Issue / MR / pipeline CLI | `drupalorg-cli` (wrapped by `issue` / `submit` / `pipeline`) |
+| Drupal AI skill install | `drupal_devkit` |
+
+## Examples
+
+### Example 1: natural-language entry, no command
+**User says:** "I want to contribute a fix to the Pathauto module."
+**Actions:**
+1. Recognize a Drupal contribution request with no specific stage named.
+2. There is no environment context yet → route to `contribution-setup` to detect the
+   workflow (someone else's contrib) and environment, then `contribution-issue`.
+**Result:** The contributor is on-ramped at the right stage without guessing.
+
+### Example 2: mid-arc entry
+**User says:** "Check my Drupal contribution before I submit it."
+**Actions:**
+1. Work is already underway → skip `setup`/`issue`.
+2. Route to `contribution-verify` (gates), then `contribution-review` (honest review).
+**Result:** Entry at `verify` — earlier stages are not forced.
+
+## Troubleshooting
+
+| Situation | Handling |
+|-----------|----------|
+| Request could be two stages | Ask which stage; never guess the route. |
+| A dev-guide slug does not resolve | The navigator degrades gracefully — proceed without it; never block. |
+| Contributor asks to skip a stage | Allowed — the arc is detect-driven. Surface what evidence the skipped stage would have produced. |
+| Request is Drupal dev but not contribution | Out of scope — this is contribution quality, not general Drupal dev. Defer to `drupal-dev-framework`. |
+
+## References
+
+- `references/dev-guides-index.md` — contribution stage → dev-guide slugs to load

--- a/drupal-ai-contrib/skills/drupal-ai-contrib/references/dev-guides-index.md
+++ b/drupal-ai-contrib/skills/drupal-ai-contrib/references/dev-guides-index.md
@@ -1,0 +1,61 @@
+# Contribution Knowledge Layer — dev-guide slugs
+
+The plugin's technical how-to is the `camoa/dev-guides` contribution guides. They are
+**already authored** in two topics: `drupal/contributing/` (10 guides) and
+`drupal/contributing-with-ai/` (20 guides).
+
+**How to load:** invoke the `dev-guides-navigator` skill with the slug or its keywords.
+Never fetch `llms.txt` or dev-guides URLs directly — the navigator owns caching and
+disambiguation. If a guide does not resolve, degrade gracefully; never block.
+
+A slug is `<topic>/<guide-name>` — e.g. `drupal/contributing/drupalci-pipeline-gitlab-templates`.
+
+## Stage → guides to load
+
+### `contribution-setup`
+- `drupal/contributing/ddev-contribution-environment` — DDEV + the workflow-matched add-on
+- `drupal/contributing/contrib-project-scaffolding` — `info.yml`, `composer.json`, `.gitignore`, CI config files
+- `drupal/contributing/three-contribution-workflows-compared` — core / own-contrib / others'
+- `drupal/contributing-with-ai/ai-toolchain-for-contribution` — Drupal AI skills, guarded dev setup
+
+### `contribution-issue`
+- `drupal/contributing/drupal-issue-lifecycle` — status workflow, drupal.org + GitLab dual-mode
+- `drupal/contributing/issue-forks-merge-requests` — fork/branch mechanics, branch naming, `drupalorg-cli`
+- `drupal/contributing/contribution-etiquette-rtbc-credit` — etiquette, RTBC, the credit system
+- `drupal/contributing-with-ai/issue-creation` — creating an issue with AI disclosure
+
+### `contribution-verify`
+- `drupal/contributing/drupalci-pipeline-gitlab-templates` — the job set, `_TARGET_*` / `SKIP_*` / `OPT_IN_TEST_*`, `allow_failure`
+- `drupal/contributing/drupal-coding-standards-ci-parity` — `phpcs` / `phpstan` at CI strictness
+- `drupal/contributing/reproducing-drupalci-failures-locally` — per-job local reproduction
+- `drupal/contributing/contrib-project-scaffolding` — `phpunit.xml.dist` version-correct schema
+- `drupal/contributing-with-ai/coding-standards` — coding-standard mistakes AI commonly makes
+- `drupal/contributing-with-ai/testing-ai-code` — testing AI-generated contributions
+- `drupal/contributing-with-ai/drupal-ai-policy` — the adopted AI-contribution policy (the AI-policy gate)
+- `drupal/contributing-with-ai/disclosure-checkboxes` — the "significant portion" disclosure threshold
+- `drupal/contributing-with-ai/ai-best-practices-and-evals` — `ai_best_practices` + the eval landscape
+
+### `contribution-review`
+- `drupal/contributing-with-ai/ai-code-review-checklist` — pre-submission checklist
+- `drupal/contributing-with-ai/human-review-requirements` — what "human review" actually requires
+- `drupal/contributing-with-ai/security-considerations` — AI-specific security risks
+- `drupal/contributing-with-ai/issue-review-guidelines` — how maintainers evaluate AI-flagged issues
+
+### `contribution-submit`
+- `drupal/contributing-with-ai/merge-request-workflow` — MR workflow with AI disclosure
+- `drupal/contributing/issue-forks-merge-requests` — draft/ready, target-branch rule
+- `drupal/contributing-with-ai/commit-messages` — AI attribution in commit messages
+- `drupal/contributing-with-ai/disclosure-checkboxes` — the disclosure checkboxes + `AI-Generated: Yes (...)`
+- `drupal/contributing/contribution-etiquette-rtbc-credit` — RTBC discipline, credit
+
+### `contribution-pipeline`
+- `drupal/contributing/drupalci-pipeline-gitlab-templates` — reading a pipeline (a green pipeline can hide red `allow_failure` + un-run manual jobs)
+- `drupal/contributing/reproducing-drupalci-failures-locally` — diagnosing a real failure
+
+### `contribution-guardrails` (cross-cutting development discipline)
+- `drupal/contributing-with-ai/evidence-over-assertion` — gates pass on artifacts, not AI claims
+- `drupal/contributing-with-ai/supervised-ai-workflow` — why unsupervised AI fails; building guardrails
+- `drupal/contributing-with-ai/human-review-requirements` — the honest-review minimum
+
+### `module-theme-maintainer` topic (surfaced by `setup` in new-module / maintainer mode)
+- `drupal/contributing/module-theme-maintainer` — owning & maintaining the CI config


### PR DESCRIPTION
## Summary

New plugin **`drupal-ai-contrib`** (v0.1.0) — AI-assisted Drupal contribution **quality**. Built per the completed `drupal_contrib_workflow` epic architecture. Core principle: **evidence over assertion** — every gate passes only on a produced, captured artifact, never on an AI claim.

The plugin makes AI a trusted, good-practice way to contribute to Drupal: AI-assisted code that passes drupalci, survives maintainer review, and follows the Code of Conduct and the adopted AI-contribution policy.

## What ships (architecture §5)

- **6 commands** — `setup`, `issue`, `verify`, `review`, `submit`, `pipeline` — thin entry points to the detect-driven contribution arc, each backed by a worker skill.
- **8 skills** — the `drupal-ai-contrib` umbrella/router + 6 worker skills + `contribution-guardrails` (the cross-cutting development discipline). Umbrella + 6 workers are `user-invocable: false`.
- **3 read-only agents** — `fresh-context-reviewer`, `external-fact-verifier`, `ai-policy-checker`; all use `tools:` (not the silently-ignored `allowed-tools:`) and carry `disallowedTools: Edit, Write`.
- **2 hooks** — a `PostToolUse` re-verification ledger (`reverify-mark.sh` + `scripts/reverify-list.sh`) so `verify` re-fires the gate for any path edited after it passed; a context-aware `SessionStart` reminder that speaks only in a contribution workspace.
- **The drupalci-parity gate set** inside `verify` — `composer`/`phpcs`/`phpstan`/`phpunit`/`cspell`/`eslint`/`stylelint`, environment-matched to the CI-target core, mirroring each enabled `gitlab_templates` job at real strictness; plus the AI-policy gate and a best-effort eval gate.
- **Knowledge layer** — worker skills cite the `camoa/dev-guides` contribution guides (`drupal/contributing/`, `drupal/contributing-with-ai/`) by slug, loaded via `dev-guides-navigator`.

## Registration

- New plugin entry in `.claude-plugin/marketplace.json`; `metadata.version` 1.14.59 → 1.14.60.
- `plugin.json` + `README.md` + `CHANGELOG.md` present.

## Validation

`/plugin-creation-tools:validate` — **PASS**, no errors, no warnings. The re-verification ledger round-trip (mark → list → clear) and the context-aware SessionStart reminder were functionally tested with captured output.

Built entirely in the `feature/drupal-ai-contrib` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)