### PR TITLE
feat(drupal-dev-framework): v4.15.0 — /implement verify-and-promote nudge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.1"
+    "version": "1.15.2"
   },
   "plugins": [
     {
@@ -57,7 +57,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow (Research → Architecture → Implementation) with enforced SOLID, TDD, DRY, and security gates. Covers epic/sub-task hierarchy, scope contracts, a Phase 4 /review gate with a change-impact dispatcher, two-stage dev-guides detection, the Playbook System, git-worktree parallel-task awareness, agent-team validation, per-project session-remembrance hooks, the ATK E2E behavioral gate (/setup-atk + /validate:e2e), the committed-Playwright visual-regression gate (/setup-visual-regression + /validate:visual-regression), and the committed-Playwright visual-parity gate with a structured CSS-actionable diff (/setup-visual-parity + /validate:visual-parity).",
-      "version": "4.14.0",
+      "version": "4.15.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.15.0] - 2026-05-21
+
+### Added
+
+- **`/implement` verify-and-promote nudge** — when a change is implemented and the developer signals it is done, `/implement` prints one declinable soft-nudge offering to (a) verify the change live (drive the DDEV site / `drush` / browser via Claude Code's built-in `verify` capability) and (b) — if the change is worth protecting — promote it to a committed gate (`/setup-atk --add-journey`, `/setup-visual-regression --add-surface`, `/setup-visual-parity --add-surface`). Soft-nudge posture: once per change, never blocks, no audit. Bridges ad-hoc verification to the epic's committed review gates.
+
+This is the residue of the dropped `task_e_change_verification` (the `visual_and_e2e_review_gates` epic's 5th subtask). Its `/research` resolved the task's own drop-or-build gate: a standalone change-verification skill would have been too thin a delta over Claude Code's built-in `verify` skill — the only framework-coupled substance was this nudge, shipped here directly. The epic concludes with Tasks A–D (v4.11.0–v4.14.0) plus this nudge.
+
 ## [4.14.0] - 2026-05-21
 
 ### Visual Parity v2 — `/setup-visual-parity` + reworked `/validate:visual-parity` (epic `visual_and_e2e_review_gates`, Task D)

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -322,7 +322,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.14.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.15.0**.
 
 ## License
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -65,6 +65,23 @@ For each acceptance criterion:
 6. Update `implementation.md` Progress + `task.md` AC checkboxes.
 7. Repeat until task complete.
 
+## Verify-and-promote nudge (v4.15.0+)
+
+When a change is implemented and the developer signals it is done, print **one
+declinable soft-nudge** (once per change — not per file, never re-asked):
+
+> Want me to verify this change live — drive the DDEV site / `drush` / the browser to
+> confirm it actually works and renders as intended? And if the change is worth
+> protecting against regression, I can promote it to a committed gate:
+> `/setup-atk --add-journey` (behavioural), or `/setup-visual-regression --add-surface`
+> / `/setup-visual-parity --add-surface` (visual).
+
+The live verification itself uses Claude Code's built-in `verify` capability — this
+nudge only surfaces it at the right moment and bridges to the epic's committed review
+gates. Soft-nudge posture (matches the change-impact dispatcher's recommender model):
+never blocks, never a gate, no audit. Skip it silently for a docs-only or
+non-functional change.
+
 ## Pointers
 
 - Full walkthrough: `references/implement-walkthrough.md`


### PR DESCRIPTION
## Summary

Adds one declinable soft-nudge at the end of `/implement`'s interactive development loop: offer to **verify the just-made change live** (drive the DDEV site / `drush` / browser via Claude Code's built-in `verify` capability) and, if the change is worth protecting against regression, **promote it to a committed gate** — `/setup-atk --add-journey`, `/setup-visual-regression --add-surface`, or `/setup-visual-parity --add-surface`.

Soft-nudge posture (matches the change-impact dispatcher's recommender model): once per change, never blocks, no audit, skipped silently for docs-only changes.

## Why — the residue of dropped Task E

This is the genuine residue of `task_e_change_verification`, the 5th and final subtask of the `visual_and_e2e_review_gates` epic. Task E's `/research` resolved the drop-or-build gate the task framing built in: a standalone Drupal change-verification skill would have been **too thin a delta** over Claude Code's built-in `verify` skill — the verification capability already exists, the Drupal change-type knowledge belongs in `camoa/dev-guides`, and the only framework-coupled substance was this nudge. Task E was dropped; the nudge ships here directly.

The epic concludes: **Task A** v4.11.0, **B** v4.12.0, **C** v4.13.0, **D** v4.14.0, plus this nudge (v4.15.0).

## Changes

- `commands/implement.md` — the verify-and-promote nudge section
- v4.15.0 metadata: `plugin.json`, root `marketplace.json` (entry + `metadata.version` 1.15.1→1.15.2), `CHANGELOG.md`, `README.md`

No scripts, no new components — a single-command documentation addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)