### PR TITLE
drupal-dev-framework v4.16.0: Model-pin footgun — readers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.6"
+    "version": "1.15.7"
   },
   "plugins": [
     {
@@ -56,8 +56,8 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "Systematic 3-phase Drupal development workflow (Research \u2192 Architecture \u2192 Implementation) with enforced SOLID, TDD, DRY, and security gates. Covers epic/sub-task hierarchy, scope contracts, a Phase 4 /review gate with a change-impact dispatcher, two-stage dev-guides detection, the Playbook System, git-worktree parallel-task awareness, agent-team validation, per-project session-remembrance hooks, the ATK E2E behavioral gate (/setup-atk + /validate:e2e), the committed-Playwright visual-regression gate (/setup-visual-regression + /validate:visual-regression), and the committed-Playwright visual-parity gate with a structured CSS-actionable diff (/setup-visual-parity + /validate:visual-parity).",
-      "version": "4.15.0",
+      "description": "Systematic 3-phase Drupal development workflow (Research \u2192 Architecture \u2192 Implementation) with enforced SOLID, TDD, DRY, and security gates. Covers epic/sub-task hierarchy, scope contracts, a Phase 4 /review gate with change-impact dispatch, two-stage dev-guides detection, the Playbook System, git-worktree parallel-task awareness, agent-team validation, per-project session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (/setup-atk, /setup-visual-regression, /setup-visual-parity).",
+      "version": "4.16.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/.claude/rules/command-conventions.md
+++ b/drupal-dev-framework/.claude/rules/command-conventions.md
@@ -19,10 +19,11 @@ paths:
 
 ## Session Context Tracking
 
-When a command resolves which project and/or task the user is working on, **invoke the `session-context-writer` skill** so compaction hooks can guide Claude to restore context from live project state files.
+When a command resolves which project and/or task the user is working on, **run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task|null>" "<task_path|null>" ["<currentEpic>"]`** (Bash) so compaction hooks can guide Claude to restore context from live project state files. (v4.16.0: a Bash call carries no model context, so the write never overflows a large session — the former `session-context-writer` skill remains as the documented contract.)
 
-- Invoke after the user selects/confirms a project and task (not before)
+- Run after the user selects/confirms a project and task (not before)
 - Pass `null` for task/taskPath if only the project is known
-- On `/complete`, invoke with task set to `null` since the task moved to completed
+- On `/complete`, run with task set to `null` since the task moved to completed
+- Omit the 5th arg (epic) to preserve the existing `currentEpic` (preserve-sentinel)
 - Session context is per-workspace (keyed by `$PWD` hash) — multiple Claude windows don't conflict
 - The pre/post-compact hooks read the workspace-specific session file to point Claude at the right `project_state.md`

--- a/drupal-dev-framework/.claude/rules/skill-conventions.md
+++ b/drupal-dev-framework/.claude/rules/skill-conventions.md
@@ -11,9 +11,10 @@ paths:
 - `version` — semantic version
 
 ## Optional Frontmatter
-- `model` — haiku (lookup/loading), sonnet (balanced), opus (complex design)
+- `model` — **`inherit` or `opus` only** (both 1M). A skill's `model:` is an inline current-turn override with no context isolation, so a sub-1M pin (`haiku`/`sonnet`) overflows when the skill activates from a large session (BUG-1; validator rule **S14**). For cheap deterministic work, delegate to a `scripts/*.sh` or a Task-dispatched `agents/*.md` instead — never pin `haiku`/`sonnet` on a skill.
 - `user-invocable: false` — for internal skills only called by other skills/agents
 - `allowed-tools` — restrict tool access when active
+- `disallowed-tools` — kebab-case on skills (the agent form is camelCase `disallowedTools`; not interchangeable — validator rules **S15**/**A04**). Use on read-only readers, e.g. `disallowed-tools: Write, Edit`.
 
 ## Body Rules
 - Imperative voice — instructions for Claude, not documentation

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.16.0] - 2026-06-03
+
+### Fixed — Model-pin footgun: readers (BUG-1, tier 1)
+
+A skill's `model:` is an **inline current-turn override with no context isolation** (Skills guide: *"the override applies for the rest of the current turn"*). DDF pinned a sub-1M model (`haiku`/`sonnet`) on 15 inline skills, so each **overflowed when invoked from a session larger than ~200k tokens** — worst case `project-state-reader` (haiku), invoked inline by ~18 lifecycle commands that run late in long sessions. This release eliminates that footgun on the six Tier-1 reader/writer skills and fixes the institutional guidance that caused it.
+
+- **Call sites rewired to deterministic scripts (Bash, zero model context).** Every inline `invoke <skill>` for the six Tier-1 skills now runs the existing `scripts/*.sh` directly and parses its output — the output contract is unchanged (the scripts were already the source of truth the skills wrapped):
+  - `project-state-reader` → `scripts/project-state-read.sh` (18 commands + `analysis-agent` + `guide-integrator`)
+  - `session-context-writer` → **new** `scripts/session-context-write.sh` (17 commands + `epic-migrator` + `guide-integrator`)
+  - `task-frontmatter-reader` → `scripts/fm-read.sh` (`next`, `complete`, `propose-epics`, `scope`, `status`, `analysis-agent`)
+  - `alignment-reader` → `scripts/alignment-read.sh` (`research`, `design`, `implement`, `scope`, `validate:team`)
+  - `screenshot-store-reader` → `scripts/screenshot-store-read.sh` (`validate:visual-regression`, `validate:team`)
+  - `epic-migrator` → `scripts/migrate-to-epic.sh` (`migrate-to-epic`, parsing the `KEY=VALUE` stderr handoff directly)
+- **New `scripts/session-context-write.sh`** — verbatim lift of the `jq` merge block that lived in the `session-context-writer` SKILL body (sources `session-paths.sh`; positional args mirror the former placeholders 1:1; preserves `loadedGuides`/`lastPhase`/`currentEpic`).
+- **Tier-1 skill frontmatter → `model: inherit`** (was `haiku`/`sonnet`) on all six (`project-state-reader`, `task-frontmatter-reader`, `alignment-reader`, `screenshot-store-reader`, `session-context-writer`, `epic-migrator`) so the validator's **S14** rule clears on them and the skills no longer overflow if invoked directly. `epic-migrator` also drops the now-unused `Skill` tool.
+- **CC-1 — `disallowed-tools: Write, Edit`** (kebab-case) added to the four read-only readers (`project-state-reader`, `task-frontmatter-reader`, `alignment-reader`, `screenshot-store-reader`); they keep `allowed-tools: Bash`.
+- **Root-cause guidance corrected** in `CONVENTIONS.md` **and** `.claude/rules/skill-conventions.md` (a second instance of the same bad advice the roadmap had not flagged) **and** `.claude/rules/command-conventions.md` (the Session Context Tracking section): a skill's `model:` must be `opus`/`inherit` (1M) or delegate to a `scripts/*.sh` / Task-dispatched agent; reserve `haiku`/`sonnet` for `agents/*.md` only.
+
+**Validation.** `/plugin-creation-tools:validate --strict` (installed validator v3.9.0): S14 cleared on all six Tier-1 skills; the nine Tier-3 synthesizer skills still pin sub-1M and are addressed in v4.17.0 (`model: inherit`). The pre-existing X02 (marketplace entry > 600 chars) is cleared by trimming the entry to 529 chars. FM01/FM02/S15/A04 clean. Scripts smoke-tested against a live project.
+
+**Surfaced (not silently changed):** `review.md` step 13 instructed `session-context-writer` "with `lastPhase: "review"`", but the writer (old inline `jq` and the lifted script alike) only *preserves* `lastPhase` — it never set it from input, so that instruction was an effective no-op since written. Preserved that behavior per the verbatim-lift mandate; the call site now states `lastPhase` is preserved, not set.
+
 ## [4.15.0] - 2026-05-21
 
 ### Added

--- a/drupal-dev-framework/CONVENTIONS.md
+++ b/drupal-dev-framework/CONVENTIONS.md
@@ -279,7 +279,7 @@ Optional scope contract authored before Phase 1 via `/scope <task>`. Produces `a
 
 ## Skills
 - Frontmatter must include: name, description, version
-- Add `model:` matched to complexity (haiku for lookup, sonnet for balanced, opus for complex)
+- **`model:` on a skill is an inline current-turn override with no context isolation** — it reinterprets the *live conversation* on the pinned model (Skills guide: *"the override applies for the rest of the current turn"*). A sub-1M pin (`haiku`/`sonnet` ≈ 200k) therefore **overflows whenever the skill activates from a session larger than that window** (BUG-1; validator rule **S14**). So: pin **`opus`** or **`inherit`** (1M), or — for cheap deterministic work — **delegate to a `scripts/*.sh` (Bash, zero model context) or a Task-dispatched `agents/*.md`**. Reserve `haiku`/`sonnet` **only** for `agents/*.md`, which run in a fresh isolated subagent window.
 - Internal-only skills must have `user-invocable: false`
 - Body uses imperative voice — instructions for Claude, not documentation
 - Under 500 lines per SKILL.md

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -322,7 +322,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.15.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.16.0**.
 
 ## License
 

--- a/drupal-dev-framework/agents/analysis-agent.md
+++ b/drupal-dev-framework/agents/analysis-agent.md
@@ -61,7 +61,7 @@ Otherwise: **folder mode**. Proceed with steps 1-2.
 
 ### 1. Read the task (folder mode only)
 
-Invoke `task-frontmatter-reader` skill on `task_folder`. Capture `kind`, `status`, `task_id`.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "$task_folder"` (Bash) and parse `.kind`, `.status`, and `.id` (`task_id`).
 
 Compute two gates (v3.12.3+):
 

--- a/drupal-dev-framework/commands/complete.md
+++ b/drupal-dev-framework/commands/complete.md
@@ -16,7 +16,7 @@ Mark a task complete and move to `completed/`. Behavior current as of v4.1.0; fu
 
 ## Runtime Steps
 
-1. **Read task hierarchy.** Invoke `task-frontmatter-reader` (v1.0.0+) to learn `kind` and `parent`. Hierarchy-aware completion rules per kind:
+1. **Read task hierarchy.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>"` (Bash) and parse `.kind` and `.parent`. Hierarchy-aware completion rules per kind:
    - `flat` → moves to project-level `completed/<name>/`.
    - `subtask` → moves from `<epic>/in_progress/<subtask>/` to `<epic>/completed/<subtask>/` (stays in epic; preserves spatial association).
    - `epic` / `sub_epic` → enforce `<epic>/in_progress/` is empty (all children done) before allowing the epic to complete; whole folder moves to project-level `completed/<epic>/`.
@@ -44,7 +44,7 @@ Mark a task complete and move to `completed/`. Behavior current as of v4.1.0; fu
 
 8. **Suggest next task.** Surface `/next` recommendation. If all tasks done: print summary + offer to mark project done.
 
-9. **Invoke `session-context-writer`** with project resolved and task set to `null`.
+9. **Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" null null`** (Bash) — project resolved, task set to `null` (the task moved to completed).
 
 ## Pointers
 

--- a/drupal-dev-framework/commands/design.md
+++ b/drupal-dev-framework/commands/design.md
@@ -27,7 +27,7 @@ Phase 2 of a task. Behavior current as of v4.0.2; full prose / examples / versio
 
 3. **Playbook load.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh <project_folder>`. Surface conflicts once-per-session per topic. Write `_playbook-load.json` audit.
 
-4. **Alignment retrofit + phase-level offer.** Invoke `alignment-reader`. If `task_level.present: false`: offer task-level retrofit (4 questions, default `[n]`). On `[y]` execute task-level scope flow inline. Then offer phase-2 scope (default `[n]`); on `[y]` execute `--phase 2` inline. Never block.
+4. **Alignment retrofit + phase-level offer.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` (Bash) and parse its JSON. If `.sections.task_level.present == false`: offer task-level retrofit (4 questions, default `[n]`). On `[y]` execute task-level scope flow inline. Then offer phase-2 scope (default `[n]`); on `[y]` execute `--phase 2` inline. Never block.
 
 5. **Author architecture.md.** Invoke `architecture-drafter` agent + `guide-integrator` for methodology refs. Write standard sections: Approach, Components, Dependencies, Pattern Reference, Interface, Data Flow, SOLID Principles Applied, Security Considerations, Acceptance Criteria. For complex tasks, optionally write `architecture/<component>.md` per component. Update `task.md` Phase 2 in-progress. **Mid-phase guide checks apply:** before designing against a Drupal API, contrib module, or pattern not already in `loadedGuides[]`, do a `dev-guides-navigator` catalog lookup (see `guide-integrator` SKILL.md §"Mid-phase guide checks").
 
@@ -39,7 +39,7 @@ Phase 2 of a task. Behavior current as of v4.0.2; full prose / examples / versio
 
 8. **Mark Phase 2 `[x]`** in `task.md`.
 
-9. **Invoke `session-context-writer`** with resolved project + task.
+9. **Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"`** (Bash) with resolved project + task.
 
 ## Pointers
 

--- a/drupal-dev-framework/commands/implement.md
+++ b/drupal-dev-framework/commands/implement.md
@@ -37,7 +37,7 @@ Phase 3 of a task. Behavior current as of v4.0.2; full prose / examples / versio
 
 4. **Playbook load.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh <project_folder>`. Surface conflicts once-per-session per topic. Write `_playbook-load.json` audit.
 
-5. **Alignment retrofit + phase-level offer.** Invoke `alignment-reader`. If `task_level.present: false`: offer task-level retrofit (4 questions, default `[n]`). On `[y]` execute task-level scope flow inline. Then offer phase-3 scope (default `[n]`); on `[y]` execute `--phase 3` inline. Never block.
+5. **Alignment retrofit + phase-level offer.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` (Bash) and parse its JSON. If `.sections.task_level.present == false`: offer task-level retrofit (4 questions, default `[n]`). On `[y]` execute task-level scope flow inline. Then offer phase-3 scope (default `[n]`); on `[y]` execute `--phase 3` inline. Never block.
 
 6. **Load context.** Read `architecture.md` (required), `research.md` (context), referenced patterns from core/contrib, methodology refs (via `guide-integrator`). Activate `tdd-companion` skill. **Mid-phase guide checks apply:** before writing code that uses a Drupal API, contrib module, or pattern not already in `loadedGuides[]`, do a `dev-guides-navigator` catalog lookup (see `guide-integrator` SKILL.md §"Mid-phase guide checks").
    - **Design-drives-build nudge (v4.14.0+).** If `project_state.md` carries `**Visual Review:** enabled` AND the surface registry holds at least one surface whose `parity_reference.type` is `react-template` or `html-template`, print ONE soft-nudge line: *"A buildable design reference is registered for surface `<id>` — if this task implements that surface, load the reference as a build input, not only a `/validate:visual-parity` check."* Silent when there is no registry, no enabled visual review, or no buildable parity reference. Never blocks — a strong nudge, not enforcement.
@@ -50,7 +50,7 @@ Phase 3 of a task. Behavior current as of v4.0.2; full prose / examples / versio
 
 9. **Traceability walkthrough (opt-in).** One-line `[y]/[n]` (default `[n]`). On `[y]`: pull AC; map each to implementation.md Progress entries OR architecture.md sections OR research.md decisions; status-annotate (`[complete]`, `[in-progress]`, `(planned)`, `— NOT YET ADDRESSED —`); print table; `[c]/[r]/[d]` (default `[c]`). Re-invokable mid-flight.
 
-10. **Invoke `session-context-writer`** with resolved project + task.
+10. **Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"`** (Bash) with resolved project + task.
 
 11. **Hand off to interactive development.** Developer guides each step. Claude proposes (test-first), developer approves, Claude writes test then implementation, developer runs tests (Claude does NOT auto-run unless explicitly asked).
 

--- a/drupal-dev-framework/commands/install-remembrance-hook.md
+++ b/drupal-dev-framework/commands/install-remembrance-hook.md
@@ -46,8 +46,8 @@ Resolve the active project. Read the per-workspace session file
 if no project is active, tell the user to run `/drupal-dev-framework:next`
 first and stop.
 
-Run the `project-state-reader` skill (or `scripts/project-state-read.sh
-<projectPath>`) to get `project_name`, the project `folder` (the **memory
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<projectPath>"` (Bash)
+and parse its JSON to get `project_name`, the project `folder` (the **memory
 path**), and `codePath`.
 
 Determine the **install directory** — the directory Claude Code is started from

--- a/drupal-dev-framework/commands/migrate-to-epic.md
+++ b/drupal-dev-framework/commands/migrate-to-epic.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when the user wants to convert a flat task into an epic folder with child sub-tasks — manual, one-task-at-a-time, transactional. Runs the 8-step migration via the epic-migrator skill. Flat tasks remain a valid permanent choice; this command is opt-in."
+description: "Use when the user wants to convert a flat task into an epic folder with child sub-tasks — manual, one-task-at-a-time, transactional. Runs the 8-step migration via scripts/migrate-to-epic.sh. Flat tasks remain a valid permanent choice; this command is opt-in."
 allowed-tools: Read, Write, Edit, Bash, Glob, Skill, Task
 argument-hint: <task-name> [--children "name1,name2,..."] [--dry-run]
 ---
@@ -26,21 +26,21 @@ Convert a single flat task into an epic folder containing child sub-tasks. Manua
 1. **Preflight** — validate the task exists, is not completed, and no in-flight migration blocks the attempt. If the task is **already** an epic/sub_epic: with `--children` it enters **expansion mode** (the new children are added to the existing epic; existing children and artifacts are preserved); with no children it is a no-op that prints how to expand.
 2. **Resolve children** — use `--children` if provided; otherwise prompt the user interactively. Classify each child as `move_existing` (there's a peer folder with that name), `already_completed` (a peer folder in `completed/`), or `create_stub` (a new subtask folder will be scaffolded). In expansion mode, every new child name must be genuinely new — collisions with the epic's existing `children[]` or its `in_progress/` / `completed/` folders are rejected at preflight.
 3. **Build in temp** — construct the new epic structure under `.migration-tmp/<task>/`. Never touches the live folder.
-4. **Validate** — run `task-frontmatter-reader` on every generated `task.md` in temp. Abort if any blocking warning surfaces.
+4. **Validate** — the script validates every generated `task.md` in temp via `fm_read` (from `fm-helpers.sh`). Abort if any blocking warning surfaces.
 5. **Atomic swap** — two-step rename (original → `.old-<task>`, then temp → live). Failure-recovers original on error.
 6. **Cleanup scheduling** — `.old-<task>/` persists for 24 hours for manual rollback.
-7. **Session context refresh** — update `session_context.json` to reflect the new epic via `session-context-writer` (sets `currentEpic` when appropriate).
+7. **Session context refresh** — update `session_context.json` to reflect the new epic via `scripts/session-context-write.sh` (sets `currentEpic` when appropriate).
 8. **Report** — print the new structure + rollback instructions + suggested next command.
 
 ## Behavior
 
-This command is a **thin orchestrator**. All file surgery lives in a real bash script (`${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`) invoked via the `epic-migrator` skill. This command is responsible only for:
+This command is a **thin orchestrator**. All file surgery lives in a real bash script (`${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`), invoked directly via Bash (v4.16.0 — was previously routed through the `epic-migrator` skill; a Bash call carries no model context, so it can't overflow a large session). This command is responsible only for:
 
 - Argument parsing and validation
 - User interaction (interactive prompt when `--children` absent)
-- Invoking the script (through the skill) with correctly-classified inputs
+- Invoking the script (Bash, directly) with correctly-classified inputs
 - Surfacing the script's output to the user
-- Invoking `session-context-writer` with the case-analysis result the script emits on stderr
+- Running `scripts/session-context-write.sh` with the case-analysis result the script emits on stderr
 
 ## Invocation steps
 
@@ -58,19 +58,19 @@ Follow these exactly:
    >
    > Leave blank to create an epic shell with no children yet.
 
-3. **Invoke `epic-migrator` skill** (which calls `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`). The script takes positional arguments:
+3. **Run `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh` directly** (Bash). The script takes positional arguments:
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh" "$PROJECT_PATH" "$TASK_NAME" [--dry-run] [<child1> <child2> ...]
    ```
 
    Resolve `$PROJECT_PATH` from session context (`session_context.json` `projectPath`) or from `pwd` if no project is active. The script handles all file surgery; this command does not touch disk directly.
 
-4. **If dry-run**, print the skill's plan output verbatim and stop.
+4. **If dry-run**, print the script's plan output verbatim and stop.
 
 5. **If live run**:
-   - Relay the skill's step-by-step progress to the user
-   - On success, print the summary the skill emits
-   - On failure, print the skill's abort message and stop — the skill has already cleaned up any temp state
+   - Relay the script's step-by-step progress to the user
+   - On success, print the summary the script emits
+   - On failure, print the script's abort message and stop — the script has already cleaned up any temp state
 
 6. **Post-success**, parse the three `KEY=VALUE` lines the script emits on stderr:
    ```
@@ -78,10 +78,10 @@ Follow these exactly:
    EPIC_FOR_CTX=<value>           # literal string "{CURRENT_EPIC_OR_NULL}" for Case A; "null" for Case B; task_name for Case C
    NEW_TASK_PATH=<path or empty>  # non-empty only for Case C
    ```
-   Invoke `session-context-writer` accordingly:
-   - **Case A**: pass `{CURRENT_EPIC_OR_NULL}` literal → preserves existing `currentEpic`
-   - **Case B**: pass `currentEpic=null`; keep `taskPath` unchanged
-   - **Case C**: pass `currentEpic=<task_name>`; also update `taskPath` to `NEW_TASK_PATH`
+   Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>" "<epic_arg>"` (Bash) accordingly — the 5th positional `<epic_arg>` and the 4th `<task_path>` vary by case:
+   - **Case A**: omit the 5th arg (or pass the literal `{CURRENT_EPIC_OR_NULL}`) → preserves existing `currentEpic`; `<task_path>` unchanged
+   - **Case B**: pass `null` as the 5th arg → clears `currentEpic`; `<task_path>` unchanged
+   - **Case C**: pass `$EPIC_FOR_CTX` (= `<task_name>`) as the 5th arg → sets `currentEpic`; set `<task_path>` to `$NEW_TASK_PATH`
 
 7. **Suggest the next command**:
    - If the migrated epic has children: `/drupal-dev-framework:next` to continue with a child

--- a/drupal-dev-framework/commands/new.md
+++ b/drupal-dev-framework/commands/new.md
@@ -28,7 +28,7 @@ Initialize a new development project with complete memory structure.
 5. Registers project in `~/.claude/drupal-dev-framework/active_projects.json` (including the `codePath` field)
 6. Invokes `project-initializer` skill (v1.4.0 accepts a `code_path` arg)
 7. Invokes `requirements-gatherer` skill
-8. **Invokes `session-context-writer` skill with the new project name and path**
+8. **Runs `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" null null`** (Bash) with the new project name and path (no task yet)
 
 ## Code path capture (v3.11.0+)
 

--- a/drupal-dev-framework/commands/next.md
+++ b/drupal-dev-framework/commands/next.md
@@ -19,9 +19,9 @@ Get recommendation for what to do next based on project state.
 
 1. Invokes `project-orchestrator` agent
 2. Analyzes current state (project requirements + active tasks)
-3. **For each in-progress task folder, invoke `task-frontmatter-reader` skill (v1.0.0+) to learn its `kind` and any `parent`/`children` relationships** — so the suggestion below can prefer "continue a subtask in the active epic" over "start an unrelated flat task."
+3. **For each in-progress task folder, run `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>"` (Bash) and parse `.kind` and any `.parent`/`.children` relationships** — so the suggestion below can prefer "continue a subtask in the active epic" over "start an unrelated flat task."
 4. Suggests prioritized next actions using the rules below
-5. **After resolving project and task, invoke `session-context-writer` skill with the resolved values**; pass `currentEpic` = the parent epic's folder name if the chosen task is a subtask, or `null` otherwise.
+5. **After resolving project and task, run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>" "<currentEpic>"` (Bash)** with the resolved values; pass `<currentEpic>` = the parent epic's folder name if the chosen task is a subtask, or `null` otherwise.
 
 ## Hierarchy-aware suggestion rules (added v3.10.0)
 
@@ -188,7 +188,7 @@ Enter a task name (e.g., "settings_form", "user_entity", "admin_dashboard")
 
 ### Playbook-config nudge (v4.2.1+)
 
-After resolving the project (Step 1) but before recommending a task action, invoke `project-state-reader` and inspect the `playbook` block. If `playbook_sets_source: "default"` (Playbook Sets line absent — implicit inheritance from the plugin's `defaults.json`) **OR** `user_playbook_state: "unset"`, print this one-line soft-nudge once per `/next` invocation:
+After resolving the project (Step 1) but before recommending a task action, run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and inspect its JSON. If `.playbookSetsSource == "default"` (Playbook Sets line absent — implicit inheritance from the plugin's `defaults.json`) **OR** `.userPlaybookState == "unset"`, print this one-line soft-nudge once per `/next` invocation:
 
 > 💡 This project has not configured a playbook (`playbook_sets_source: default` and/or `user_playbook_state: unset`). Playbook loads at every phase entry. Consider `/drupal-dev-framework:set-playbook-sets` and `/drupal-dev-framework:set-user-playbook` before your first task. Or run `/drupal-dev-framework:upgrade-project` to retrofit all project-state fields at once. (Optional — never blocks.)
 

--- a/drupal-dev-framework/commands/playbook-active.md
+++ b/drupal-dev-framework/commands/playbook-active.md
@@ -17,7 +17,7 @@ Read-only view of the project's playbook state. Shows subscribed sets, local pla
 
 ### Step 1 — Resolve project state
 
-Invoke `project-state-reader` to get `playbookSets[]`, `playbookSetsSource`, `userPlaybook`, `userPlaybookState`, `playbookResolutions[]`.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON for `playbookSets[]`, `playbookSetsSource`, `userPlaybook`, `userPlaybookState`, `playbookResolutions[]`.
 
 ### Step 2 — Read local playbook (if set)
 

--- a/drupal-dev-framework/commands/playbook-capture.md
+++ b/drupal-dev-framework/commands/playbook-capture.md
@@ -19,7 +19,7 @@ Interactive flow that drafts a new play and appends it to the project's local us
 
 ### Step 1 — Resolve project context + check userPlaybook
 
-Invoke `project-state-reader`. If `userPlaybookState != "set"`:
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON. If `userPlaybookState != "set"`:
 > Refuse with: "No user playbook configured for this project. Run `/drupal-dev-framework:set-user-playbook` first."
 
 If `userPlaybookState == "set"`, continue.

--- a/drupal-dev-framework/commands/playbook-review.md
+++ b/drupal-dev-framework/commands/playbook-review.md
@@ -17,7 +17,7 @@ Walk every play in the project-local user playbook one at a time. Per-play promp
 
 ### Step 1 — Resolve project context + load playbook
 
-Invoke `project-state-reader`. If `userPlaybookState != "set"`:
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON. If `userPlaybookState != "set"`:
 > Refuse with: "No user playbook configured. Run `/drupal-dev-framework:set-user-playbook` first."
 
 Invoke `scripts/playbook-read.sh` against the path. Parse JSON output.

--- a/drupal-dev-framework/commands/propose-epics.md
+++ b/drupal-dev-framework/commands/propose-epics.md
@@ -20,8 +20,8 @@ This is the bulk-review counterpart to the inline pre-analysis hook in `/researc
 ## What this does
 
 1. Resolves the active project from `session_context.json`. If no project active, asks user to run `/drupal-dev-framework:next` first.
-2. **Resolves `codePath`** via `project-state-reader` skill. If unknown, runs the detect+confirm flow (shared with `/set-code-path`) and persists the answer.
-3. **Enumerates candidates** — every subfolder of `<project>/implementation_process/in_progress/` that is `kind: flat` (via `task-frontmatter-reader`). Skips:
+2. **Resolves `codePath`** by running `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parsing `.codePath`. If unknown, runs the detect+confirm flow (shared with `/set-code-path`) and persists the answer.
+3. **Enumerates candidates** — every subfolder of `<project>/implementation_process/in_progress/` that is `kind: flat` (via `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>"`, Bash, parse `.kind`). Skips:
    - `kind: epic` / `kind: sub_epic` (already an epic)
    - `kind: subtask` (inside an epic; subject to different analysis)
    - `completed/` subtasks (via folder-location check inside any epic's `completed/`)
@@ -65,7 +65,7 @@ Options:
 
 ## Implementation notes (for the command body)
 
-1. **Candidate enumeration** — iterate `<project>/implementation_process/in_progress/*/` and for each subfolder call `task-frontmatter-reader`. Filter to `kind: flat`. Do NOT recurse into epic folders; this run only considers top-level flat tasks.
+1. **Candidate enumeration** — iterate `<project>/implementation_process/in_progress/*/` and for each subfolder run `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>"` (Bash, parse `.kind`). Filter to `kind: flat`. Do NOT recurse into epic folders; this run only considers top-level flat tasks.
 2. **Parallel analysis** — Agent SDK Subagents model fits: spawn N subagents (one per candidate) via the Task tool. Each subagent invokes `analysis-agent` and returns the JSON. Parent aggregates. Reference: Claude Code Agent SDK Subagents docs [cite AS-1 in research.md].
 3. **Accept flow** — on accept, build the child-names string (comma-separated) and invoke `/drupal-dev-framework:migrate-to-epic <task> --children "<csv>"`. The migration command handles the transactional work; this command only surfaces the proposal and relays the decision.
 4. **Edit flow** — on edit, show the proposed children as an editable list; user can rename, remove, add. Validate names match `^[A-Za-z0-9_][A-Za-z0-9._-]*$` before passing to `/migrate-to-epic`.

--- a/drupal-dev-framework/commands/research-team.md
+++ b/drupal-dev-framework/commands/research-team.md
@@ -26,7 +26,7 @@ When this command is invoked with `$ARGUMENTS`:
 
 ### Step 0 — Update Session Context
 
-After resolving the project and task, **invoke `session-context-writer` skill** with the resolved project and task values.
+After resolving the project and task, **run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"`** (Bash) with the resolved project and task values.
 
 ### Step 1 — Locate Task
 

--- a/drupal-dev-framework/commands/research.md
+++ b/drupal-dev-framework/commands/research.md
@@ -20,7 +20,7 @@ Phase 1 of a task. Behavior current as of v4.0.2; full prose / examples / versio
 
 Run in order. Each "gate" step writes an audit JSON; non-bypassable unless an explicit `--skip-*` flag is supplied (records `bypass_reason`).
 
-1. **Pre-analysis gate (v4.0.0+, always-on, non-bypassable).** Compute strong signals from task name + description (length > 500, ≥3 bullets, conjunctive phrasing — informational only). Invoke `analysis-agent` in description mode (`task_description_text`, codePath via `project-state-reader`, `schema_version: "1.0"`). **Normalize the agent's JSON** through `${CLAUDE_PLUGIN_ROOT}/scripts/analysis-agent-normalize.sh` immediately on return — it deterministically clamps `confidence` to `low` when `code_read:false` (schema invariant 2). Use the normalized JSON for everything below. Write `<task>/_pre-analysis.json` via `${CLAUDE_PLUGIN_ROOT}/scripts/gate-audit-write.sh`. Display verbatim to user using `prompts:pre-analysis-decision` template (`references/gate-hardening-prompts.md`). Block on choice. Branch: `epic_candidate + y` → `/migrate-to-epic <task> --children "<list>"`; else flat-task flow.
+1. **Pre-analysis gate (v4.0.0+, always-on, non-bypassable).** Compute strong signals from task name + description (length > 500, ≥3 bullets, conjunctive phrasing — informational only). Invoke `analysis-agent` in description mode (`task_description_text`, codePath from `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash, parse `.codePath`), `schema_version: "1.0"`). **Normalize the agent's JSON** through `${CLAUDE_PLUGIN_ROOT}/scripts/analysis-agent-normalize.sh` immediately on return — it deterministically clamps `confidence` to `low` when `code_read:false` (schema invariant 2). Use the normalized JSON for everything below. Write `<task>/_pre-analysis.json` via `${CLAUDE_PLUGIN_ROOT}/scripts/gate-audit-write.sh`. Display verbatim to user using `prompts:pre-analysis-decision` template (`references/gate-hardening-prompts.md`). Block on choice. Branch: `epic_candidate + y` → `/migrate-to-epic <task> --children "<list>"`; else flat-task flow.
    - **Idempotent.** If `_pre-analysis.json` already exists, skip (re-fire requires `--re-run-pre-analysis`).
    - **Grandfathering.** If `research.md` exists AND `_pre-analysis.json` absent → soft-nudge "pre-dates v4.0.0," do not block.
    - **Skip flag.** `--skip-pre-analysis <reason>` writes audit with `bypass_reason`.
@@ -36,7 +36,7 @@ Run in order. Each "gate" step writes an audit JSON; non-bypassable unless an ex
 
 4. **Playbook load (deterministic, v4.0.0+).** Run `${CLAUDE_PLUGIN_ROOT}/scripts/playbook-load-deterministic.sh <project_folder>` → loads active sets + local user playbook; writes `_playbook-load.json` audit. Surface conflicts once-per-session per topic via `playbook-conflicts-write.sh` (precedence local > active set > generic).
 
-5. **Alignment retrofit + phase-level offer.** Invoke `alignment-reader`. If `task_level.present: false` AND task folder pre-existed AND pre-analysis didn't fire this session: offer task-level retrofit (4 questions, default `[skip]`). Then offer phase-1 scope per the table in `references/research-walkthrough.md` §"Phase 1 alignment sub-step" (default `[n]`). On `[y]` for either: execute task-level / `--phase 1` flow from `commands/scope.md` inline (do NOT shell out).
+5. **Alignment retrofit + phase-level offer.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` (Bash) and parse its JSON. If `.sections.task_level.present == false` AND task folder pre-existed AND pre-analysis didn't fire this session: offer task-level retrofit (4 questions, default `[skip]`). Then offer phase-1 scope per the table in `references/research-walkthrough.md` §"Phase 1 alignment sub-step" (default `[n]`). On `[y]` for either: execute task-level / `--phase 1` flow from `commands/scope.md` inline (do NOT shell out).
 
 6. **Author research findings.** Invoke `contrib-researcher` agent + `core-pattern-finder` skill.
    - **Per-subject research files (v4.10.0+).** Save each distinct subject the research investigates as **its own `research/<subject>.md` file** — one file per investigated subject (a contrib module, an integration approach, a core subsystem, a competing option), named after that subject, holding that subject's complete findings. `research.md` is the **index/hub**: Problem Statement, a Research Index table linking the subject files, Recommendation, Key Patterns to Apply, Decision Log. The hub synthesizes and links — it does NOT restate each subject's detail, so `/design` and `/implement` load only the subjects they need instead of one monolithic file. A flat single-file `research.md` is fine only when research genuinely covered a single subject.
@@ -58,7 +58,7 @@ Run in order. Each "gate" step writes an audit JSON; non-bypassable unless an ex
 
 11. **Update `project_state.md`** with current task.
 
-12. **Invoke `session-context-writer`** with resolved project + task.
+12. **Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"`** (Bash) with resolved project + task.
 
 ## Anti-bypass clause (applies to gates 1, 3, 4, 7)
 

--- a/drupal-dev-framework/commands/review.md
+++ b/drupal-dev-framework/commands/review.md
@@ -32,7 +32,7 @@ Run in order. Each "gate" step writes audit; non-bypassable unless documented `-
 
 1. **Phase Transition Check.** Read `task.md` Phase Status. If Phase 3 not `[x]`, soft-nudge once. If `## Phase Status` H2 absent entirely, append it with the four standard phase lines (1 Research, 2 Architecture, 3 Implementation, 4 Review). If only Phase 4 line missing, idempotently insert before next `## ` boundary (or EOF if none).
 
-2. **Resolve task + project context.** Validate `<task-name>` charset (above). If absent, try session-context-reader; if also null, exit 2 with usage. Resolve project folder via project-state-reader.
+2. **Resolve task + project context.** Validate `<task-name>` charset (above). If absent, try session-context-reader; if also null, exit 2 with usage. Resolve the project folder by running `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parsing its JSON.
 
 3. **Working-tree warning.** Run `git diff --name-only`. If non-empty AND `--allow-dirty` not set: print warning ("gates run on staged + working tree state, not committed state. Continue? [y/N]"). Default `[N]`. User declines → exit 0.
 
@@ -61,7 +61,7 @@ Run in order. Each "gate" step writes audit; non-bypassable unless documented `-
 
 12. **Mark Phase 4 `[x]`** in `task.md` (only if not `--dry-run` AND `overall_verdict in ("pass", "bypassed")`).
 
-13. **Display `review-summary` mandated wording** (literal text below). Then invoke `session-context-writer` with `lastPhase: "review"`.
+13. **Display `review-summary` mandated wording** (literal text below). Then persist session context: `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"` (Bash). (`lastPhase` is **preserved**, not set, by the writer — it is managed by the phase components; this step does not change it.)
 
 ## Anti-bypass clause (applies to gates 1-9)
 

--- a/drupal-dev-framework/commands/scope.md
+++ b/drupal-dev-framework/commands/scope.md
@@ -22,11 +22,11 @@ Without `--phase`, authors the `## Task-Level` section. With `--phase N`, author
 ## What this does
 
 1. Resolves `<task-name>` to a task folder using the usual resolver (in-progress folder, epic subfolder, etc.). If the folder does not exist, **scaffold a minimal task stub** (see "Task resolution" below) so brand-new tasks can author scope before `/research` runs.
-2. Invokes `alignment-reader` skill to read the current state of `alignment.md` (if any).
+2. Runs `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` (Bash) and parses its JSON to read the current state of `alignment.md` (if any).
 3. **Overwrite guard** — if the target section already exists, asks before overwriting.
 4. Runs the alignment conversation — **one question at a time**, author-authored, never auto-generated.
 5. Writes the section to `alignment.md` (creates the file with H1 + metadata if absent).
-6. Invokes `session-context-writer` skill with resolved project + task.
+6. Runs `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"` (Bash) with resolved project + task.
 7. Prints next-step hint.
 
 ## Task resolution
@@ -82,7 +82,7 @@ Skip stub scaffolding if invoked with `--phase N` — phase-level scope only mak
 
 ## Overwrite guard (retrofit case)
 
-Invoke `alignment-reader` at start. Behavior:
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` (Bash) at start and parse its JSON. Behavior:
 
 | Current state | Target | Behavior |
 |---|---|---|
@@ -106,9 +106,9 @@ The conversation produces a 4-field contract (Goal / Expected result / Success c
 
 Before asking anything, read the task's current content:
 
-1. Invoke `task-frontmatter-reader` on the task folder to get `kind`, `status`, description, dependencies.
+1. Run `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>"` (Bash) and parse `.kind`, `.status`, description, dependencies.
 2. Read `task.md` body (Goal, Current State, Acceptance Criteria, Research Questions, Notes — whatever exists).
-3. Read `alignment.md` via `alignment-reader` (should be missing or have no Task-Level section, since this command path only runs when we intend to author).
+3. Read `alignment.md` via `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` (Bash) (should be missing or have no Task-Level section, since this command path only runs when we intend to author).
 
 ### Step 2 — Decide the conversation mode
 
@@ -212,7 +212,7 @@ Default answer: `[y]` (the warnings don't block; the user may have intentionally
 
 ## Session context
 
-After writing (or cleanly cancelling), invoke `session-context-writer` skill with the resolved project + task so compaction hooks can restore focus. Pass `{CURRENT_EPIC_OR_NULL}` as the epic sentinel per the skill's contract.
+After writing (or cleanly cancelling), run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"` (Bash) with the resolved project + task so compaction hooks can restore focus. **Omit the 5th arg** (epic) so the preserve-sentinel `{CURRENT_EPIC_OR_NULL}` applies and the existing `currentEpic` is kept.
 
 ## Next-step hint
 

--- a/drupal-dev-framework/commands/set-code-path.md
+++ b/drupal-dev-framework/commands/set-code-path.md
@@ -19,7 +19,7 @@ Set or update the `codePath` metadata for the active drupal-dev-framework projec
 ## What this does
 
 1. Resolves the active project from `session_context.json` (`projectPath`). If no project active, prompts the user to pick one via `/drupal-dev-framework:next` first.
-2. **Reads current value** via `project-state-reader` skill (so the confirm prompt can show what's changing).
+2. **Reads current value** by running `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parsing its JSON (so the confirm prompt can show what's changing).
 3. **Resolves new value:**
    - With `<path>` arg: `realpath -m` normalize; validate exists (unless `--docs-only` or the path resolves to an acceptable path that may not yet exist; in that case, warn and continue).
    - With `--docs-only`: set to `(docs-only)` sentinel (null at runtime).

--- a/drupal-dev-framework/commands/set-playbook-sets.md
+++ b/drupal-dev-framework/commands/set-playbook-sets.md
@@ -21,7 +21,7 @@ Set or update the project's `**Playbook Sets:**` field in `project_state.md`. Th
 
 ### Step 1 — Resolve project context
 
-Invoke `project-state-reader` to get current `playbookSets[]`, `playbookSetsSource`, and `folder`. Refuse with helpful message if no project resolved.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON for current `playbookSets[]`, `playbookSetsSource`, and `folder`. Refuse with helpful message if no project resolved.
 
 ### Step 2 — Parse arg
 

--- a/drupal-dev-framework/commands/set-user-playbook.md
+++ b/drupal-dev-framework/commands/set-user-playbook.md
@@ -20,7 +20,7 @@ Set or update the project's `**User Playbook:**` and `**User Playbook State:**` 
 
 ### Step 1 — Resolve project context
 
-Invoke `project-state-reader`. Refuse with helpful message if no project resolved.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON. Refuse with helpful message if no project resolved.
 
 ### Step 2 — Mode dispatch
 

--- a/drupal-dev-framework/commands/setup-atk.md
+++ b/drupal-dev-framework/commands/setup-atk.md
@@ -22,7 +22,7 @@ Unsupported flag: `--variant cypress` → print `"/setup-atk: only the Playwrigh
 
 Parse `$ARGUMENTS`. If `--variant` appears (in any form: `--variant cypress`, `--variant=cypress`, `--VARIANT cypress`, case-insensitive) with the value `cypress`, print the literal message above and stop. (EC-F14)
 
-Read `codePath` from the active project's `project_state.md` via the `project-state-reader` skill. If `codePath` is null or unknown, prompt the user to run `/set-code-path` first and stop.
+Read `codePath` from the active project's `project_state.md` by running `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parsing its JSON `.codePath`. If `codePath` is null or unknown (`.codePath == null` or a `code_path_unknown`/`code_path_missing` warning), prompt the user to run `/set-code-path` first and stop.
 
 ## Step 2: --add-journey branch
 

--- a/drupal-dev-framework/commands/setup-visual-parity.md
+++ b/drupal-dev-framework/commands/setup-visual-parity.md
@@ -37,9 +37,11 @@ The reworked parity scripts run `npx playwright test` from the codePath root.
 
 ## Step 0: Resolve project + codePath
 
-Resolve the active project and `codePath` from `project_state.md` via the
-`project-state-reader` skill. If `codePath` is null, prompt the user to run
-`/set-code-path` and stop. Invoke the `session-context-writer` skill.
+Resolve the active project and `codePath` from `project_state.md` by running
+`${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash)
+and parsing `.codePath`. If `codePath` is null, prompt the user to run
+`/set-code-path` and stop. Then persist session context:
+`${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" null null` (Bash).
 
 The surface registry is `<codePath>/.visual-review/registry.yml` — **shared** with
 `/setup-visual-regression` and `/setup-atk`. This command **merges** into it; it never

--- a/drupal-dev-framework/commands/setup-visual-regression.md
+++ b/drupal-dev-framework/commands/setup-visual-regression.md
@@ -34,9 +34,11 @@ directories, not separate npm packages.
 
 ## Step 0: Resolve project + codePath
 
-Resolve the active project and `codePath` from `project_state.md` via the
-`project-state-reader` skill. If `codePath` is null, prompt the user to run
-`/set-code-path` and stop. Invoke the `session-context-writer` skill.
+Resolve the active project and `codePath` from `project_state.md` by running
+`${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash)
+and parsing `.codePath`. If `codePath` is null, prompt the user to run
+`/set-code-path` and stop. Then persist session context:
+`${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" null null` (Bash).
 
 The surface registry is `<codePath>/.visual-review/registry.yml` — shared with
 `/setup-atk`. If `/setup-atk` already created it, this command **merges** into

--- a/drupal-dev-framework/commands/status.md
+++ b/drupal-dev-framework/commands/status.md
@@ -22,7 +22,7 @@ Show current project status and task progress.
 2. Loads `project_state.md` from project path
 3. Scans `implementation_process/` for task files
 4. Invokes `phase-detector` for each task
-5. **For each task folder, invoke `task-frontmatter-reader` skill (v1.0.0+) to determine `kind`** — flat/epic/sub_epic/subtask — so the rendering below knows whether to show a flat line or a tree.
+5. **For each task folder, run `${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>"` (Bash) and parse `.kind`** — flat/epic/sub_epic/subtask — so the rendering below knows whether to show a flat line or a tree.
 6. Presents comprehensive status with hierarchy-aware rendering
 
 ## Hierarchy-aware rendering (added v3.10.0)
@@ -45,7 +45,7 @@ For each top-level task folder in `implementation_process/in_progress/`:
 - Mixed output: flat tasks appear separately from trees for readability.
 
 Do NOT walk dependency graphs here — that's `/next`'s (future) responsibility.
-6. **Invokes `session-context-writer` skill with the resolved project (and task if one is active)**
+6. **Runs `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task|null>" "<task_path|null>"`** (Bash) with the resolved project (and task if one is active; pass `null null` if not)
 
 ## Output Format
 

--- a/drupal-dev-framework/commands/validate-e2e.md
+++ b/drupal-dev-framework/commands/validate-e2e.md
@@ -24,7 +24,7 @@ Full walkthrough: `references/atk-e2e-walkthrough.md`.
 
 Parse `$ARGUMENTS`. Extract task name (positional or `--task`).
 
-Resolve `codePath` from `project_state.md` via the `project-state-reader` skill. If `codePath` is null or unknown, prompt the user to run `/set-code-path` first and stop.
+Resolve `codePath` from `project_state.md` by running `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parsing `.codePath`. If `codePath` is null or unknown, prompt the user to run `/set-code-path` first and stop.
 
 If no task name is provided (neither positional nor `--task`): resolve from `session_context.json` active task. If no active task is found, print: `"validate:e2e: no task specified — provide a task name or run with an active task."` and stop. (EC-F25)
 

--- a/drupal-dev-framework/commands/validate-team.md
+++ b/drupal-dev-framework/commands/validate-team.md
@@ -29,7 +29,7 @@ Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Without it, this command prin
 ### Step 1 — Resolve task + project context
 
 - Accept `<task>` arg (falls back to session-context `task` if omitted).
-- Invoke `project-state-reader` → `codePath`, `codePathState`, memory project folder.
+- Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) → parse `.codePath`, `.folder` (memory project folder), and `.warnings` (a `code_path_unknown`/`code_path_missing` warning, or `.codePath == null`, ⇒ `codePathState` is not `set`).
 - Resolve task folder. Refuse if the folder doesn't exist.
 
 ### Step 2 — Detect agent-teams availability (fallback chain)
@@ -57,11 +57,11 @@ With `--no-fallback`: print the reason, exit 2, do NOT invoke `/validate:all`.
 
 ### Step 3 — Read context for manifest
 
-Invoke these skills/readers **in parallel** where possible:
+Run these readers (Bash) **in parallel** where possible:
 
-- `alignment-reader` → `sections.task_level` (used by teammates that need the goal/success-criteria)
-- `project-state-reader` → `codePath`, `codePathState` (already loaded in Step 1; re-use)
-- `screenshot-store-reader` → enumerate `<component>/<viewport>` pairs with `role: baseline` → used to populate `visual_fanout[]` for the visual gate entry
+- `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh "<task_folder>"` → parse `.sections.task_level` (used by teammates that need the goal/success-criteria)
+- project-state — `.codePath`, `codePathState` (already loaded in Step 1 via `project-state-read.sh`; re-use)
+- `${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-read.sh "<codePath>"` → enumerate `<component>/<viewport>` pairs with `role: baseline` → used to populate `visual_fanout[]` for the visual gate entry
 
 If the screenshot store is empty OR `codePathState != "set"` for visual gates, the visual-regression entry in the manifest still ships but its `visual_fanout[]` is an empty array (teammate will emit `verdict: "skipped"` with reason).
 

--- a/drupal-dev-framework/commands/validate-visual-parity.md
+++ b/drupal-dev-framework/commands/validate-visual-parity.md
@@ -48,13 +48,16 @@ The v3.13.0 positional `<component> <viewport> <reference> [<url>]` signature is
 ## Step 1: Resolve task + project context
 
 Resolve the task and project the same way other `/validate:*` commands do. Resolve
-`codePath` from `project_state.md` via the `project-state-reader` skill. If `codePath`
-is null, prompt the user to run `/set-code-path` and stop. Invoke the
-`session-context-writer` skill with the resolved project + task.
+`codePath` from `project_state.md` by running
+`${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and
+parsing the JSON (keep the whole object — Step 2 reuses `.visualReview`). If `.codePath`
+is null, prompt the user to run `/set-code-path` and stop. Then persist session context
+with the resolved project + task:
+`${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"` (Bash).
 
 ## Step 2: Read the Visual Review pointer
 
-Read `project_state.md` via `project-state-reader`; inspect `visualReview`. Parity
+Inspect `.visualReview` from the Step 1 JSON. Parity
 rides the **same** surface registry as visual regression — there is no separate parity
 enable pointer.
 

--- a/drupal-dev-framework/commands/validate-visual-regression.md
+++ b/drupal-dev-framework/commands/validate-visual-regression.md
@@ -35,13 +35,16 @@ Soft-nudge — `fail` signals but never blocks. Full walkthrough:
 ## Step 1: Resolve task + project context
 
 Resolve the task and project the same way other `/validate:*` commands do.
-Resolve `codePath` from `project_state.md` via the `project-state-reader`
-skill. If `codePath` is null, prompt the user to run `/set-code-path` and stop.
-Invoke the `session-context-writer` skill with the resolved project + task.
+Resolve `codePath` from `project_state.md` by running
+`${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash)
+and parsing the JSON (keep the whole object — Step 2 reuses `.visualReview`).
+If `.codePath` is null, prompt the user to run `/set-code-path` and stop.
+Then persist session context with the resolved project + task:
+`${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh "<project_name>" "<project_folder>" "<task>" "<task_path>"` (Bash).
 
 ## Step 2: Read the Visual Review pointer
 
-Read `project_state.md` via `project-state-reader`; inspect `visualReview`.
+Inspect `.visualReview` from the Step 1 JSON.
 
 - `visualReview: null` (field absent) or `visualReview.enabled: false` → visual
   review is not set up. Print: `"visual review is not set up — run /setup-visual-regression first."` and stop.
@@ -78,8 +81,8 @@ message `"registry has no visual_regression surfaces"`, persist, and stop.
 
 For each (surface × viewport), the expected baseline is
 `<codePath>/tests/visual/<id>.spec.ts-snapshots/<id>-1-visual-chromium-<viewport>-linux.png`.
-Use the `screenshot-store-reader` skill (`screenshot-store-read.sh <codePath>`)
-to enumerate what exists.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/screenshot-store-read.sh "<codePath>"` (Bash)
+and parse its JSON to enumerate what exists.
 
 If any (surface × viewport) has **no baseline** and neither `--bootstrap` nor
 `--update-baselines` was passed → emit `verdict: fail` with the remediation

--- a/drupal-dev-framework/commands/worktree-prune.md
+++ b/drupal-dev-framework/commands/worktree-prune.md
@@ -17,7 +17,7 @@ List and selectively remove worktrees in the current project. Each worktree gets
 
 ### Step 1 — Resolve project context
 
-Invoke `project-state-reader`. Refuse if no project resolved.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON. Refuse if no project resolved.
 
 ### Step 2 — Refuse if in a worktree
 

--- a/drupal-dev-framework/commands/worktree.md
+++ b/drupal-dev-framework/commands/worktree.md
@@ -24,7 +24,7 @@ See `references/worktree-conventions.md` v1.2 for the full convention — includ
 
 ### Step 1 — Resolve task + project context
 
-Invoke `project-state-reader` to get `folder` (project path), `codePath`, `worktreeByDefault`. Resolve task folder under `<project>/implementation_process/**/<task-name>/`. Refuse with helpful message if task folder doesn't exist.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse its JSON for `folder` (project path), `codePath`, `worktreeByDefault`. Resolve task folder under `<project>/implementation_process/**/<task-name>/`. Refuse with helpful message if task folder doesn't exist.
 
 ### Step 2 — Refuse if already in a worktree
 
@@ -113,12 +113,17 @@ Default: skip baseline (Drupal/DDEV setups make this heavy).
 
 ### Step 9 — Pre-seed session-context
 
-Invoke `session-context-writer` skill from inside the worktree (`$PWD` is now the worktree path) with:
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh` **from inside the worktree** (`$PWD` is now the worktree path — the script keys the session file by `md5($PWD)`):
 
-- `project: <project_name>` (from project-state-reader)
-- `projectPath: <abs project memory folder>`
-- `task: null`
-- `taskPath: null`
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh" \
+  "<project_name>" "<abs project memory folder>" null null
+```
+
+- `$1` `<project_name>` (from `project-state-read.sh`)
+- `$2` `<abs project memory folder>`
+- `$3` `null` (task)
+- `$4` `null` (taskPath)
 
 This ensures the worktree's session-context file exists; the user's first `/research` or `/implement` populates the task field.
 

--- a/drupal-dev-framework/scripts/session-context-write.sh
+++ b/drupal-dev-framework/scripts/session-context-write.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# session-context-write.sh — persist per-workspace session context for hooks.
+#
+# Verbatim lift (v4.16.0) of the jq merge block that used to live in the
+# session-context-writer SKILL body. Extracted so lifecycle commands can write
+# session context via a Bash call with ZERO model context, instead of invoking
+# an inline skill whose model: pin overflowed in large sessions (BUG-1).
+#
+# Usage:
+#   session-context-write.sh <project_name> <project_path> <task|null> <taskPath|null> [<currentEpic>|null|{CURRENT_EPIC_OR_NULL}]
+#
+# Args (mirror the former SKILL placeholders 1:1):
+#   $1  project_name      resolved project name (e.g. wasatch_update)
+#   $2  project_path      absolute project path
+#   $3  task              task name, or the literal string "null" / "" for none
+#   $4  taskPath          absolute task path, or the literal string "null" / "" for none
+#   $5  currentEpic       (optional) epic folder name; the literal "null"/"" to clear;
+#                         or the preserve-sentinel {CURRENT_EPIC_OR_NULL} (the default
+#                         when omitted) to keep whatever is already on disk.
+#
+# Merges the new core fields over any existing session file, seeding
+# loadedGuides: [] and lastPhase: null only when the file is first created.
+# loadedGuides, lastPhase, and currentEpic are managed by other components
+# (guide-integrator, task-frontmatter-reader, the context-reminder hook) — this
+# script must not clobber them.
+#
+# The session file path is resolved by the shared session-paths.sh helper
+# (ddf_session_file): keyed by md5($PWD) and, when CLAUDE_CODE_SESSION_ID is set,
+# additionally by the session ID. Silent — emits nothing to stdout.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./session-paths.sh
+. "$SCRIPT_DIR/session-paths.sh"
+
+PROJECT_NAME="${1:-}"
+PROJECT_PATH="${2:-}"
+TASK_ARG="${3:-null}"
+TASK_PATH_ARG="${4:-null}"
+# NOTE: do not fold the brace default into ${5:-...} — a literal "}" inside the
+# expansion closes it at the first brace and appends a stray "}" to the value.
+if [ "$#" -ge 5 ]; then
+  NEW_EPIC_ARG="$5"
+else
+  NEW_EPIC_ARG='{CURRENT_EPIC_OR_NULL}'
+fi
+
+SESS_FILE=$(ddf_session_file)
+mkdir -p "$(dirname "$SESS_FILE")"
+
+NEW_CORE=$(jq -n \
+  --arg workspace "$PWD" \
+  --arg project "$PROJECT_NAME" \
+  --arg projectPath "$PROJECT_PATH" \
+  --arg task "$TASK_ARG" \
+  --arg taskPath "$TASK_PATH_ARG" \
+  --arg updatedAt "$(date -I)" \
+  '{
+    workspace: $workspace,
+    project: $project,
+    projectPath: $projectPath,
+    task: (if $task == "null" or $task == "" then null else $task end),
+    taskPath: (if $taskPath == "null" or $taskPath == "" then null else $taskPath end),
+    updatedAt: $updatedAt
+  }')
+
+if [ -s "$SESS_FILE" ] && jq -e . "$SESS_FILE" >/dev/null 2>&1; then
+  # Preserve loadedGuides, lastPhase, and currentEpic; overwrite core fields.
+  # currentEpic behavior: if the caller passed an explicit value (not the literal
+  # "{CURRENT_EPIC_OR_NULL}" preserve-sentinel), use it; otherwise preserve existing.
+  jq --argjson new "$NEW_CORE" --arg epic "$NEW_EPIC_ARG" \
+    '. * $new
+     | .loadedGuides = (.loadedGuides // [])
+     | .lastPhase = (.lastPhase // null)
+     | .currentEpic = (
+         if $epic == "{CURRENT_EPIC_OR_NULL}" then (.currentEpic // null)
+         elif $epic == "null" or $epic == "" then null
+         else $epic
+         end
+       )' \
+    "$SESS_FILE" > "$SESS_FILE.tmp" && mv "$SESS_FILE.tmp" "$SESS_FILE"
+else
+  # First write, empty, or corrupt JSON — reseed from scratch with fresh core +
+  # preserved-field defaults.
+  echo "$NEW_CORE" | jq --arg epic "$NEW_EPIC_ARG" '. + {
+    loadedGuides: [],
+    lastPhase: null,
+    currentEpic: (if $epic == "{CURRENT_EPIC_OR_NULL}" or $epic == "null" or $epic == "" then null else $epic end)
+  }' > "$SESS_FILE"
+fi

--- a/drupal-dev-framework/skills/alignment-reader/SKILL.md
+++ b/drupal-dev-framework/skills/alignment-reader/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: alignment-reader
 description: Use when a framework command needs to parse a task's alignment.md (the scope contract — Goal / Expected result / Success criteria / Non-goals per section). Reads defensively via scripts/alignment-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
-version: 1.0.0
+version: 1.1.0
 user-invocable: false
-model: haiku
+model: inherit
 allowed-tools: Bash
+disallowed-tools: Write, Edit
 ---
 
 # Alignment Reader

--- a/drupal-dev-framework/skills/epic-migrator/SKILL.md
+++ b/drupal-dev-framework/skills/epic-migrator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: epic-migrator
 description: Use when converting a flat task into an epic folder with children, promoting a subtask to a sub_epic, or expanding an existing epic with more children. Runs the 8-step transactional migration via scripts/migrate-to-epic.sh. Supports --dry-run for preflight plan. Never leaves half-migrated state on disk.
-version: 2.1.0
+version: 2.2.0
 user-invocable: false
-model: sonnet
-allowed-tools: Bash, Skill
+model: inherit
+allowed-tools: Bash
 ---
 
 # Epic Migrator
@@ -42,13 +42,20 @@ Thin wrapper around `${CLAUDE_PLUGIN_ROOT}/scripts/migrate-to-epic.sh`. The scri
 
 ## Session-context dispatch (apply after live run)
 
-Parse the stderr `KEY=VALUE` lines, then invoke `session-context-writer`:
+Parse the stderr `KEY=VALUE` lines (`SESSION_CONTEXT_CASE`, `EPIC_FOR_CTX`, `NEW_TASK_PATH`), then write session context by running `scripts/session-context-write.sh` directly (Bash, zero model context — v4.16.0):
 
-| Case | When | `currentEpic` arg | `taskPath` arg |
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh" \
+  "$PROJECT_NAME" "$PROJECT_PATH" "$TASK" "$TASK_PATH" "$EPIC_ARG"
+```
+
+Choose the `$EPIC_ARG` (5th positional) and `$TASK_PATH` by the case the script emitted:
+
+| Case | When | `$EPIC_ARG` (5th arg) | `$TASK_PATH` (4th arg) |
 |---|---|---|---|
 | **A** | Migrated task != active task | literal `{CURRENT_EPIC_OR_NULL}` (preserve) | unchanged |
-| **B** | Migrated task == active task | `"null"` (clear) | unchanged |
-| **C** | A `move_existing` child == active task | `$TASK_NAME` (set epic) | `$NEW_TASK_PATH` |
+| **B** | Migrated task == active task | `null` (clear) | unchanged |
+| **C** | A `move_existing` child == active task | `$EPIC_FOR_CTX` (= `$TASK_NAME`, set epic) | `$NEW_TASK_PATH` |
 
 ## See also
 

--- a/drupal-dev-framework/skills/guide-integrator/SKILL.md
+++ b/drupal-dev-framework/skills/guide-integrator/SKILL.md
@@ -99,7 +99,7 @@ jq --arg g "$GUIDE_ID" \
   "$SESS_FILE" > "$SESS_FILE.tmp" && mv "$SESS_FILE.tmp" "$SESS_FILE"
 ```
 
-If `session_context.json` does not yet exist, skip silently — the next framework command will create it via `session-context-writer` and future loads will be recorded.
+If `session_context.json` does not yet exist, skip silently — the next framework command will create it via `scripts/session-context-write.sh` and future loads will be recorded.
 
 ### 3. Extract Applicable Patterns
 
@@ -151,7 +151,7 @@ After loading methodology refs and dev-guides topics, load the project's playboo
 
 #### 6a. Read project state
 
-Invoke `project-state-reader` skill to get `playbookSets[]`, `userPlaybook`, `userPlaybookState`, and `playbookResolutions[]`.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/project-state-read.sh "<project_folder>"` (Bash) and parse `.playbookSets[]`, `.userPlaybook`, `.userPlaybookState`, and `.playbookResolutions[]`.
 
 #### 6b-c. Deterministic load (v4.0.0+)
 

--- a/drupal-dev-framework/skills/project-state-reader/SKILL.md
+++ b/drupal-dev-framework/skills/project-state-reader/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: project-state-reader
 description: Use when a framework command needs project-level metadata (codePath, playbookSets, userPlaybook, playbookResolutions, project_name). Reads project_state.md defensively via scripts/project-state-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
-version: 1.2.0
+version: 1.3.0
 user-invocable: false
-model: haiku
+model: inherit
 allowed-tools: Bash
+disallowed-tools: Write, Edit
 ---
 
 # Project State Reader

--- a/drupal-dev-framework/skills/screenshot-store-reader/SKILL.md
+++ b/drupal-dev-framework/skills/screenshot-store-reader/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: screenshot-store-reader
 description: Use when a framework command needs to inspect the project's visual-regression baseline store — the codePath-native tests/visual/ snapshot tree. Reads the store defensively via scripts/screenshot-store-read.sh and returns structured JSON. Never blocks on malformed input.
-version: 1.1.0
+version: 1.2.0
 user-invocable: false
-model: haiku
+model: inherit
 allowed-tools: Bash
+disallowed-tools: Write, Edit
 ---
 
 # Screenshot Store Reader

--- a/drupal-dev-framework/skills/session-context-writer/SKILL.md
+++ b/drupal-dev-framework/skills/session-context-writer/SKILL.md
@@ -2,8 +2,8 @@
 name: session-context-writer
 description: Use when a framework command has resolved the active project and/or task and needs to persist that context for hooks. Writes per-workspace session_context.json so compaction hooks and the context-reminder hook can restore the right project/task context. Preserves loadedGuides[], lastPhase, and currentEpic across writes.
 user-invocable: false
-version: 1.5.0
-model: haiku
+version: 1.6.0
+model: inherit
 allowed-tools: Bash
 ---
 
@@ -37,62 +37,20 @@ You receive the resolved project and task values from the calling command. Write
 
 ## Action
 
-Run this bash command with the provided values. It merges the new core fields over any existing file, seeding `loadedGuides: []` and `lastPhase: null` only when the file is first created.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh` with the provided values. The script merges the new core fields over any existing file, seeding `loadedGuides: []` and `lastPhase: null` only when the file is first created. It sources `scripts/session-paths.sh` for the session-file path (keyed by `md5($PWD)` and — when `CLAUDE_CODE_SESSION_ID` is set — additionally by the session ID, so two Claude Code sessions in the same directory get distinct files; when the variable is absent the key is `md5($PWD)` exactly as before v4.9.0).
 
-The session file path is resolved by the shared `scripts/session-paths.sh` helper (`ddf_session_file`). The path is keyed by `md5($PWD)` and — when `CLAUDE_CODE_SESSION_ID` is set — additionally by the session ID, so two Claude Code sessions in the same directory get distinct session files instead of colliding. When the variable is absent the key is `md5($PWD)` exactly as before v4.9.0 (backward compatible).
+> **v4.16.0:** the `jq` merge logic moved verbatim into `scripts/session-context-write.sh`. Callers run the script via Bash directly — a Bash call carries no model context, so the write no longer overflows when triggered from a large session (BUG-1). This skill is the documented name/contract; prefer the script at call sites.
 
 ```bash
-. "${CLAUDE_PLUGIN_ROOT}/scripts/session-paths.sh"
-SESS_FILE=$(ddf_session_file)
-mkdir -p "$(dirname "$SESS_FILE")"
-
-NEW_CORE=$(jq -n \
-  --arg workspace "$PWD" \
-  --arg project "{PROJECT_NAME}" \
-  --arg projectPath "{PROJECT_PATH}" \
-  --arg task "{TASK_NAME_OR_NULL}" \
-  --arg taskPath "{TASK_PATH_OR_NULL}" \
-  --arg updatedAt "$(date -I)" \
-  '{
-    workspace: $workspace,
-    project: $project,
-    projectPath: $projectPath,
-    task: (if $task == "null" or $task == "" then null else $task end),
-    taskPath: (if $taskPath == "null" or $taskPath == "" then null else $taskPath end),
-    updatedAt: $updatedAt
-  }')
-
-NEW_EPIC_ARG='{CURRENT_EPIC_OR_NULL}'
-
-if [ -s "$SESS_FILE" ] && jq -e . "$SESS_FILE" >/dev/null 2>&1; then
-  # Preserve loadedGuides, lastPhase, and currentEpic; overwrite core fields.
-  # currentEpic behavior: if the caller passed an explicit value (not the literal "{CURRENT_EPIC_OR_NULL}" placeholder), use it; otherwise preserve existing.
-  jq --argjson new "$NEW_CORE" --arg epic "$NEW_EPIC_ARG" \
-    '. * $new
-     | .loadedGuides = (.loadedGuides // [])
-     | .lastPhase = (.lastPhase // null)
-     | .currentEpic = (
-         if $epic == "{CURRENT_EPIC_OR_NULL}" then (.currentEpic // null)
-         elif $epic == "null" or $epic == "" then null
-         else $epic
-         end
-       )' \
-    "$SESS_FILE" > "$SESS_FILE.tmp" && mv "$SESS_FILE.tmp" "$SESS_FILE"
-else
-  # First write, empty, or corrupt JSON — reseed from scratch with fresh core + preserved-field defaults.
-  echo "$NEW_CORE" | jq --arg epic "$NEW_EPIC_ARG" '. + {
-    loadedGuides: [],
-    lastPhase: null,
-    currentEpic: (if $epic == "{CURRENT_EPIC_OR_NULL}" or $epic == "null" or $epic == "" then null else $epic end)
-  }' > "$SESS_FILE"
-fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/session-context-write.sh" \
+  "{PROJECT_NAME}" "{PROJECT_PATH}" "{TASK_NAME_OR_NULL}" "{TASK_PATH_OR_NULL}" "{CURRENT_EPIC_OR_NULL}"
 ```
 
-Replace placeholders:
-- `{PROJECT_NAME}` — resolved project name (e.g., `wasatch_update`)
-- `{PROJECT_PATH}` — absolute project path
-- `{TASK_NAME_OR_NULL}` — task name if known, or the literal string `null`
-- `{TASK_PATH_OR_NULL}` — absolute task path if known, or the literal string `null`
-- `{CURRENT_EPIC_OR_NULL}` — (added v1.4.0) epic folder name if the task is inside an epic, `null` if not, or leave as the literal string `{CURRENT_EPIC_OR_NULL}` to preserve whatever was there before (i.e., caller doesn't know or doesn't want to change it).
+Positional args (mirror the former placeholders 1:1):
+- `$1` `{PROJECT_NAME}` — resolved project name (e.g., `wasatch_update`)
+- `$2` `{PROJECT_PATH}` — absolute project path
+- `$3` `{TASK_NAME_OR_NULL}` — task name if known, or the literal string `null`
+- `$4` `{TASK_PATH_OR_NULL}` — absolute task path if known, or the literal string `null`
+- `$5` `{CURRENT_EPIC_OR_NULL}` — (added v1.4.0) epic folder name if the task is inside an epic, `null` to clear, or the literal string `{CURRENT_EPIC_OR_NULL}` to preserve whatever was there before. **Omit the 5th arg entirely** for the same preserve behavior.
 
 Do not output anything to the user. This is a silent background operation.

--- a/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
+++ b/drupal-dev-framework/skills/task-frontmatter-reader/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: task-frontmatter-reader
 description: "Use when a framework command needs to read the hierarchy metadata of a task — parses the YAML frontmatter block at the top of task.md and returns structured data (id, kind, parent, children, blocks, blocked_by, external_ids, derived status) plus any warnings. Defensive: never blocks on malformed input; absent frontmatter yields kind=flat. Delegates to scripts/fm-read.sh."
-version: 2.0.0
+version: 2.1.0
 user-invocable: false
-model: haiku
+model: inherit
 allowed-tools: Bash
+disallowed-tools: Write, Edit
 ---
 
 # Task Frontmatter Reader


### PR DESCRIPTION
## v4.16.0 — Model-pin footgun: readers (BUG-1, tier 1)

First release of the 2026-05-29 feature wave. Eliminates **BUG-1** on the six Tier-1 reader/writer skills.

### Why
A skill's `model:` is an **inline current-turn override with no context isolation** (Skills guide: *"the override applies for the rest of the current turn"*). DDF pinned a sub-1M model (`haiku`/`sonnet`) on 15 inline skills, so each **overflowed when invoked from a session larger than ~200k tokens** — worst case `project-state-reader` (haiku), invoked inline by ~18 lifecycle commands that run late in long sessions.

### What changed
- **Call sites rewired to deterministic scripts** (Bash, zero model context). Every inline `invoke <skill>` for the six Tier-1 skills now runs the existing `scripts/*.sh` directly and parses its output — **output contracts unchanged** (the scripts were already the source of truth the skills wrapped).
  - `project-state-reader` → `project-state-read.sh`; `task-frontmatter-reader` → `fm-read.sh`; `alignment-reader` → `alignment-read.sh`; `screenshot-store-reader` → `screenshot-store-read.sh`; `epic-migrator` → `migrate-to-epic.sh`.
- **New `scripts/session-context-write.sh`** — verbatim lift of the `jq` merge block from the `session-context-writer` SKILL body (sources `session-paths.sh`; args mirror the former placeholders 1:1; preserves `loadedGuides`/`lastPhase`/`currentEpic`). A `${5:-{…}}` brace-default bug was caught and fixed during smoke test.
- **Tier-1 frontmatter → `model: inherit`** on all six (was `haiku`/`sonnet`) so the validator's **S14** rule clears on them. `epic-migrator` also drops the now-unused `Skill` tool.
- **CC-1** — `disallowed-tools: Write, Edit` (kebab-case) on the four read-only readers; they keep `allowed-tools: Bash`.
- **Root-cause guidance corrected** in `CONVENTIONS.md` **plus** `.claude/rules/skill-conventions.md` and `.claude/rules/command-conventions.md` (two extra instances the roadmap had not named).

### Validation
`/plugin-creation-tools:validate drupal-dev-framework --strict` (installed validator **v3.9.0**):
- ✅ **S14 cleared on all six Tier-1 skills.**
- 9 Tier-3 synthesizer skills still pin sub-1M → S14 fires, **deferred to v4.17.0** (frontmatter-only).
- FM01 / FM02 / S15 / A04 clean. Pre-existing **X02** (marketplace entry > 600 chars) cleared by trimming to 529.
- Scripts smoke-tested against a live project (`project-state-read.sh`, `fm-read.sh`, `alignment-read.sh` all emit valid JSON).

### Surfaced (not silently changed)
- `review.md` step 13 instructed the writer "with `lastPhase: "review"`", but the writer (old inline `jq` and the lifted script alike) only **preserves** `lastPhase` — it never set it from input. That instruction has been an effective no-op since written. Behavior preserved per the verbatim-lift mandate; the call site now documents the preserve semantics.
- The Tier-1 `model: inherit` change was **required** by the validation criterion, though the roadmap's fix-list under-specified it (S14 is a static check; rewiring call sites alone does not clear it). Confirmed with the maintainer before implementing.

### Scope
43 files + 1 new script; one minor bump, one release. `plugin.json` 4.15.0 → 4.16.0; root `marketplace.json` entry + `metadata.version` 1.15.6 → 1.15.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)