### PR TITLE
code-quality-tools v3.7.0: native review/security alignment + security-guidance adoption

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.11"
+    "version": "1.15.12"
   },
   "plugins": [
     {
@@ -127,8 +127,8 @@
     {
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
-      "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.6.1",
+      "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
+      "version": "3.7.0",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
-  "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, an /ultrareview cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.6.1",
+  "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
+  "version": "3.7.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] - 2026-06-06
+
+### Native review/security alignment + security-guidance adoption
+
+First release of the 2026-05-29 feature wave. Stops pointing the cloud-review wrapper at a deprecated alias, adopts the one in-session security layer the plugin lacked, and positions the plugin in its real lane — whole-codebase / CI SAST, the layer native diff-scoped review does not cover. No SAST script or gate logic changed — doc / wrapper retargeting + a soft install offer only. Grounded in the cached Code Review, Ultrareview, Security Guidance, and Security guides (2026-05-29 snapshot).
+
+### Changed
+
+- **Cloud-review wrapper repointed to canonical `/code-review ultra`.** `commands/ultrareview.md` targeted the **deprecated alias** `/ultrareview` throughout (description, body, hand-off step, platform-refusal + cost notices, See-also). All **interactive** references now point to `/code-review ultra` (the canonical form per the Ultrareview guide — `/ultrareview` remains a working alias, noted inline). The headless **`claude ultrareview` CLI subcommand is kept unchanged** (still the documented non-interactive form; exit-code contract `0`/`1`/`130` intact). `plugin.json` + root `marketplace.json` descriptions: "an /ultrareview cloud-review wrapper" → "a /code-review ultra cloud-review wrapper". The `/code-quality:ultrareview` command name and file are **kept** for back-compat; only the built-in target changed. Cross-links in `audit.md` / `review.md` / `generate-review-md.md` / `SKILL.md` / `README.md` were verified to reference only the kept CLI, the kept plugin-command name, or the `commands/ultrareview.md` file path — no interactive-target edit was needed there.
+
+### Added
+
+- **Adopted the official `security-guidance` plugin as the in-session layer (CC-3).** Positioned per the official defense-in-depth layering model (in-session edits → security-guidance; on-demand diff → native `/security-review`; PR → Code Review / `/code-review ultra`; whole-codebase / CI → this plugin) at four points:
+  - **`commands/security.md`** — new "How This Fits — Security Layering" table + Related Commands entries (security-guidance, native `/security-review`, `generate-review-md`).
+  - **`skills/code-quality-audit/SKILL.md`** — a Note block parallel to the existing `/simplify` note: this skill's security flows are the whole-codebase SAST layer; native `/security-review` + security-guidance reduce what reaches it but cannot do whole-repo framework SAST / taint / CVE / OWASP debate.
+  - **`commands/security-debate.md`** — a "Where This Fits" note (the multi-agent OWASP debate has no native equivalent) + a Related Commands entry.
+  - **`README.md`** — a "Where this fits (defense in depth)" table at the top of Security Layers + an "In-session security" bullet in Watch-mode & Scheduled Sweeps.
+- **Soft install offer for `security-guidance` in `commands/setup.md`** — new "In-Session Security Plugin (recommended, optional)" section: `/plugin install security-guidance@claude-plugins-official` + `/reload-plugins`, prerequisites (Claude Code 2.1.144+, python3, git; venv under `~/.claude/security/`). **Never auto-installs** — the wizard asks (default No) because the install needs network + the user's consent. Added to the "What This Does" list and the Setup Workflow diagram.
+
+Marketplace metadata bumped 1.15.11 → 1.15.12.
+
 ## [3.6.1] - 2026-05-20
 
 ### Fixed

--- a/code-quality-tools/README.md
+++ b/code-quality-tools/README.md
@@ -196,6 +196,19 @@ All results save to `.reports/` (git-ignored):
 
 ## Security Layers
 
+### Where this fits (defense in depth)
+
+These layers are the **whole-codebase / CI SAST** stage of Claude Code's defense-in-depth model — framework-aware multi-tool scans across the entire tree. The earlier stages are **native** and complementary:
+
+| Stage | Tool | Covers |
+|---|---|---|
+| In session — Claude's own edits | **security-guidance** plugin (auto, no command) | Vulns in code Claude writes, fixed the same session — `/code-quality:setup` offers to install it |
+| On demand — diff | native `/security-review` | One generic, diff-scoped vuln pass |
+| On the PR | **Code Review** / `/code-review ultra` | Multi-agent correctness + security with full-codebase context (tune via `/code-quality:generate-review-md`) |
+| Whole-codebase / CI | **this plugin** (`/code-quality:security` + debates) | Framework-aware multi-tool SAST + OWASP debate native review does not perform |
+
+The native layers reduce what reaches these scans; they do **not** replace them — `/security-review` is generic and diff-only, with no whole-repo Drupal/Next.js SAST, taint analysis, dependency CVEs, or multi-agent OWASP debate.
+
 ### Drupal (10 layers)
 
 | # | Tool | What It Checks |
@@ -261,6 +274,7 @@ ddev exec vendor/bin/grumphp git:init
 
 ## Watch-mode & Scheduled Sweeps
 
+- **In-session security** — the official **security-guidance** plugin reviews Claude's *own* edits as it writes (per-edit pattern match, end-of-turn diff review, and a deeper agentic review on each commit/push Claude makes). It's the in-session counterpart to this plugin's whole-tree scans — it reduces what reaches the PR and the whole-codebase scan without replacing either. `/code-quality:setup` offers to install it (`/plugin install security-guidance@claude-plugins-official`; needs Claude Code 2.1.144+, python3, git). See the layering table under "Security Layers".
 - **Watch-mode linting** activates while the `code-quality-audit` skill is loaded — edits to `composer.json`, `package.json`, `phpstan.neon*`, `psalm.xml`, `eslint.config.*`, or `tsconfig.json` re-run the lint. Disable mid-session: `export CLAUDE_CODE_QUALITY_WATCH=0`.
 - **Scheduled sweeps** — pick a surface (Desktop / Cloud Routine / `/loop`) based on whether the audit needs local file access, machine-off reliability, or in-session polling. Templates in `skills/code-quality-audit/references/scheduled-sweeps.md`, `desktop-sweep-template.md`, `cloud-routine-sweep.md`.
 - **Pre-merge CI gate** — Cloud Routine with API trigger callable from GitHub Actions / GitLab CI. Full template in `skills/code-quality-audit/references/premerge-gate-routine.md`.

--- a/code-quality-tools/commands/security-debate.md
+++ b/code-quality-tools/commands/security-debate.md
@@ -340,9 +340,14 @@ The lead synthesizes into `.reports/security-debate.md`:
 {Key disagreements and how they resolved}
 ```
 
+## Where This Fits (defense in depth)
+
+This debate is the **whole-codebase, multi-agent OWASP** layer — it has **no native equivalent**. It sits above the native diff/in-session layers: the official **security-guidance** plugin reviews Claude's *own* edits in session (auto, no command; offered by `/code-quality:setup`), and native `/security-review` runs one generic, diff-scoped pass on demand. Neither chains findings into attack scenarios, maps OWASP/CWE coverage, or challenges severity across competing perspectives. Run those native layers to reduce what reaches a scan; run this debate to pressure-test the whole-tree findings `/code-quality:security` produced.
+
 ## Related Commands
 
 - `/code-quality:security` - Run security audit (prerequisite — generates the report this command debates)
 - `/code-quality:audit` - Full audit (includes security)
 - `/code-quality:architecture-debate` - Architecture and SOLID debate (Pragmatist + Purist + Maintainer)
 - `/code-quality:review` - Rubric-scored code review
+- native `/security-review` - generic diff-scoped vuln pass; the **security-guidance** plugin covers Claude's own in-session edits. Both complement — neither replaces — this whole-codebase debate layer.

--- a/code-quality-tools/commands/security.md
+++ b/code-quality-tools/commands/security.md
@@ -108,8 +108,23 @@ Common issues:
 
 See: `references/troubleshooting.md#security-scan-issues`
 
+## How This Fits — Security Layering (defense in depth)
+
+`/code-quality:security` is the **whole-codebase / CI SAST** layer — a multi-tool scan (Semgrep, Trivy, Gitleaks, Psalm taint, Drush/Composer advisories, Roave, Socket) across the entire tree, framework-aware for Drupal/Next.js. It is one layer in Claude Code's defense-in-depth model; the earlier layers are **native** and complementary:
+
+| Stage | Tool | Covers |
+|---|---|---|
+| In session — Claude's own edits | **security-guidance** plugin (auto, no command) | Common vulns in code Claude writes, fixed the same session. `/code-quality:setup` offers to install it. |
+| On demand — diff | native `/security-review` | One generic, diff-scoped vuln pass on the current branch |
+| On the PR | **Code Review** / `/code-review ultra` | Multi-agent correctness + security with full-codebase context; tune via `/code-quality:generate-review-md` |
+| Whole-codebase / CI | **`/code-quality:security`** (this command) + the debates | Framework-aware multi-tool SAST + OWASP debate native review does not perform |
+
+The native diff-scoped layers reduce what reaches this scan — they do **not** replace it. `/security-review` is generic and diff-only; it cannot do whole-repo Drupal/Next.js SAST, taint analysis, dependency CVEs, or multi-agent OWASP debate. Run `/code-quality:security` for the whole-tree, framework-specific coverage.
+
 ## Related Commands
 
 - `/code-quality:audit` - Full audit (includes security)
-- `/code-quality:setup` - Install security tools
+- `/code-quality:setup` - Install security tools (also offers the in-session **security-guidance** plugin)
 - `/code-quality:security-debate` - Multi-perspective debate analysis of security findings (requires agent teams)
+- `/code-quality:generate-review-md` - Configure the PR-stage managed Code Review (`REVIEW.md`)
+- native `/security-review` - on-demand generic diff-scoped vuln pass (complements, does not replace, this whole-codebase scan)

--- a/code-quality-tools/commands/setup.md
+++ b/code-quality-tools/commands/setup.md
@@ -21,14 +21,15 @@ Interactive wizard to install and configure code quality tools for your project.
 3. Configures quality thresholds
 4. Installs selected tools
 5. Generates `.code-quality.json` configuration
-6. Optionally sets up git hooks (GrumPHP/Husky)
-7. Runs baseline audit
-8. Displays next steps
+6. Optionally offers the in-session **security-guidance** plugin (soft offer — never auto-installs)
+7. Optionally sets up git hooks (GrumPHP/Husky)
+8. Runs baseline audit
+9. Displays next steps
 
 ## Setup Workflow
 
 ```
-Detection → Tool Selection → Threshold Config → Installation → Git Hooks (optional) → Baseline Audit → Summary
+Detection → Tool Selection → Threshold Config → Installation → Security Plugin (optional) → Git Hooks (optional) → Baseline Audit → Summary
 ```
 
 ## Tool Categories
@@ -114,6 +115,27 @@ The `/code-quality:solid`, `/code-quality:dry`, and `/code-quality:review` comma
 Then install the language-server binary so it is on `$PATH` (see each plugin's README for the exact package). If `/plugin` shows `Executable not found in $PATH`, the binary is missing.
 
 This is **recommended, not required** — every command falls back to full-file reads when no LSP plugin is present. Analysis-depth gains and the Drupal `.module`/`.inc`/`.theme` indexing caveat: `skills/code-quality-audit/references/code-intelligence.md`.
+
+## In-Session Security Plugin (recommended, optional)
+
+The official **security-guidance** plugin reviews Claude's *own* code edits for vulnerabilities while it works — a fast per-edit pattern match (no model call), a background end-of-turn diff review, and a deeper agentic review on each commit/push Claude makes — and feeds findings back into the same session for Claude to fix. It is the **in-session** layer of defense in depth: it reduces what reaches the PR (Code Review / `/code-review ultra`) and the whole-codebase scan (`/code-quality:security`) without replacing either.
+
+This plugin's audits scan the *whole tree*; security-guidance watches Claude's *live edits*. They complement each other.
+
+**Soft offer — never auto-install.** Ask the user (plain chat, not a silent install):
+
+> Install the in-session **security-guidance** plugin? It reviews Claude's own edits for vulnerabilities as it works, in addition to this plugin's whole-tree scans. [y/N]
+
+On **yes**, have the user run (the install needs network + their consent, so the wizard does not run it for them):
+
+```
+/plugin install security-guidance@claude-plugins-official
+/reload-plugins
+```
+
+Prerequisites: Claude Code **2.1.144+**, `python3` on `PATH`, and a git repository. On first run it creates a virtual environment under `~/.claude/security/` (needs `pip` + network); if that install fails it falls back to a single-shot commit review. Once installed it runs automatically — nothing to invoke. If the marketplace isn't found, run `/plugin marketplace add anthropics/claude-plugins-official` first, then retry.
+
+Default is **No**. To enable it for everyone who clones the repo, add it to checked-in `.claude/settings.json` under `enabledPlugins` instead (see the plugin's docs).
 
 ## Threshold Configuration
 

--- a/code-quality-tools/commands/ultrareview.md
+++ b/code-quality-tools/commands/ultrareview.md
@@ -1,12 +1,14 @@
 ---
-description: Run Claude Code's cloud-hosted multi-agent deep code review (/ultrareview) with pre-flight platform checks and cost transparency. Use when user says "deep review", "pre-merge review", "ultrareview", "cloud review", "rigorous review", "thorough review", "find bugs before merge", "multi-agent review", "verified review".
+description: Run Claude Code's cloud-hosted multi-agent deep code review (/code-review ultra) with pre-flight platform checks and cost transparency. Use when user says "deep review", "pre-merge review", "ultrareview", "cloud review", "rigorous review", "thorough review", "find bugs before merge", "multi-agent review", "verified review".
 allowed-tools: Bash, Read
 argument-hint: "[PR-number]"
 ---
 
 # Ultrareview (Deep Cloud Review)
 
-Wrap Claude Code's built-in `/ultrareview` with pre-flight platform compatibility checks and cost transparency. `/ultrareview` launches a fleet of reviewer agents in a remote Anthropic-managed sandbox, independently verifies each finding, and reports back via `/tasks` — best for pre-merge review on substantial changes.
+Wrap Claude Code's built-in `/code-review ultra` with pre-flight platform compatibility checks and cost transparency. `/code-review ultra` launches a fleet of reviewer agents in a remote Anthropic-managed sandbox, independently verifies each finding, and reports back via `/tasks` — best for pre-merge review on substantial changes.
+
+> **Command name note:** the canonical interactive command is **`/code-review ultra`**. `/ultrareview` still works as an alias, but this wrapper targets the canonical form. The **headless CLI** is the separate `claude ultrareview` subcommand (still valid — see "CI / Headless Mode" below).
 
 ## Usage
 
@@ -21,7 +23,7 @@ PR mode requires a `github.com` remote on the repository. If the repo is too lar
 
 1. Pre-flight compatibility check (fails cleanly on unsupported platforms)
 2. Cost transparency notice on first use of this session
-3. Invokes the built-in `/ultrareview` command with `$ARGUMENTS`
+3. Invokes the built-in `/code-review ultra` command with `$ARGUMENTS`
 4. Points user to `/tasks` to monitor progress
 
 ## Instructions
@@ -36,7 +38,7 @@ Ultrareview is NOT available on:
 - Organizations with Zero Data Retention (ZDR) enabled
 - API-key-only authentication (requires Claude.ai login via `/login`)
 
-Only Bedrock and Vertex expose local env vars. **Foundry, ZDR, and API-only cannot be reliably detected from the shell** — for those, the built-in `/ultrareview` itself will refuse with a platform error when the session tries to launch. Warn the user accordingly.
+Only Bedrock and Vertex expose local env vars. **Foundry, ZDR, and API-only cannot be reliably detected from the shell** — for those, the built-in `/code-review ultra` itself will refuse with a platform error when the session tries to launch. Warn the user accordingly.
 
 Check the env-var-detectable platforms. Treat only truthy values as "set" (empty, `0`, `false`, `no` mean disabled even if the variable exists):
 
@@ -53,7 +55,7 @@ fi
 
 If an env-detectable platform matches, STOP and respond:
 
-> `/ultrareview` is not available on {platform}. It runs on Claude Code on the web infrastructure, which is not reachable from Bedrock/Vertex/Foundry and is unavailable to organizations with Zero Data Retention enabled.
+> `/code-review ultra` is not available on {platform}. It runs on Claude Code on the web infrastructure, which is not reachable from Bedrock/Vertex/Foundry and is unavailable to organizations with Zero Data Retention enabled.
 >
 > Alternatives:
 > - `/code-quality:review <path>` — local single-pass rubric review
@@ -62,11 +64,11 @@ If an env-detectable platform matches, STOP and respond:
 
 If no env var matched, proceed — but tell the user:
 
-> Pre-flight only detects Bedrock and Vertex locally. If you're on Foundry, a ZDR organization, or authenticated with an API key only, the built-in `/ultrareview` will refuse at session launch. If that happens, run `/login` and sign in with Claude.ai, or fall back to `/code-quality:review`.
+> Pre-flight only detects Bedrock and Vertex locally. If you're on Foundry, a ZDR organization, or authenticated with an API key only, the built-in `/code-review ultra` will refuse at session launch. If that happens, run `/login` and sign in with Claude.ai, or fall back to `/code-quality:review`.
 
 ### Step 2 — Cost Transparency
 
-`/ultrareview` bills as extra usage — not included usage. On first invocation per session, show:
+`/code-review ultra` bills as extra usage — not included usage. On first invocation per session, show:
 
 > **Ultrareview runs on Anthropic cloud infrastructure and bills as extra usage** (separate from your plan's included tokens).
 >
@@ -75,7 +77,7 @@ If no env var matched, proceed — but tell the user:
 > | Pro / Max | 3 free runs (one-time, never refresh) | $5–$20 per run |
 > | Team / Enterprise | none | $5–$20 per run |
 >
-> Usage credits must be enabled on the account. Run `/usage-credits` to check or change the setting. If disabled, `/ultrareview` will block and link to billing settings.
+> Usage credits must be enabled on the account. Run `/usage-credits` to check or change the setting. If disabled, `/code-review ultra` will block and link to billing settings.
 >
 > A review takes 5–10 minutes and runs in the background — track it with `/tasks`.
 
@@ -104,17 +106,17 @@ If missing, STOP:
 
 > PR mode requires a `github.com` remote. Either push your branch to GitHub and retry, or run `/code-quality:ultrareview` (no arguments) to review your local branch diff instead.
 
-### Step 4 — Hand Off to the Built-in /ultrareview
+### Step 4 — Hand Off to the Built-in /code-review ultra
 
-A command body cannot invoke another *slash* command, so the interactive `/ultrareview` must be run by the user. (This limitation does **not** apply to CI/headless use — the `claude ultrareview` CLI subcommand *is* Bash-invokable; see "CI / Headless Mode" below.) After the pre-flight passes, tell the user:
+A command body cannot invoke another *slash* command, so the interactive `/code-review ultra` must be run by the user. (This limitation does **not** apply to CI/headless use — the `claude ultrareview` CLI subcommand *is* Bash-invokable; see "CI / Headless Mode" below.) After the pre-flight passes, tell the user:
 
-> Pre-flight passed. Run `/ultrareview $ARGUMENTS` to start the review.
+> Pre-flight passed. Run `/code-review ultra $ARGUMENTS` to start the review.
 >
 > The built-in will show a confirmation dialog with the file/line count, remaining free runs, and estimated cost before the session launches. Monitor progress with `/tasks` — the review runs in the background, so you can keep coding or close the terminal.
 
 ## CI / Headless Mode (`claude ultrareview`)
 
-For pre-merge gating in CI or scripts, use the `claude ultrareview` CLI subcommand instead of the interactive slash command. It launches the same cloud review, blocks until the remote review finishes, prints findings to stdout, and returns an exit code — so a pipeline step can gate on it directly. Unlike the `/ultrareview` slash command, this subcommand runs from a Bash step.
+For pre-merge gating in CI or scripts, use the `claude ultrareview` CLI subcommand instead of the interactive slash command. It launches the same cloud review, blocks until the remote review finishes, prints findings to stdout, and returns an exit code — so a pipeline step can gate on it directly. Unlike the `/code-review ultra` slash command, this subcommand runs from a Bash step.
 
 ### Invocation
 
@@ -156,7 +158,7 @@ jq -e '[.bugs[]? | select(.severity=="high" or .severity=="critical")] | length 
 
 ### Cost discipline for CI
 
-A run that fails or is stopped **still consumes** one of the three free Pro/Max runs; paid runs bill $5–$20 as usage credits. Reserve `claude ultrareview` for merge-ready / release branches — do **not** wire it to `on: push`. For every-push gating use the cheaper local `/code-quality:audit --json`; use `claude ultrareview --json` only as a release-gate step. The Step 1 pre-flight platform constraints (Bedrock/Vertex/Foundry/ZDR/API-key-only) apply to the subcommand identically — it has the same authentication and usage-credit requirements as `/ultrareview`.
+A run that fails or is stopped **still consumes** one of the three free Pro/Max runs; paid runs bill $5–$20 as usage credits. Reserve `claude ultrareview` for merge-ready / release branches — do **not** wire it to `on: push`. For every-push gating use the cheaper local `/code-quality:audit --json`; use `claude ultrareview --json` only as a release-gate step. The Step 1 pre-flight platform constraints (Bedrock/Vertex/Foundry/ZDR/API-key-only) apply to the subcommand identically — it has the same authentication and usage-credit requirements as `/code-review ultra`.
 
 ## When to Use This vs `/code-quality:review`
 
@@ -174,4 +176,4 @@ A run that fails or is stopped **still consumes** one of the three free Pro/Max 
 - `/code-quality:audit` — full local audit (all tools, no rubric)
 - `/code-quality:generate-review-md` — tune managed Code Review (separate from ultrareview)
 - `skills/code-quality-audit/references/scheduled-sweeps.md` — scheduling reviews across local and cloud surfaces
-- `claude --from-pr <number>` — resumes the Claude Code session linked to a PR (linked automatically when Claude opened it). Use it to pick up review or fix work on a PR; distinct from `/ultrareview <PR>`, which clones a PR fresh to review it.
+- `claude --from-pr <number>` — resumes the Claude Code session linked to a PR (linked automatically when Claude opened it). Use it to pick up review or fix work on a PR; distinct from `/code-review ultra <PR>`, which clones a PR fresh to review it.

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -78,6 +78,8 @@ Unset the variable (or set to anything other than `0`) to re-enable.
 
 > **Note — Claude Code's built-in `/simplify`:** Claude Code ships a built-in `/simplify` skill for quick single-pass code review. `/code-quality:review` is different: it runs automated tools (PHPStan/ESLint), scores across 10 rubric categories with a /50 scale, enforces a quality gate (PASS 35+/FAIL), and writes a persisted report. Use `/simplify` for fast ad-hoc feedback; use `/code-quality:review` when you need a structured, scored, and documented assessment.
 
+> **Note — the `security-guidance` plugin and native `/security-review`:** This skill's security flows (`/code-quality:security`, the debates) are the **whole-codebase / CI SAST** layer — framework-aware multi-tool scans across the whole tree. They sit *below* two native layers in Claude Code's defense-in-depth model: the official **security-guidance** plugin reviews Claude's *own* edits as it writes (per-edit / end-of-turn / commit — auto, no command; offered by `/code-quality:setup`), and native `/security-review` runs one generic, diff-scoped pass on demand. The native layers reduce what reaches a whole-tree scan; they do **not** replace it — `/security-review` cannot do whole-repo Drupal/Next.js SAST, taint analysis, dependency CVEs, or multi-agent OWASP debate. Run this skill's security audit for the framework-specific, whole-codebase coverage native review does not perform.
+
 ## When to Use
 
 **Drupal projects:**


### PR DESCRIPTION
## Summary

First release of the 2026-05-29 feature wave. Stops pointing the cloud-review wrapper at a deprecated alias, adopts the one in-session security layer the plugin lacked (the official **security-guidance** plugin), and positions CQT in its real lane — **whole-codebase / CI SAST**, the layer native diff-scoped review does not cover.

**No SAST script or gate logic changed** — doc / wrapper retargeting + a soft install offer only. Grounded in the cached Code Review, Ultrareview, Security Guidance, and Security guides (2026-05-29 snapshot).

## Changes

### Repoint cloud-review wrapper → canonical `/code-review ultra`
- `commands/ultrareview.md`: all **interactive** `/ultrareview` targets → `/code-review ultra` (description, body, hand-off step, platform-refusal + cost notices, See-also). `/ultrareview` documented inline as a still-working alias.
- **Kept unchanged:** the headless `claude ultrareview` CLI subcommand (still the documented non-interactive form; exit-code contract `0`/`1`/`130` intact), and the `/code-quality:ultrareview` command name + file (back-compat — only the *built-in target* changed).
- `plugin.json` + root `marketplace.json` descriptions: "an /ultrareview cloud-review wrapper" → "a /code-review ultra cloud-review wrapper".
- The five cross-link files (`audit.md`, `review.md`, `generate-review-md.md`, `SKILL.md`, `README.md`) reference only the kept CLI / plugin-command name / `commands/ultrareview.md` file path — **no interactive-target edit needed** (verified by grep).

### Adopt security-guidance (CC-3) — in-session security layer
Positioned per the official defense-in-depth layering model (in-session → security-guidance; on-demand diff → native `/security-review`; PR → Code Review / `/code-review ultra`; whole-codebase/CI → this plugin) at four points:
- `commands/security.md` — "How This Fits — Security Layering" table + Related Commands entries.
- `skills/code-quality-audit/SKILL.md` — Note block parallel to the existing `/simplify` note.
- `commands/security-debate.md` — "Where This Fits" note + Related Commands entry.
- `README.md` — "Where this fits" table under Security Layers + a Watch-mode bullet.

Every positioning point states the native layers **complement, never replace** the whole-codebase SAST suite (guards the non-goal).

### Soft install offer
- `commands/setup.md` — new "In-Session Security Plugin (recommended, optional)" section offering `/plugin install security-guidance@claude-plugins-official` (+ `/reload-plugins`); prereqs CC 2.1.144+, python3, git; venv under `~/.claude/security/`. **Never auto-installs** — wizard asks (default No).

## Bumps
- `plugin.json` 3.6.1 → **3.7.0**; marketplace entry → 3.7.0; `metadata.version` 1.15.11 → 1.15.12; CHANGELOG `[3.7.0]`.

## Validation
- Self-test grep: no stray **interactive** `/ultrareview` targets (only the kept `claude ultrareview` CLI, `/code-quality:ultrareview` command name, `commands/ultrareview.md` file path, and a deliberate alias note). security-guidance referenced at the four points + the setup install offer.
- `/plugin-creation-tools:validate ./code-quality-tools` (non-strict): **PASS**, zero new findings introduced.
- `--strict`: FAILs only on **pre-existing** S14 (`model: sonnet` on the audit skill) and S10 (307-line hub-skill body) — both explicitly owned by **v3.8.0** per the roadmap (S14 → `model: inherit`; S10 is the accepted carve-out). Not touched here: fixing S14 would change the audit skill's model, out of scope for this release.

## Non-goals respected
- `/security`, the SAST suite, the debates, and the scored/gated rubric are unchanged — native review is not substituted for any of them.
- security-guidance is **offered, not auto-installed**.
- `claude ultrareview` CLI references intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)