### PR TITLE
dev-guides-navigator v0.7.0: recipe-search mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.9"
+    "version": "1.15.10"
   },
   "plugins": [
     {
       "name": "dev-guides-navigator",
       "source": "./dev-guides-navigator",
-      "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content. v0.6.0 adds a Setup hook that pre-warms the llms.txt cache for instant first lookups, a leaner SKILL.md with reference extraction, and skillOverrides / skill-listing-budget documentation.",
-      "version": "0.6.0",
+      "description": "Smart guide discovery and routing for dev-guides. Hash-based caching + KG metadata route AI to the correct guide; all fetches use curl (never WebFetch) to preserve raw structured content. v0.7.0 adds a second routing mode — recipe search — over the separate agentic-recipes catalog (verifier-carrying capability deliveries that name guides/plays end-to-end), a dev-guides-recipes-cache.json sibling cache with two-hash invalidation (index hash + per-recipe sha, download-once bodies), and disallowed-tools: WebFetch. Both modes exposed, caller owns order; guide search untouched.",
+      "version": "0.7.0",
       "author": {
         "name": "camoa"
       },
@@ -23,6 +23,8 @@
         "guides",
         "dev-guides",
         "llms-txt",
+        "agentic-recipes",
+        "recipe-search",
         "knowledge-graph",
         "caching",
         "routing",

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dev-guides-navigator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"

--- a/dev-guides-navigator/CHANGELOG.md
+++ b/dev-guides-navigator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.0 (2026-06-06)
+
+### Added
+- **Recipe Search mode** — a second routing path, symmetric to guide search, over the separate **agentic-recipes** catalog (`agentic-recipes.txt` + `agentic-recipes.hash`). Recipes are goal-oriented, prescriptive capability deliveries that **name** the guides/plays they need (never duplicate them) and carry a **verifier**. New `## Recipe Search` SKILL.md section: index-cache via `.hash`/`.txt`; match on `capability` + when-to-use (no match → "fall back to guide search" + STOP, never fabricate); body download-once keyed by the per-line `(sha:XXXXXXXX)` (raw markdown only, URL derived from the index line's site-url); apply by handing each named guide/play to the existing guide-search flow and **surfacing the verifier** to the caller.
+- **Two modes, caller owns order** — a "Two modes" overview + a When-to-Use note state that the navigator exposes both guide search and recipe search with **no hardcoded order**; the caller (e.g. the drupal-dev-framework orchestrator) decides, typically recipe-search first then guide-search.
+- **`dev-guides-recipes-cache.json`** — a new sibling cache file (same dasherized-cwd derivation as the guides cache), schema `{ index: { hash, fetched_at, content }, recipes: { <name>: { sha, fetched_at, content } } }`. Two-hash invalidation: `agentic-recipes.hash` gates the index; each per-line `sha` gates one body, checkable without a fetch. Documented in `references/cache-format.md` as a cross-plugin contract.
+- **`disallowed-tools: WebFetch`** in SKILL.md frontmatter (CC-1) — turns the three prose "NEVER use WebFetch" warnings into a harness-level hard block, reinforcing the curl-only discipline for both modes.
+
+### Unchanged
+- **Guide search, `llms.txt`, and the guides cache (`dev-guides-cache.json`) are byte-for-byte untouched.** Recipe search is strictly additive.
+
 ## 0.6.0 (2026-05-21)
 
 ### Added

--- a/dev-guides-navigator/README.md
+++ b/dev-guides-navigator/README.md
@@ -2,6 +2,13 @@
 
 Smart guide discovery and routing for the [dev-guides](https://camoa.github.io/dev-guides/) site. Routes AI to the correct guide using hash-based caching and KG metadata for disambiguation.
 
+**Two modes (v0.7.0+):** the navigator routes over two separate published catalogs —
+**guide search** (`llms.txt`, atomic mechanics-level guides) and **recipe search**
+(`agentic-recipes.txt`, goal-oriented capability deliveries that sequence guides/plays
+end-to-end and carry a verifier). Both modes are exposed with **no hardcoded order** — the
+caller decides, typically recipe-search first, then guide-search. See
+[Recipe Search](#recipe-search-v070) below.
+
 > **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — this plugin is pure-skill and the highest-portability one in the marketplace.
 
 ## Installation
@@ -60,6 +67,36 @@ curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/drupal/form
 # Specific guide (raw GitHub)
 curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/drupal/forms/form-validation.md
 ```
+
+The `disallowed-tools: WebFetch` frontmatter (v0.7.0+) makes this a harness-level hard
+block, not just a convention.
+
+## Recipe Search (v0.7.0)
+
+Alongside guide search, the navigator exposes **recipe search** over the separate
+**agentic-recipes** catalog. A recipe is a prescriptive, goal-oriented delivery of **one
+capability** end-to-end: it **names** the guides and plays it needs (never duplicating
+them) and carries a **verifier** (the drift check). The recipes index is published
+separately from `llms.txt` so the guides index never grows by a recipe.
+
+```bash
+# Recipe index hash (gates the index cache)
+curl -s https://camoa.github.io/dev-guides/agentic-recipes.hash
+
+# Recipe index
+curl -s https://camoa.github.io/dev-guides/agentic-recipes.txt
+
+# Recipe body (raw GitHub — derived from the index line's site-url)
+curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/agentic-recipes/drupal/responsive-image-wiring.md
+```
+
+Flow: cache the index by `agentic-recipes.hash` → match a line on `capability` +
+when-to-use (no match → fall back to guide search, never fabricate) → download the body
+**once**, keyed by the line's per-recipe `(sha:XXXXXXXX)` → hand each guide/play the recipe
+names to the existing guide-search flow, and surface the recipe's verifier to the caller.
+Guide search, `llms.txt`, and the guides cache are untouched — recipe search is strictly
+additive. Recipe bodies cache to a separate sibling file,
+`dev-guides-recipes-cache.json` (see `references/cache-format.md`).
 
 ## Configuration
 
@@ -122,7 +159,7 @@ KG metadata in each topic's `index.md` prevents routing to the wrong guide:
 
 | Problem | Fix |
 |---------|-----|
-| AI uses WebFetch instead of curl | The `allowed-tools` field excludes WebFetch — if it still happens, check that the plugin is installed |
+| AI uses WebFetch instead of curl | The `disallowed-tools: WebFetch` frontmatter hard-blocks it — if it still happens, check that the plugin is installed and the skill is active |
 | curl fails (network error) | Falls back to built-in `references/guide-index.md` keyword table |
 | No topic matches | Broaden keywords or check category sections in llms.txt |
 | Guide too large for context | Request only the specific section from the routing table |
@@ -134,10 +171,13 @@ KG metadata in each topic's `index.md` prevents routing to the wrong guide:
 
 ## Version
 
-**v0.6.0** (Current) — SKILL.md conciseness pass (extracted quick-reference,
-examples, and troubleshooting to `references/`); `Setup` hook for `llms.txt`
-cache pre-warming; `skillOverrides` and skill-listing-budget documentation. See
-`CHANGELOG.md` for the full history.
+**v0.7.0** (Current) — Recipe Search mode over the separate agentic-recipes
+catalog (goal-oriented, verifier-carrying capability deliveries that name
+guides/plays end-to-end); new `dev-guides-recipes-cache.json` sibling cache with
+two-hash invalidation (index hash + per-recipe sha, download-once bodies);
+`disallowed-tools: WebFetch` hard-blocking the curl-only discipline. Guide search,
+`llms.txt`, and the guides cache are untouched. See `CHANGELOG.md` for the full
+history.
 
 ## License
 

--- a/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: dev-guides-navigator
 description: Use when ANY development task might benefit from a guide. Use when user says "how do I", "best practice", "pattern for", "guide for", "Drupal form", "entity type", "plugin type", "routing", "caching", "config management", "SDC component", "design system", "Bootstrap mapping", "Radix theme", "JSX to Twig", "Tailwind tokens", "SOLID", "DRY", "TDD", "security", "CSS", "Next.js". Use PROACTIVELY before any design, architecture, or implementation work. MUST be invoked before writing code that touches Drupal APIs, theming, design systems, or security. NEVER skip guide check — patterns prevent bugs.
-version: 0.6.0
+version: 0.7.0
 allowed-tools: Read, Bash, Glob, Grep, Write
+disallowed-tools: WebFetch
 user-invocable: true
 ---
 
@@ -10,11 +11,21 @@ user-invocable: true
 
 Route to the correct online guide and enforce guide application.
 
+## Two modes
+
+The navigator exposes **two independent routing modes** over two separate published catalogs:
+
+- **Guide search** (`llms.txt`) — atomic, mechanics-level decision guides. The original flow. See **Core Workflow** below.
+- **Recipe search** (`agentic-recipes.txt`) — goal-oriented, prescriptive capability deliveries that sequence existing guides/plays end-to-end and carry a verifier. See **Recipe Search** below.
+
+The navigator does **not** hardcode an order. The **caller** owns ordering — typically recipe-search first (is there a prescriptive end-to-end recipe for this capability?), then guide-search (fall back to raw mechanics). Recipe search never fabricates a recipe: a miss cleanly defers to guide search.
+
 ## When to Use
 
 - Any Drupal, Next.js, design system, or dev-practice task where a guide might help
 - When another skill or agent needs domain knowledge beyond its bundled references
 - When the user mentions a specific guide topic
+- When a task is a whole **capability** (one end-to-end goal) rather than a single mechanic — try **recipe search** first
 - NOT for: plugin methodology references (those are in drupal-dev-framework/references/)
 
 ## Core Workflow
@@ -126,11 +137,80 @@ Example: `curl -s https://raw.githubusercontent.com/camoa/dev-guides/main/docs/d
 3. Apply them directly to the implementation
 4. Reference the guide in architecture docs if in design phase
 
+## Recipe Search
+
+Recipe search is **symmetric to guide search** but consumes a **separate** catalog —
+the **agentic recipes** index. A recipe is a prescriptive, goal-oriented delivery of
+**one capability** end-to-end: it **names** the guides and plays it needs (it never
+duplicates them) and carries a **verifier** (the drift check). Recipes publish to their
+**own** index, deliberately separate from `llms.txt` so the guides index never grows by
+a recipe.
+
+This flow is **strictly additive** — it does not touch guide search, `llms.txt`, or the
+guides cache.
+
+### Catalog contract (build to exactly this)
+
+- **Index** (`curl`, never WebFetch):
+  `https://camoa.github.io/dev-guides/agentic-recipes.txt` + `agentic-recipes.hash`
+- One line per recipe, grouped under a `## Domain` heading:
+  `- <name> [<capability>] (sha:XXXXXXXX): <one-line when-to-use> — <site-url>`
+- **Recipe body** (full RECIPE.md) fetched as **raw markdown**, never the GH Pages HTML —
+  derive from the `<site-url>` in the index line:
+  `https://raw.githubusercontent.com/camoa/dev-guides/main/docs/agentic-recipes/<domain>/<name-dasherized>.md`
+  (e.g. site-url `.../agentic-recipes/drupal/responsive-image-wiring/` →
+  raw `.../docs/agentic-recipes/drupal/responsive-image-wiring.md`). Born-atomic: one file, one fetch.
+- **Two hashes, two jobs:** `agentic-recipes.hash` gates the **index** cache; the per-line
+  `(sha:XXXXXXXX)` gates each **recipe body** cache — checkable without fetching the body.
+
+### 1. Get `agentic-recipes.txt` (with caching)
+
+Cache file: `~/.claude/projects/<dasherized-cwd>/memory/dev-guides-recipes-cache.json` —
+a **separate sibling** to the guides cache, same path derivation. See
+`references/cache-format.md` for the schema and the cross-plugin contract.
+
+**NEVER use WebFetch.** All fetches use `curl -s` via Bash (same discipline, same reasons
+as guide search). The frontmatter `disallowed-tools: WebFetch` makes this a hard block.
+
+- Bash: `curl -s https://camoa.github.io/dev-guides/agentic-recipes.hash`
+- Compare with the cached `index.hash`:
+  - **Same** → use cached `index.content`, skip re-fetch
+  - **Different or no cache** → Bash: `curl -s https://camoa.github.io/dev-guides/agentic-recipes.txt`,
+    rewrite `index` as `{ hash, fetched_at, content }`
+
+### 2. Match capability
+
+Scan the index lines and match on **`capability`** (the machine key in `[...]`) plus the
+**when-to-use description**. Keep this lean — **do not fetch any recipe body during matching.**
+
+- **Match** → proceed to step 3 with that line's `<name>`, `<sha>`, and `<site-url>`.
+- **No match** → report "no recipe for this capability; fall back to guide search" and **STOP**.
+  Never fabricate a recipe.
+
+### 3. Fetch the body (download-once)
+
+Read the matched line's `(sha:XXXXXXXX)`:
+
+- Cached body for `<name>` exists with the **same sha** → **reuse it, no fetch.**
+- Otherwise → `curl -s` the raw `.md` **once** (raw URL derived from the site-url, per the
+  contract above) and store `recipes.<name> = { sha, fetched_at, content }`.
+
+A body is downloaded **exactly once per content version** and reused for the session.
+
+### 4. Apply (hand off + surface the verifier)
+
+The recipe is **sequence + opinion + verifier**; the guides it cites are the **mechanics**.
+
+1. For each guide or play the recipe **names**, hand off to the **existing guide-search flow**
+   above (Core Workflow steps 2–7). The recipe does not replace guide search — it drives it.
+2. **Surface the recipe's verifier to the caller** — it is the drift check that confirms the
+   capability was delivered correctly.
+
 ## See Also
 
 - `references/quick-reference.md` — condensed workflow table + common mistakes
 - `references/examples.md` — worked routing examples (user request → correct guide)
 - `references/troubleshooting.md` — what to do when a workflow step fails
-- `references/cache-format.md` — cache file format and the cross-plugin contract
+- `references/cache-format.md` — guides cache + recipes cache formats (cross-plugin contract)
 - `references/manifest-schema.md` — build output (llms.txt + llms.hash)
 - `references/guide-index.md` — fallback keyword table (offline/network failure)

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/cache-format.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/cache-format.md
@@ -4,6 +4,16 @@ This file is a **contract**. Other plugins (notably `drupal-dev-framework`)
 locate and parse this cache directly. Do not change the location derivation or
 the schema without updating those consumers.
 
+There are **two sibling cache files**, same directory, same path derivation:
+
+| File | Catalog | Written by | Schema |
+|------|---------|-----------|--------|
+| `dev-guides-cache.json` | guides (`llms.txt`) | guide search | `{ hash, fetched_at, content }` |
+| `dev-guides-recipes-cache.json` | agentic recipes (`agentic-recipes.txt`) | recipe search (v0.7.0+) | `{ index, recipes }` (below) |
+
+The two files are independent. Recipe search (v0.7.0) added the recipes cache; it
+does **not** change the guides-cache schema.
+
 ## Location
 
 ```
@@ -84,3 +94,73 @@ the compact `llms_txt` placeholder variant.
 
 **NEVER use WebFetch** — it summarizes content through AI, destroying the
 structured formats needed for matching and routing.
+
+---
+
+## Recipes Cache (v0.7.0)
+
+A **second, independent** cache file for the agentic-recipes catalog. Recipe
+search consumes a separate published index (`agentic-recipes.txt` +
+`agentic-recipes.hash`), deliberately distinct from `llms.txt`, so it gets its
+own cache file. The guides cache above is untouched.
+
+### Location
+
+```
+~/.claude/projects/<dasherized-cwd>/memory/dev-guides-recipes-cache.json
+```
+
+Same `<dasherized-cwd>` derivation and the same glob fallback as the guides
+cache (see [Location](#location) above). Only the filename differs.
+
+### Structure
+
+```json
+{
+  "index": {
+    "hash":       "<contents of agentic-recipes.hash>",
+    "fetched_at": "<ISO-8601 timestamp>",
+    "content":    "<full agentic-recipes.txt markdown>"
+  },
+  "recipes": {
+    "<name>": {
+      "sha":        "<8-char per-recipe content hash from the index line>",
+      "fetched_at": "<ISO-8601 timestamp>",
+      "content":    "<full RECIPE.md markdown>"
+    }
+  }
+}
+```
+
+- `index` — caches the recipe **index** (`agentic-recipes.txt`), gated by the
+  global `agentic-recipes.hash`. Same `{ hash, fetched_at, content }` shape as
+  the guides cache, nested under `index`.
+- `recipes` — a map keyed by recipe **name** (the `<name>` token from the index
+  line, e.g. `responsive_image_wiring`). Each entry caches one recipe body
+  (`RECIPE.md`), gated by that recipe's per-line `(sha:XXXXXXXX)`.
+
+### Two hashes, two jobs
+
+- **Index invalidation** — `agentic-recipes.hash` gates the `index` cache, exactly
+  as `llms.hash` gates the guides cache.
+- **Per-body invalidation** — each recipe body is gated by its own per-line
+  `(sha:XXXXXXXX)`, **checkable without fetching the body**. A body is downloaded
+  **exactly once per content version** and reused while its sha is unchanged.
+
+### Flow
+
+**Index (every recipe search):**
+1. `curl -s https://camoa.github.io/dev-guides/agentic-recipes.hash`
+2. Compare with cached `index.hash`
+   - Same → use cached `index.content`
+   - Different / no cache → `curl -s …/agentic-recipes.txt`, rewrite
+     `index = { hash, fetched_at, content }`
+
+**Body (download-once, per matched recipe):**
+1. Read the matched index line's `(sha:XXXXXXXX)`
+2. `recipes.<name>.sha` equals it → reuse `recipes.<name>.content`, **no fetch**
+3. Else → `curl -s` the raw `.md` **once** (raw URL derived from the index line's
+   site-url — never the GH Pages HTML), store
+   `recipes.<name> = { sha, fetched_at, content }`
+
+**NEVER use WebFetch**, never the GH Pages HTML URL for a body (raw only).


### PR DESCRIPTION
## dev-guides-navigator v0.7.0 — Recipe-search mode

Adds a **second routing mode — recipe search** — symmetric to guide search, over the separate **agentic-recipes** catalog. Recipes are goal-oriented, verifier-carrying capability deliveries that **name** the guides/plays they need end-to-end (never duplicating them). **Strictly additive** — guide search, `llms.txt`, and the guides cache (`dev-guides-cache.json`) are byte-for-byte untouched.

Scoped to this one release per the roadmap (`dev-guides-navigator-roadmap-2026-05-29.md`).

### What changed
- **New `## Recipe Search` SKILL.md section** (catalog contract + 4-step flow): index cached via `agentic-recipes.hash`/`.txt`; match on `capability` + when-to-use (no match → "fall back to guide search" + STOP, never fabricate); body **download-once** keyed by the per-line `(sha:XXXXXXXX)`, **raw markdown only**, URL derived from the index line's site-url; apply by handing each named guide/play to the **existing guide-search flow** and **surfacing the recipe's verifier** to the caller.
- **Two modes, caller owns order** — overview + When-to-Use note: both modes exposed, **no hardcoded order**.
- **`dev-guides-recipes-cache.json`** — new sibling cache (same dasherized-cwd derivation), documented in `references/cache-format.md` as a **cross-plugin contract**: `{ index: {hash,fetched_at,content}, recipes: {<name>:{sha,fetched_at,content}} }`, two-hash invalidation (global hash gates the index; per-recipe sha gates each body). **Guides-cache schema unchanged.**
- **CC-1** — `disallowed-tools: WebFetch` added to SKILL.md frontmatter: turns the three prose "never WebFetch" warnings into a harness-level hard block.
- Version → **0.7.0** (`plugin.json` + SKILL.md frontmatter); root `marketplace.json` entry → 0.7.0 + `metadata.version` 1.15.9 → **1.15.10**; CHANGELOG + README updated.

### Live self-test (capability `responsive-image-delivery`)
- **Cold:** index MISS → fetched `agentic-recipes.txt`; matched `responsive_image_wiring [responsive-image-delivery] (sha:cb4170a0)`; derived raw body URL `…/docs/agentic-recipes/drupal/responsive-image-wiring.md`; body MISS → **fetched once (12709 bytes)**; verifier present (`## Verifier`).
- **Warm:** `.hash` unchanged → index HIT (no `.txt` fetch); sha `cb4170a0` unchanged → body HIT, **0 re-fetches**; cache not rewritten.

`/plugin-creation-tools:validate --strict` against the working tree: **PASS** (frontmatter, version sync, hooks, references, structure all clean; description trimmed to 579 ≤ 600 to clear strict-promoted X02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)