### PR TITLE
dev-guides-navigator v0.8.0: create-on-miss (maintainer mode)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.10"
+    "version": "1.15.11"
   },
   "plugins": [
     {
       "name": "dev-guides-navigator",
       "source": "./dev-guides-navigator",
-      "description": "Smart guide discovery and routing for dev-guides. Hash-based caching + KG metadata route AI to the correct guide; all fetches use curl (never WebFetch) to preserve raw structured content. v0.7.0 adds a second routing mode — recipe search — over the separate agentic-recipes catalog (verifier-carrying capability deliveries that name guides/plays end-to-end), a dev-guides-recipes-cache.json sibling cache with two-hash invalidation (index hash + per-recipe sha, download-once bodies), and disallowed-tools: WebFetch. Both modes exposed, caller owns order; guide search untouched.",
-      "version": "0.7.0",
+      "description": "Smart guide discovery and routing for dev-guides. Hash-based caching + KG metadata route AI to the correct guide; all fetches use curl (never WebFetch). Two routing modes — guide search (llms.txt) and recipe search (agentic-recipes catalog, verifier-carrying capability deliveries). v0.8.0 adds maintainer-mode create-on-miss: when guide search finds nothing and the dev-guides source repo is detected, it offers to author the topic and hands off to that repo's /create-guide command (which opens a PR, never deploys). Detect + offer + hand off only; consumer mode byte-for-byte unchanged.",
+      "version": "0.8.0",
       "author": {
         "name": "camoa"
       },
@@ -25,6 +25,7 @@
         "llms-txt",
         "agentic-recipes",
         "recipe-search",
+        "create-on-miss",
         "knowledge-graph",
         "caching",
         "routing",

--- a/dev-guides-navigator/.claude-plugin/plugin.json
+++ b/dev-guides-navigator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dev-guides-navigator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Smart guide discovery and routing for dev-guides. Uses hash-based caching and KG metadata (concepts, disambiguation, relationships) to route AI to the correct guide. All fetches use curl (never WebFetch) to preserve raw structured content.",
   "author": {
     "name": "camoa"

--- a/dev-guides-navigator/CHANGELOG.md
+++ b/dev-guides-navigator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.0 (2026-06-06)
+
+### Added
+- **Create-on-Miss (maintainer mode)** — when guide search finds **no** guide for a topic **and** the local dev-guides **source** repo is detected, the navigator now **offers** to author the missing guide and **hands off** to that repo's own `/create-guide` command. New `## Create-on-Miss (maintainer mode only)` SKILL.md section + `references/create-on-miss.md` with the full protocol.
+- **Detection** — resolves a source root in priority order: `DEV_GUIDES_SRC` env/config → `$PWD` → `~/workspace/dev-guides`, accepting a candidate only if it carries the full 4-part signature (`mkdocs.yml` + `scripts/generate_llms.py` + `docs/agentic-recipes/` + a `.claude/agents/guide-*` agent). A partial signature is not a match.
+- **Thin by design** — the navigator only **detects + offers + hands off**. It never authors, partitions, commits, pushes, or deploys; authoring belongs to the dev-guides repo's agents/scripts via `/create-guide`. The offer is explicit (never auto). `/create-guide` itself pauses for human source review and ends at a **PR** — it never merges or deploys (deploy = a human merging the PR).
+- **Misses only** — fires on a genuine guide-search miss (Core Workflow steps 1–7 + the `guide-index.md` fallback exhausted). Recipe-search misses defer to guide search, not to this flow. Refreshing existing guides is out of scope.
+
+### Unchanged
+- **Consumer mode is byte-for-byte unchanged.** No dev-guides source repo detected → no offer, no behavior change. Guide search, recipe search, `llms.txt`, the guides cache, and the recipes cache are untouched.
+
 ## 0.7.0 (2026-06-06)
 
 ### Added

--- a/dev-guides-navigator/README.md
+++ b/dev-guides-navigator/README.md
@@ -98,6 +98,26 @@ Guide search, `llms.txt`, and the guides cache are untouched — recipe search i
 additive. Recipe bodies cache to a separate sibling file,
 `dev-guides-recipes-cache.json` (see `references/cache-format.md`).
 
+## Create-on-Miss (v0.8.0, maintainer mode)
+
+If you **maintain** the dev-guides source repo, the navigator can help close gaps. When
+guide search finds **no** guide for a topic **and** the local dev-guides source repo is
+detected, the navigator **offers** to author the missing guide and **hands off** to that
+repo's own `/create-guide` command. It only **detects + offers + hands off** — it never
+authors, partitions, commits, or deploys.
+
+- **Detection** — `DEV_GUIDES_SRC` env/config → `$PWD` → `~/workspace/dev-guides`,
+  accepting a candidate only with the full 4-part signature (`mkdocs.yml` +
+  `scripts/generate_llms.py` + `docs/agentic-recipes/` + a `.claude/agents/guide-*`).
+- **Offer, never auto** — on a genuine miss it asks before doing anything.
+- **`/create-guide`** researches a source guide, **pauses for your review**, partitions
+  it, and opens a **PR** — it never merges or deploys (a human merging the PR is the
+  deploy).
+- **Consumer mode is byte-for-byte unchanged** — no repo detected → no offer, no behavior
+  change.
+
+See `references/create-on-miss.md` for the detection probe and full handoff protocol.
+
 ## Configuration
 
 No configuration required. The skill automatically caches `llms.txt` per project at:
@@ -171,10 +191,16 @@ KG metadata in each topic's `index.md` prevents routing to the wrong guide:
 
 ## Version
 
-**v0.7.0** (Current) — Recipe Search mode over the separate agentic-recipes
-catalog (goal-oriented, verifier-carrying capability deliveries that name
-guides/plays end-to-end); new `dev-guides-recipes-cache.json` sibling cache with
-two-hash invalidation (index hash + per-recipe sha, download-once bodies);
+**v0.8.0** (Current) — Create-on-Miss (maintainer mode): when guide search finds
+nothing and the dev-guides source repo is detected (`DEV_GUIDES_SRC` /
+auto-probe + 4-part signature), the navigator offers to author the topic and
+hands off to that repo's `/create-guide` command (which opens a PR, never
+deploys). Detect + offer + hand off only; consumer mode byte-for-byte unchanged.
+
+**v0.7.0** — Recipe Search mode over the separate agentic-recipes catalog
+(goal-oriented, verifier-carrying capability deliveries that name guides/plays
+end-to-end); new `dev-guides-recipes-cache.json` sibling cache with two-hash
+invalidation (index hash + per-recipe sha, download-once bodies);
 `disallowed-tools: WebFetch` hard-blocking the curl-only discipline. Guide search,
 `llms.txt`, and the guides cache are untouched. See `CHANGELOG.md` for the full
 history.

--- a/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-guides-navigator
 description: Use when ANY development task might benefit from a guide. Use when user says "how do I", "best practice", "pattern for", "guide for", "Drupal form", "entity type", "plugin type", "routing", "caching", "config management", "SDC component", "design system", "Bootstrap mapping", "Radix theme", "JSX to Twig", "Tailwind tokens", "SOLID", "DRY", "TDD", "security", "CSS", "Next.js". Use PROACTIVELY before any design, architecture, or implementation work. MUST be invoked before writing code that touches Drupal APIs, theming, design systems, or security. NEVER skip guide check — patterns prevent bugs.
-version: 0.7.0
+version: 0.8.0
 allowed-tools: Read, Bash, Glob, Grep, Write
 disallowed-tools: WebFetch
 user-invocable: true
@@ -26,6 +26,7 @@ The navigator does **not** hardcode an order. The **caller** owns ordering — t
 - When another skill or agent needs domain knowledge beyond its bundled references
 - When the user mentions a specific guide topic
 - When a task is a whole **capability** (one end-to-end goal) rather than a single mechanic — try **recipe search** first
+- **Maintainer mode only:** when you maintain the dev-guides source repo and guide search finds *nothing* for a topic — see **Create-on-Miss** below
 - NOT for: plugin methodology references (those are in drupal-dev-framework/references/)
 
 ## Core Workflow
@@ -206,11 +207,41 @@ The recipe is **sequence + opinion + verifier**; the guides it cites are the **m
 2. **Surface the recipe's verifier to the caller** — it is the drift check that confirms the
    capability was delivered correctly.
 
+## Create-on-Miss (maintainer mode only)
+
+When guide search finds **no** guide for a topic **and** the local dev-guides
+**source** repo is detected, the navigator **offers** to author the missing guide
+and **hands off** to the repo's own `/create-guide` command. It only detects,
+offers, and hands off — it **never** authors, partitions, commits, or deploys.
+**Consumer mode is unchanged:** no repo detected → no offer, no behavior change;
+this section never alters guide search, `llms.txt`, or the guides cache.
+
+**Fires only when both hold:** (1) a *genuine* guide-search miss — Core Workflow
+steps 1–7 **and** the `references/guide-index.md` fallback exhausted with no
+matching topic/guide (a weak match is not a miss; recipe-search misses defer to
+guide search, not here); and (2) **maintainer mode** — a source root resolved
+from `DEV_GUIDES_SRC` → `$PWD` → `~/workspace/dev-guides`, accepted only on the
+full 4-part signature (`mkdocs.yml` + `scripts/generate_llms.py` +
+`docs/agentic-recipes/` + a `.claude/agents/guide-*`; partial = consumer mode).
+
+Then: **offer, never auto** ("No topic exists for `<topic>` — author via
+`/create-guide`?"; declined → STOP), and **hand off, don't reimplement** —
+`/create-guide` is a dev-guides *project* command the navigator can't invoke
+programmatically, so tell the user to run `/create-guide <topic>` from the
+detected repo (cd / open a session there first if needed), then **STOP**. Frame
+it honestly: `/create-guide` researches a source guide, pauses for review,
+partitions, and **opens a PR — never merges or deploys** (deploy = a human
+merging the PR).
+
+See `references/create-on-miss.md` for the exact detection probe, the offer
+protocol, and the full `/create-guide` lifecycle.
+
 ## See Also
 
 - `references/quick-reference.md` — condensed workflow table + common mistakes
 - `references/examples.md` — worked routing examples (user request → correct guide)
 - `references/troubleshooting.md` — what to do when a workflow step fails
 - `references/cache-format.md` — guides cache + recipes cache formats (cross-plugin contract)
+- `references/create-on-miss.md` — maintainer-mode detection + `/create-guide` handoff protocol
 - `references/manifest-schema.md` — build output (llms.txt + llms.hash)
 - `references/guide-index.md` — fallback keyword table (offline/network failure)

--- a/dev-guides-navigator/skills/dev-guides-navigator/references/create-on-miss.md
+++ b/dev-guides-navigator/skills/dev-guides-navigator/references/create-on-miss.md
@@ -1,0 +1,123 @@
+# Create-on-Miss (maintainer mode)
+
+This is the **navigator side only** of the create-on-miss flow (v0.8.0+). When
+guide search finds **no** guide for a topic **and** the local dev-guides source
+repo is detected, the navigator **offers** to author the missing guide and
+**hands off** to the repo's own `/create-guide` command. It never authors,
+partitions, commits, or deploys anything itself.
+
+For ordinary consumers (no repo present) this flow **never fires** — guide search
+falls back exactly as it always has. Consumer behavior is unchanged.
+
+## Navigator hard rules
+
+- **Detect + offer + hand off — nothing more.** Authoring belongs to the
+  dev-guides repo's own agents/scripts via `/create-guide`. The navigator stays
+  thin.
+- **Offer, never auto.** On a genuine miss, *ask* "no guide exists for X —
+  author one?" Do not silently start writing.
+- **Never author, commit, push, or deploy** from the navigator. Surface the
+  handoff and STOP.
+- **Maintainer-only.** No repo detected → consumer mode → no offer, no behavior
+  change.
+- **Misses only, not refreshes.** This flow fires when a topic is *absent*.
+  Refreshing/updating an existing guide is out of scope for this wave.
+
+## When it applies
+
+All of these must hold:
+
+1. **Genuine guide-search miss** — the guide-search flow (SKILL.md Core Workflow
+   steps 1–7) plus the `references/guide-index.md` fallback keyword table are
+   exhausted with **no** matching topic or guide. A weak/partial match is not a
+   miss — only a true absence is.
+2. **Maintainer mode** — the dev-guides source repo is detected (below).
+
+If either is false, do not offer. (Recipe-search misses defer to guide search;
+only a *guide-search* miss can escalate to create-on-miss.)
+
+## Detection (maintainer mode)
+
+Resolve a dev-guides **source** root, in priority order: explicit
+`DEV_GUIDES_SRC` env/config first, then auto-probe the current working directory,
+then the conventional `~/workspace/dev-guides` checkout. A candidate is the repo
+only if it carries the full **4-part signature**:
+
+- `mkdocs.yml`
+- `scripts/generate_llms.py`
+- `docs/agentic-recipes/` (directory)
+- at least one `.claude/agents/guide-*` agent
+
+```bash
+# Returns DG_SRC (non-empty → maintainer mode; empty → consumer mode, unchanged)
+candidates=()
+[ -n "$DEV_GUIDES_SRC" ] && candidates+=("$DEV_GUIDES_SRC")
+candidates+=("$PWD" "$HOME/workspace/dev-guides")
+
+DG_SRC=""
+for d in "${candidates[@]}"; do
+  if [ -f "$d/mkdocs.yml" ] \
+     && [ -f "$d/scripts/generate_llms.py" ] \
+     && [ -d "$d/docs/agentic-recipes" ] \
+     && ls "$d/.claude/agents/"guide-* >/dev/null 2>&1; then
+    DG_SRC="$d"; break
+  fi
+done
+[ -n "$DG_SRC" ] && echo "maintainer mode: $DG_SRC" || echo "consumer mode"
+```
+
+A partial signature (e.g. `mkdocs.yml` but no `docs/agentic-recipes/`) is **not**
+a match — treat it as consumer mode. This avoids false positives on unrelated
+MkDocs sites.
+
+## The offer
+
+On a genuine miss in maintainer mode, present a single, plain offer — for example:
+
+> No dev-guides topic exists for **`<topic>`**. The dev-guides source repo is
+> detected at `<DG_SRC>`. Author the missing guide via `/create-guide <topic>`?
+> (It researches a source guide, pauses for your review, partitions it into
+> `docs/<topic>/`, and opens a PR — it never merges or deploys.)
+
+If declined → STOP (the user proceeds without a guide). If accepted → hand off.
+
+## The handoff
+
+`/create-guide` is a **dev-guides project slash command** (lives in that repo's
+`.claude/commands/`), not a navigator/plugin command. The navigator cannot invoke
+it programmatically — it instructs the user to run it:
+
+- If the current session's cwd **is** the detected repo (`DG_SRC == $PWD`), the
+  command is already loaded — tell the user to run `/create-guide <topic>`.
+- Otherwise, tell the user to open a session in `DG_SRC` (or `cd` there) and run
+  `/create-guide <topic>` — the command only loads when that repo's `.claude/` is
+  active.
+
+Then **STOP**. Do not attempt to replicate any authoring step.
+
+## What `/create-guide` does (for accurate framing — do not reimplement)
+
+A summary of the handoff target so the navigator can describe it honestly. The
+command itself owns every step:
+
+1. **Charter scope gate** — mechanics/how-to only; IA/methodology/strategy is
+   refused and routed elsewhere.
+2. **Miss check** — new topic only (`docs/<topic>/` must not exist).
+3. **Branch off `main`.**
+4. **Research + write the SOURCE guide** (`guide-framework-maintainer` agent),
+   outside the repo in `~/workspace/claude_memory/guides/` — not committed.
+5. **PAUSE for human review** of the source guide.
+6. **Partition** into `docs/<topic>/` (`guide-partitioner`): atomic guides,
+   `index.md` with `guide-meta:` + 3-column routing table, nav, category index,
+   manifest entry.
+7. **Populate `guide-meta:`** (`guide-meta-populator`, idempotent backstop).
+8. **Backfill the Summary column** (idempotent).
+9. **Normalize cross-partition links.**
+10. **Local `mkdocs build` preview** (output gitignored, never committed).
+11. **Stage `docs/**` + `mkdocs.yml` + `partition-manifest.json` only, commit,
+    push branch, open PR — then STOP.**
+
+**Deploy = merge.** `/create-guide` ends at an opened PR; it never pushes to
+`main`, never merges, never deploys. A human reviewer merging the PR into
+protected `main` is what triggers the CI index regeneration + GH Pages deploy.
+The navigator therefore never participates in deploy at all.


### PR DESCRIPTION
## dev-guides-navigator v0.8.0 — Create-on-miss (maintainer mode, entry point B)

When guide search finds **no** guide for a topic **and** the local dev-guides **source** repo is detected, the navigator **offers** to author the missing guide and **hands off** to that repo's own `/create-guide` command. **Detect + offer + hand off only** — the navigator never authors, partitions, commits, pushes, or deploys.

Scoped to this one release per the roadmap (`dev-guides-navigator-roadmap-2026-05-29.md`).

### Scope decision (confirmed by maintainer)
Ships **entry point B (maintainer create-on-miss) only**. The consumer **bootstrap** (entry point A — clone + pip install + register `DEV_GUIDES_SRC` + verify push access) is **deliberately deferred to v0.9.0**, honoring the prompt's *"consumer mode byte-for-byte unchanged"* constraint and the maintainer's direction (*"I do not want to offer everyone to be a maintainer"*).

### What changed
- **New `## Create-on-Miss (maintainer mode only)` SKILL.md section** + a maintainer-gated When-to-Use bullet. Body trimmed to 239 lines (clears strict S10); full protocol in the new reference.
- **New `references/create-on-miss.md`** — detection bash probe, the 4-part signature, the offer protocol, and a summary of `/create-guide`'s PR-not-deploy lifecycle.
- **Detection** — `DEV_GUIDES_SRC` env/config → `$PWD` → `~/workspace/dev-guides`, accepted only on the full **4-part signature** (`mkdocs.yml` + `scripts/generate_llms.py` + `docs/agentic-recipes/` + a `.claude/agents/guide-*`). Partial signature → consumer mode.
- **Offer, never auto; hand off, don't reimplement** — `/create-guide` is a dev-guides *project* command the navigator can't invoke programmatically, so it instructs the user to run `/create-guide <topic>` from the detected repo, then STOPS. Framed honestly: `/create-guide` pauses for review and **opens a PR — never merges/deploys**.
- **Consumer mode byte-for-byte unchanged** — no repo → no offer. Guide search, recipe search, `llms.txt`, and both caches untouched.
- Version → **0.8.0** (`plugin.json` + SKILL.md frontmatter); marketplace entry → 0.8.0 + `metadata.version` 1.15.10 → **1.15.11**; CHANGELOG + README updated.

### Gate verified before shipping
All three roadmap prerequisites present in `~/workspace/dev-guides`:
1. **`/create-guide`** command (`.claude/commands/create-guide.md`)
2. **`pr-check.yml`** — `pull_request: [main]` → `validate_recipes.py` + `mkdocs build --strict`, no deploy (the required "build" check)
3. **Branch protection** on `main` — required check `["build"]`, ≥1 review, `allow_force_pushes: false`

### Self-test (detection only — no authoring)
Progressive 4-part-signature probe: parts 1→3 of 4 each return **consumer mode**; only the full signature flips to **maintainer mode**. Real repo detected via env / `$PWD` / default-path candidates; non-repo set → consumer mode. **Consumer mode (no repo) confirmed byte-for-byte unchanged.** No authoring triggered (that is a deliberate maintainer action).

`/plugin-creation-tools:validate --strict` against the working tree: **PASS** (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)