### PR TITLE
fix(drupal-ai-contrib): v0.1.1 — clarify drupalorg-cli, guide setup on auth + issue-creation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.2"
+    "version": "1.15.3"
   },
   "plugins": [
     {
@@ -101,7 +101,7 @@
       "name": "drupal-ai-contrib",
       "source": "./drupal-ai-contrib",
       "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline), a local drupalci-parity gate set plus AI-policy and eval gates inside verify, 3 read-only agents (fresh-context review, external-fact verification, live AI-policy checking), and a PostToolUse re-verification ledger. A quality layer outside drupal-dev-framework; cites the camoa/dev-guides contribution guides as its knowledge layer.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "camoa"
       },

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-ai-contrib",
   "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "camoa"
   },

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-05-22
+
+First post-release bug-fix patch. Five gaps surfaced by the first live `setup`→`issue`
+flow, all in how the plugin explained the `mglaman/drupalorg-cli` toolchain and its
+prerequisites. Bundled into one patch because they share the same files.
+
+### Fixed
+
+- **B1 — `drupalorg-cli` was unexplained.** Three skills wrapped the tool but the
+  plugin never said what it is or how to install it. Added
+  `skills/drupal-ai-contrib/references/drupalorg-cli.md` as the single source of truth
+  (what it is, PHAR install, Composer-global path + `PATH` note, authentication, what
+  the CLI can and cannot do). `setup` / `issue` / `submit` cite it; the umbrella skill
+  lists it.
+- **B2 — Executable named wrong.** Skills said *"wrap `drupalorg-cli`"* but the binary
+  on `PATH` is `drupalorg` (`drupalorg-cli` is only the package name). All wrap sites,
+  troubleshooting rows, and README/CONVENTIONS now name `drupalorg` as the executable.
+- **B3 — `submit` overstated CLI capability.** §4 was titled "Create or update the MR
+  — via drupalorg-cli", but there is no `mr:create`. Rewritten to state the real flow:
+  on GitLab, MRs are created by pushing the issue-fork branch; `submit` uses
+  `mr:list` / `mr:status` to confirm and report.
+- **B4 — `setup` never guided on auth.** New `contribution-setup` §5 "Check
+  contribution credentials" — detects the drupal.org SSH key
+  (`ssh -T git@git.drupal.org`), explains plainly that `git push` to issue forks and
+  `/do:` bot commands need a key registered on the contributor's account, distinguishes
+  read ops (public APIs) from write ops, guides registration at *drupal.org → My
+  account → SSH keys*, and reports status — never blocks. §7 Report now states
+  ready vs. needs-action per item. `issue` and `submit` gained matching troubleshooting
+  rows for push-rejected.
+- **B5 — `issue` claimed it could create issues.** `drupalorg-cli` has no
+  `issue:create` (verified against repo source — all 19 `Issue/*` command classes
+  operate on existing issues). `issue` §3 now states this explicitly: the skill drafts
+  the issue and guides the contributor to file it in the web UI (Drupal.org queue or
+  GitLab), then resumes with the new issue ID.
+- **Reference subcommand list de-brittled.** The initial hand-enumerated table had
+  already missed `issue:fork`. Replaced with command-*groups* + verified negatives
+  (no `issue:create`, no `mr:create`) + a `drupalorg list` pointer — evidence over
+  assertion.
+
+### Verified
+
+- drupalorg-cli command set verified against the live repo source
+  (`gh api repos/mglaman/drupalorg-cli/contents/src/Cli/Command/*`): 19 `Issue/*`
+  classes (all on existing issues — no `Create`); 5 `MergeRequest/*` classes
+  (no `Create`). Confirms B3 + B5.
+
+### Bumped
+
+- Plugin `0.1.0` → `0.1.1`. Skill versions for the four edited skills
+  (`contribution-setup`, `contribution-issue`, `contribution-submit`, umbrella
+  `drupal-ai-contrib`) `0.1.0` → `0.1.1`. Root `marketplace.json` `metadata.version`
+  `1.15.2` → `1.15.3`.
+
 ## [0.1.0] - 2026-05-21
 
 Initial release — AI-assisted Drupal contribution quality, built per the

--- a/drupal-ai-contrib/CONVENTIONS.md
+++ b/drupal-ai-contrib/CONVENTIONS.md
@@ -48,8 +48,9 @@ Both are fetched live, never hard-coded — they move fast.
 ## General
 - Current truth only — no historical narratives in skill/command bodies.
 - Delegate, don't reinvent: `drupal-dev-framework` (phase lifecycle), `code-quality-tools`
-  (philosophy/standards review), `code-paper-test` (paper testing), `drupalorg-cli`
-  (issue/MR/CI). The plugin owns orchestration + evidence-gating + the contribution arc.
+  (philosophy/standards review), `code-paper-test` (paper testing), `mglaman/drupalorg-cli`
+  (issue/MR/CI — executable `drupalorg`; see `skills/drupal-ai-contrib/references/drupalorg-cli.md`).
+  The plugin owns orchestration + evidence-gating + the contribution arc.
 
 ## Enforcement model & known limitations
 

--- a/drupal-ai-contrib/README.md
+++ b/drupal-ai-contrib/README.md
@@ -69,9 +69,11 @@ The plugin is the **implementation layer** for those standards inside your edito
 ```
 
 **Companions & tools** — `dev-guides-navigator` (companion — supplies the contribution
-how-to guides; install it alongside), `drupalorg-cli` (issue / MR / pipeline
-operations), DDEV (the local environment), and a drupal.org account with GitLab access.
-`setup` detects what is missing and points you at it; nothing is a hard prerequisite.
+how-to guides; install it alongside), `mglaman/drupalorg-cli` (issue / MR / pipeline
+operations — the executable is `drupalorg`; install the PHAR per
+`skills/drupal-ai-contrib/references/drupalorg-cli.md`), DDEV (the local environment),
+and a drupal.org account with GitLab access. `setup` detects what is missing and points
+you at it; nothing is a hard prerequisite.
 
 ## The contribution arc
 
@@ -175,5 +177,6 @@ contribution-quality commands and gates on top, without forking or modifying DDF
 ## Interop — delegate, never reinvent
 
 `code-quality-tools` (philosophy / standards review) · `code-paper-test` (paper
-testing) · `drupalorg-cli` (issue / MR / pipeline CLI) · `drupal_devkit` (Drupal AI
-skill install) · `ai_best_practices` (the canonical AI policy + evals).
+testing) · `mglaman/drupalorg-cli` (issue / MR / pipeline CLI — executable `drupalorg`)
+· `drupal_devkit` (Drupal AI skill install) · `ai_best_practices` (the canonical AI
+policy + evals).

--- a/drupal-ai-contrib/commands/setup.md
+++ b/drupal-ai-contrib/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-description: "Onboard and environment-match a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config, and the Drupal AI skills. Use when user says 'set up Drupal contribution', 'contribution environment', 'scaffold a contrib module', 'drupal-ai-contrib setup'. Idempotent — does only what is missing."
+description: "Onboard and environment-match a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config, the Drupal AI skills, the drupalorg CLI, and a contribution-credentials (SSH-key) check. Use when user says 'set up Drupal contribution', 'contribution environment', 'scaffold a contrib module', 'drupal-ai-contrib setup'. Idempotent — does only what is missing."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, AskUserQuestion
 argument-hint: "[project-path]"
 ---
@@ -23,7 +23,9 @@ Thin entry point. Onboarding is optional, idempotent, and never a gate.
 2. Invoke the `drupal-ai-contrib:contribution-setup` skill via the Skill tool, passing
    the resolved path.
 3. Present the skill's result: the detected workflow and issue system, environment
-   status, the resolved gate set, AI-skill status, and the environment-match result.
+   status, the resolved gate set, AI-skill status, the `drupalorg` CLI status, the
+   contribution-credentials (SSH-key) status, and the environment-match result. If the
+   SSH key is missing, name registering it as the contributor's first next step.
 
 ## Notes
 

--- a/drupal-ai-contrib/skills/contribution-issue/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contribution-issue
 description: "Works the Drupal issue lifecycle — reviews prior work on an issue first, then creates / comments on / claims it, and checks out the issue fork + branch with three-way fork handling. Use when the user runs /drupal-ai-contrib:issue or asks to find, create, claim, or check out a Drupal issue or issue fork. Wraps drupalorg-cli."
-version: 0.1.0
+version: 0.1.1
 model: sonnet
 user-invocable: false
 ---
@@ -36,7 +36,13 @@ handle dual-mode per the issue-lifecycle dev-guide.
 
 ### 3. Act — create, comment, or claim
 
-- **Create** an issue — a clear summary, steps to reproduce, the proposed resolution.
+- **Create** an issue — `drupalorg-cli` has **no** `issue:create` command. A *new*
+  issue is filed through the **web UI**: the project's Drupal.org issue queue, or its
+  GitLab issues page if the project has migrated. Draft the issue *for* the
+  contributor — title, summary, steps to reproduce, proposed resolution, the component,
+  and the affected version — then guide them to file it in the web UI and resume with
+  the new issue ID. Cite `drupal/contributing-with-ai/issue-creation`. Do not attempt a
+  CLI creation command.
 - **Comment** on an issue — shape: thank → what works → feedback → next step.
 - **Claim** an issue — set the appropriate status; then proceed to fork checkout (§4).
 
@@ -56,12 +62,25 @@ the most recent development branch (`main` for core; per-project for contrib).
 
 ### 5. Wrap drupalorg-cli — safely
 
-All issue/fork operations wrap `mglaman/drupalorg-cli`. Use **fixed, validated
-subcommands**. Before passing any identifier to the CLI, validate it against an
-explicit pattern — issue IDs must match `^[0-9]+$`, project machine-names must match
-`^[a-z][a-z0-9_]*$` — and **reject anything that does not match** rather than shelling
-out with it. Never interpolate unsanitized input into a shell command. drupal.org /
-GitLab credentials are the contributor's own — never store or transmit them.
+Issue/fork operations wrap `mglaman/drupalorg-cli`. The executable on `PATH` is
+**`drupalorg`** (not `drupalorg-cli` — that is only the package name); detect it with
+`command -v drupalorg`. See `${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md`
+for what the tool is, how to install it, authentication, and what it can and cannot do.
+Confirm exact subcommand names with `drupalorg list` — names can drift between
+releases; do not assume them.
+
+**Pushing needs credentials.** Reviewing and reading an issue work over public APIs,
+but creating the issue-fork branch and `git push`ing it need an **SSH key registered
+on the contributor's drupal.org account** (issue-fork remotes are SSH URLs). If a push
+is rejected, that missing/unregistered key is the first thing to check — surface it and
+point at `setup` §5 and the reference's Authentication section; never fabricate fork or
+push state.
+
+Use **fixed subcommands** — never build a subcommand name from user input. Before
+passing any identifier, validate it: issue IDs must match `^[0-9]+$`, project
+machine-names must match `^[a-z][a-z0-9_]*$` — and **reject anything that does not
+match** rather than shelling out with it. Never interpolate unsanitized input into a
+shell command. Credentials are the contributor's own — never store or transmit them.
 
 ### 6. Report
 
@@ -88,7 +107,9 @@ state and what was done. Point the contributor at the development phase, then `v
 
 | Situation | Handling |
 |-----------|----------|
-| Issue ID is non-numeric / malformed | Reject before calling `drupalorg-cli`; ask for a valid ID. |
-| `drupalorg-cli` not installed | Report how to install `mglaman/drupalorg-cli`; do not fabricate fork state. |
+| Issue ID is non-numeric / malformed | Reject before calling `drupalorg`; ask for a valid ID. |
+| `drupalorg` not installed | Surface the install steps from `references/drupalorg-cli.md`; do not fabricate fork state. |
+| User asks to "create an issue" | There is no `issue:create` — draft the issue and guide the contributor to file it in the web UI (Drupal.org queue or GitLab); resume with the new issue ID. |
+| `git push` to the issue fork is rejected | The drupal.org SSH key is likely missing or unregistered — point at `setup` §5 and `references/drupalorg-cli.md` §Authentication; do not fabricate push state. |
 | Project uses GitLab, not the classic queue | Use the `state::*` scoped-label taxonomy per the issue-lifecycle dev-guide. |
 | Prior work fully resolves the issue | Surface it — the contribution may be unnecessary; let the contributor decide. |

--- a/drupal-ai-contrib/skills/contribution-setup/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contribution-setup
-description: "Stands up and environment-matches a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config (new-module scaffold or existing-module discovery), and the Drupal AI skills. Use when the user runs /drupal-ai-contrib:setup or asks to set up a Drupal contribution environment. Idempotent and detect-driven — does only what is missing; never a gate, never a prerequisite."
-version: 0.1.0
+description: "Stands up and environment-matches a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config (new-module scaffold or existing-module discovery), the Drupal AI skills, the drupalorg CLI, and a contribution-credentials (SSH-key) check. Use when the user runs /drupal-ai-contrib:setup or asks to set up a Drupal contribution environment. Idempotent and detect-driven — does only what is missing; never a gate, never a prerequisite."
+version: 0.1.1
 model: sonnet
 user-invocable: false
 ---
@@ -63,23 +63,60 @@ Generate, version-resolved per the target core, from the scaffolding dev-guide:
 - `drupal/core-dev` (+ `drupal/coder`, `phpstan/phpstan`, `mglaman/phpstan-drupal`) in
   `require-dev`, constrained to the target major
 
-### 4. Ensure the Drupal AI skills
+### 4. Ensure the toolchain
 
-Ensure `ai_best_practices` and `ai_skills` are installed via `drupal_devkit` (the
-cross-harness skill installer). If `drupal_devkit` is absent, report how to obtain it;
-do not block.
+**Drupal AI skills** — ensure `ai_best_practices` and `ai_skills` are installed via
+`drupal_devkit` (the cross-harness skill installer). If `drupal_devkit` is absent,
+report how to obtain it; do not block.
 
-### 5. Environment-match
+**The issue / MR CLI** — the `issue`, `submit`, and `pipeline` skills wrap
+`mglaman/drupalorg-cli`. Detect it with `command -v drupalorg` (the executable is
+`drupalorg`, not `drupalorg-cli`). If it is missing, surface the install instructions
+from `${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md` —
+that reference covers what the tool is, the recommended PHAR install, the deprecated
+Composer path, and the subcommand set. Offer to install it; do not block if the
+contributor declines (`issue`/`submit` re-surface the same instructions).
+
+### 5. Check contribution credentials — and guide, do not assume
+
+The contribution arc needs the contributor's **drupal.org credentials** for its write
+operations. Surface this now — do not let it surface mid-`issue` as a failed `git
+push`. The plugin and the CLI **cannot** set credentials up; this is the contributor's
+own account action. Guide them through it.
+
+- **Read operations** (`drupalorg issue:show`, `mr:list`, `project:issues`) hit public
+  APIs — no credentials needed. An empty `project:issues` result can itself be an
+  auth/config gap rather than "no issues" — note that when reporting.
+- **Write / push operations** — `git push` to an issue fork, and the `/do:` issue-bot
+  commands — need an **SSH key registered on the contributor's drupal.org account**,
+  because issue-fork git remotes use SSH URLs (`git@git.drupal.org:…`).
+
+Detect, then guide:
+
+```bash
+ssh -T git@git.drupal.org      # a working key greets the contributor by username
+```
+
+If it does not authenticate, tell the contributor plainly: this is a ~2-minute action —
+register an SSH key at *drupal.org → My account → SSH keys* (add the public key, e.g.
+`~/.ssh/id_ed25519.pub`). It is the prerequisite for `git push` to issue forks; without
+it, `issue` can still review and read, but cannot push a branch. Never block setup on
+it — report it as the next thing to do. See
+`${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md` §Authentication.
+
+### 6. Environment-match
 
 Install the **CI-target core version** + `drupal/core-dev` so `phpunit` / `phpstan`
 resolve to the same releases CI uses (the local DDEV default usually will not match).
 This is the mechanism that makes `verify`'s gates trustworthy — see `contribution-verify`.
 
-### 6. Report
+### 7. Report
 
-Summarize: workflow, issue system, environment status, the resolved gate set, AI-skill
+Summarize, and for each item state ready vs. needs-action so the contributor knows
+their exact next step: workflow, issue system, environment status, the resolved gate
+set, AI-skill status, the issue/MR CLI (`drupalorg`) status, the **credentials/SSH-key**
 status, the environment-match result. Point the contributor at `issue` (or, if work is
-underway, `verify`).
+underway, `verify`) — and if the SSH key is missing, name *that* as the first step.
 
 ## Writes — explicit confirmation only
 
@@ -115,6 +152,8 @@ environment is a no-op that simply reports state.
 | Situation | Handling |
 |-----------|----------|
 | `drupal_devkit` not installed | Report how to obtain it; do not block setup. |
+| `drupalorg` not on `PATH` | Surface `references/drupalorg-cli.md` (PHAR install); offer to install; do not block. If installed via Composer global, the bin dir may just be off `PATH` — see the reference's Install note. |
+| No SSH key registered on the drupal.org account | Guide the contributor to add one (*drupal.org → My account → SSH keys*); report it as the next step. Read/review still works; `git push` to issue forks does not. Never block. |
 | Workflow cannot be inferred | Ask the contributor — never assume core vs. contrib. |
 | `.gitlab-ci.yml` exists but uses a non-`gitlab_templates` setup | Record what is there; `verify` mirrors the discovered jobs as-is. |
 | Contributor declines a scaffold write | Skip that file; report which gates remain unconfigured. |

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: contribution-submit
 description: "Creates or updates a Drupal merge request and generates the AI-disclosure comment at the policy threshold. Use when the user runs /drupal-ai-contrib:submit or asks to submit, open, or update a Drupal merge request or patch. Wraps drupalorg-cli; surfaces status and RTBC guidance."
-version: 0.1.0
+version: 0.1.1
 model: sonnet
 user-invocable: false
 ---
@@ -59,13 +59,22 @@ Fetch the **current** policy state via the `drupal-ai-contrib:ai-policy-checker`
 Attribute AI involvement in commit messages per the commit-messages dev-guide. Keep the
 contributor as the responsible author — "the AI wrote it" is never a defense.
 
-### 4. Create or update the MR — via drupalorg-cli
+### 4. Create or update the MR
 
-Wrap `mglaman/drupalorg-cli` with **fixed, validated subcommands**. Before any
-shell-out, validate identifiers against an explicit pattern — issue IDs `^[0-9]+$`,
-project machine-names `^[a-z][a-z0-9_]*$` — and reject non-matching values; never
-interpolate unsanitized input. Credentials are the contributor's own — never stored or
-transmitted.
+The contribution tool is `mglaman/drupalorg-cli`; the executable on `PATH` is
+**`drupalorg`** (detect with `command -v drupalorg`). See
+`${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md` for what
+it is, how to install it, and the subcommand set.
+
+On GitLab there is **no MR-create subcommand** — a merge request is created by
+**pushing the issue-fork branch** (`issue:branch` / `issue:checkout` set up the fork +
+branch; develop, commit, `git push`, and GitLab opens the MR). Use `drupalorg mr:list`
+and `mr:status` to confirm and report the MR. Do not invent an `mr:create` subcommand.
+
+Wrap the CLI with **fixed, validated subcommands**. Before any shell-out, validate
+identifiers against an explicit pattern — issue IDs `^[0-9]+$`, project machine-names
+`^[a-z][a-z0-9_]*$` — and reject non-matching values; never interpolate unsanitized
+input. Credentials are the contributor's own — never stored or transmitted.
 
 The MR description states: what the change does, the issue it resolves, the AI
 disclosure (§2), and how it was verified (cite the captured `verify` artifacts).
@@ -111,6 +120,7 @@ submission, including copyright and licensing.
 | Situation | Handling |
 |-----------|----------|
 | `verify` / `review` not run | Surface it; report, do not refuse — the contributor decides. |
-| `drupalorg-cli` not installed | Report how to install it; do not fabricate an MR URL. |
+| `drupalorg` not installed | Surface the install steps from `references/drupalorg-cli.md`; do not fabricate an MR URL. |
+| `git push` rejected — no MR opens | The drupal.org SSH key is likely missing/unregistered — point at `setup` §5 and `references/drupalorg-cli.md` §Authentication. No push, no MR. |
 | Disclosure threshold ambiguous | Fetch the live policy via `drupal-ai-contrib:ai-policy-checker`; when still unclear, disclose. |
 | Project uses GitLab `state::*` labels | Set the GitLab scoped label, not a classic-queue status. |

--- a/drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md
+++ b/drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drupal-ai-contrib
 description: "Routes Drupal contribution work to the right contribution-quality stage and supplies the contribution knowledge layer. Use when user says 'contribute to Drupal', 'Drupal contribution', 'submit a Drupal patch', 'Drupal merge request', 'fix a Drupal core issue', 'contribute a module', 'AI-assisted Drupal contribution', or works a drupal.org / GitLab Drupal issue. Use PROACTIVELY whenever AI-assisted code is headed for a Drupal contribution — drupalci and maintainer review are unforgiving."
-version: 0.1.0
+version: 0.1.1
 model: sonnet
 user-invocable: false
 ---
@@ -88,7 +88,7 @@ use this plugin's commands alongside it.
 | Phase lifecycle + phase gates | `drupal-dev-framework` |
 | Philosophy / standards review (SOLID, DRY) | `code-quality-tools` |
 | Paper-testing before submission | `code-paper-test` |
-| Issue / MR / pipeline CLI | `drupalorg-cli` (wrapped by `issue` / `submit` / `pipeline`) |
+| Issue / MR / pipeline CLI | `mglaman/drupalorg-cli` — executable `drupalorg`, wrapped by `issue` / `submit` / `pipeline`; see `references/drupalorg-cli.md` |
 | Drupal AI skill install | `drupal_devkit` |
 
 ## Examples
@@ -120,3 +120,4 @@ use this plugin's commands alongside it.
 ## References
 
 - `references/dev-guides-index.md` — contribution stage → dev-guide slugs to load
+- `references/drupalorg-cli.md` — the `drupalorg` CLI: what it is, install, subcommands

--- a/drupal-ai-contrib/skills/drupal-ai-contrib/references/drupalorg-cli.md
+++ b/drupal-ai-contrib/skills/drupal-ai-contrib/references/drupalorg-cli.md
@@ -1,0 +1,109 @@
+# drupalorg-cli — the issue / MR / pipeline CLI
+
+The `issue`, `submit`, and `pipeline` skills wrap this tool. This reference is the
+single source of truth for what it is, how to install it, how authentication works,
+and what it can and cannot do. Skills point here instead of repeating these details.
+
+## What it is
+
+`mglaman/drupalorg-cli` is a command-line tool that talks to Drupal.org and GitLab
+(`git.drupalcode.org`) through their REST APIs — it manages issues, issue forks,
+branches, and merge requests from the terminal. It auto-detects whether a project's
+issues live in the classic Drupal.org queue or have migrated to GitLab work items, and
+accepts work-item references and merge-request URLs directly.
+
+## The executable is `drupalorg` — not `drupalorg-cli`
+
+`drupalorg-cli` is the **package / repository name**. The **command on `PATH` is
+`drupalorg`**. Always shell out `drupalorg <subcommand>`, never `drupalorg-cli …`.
+
+Detect whether it is installed:
+
+```bash
+command -v drupalorg
+```
+
+## Install
+
+**Requirements:** PHP 8.1+ with cURL, and Git.
+
+**Recommended — PHAR download** (the project's preferred method):
+
+```bash
+curl -OL https://github.com/mglaman/drupalorg-cli/releases/latest/download/drupalorg.phar
+chmod +x drupalorg.phar
+mv drupalorg.phar /usr/local/bin/drupalorg
+```
+
+**Composer global install — deprecated** (the project marks this path deprecated; use
+the PHAR unless a contributor specifically needs the Composer install):
+
+```bash
+composer global require mglaman/drupalorg-cli
+```
+
+The Composer install puts the binary in Composer's **global bin directory**, which is
+often *not* on `PATH` by default. Find it with `composer global config bin-dir
+--absolute` (commonly `~/.config/composer/vendor/bin`) and add that directory to
+`PATH`, or `command -v drupalorg` will fail even though the tool is installed.
+
+Confirm the install either way: `drupalorg --version`.
+
+## Authentication — read vs. write
+
+The tool's auth requirement depends on the operation. `setup` checks this; `issue`'s
+fork/push step depends on it.
+
+- **Read operations** (`issue:show`, `mr:list`, `project:issues`, `issue:search`, …)
+  hit **public** Drupal.org / GitLab APIs — no credentials needed for public projects.
+- **Write / push operations** — `git push` to an issue fork, and the `/do:` issue-bot
+  commands — need the contributor's own **drupal.org credentials**. Specifically: an
+  **SSH key registered on the contributor's drupal.org account**, because issue-fork
+  git remotes use SSH URLs (`git@git.drupal.org:…`).
+
+**The plugin and the CLI cannot set this up — it is the contributor's account action.**
+Register a key at *drupal.org → My account → SSH keys*. Verify it works:
+
+```bash
+ssh -T git@git.drupal.org
+```
+
+A working key greets the contributor by drupal.org username. If push fails with a
+permission error, the missing/unregistered SSH key is the first thing to check.
+Credentials are the contributor's own — never store or transmit them.
+
+## What the CLI can and cannot do
+
+Run `drupalorg list` for the authoritative command set on the installed version, and
+`drupalorg <command> --help` for a command's exact name and arguments — names can drift
+between releases, so confirm against the install rather than assuming.
+
+**Command groups** (current as of v0.10.x):
+
+| Group | Operates on |
+|-------|-------------|
+| `issue:*` | An **existing** issue / issue fork — fork, branch, checkout, assign, label, apply, patch, interdiff, link, search, show, set up the remote |
+| `mr:*` | An **existing** merge request — list, status, diff, files, logs |
+| `project:*` | A project — issues, kanban, releases, release notes |
+| `maintainer:*` | Maintainer views — issues, release notes |
+| `skill:*` / `mcp:*` | Drupal AI skill install; MCP server mode |
+
+**Two things the CLI does NOT do — do not invent a subcommand for either:**
+
+1. **No `issue:create`.** Every `issue:*` command operates on an issue that already
+   exists. A *new* issue is filed through the **web UI** — the project's Drupal.org
+   issue queue, or its GitLab issues page if it has migrated. `contribution-issue`
+   drafts the issue (title, summary, steps, component, version) and guides the
+   contributor to file it, then resumes with the new issue ID.
+2. **No `mr:create`.** On GitLab a merge request is created by **pushing the
+   issue-fork branch** — `issue:branch` / `issue:checkout` set up the fork + branch;
+   the contributor develops, commits, and `git push`es, and GitLab opens the MR (the
+   push output includes a create-MR URL). `submit` then uses `mr:list` / `mr:status`
+   to confirm and report it.
+
+## Safe invocation
+
+Invoke only **fixed subcommands** — never build a subcommand name from user input.
+Before passing any identifier, validate it: issue IDs must match `^[0-9]+$`, project
+machine-names `^[a-z][a-z0-9_]*$`. Reject anything that does not match rather than
+shelling out with it. Never interpolate unsanitized input into a shell command.


### PR DESCRIPTION
## Summary

First post-release bug-fix patch for the **drupal-ai-contrib** plugin (`v0.1.0` → `v0.1.1`). Five gaps surfaced by the first live `/setup → /issue` flow, all about how the plugin explained the `mglaman/drupalorg-cli` toolchain and its prerequisites. Bundled into one patch because they share the same files.

## Bugs fixed

| # | Bug | Fix |
|---|-----|-----|
| **B1** | `drupalorg-cli` was unexplained — three skills wrapped it, plugin never said what it is or how to install it | New reference `skills/drupal-ai-contrib/references/drupalorg-cli.md` (what it is, PHAR install, Composer-global `PATH` note, authentication, what the CLI can and cannot do); `setup`/`issue`/`submit` cite it |
| **B2** | Executable named wrong — skills said *"wrap `drupalorg-cli`"* but the binary on `PATH` is `drupalorg` (`drupalorg-cli` is only the package name) | All wrap sites, troubleshooting rows, README, CONVENTIONS now name `drupalorg` as the executable |
| **B3** | `submit` §4 overstated CLI capability — there is **no `mr:create`**; on GitLab, MRs are created by pushing the issue-fork branch | §4 rewritten to state the real flow; `submit` uses `mr:list` / `mr:status` to confirm + report |
| **B4** | `setup` never guided on auth — `git push` to issue forks needs an SSH key registered on the contributor's drupal.org account | New `contribution-setup` §5 *"Check contribution credentials"* detects (`ssh -T git@git.drupal.org`), guides registration at *drupal.org → My account → SSH keys*, distinguishes read/write ops, never blocks; matching push-rejected troubleshooting rows in `issue` + `submit` |
| **B5** | `issue` claimed it could create issues — `drupalorg-cli` has **no `issue:create`**; all 19 `Issue/*` command classes operate on existing issues | `issue` §3 now drafts the issue (title/summary/steps/component/version) and guides the contributor to file it in the web UI, then resumes with the new ID |

**Reference subcommand list de-brittled.** Initial hand-enumerated table had already missed `issue:fork`. Replaced with command-*groups* + verified negatives + a `drupalorg list` pointer — evidence over assertion.

## Verification

`drupalorg-cli` command set verified against live repo source (`gh api repos/mglaman/drupalorg-cli/contents/src/Cli/Command/*`): 19 `Issue/*` classes, all on existing issues — **no `Create`**; 5 `MergeRequest/*` classes — **no `Create`**. Confirms B3 + B5.

`/plugin-creation-tools:validate` — **PASS, zero findings** (8 skills, 6 commands, 3 agents, 2 hooks, marketplace sync, frontmatter, references all clean).

## Bumped

- `drupal-ai-contrib/.claude-plugin/plugin.json`: `0.1.0` → `0.1.1`
- Skill `version:` for the four edited skills: `0.1.0` → `0.1.1` (`contribution-setup`, `contribution-issue`, `contribution-submit`, umbrella `drupal-ai-contrib`)
- Root `marketplace.json`: plugin entry `0.1.0` → `0.1.1`; `metadata.version` `1.15.2` → `1.15.3`
- `CHANGELOG.md` entry added

## Files touched

- `drupal-ai-contrib/skills/drupal-ai-contrib/references/drupalorg-cli.md` (new — 96 lines)
- `drupal-ai-contrib/skills/contribution-setup/SKILL.md` (new §5 credentials step)
- `drupal-ai-contrib/skills/contribution-issue/SKILL.md` (§3 web-UI routing, §5 auth note)
- `drupal-ai-contrib/skills/contribution-submit/SKILL.md` (§4 push-creates-MR, troubleshooting)
- `drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md` (toolchain table, references list)
- `drupal-ai-contrib/commands/setup.md` (description, report bullets)
- `drupal-ai-contrib/README.md` + `CONVENTIONS.md` (interop wording)
- `drupal-ai-contrib/CHANGELOG.md` (0.1.1 entry)
- Plugin + marketplace metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)