### PR TITLE
code-quality-tools v3.8.0: 2026-05-29 doc hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Drupal development workflow, dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.12"
+    "version": "1.15.13"
   },
   "plugins": [
     {
@@ -128,7 +128,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0] - 2026-06-06
+
+### 2026-05-29 doc hardening
+
+Second release of the 2026-05-29 feature wave. Validator hygiene + threat-model accuracy on the `code-quality-audit` hub skill. No SAST script, gate logic, or command behavior changed — skill frontmatter + two doc notes + a CONVENTIONS section.
+
+### Changed
+
+- **S14 — `skills/code-quality-audit/SKILL.md` `model: sonnet` → `model: inherit`.** The audit skill runs **inline** (not as a Task-dispatched agent — it needs live conversation context) and is meant to scan whole codebases, so pinning it to sonnet's ~200k window was doubly wrong: context-overflow risk when invoked from a large session, **and** an undersized window for large-repo audits. `inherit` runs it on the session model (up to 1M). The six `**Model:** sonnet` markers in `architecture-debate.md` / `security-debate.md` are agent-**spawn** intent (fresh context, isolated worktrees) and are **S14-exempt — left unchanged**.
+- **CC-4 — "Sandbox users" note rewritten for the process-level sandbox runtime.** The note now states that the built-in **sandboxed Bash tool** restricts *only Bash* — hooks run unconstrained on the host — so the `npx`-trojan-in-hook risk (watch-mode dispatcher `lint-changed.sh`, documented under "Known limitations") is **outside** that boundary. Adds the **sandbox runtime** (`@anthropic-ai/sandbox-runtime`, no Docker, wraps file tools + Bash + hooks) with `~/.srt-settings.json` config + `npx @anthropic-ai/sandbox-runtime claude` launch, and **recommends running audits of untrusted checkouts under it** (or a VM / Claude Code on the web). Cross-references the **Sandbox Environments** guide. Grounded in the cached Sandbox Environments guide (2026-05-29 snapshot).
+
+### Added
+
+- **CC-1 — `disallowed-tools: Write, Edit` on `code-quality-audit/SKILL.md`.** The audit skill is read-only analysis (already `allowed-tools: Read, Bash, Grep, Glob`); declaring the denial hardens the documented hostile-clone threat model at the harness level. **Not** applied to the report-writing commands (`review.md`, `audit.md`, `generate-review-md.md`) — they legitimately write `.reports/` / `REVIEW.md`.
+- **CC-2 — `/plugin-creation-tools:validate --strict` added to `CONVENTIONS.md` release hygiene.** New "Release Hygiene" section names `--strict` as the pre-PR gate (promotes S-series warnings to gating errors) alongside the lockstep version-bump checklist.
+
+### Note
+
+- Skill frontmatter `version` resynced `3.5.0` → `3.8.0` (it had lagged two releases; this release makes substantive frontmatter changes, so it's the natural resync point).
+
+Marketplace metadata bumped 1.15.12 → 1.15.13.
+
 ## [3.7.0] - 2026-06-06
 
 ### Native review/security alignment + security-guidance adoption

--- a/code-quality-tools/CONVENTIONS.md
+++ b/code-quality-tools/CONVENTIONS.md
@@ -86,6 +86,11 @@ For Drupal-specific patterns when explaining violations or suggesting fixes, fet
 - WebFetch the index to discover available topics, then fetch specific topic pages
 - Likely relevant topics: solid-principles, dry-principles, security, testing, tdd, js-development, github-actions
 
+## Release Hygiene
+- Per release, bump in lockstep: `.claude-plugin/plugin.json` `version`, the plugin entry **and** `metadata.version` in the camoa-skills root `marketplace.json`, the `CHANGELOG.md` entry, and any skill/agent frontmatter `version` touched.
+- **Pre-PR gate:** run `/plugin-creation-tools:validate --strict` against the plugin (`cd code-quality-tools/`). `--strict` promotes the S-series warnings (e.g. S10 body length, S14 inline-model context risk) to gating errors — treat a `--strict` FAIL as a blocker unless the finding is an explicitly accepted carve-out recorded in the release notes. Plain `/plugin-creation-tools:validate` is the looser check; `--strict` is the release gate.
+- One minor bump per PR; one release = one PR.
+
 ## General
 - Reference files instead of reproducing content
 - Current state only — no historical narratives

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: code-quality-audit
 description: Use when checking code quality, running security audits, testing coverage, finding SOLID/DRY violations, or setting up quality tools. Use when user says "audit this code", "check security", "run PHPStan", "code quality", "find violations", "SOLID check", "DRY check", "test coverage", "lint this", "security review", "is this production ready", "check for vulnerabilities", "code review", "grade this code", "watch mode lint", "deep review", "ultrareview", "schedule quality sweep". Supports Drupal (PHPStan, PHPMD, Psalm, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Use proactively before deployment or after significant code changes.
-version: 3.5.0
-model: sonnet
+version: 3.8.0
+model: inherit
 allowed-tools: Read, Bash, Grep, Glob
+disallowed-tools: Write, Edit
 user-invocable: false
 hooks:
   FileChanged:
@@ -141,7 +142,9 @@ Unset the variable (or set to anything other than `0`) to re-enable.
 1. Verify npm: `npm --version`
 2. Create reports directory: `mkdir -p .reports && echo ".reports/" >> .gitignore`
 
-> **Sandbox users:** If Claude Code sandbox mode is enabled, bash scripts that invoke linters (PHPStan, ESLint, Semgrep, Trivy, Gitleaks) require their binary paths to be whitelisted. Add the tool binaries to your `allowedPaths` in `claude_code_config.json` (e.g., `vendor/bin/phpstan`, `/usr/local/bin/semgrep`). DDEV-proxied commands run inside the container and are unaffected.
+> **Sandbox users:** If the built-in **sandboxed Bash tool** (`/sandbox`) is enabled, bash scripts that invoke linters (PHPStan, ESLint, Semgrep, Trivy, Gitleaks) require their binary paths to be whitelisted. Add the tool binaries to your `allowedPaths` (e.g., `vendor/bin/phpstan`, `/usr/local/bin/semgrep`). DDEV-proxied commands run inside the container and are unaffected.
+>
+> The Bash sandbox restricts **only Bash** — built-in file tools, MCP servers, and **hooks run unconstrained on the host**. That matters here because the watch-mode dispatcher runs as a `FileChanged` **hook** (`lint-changed.sh`), so the `npx`-trojan risk documented under "Known limitations" above is **outside** the Bash sandbox's boundary. To contain hooks (and file tools and MCP) under one OS boundary **without Docker**, run the whole Claude Code process under the **sandbox runtime** (`@anthropic-ai/sandbox-runtime`, a beta research preview): configure `~/.srt-settings.json` (it denies all write + network by default) to allow your project dir, `~/.claude`/`~/.claude.json`, and `api.anthropic.com`, then launch with `npx @anthropic-ai/sandbox-runtime claude`. **Recommendation:** run audits of **untrusted checkouts** under the sandbox runtime (or, for kernel-level separation, a dedicated VM / Claude Code on the web). Compare the isolation approaches in the **Sandbox Environments** guide (`/en/sandbox-environments`).
 
 ## When to Run What
 


### PR DESCRIPTION
## Summary

Second release of the 2026-05-29 feature wave. Validator hygiene + threat-model accuracy on the `code-quality-audit` hub skill. **No SAST script, gate logic, or command behavior changed** — skill frontmatter + two doc notes + a CONVENTIONS section.

## Changes

### S14 — `model: sonnet` → `model: inherit` (`skills/code-quality-audit/SKILL.md`)
The audit skill runs **inline** (needs live conversation context — it is not a Task-dispatched agent) and is meant to scan whole codebases. Pinning it to sonnet's ~200k window was doubly wrong: context-overflow risk from a large session **and** an undersized window for large-repo audits. `inherit` runs it on the session model (up to 1M).
- The six `**Model:** sonnet` markers in `architecture-debate.md` / `security-debate.md` are agent-**spawn** intent (fresh context, isolated worktrees) — **S14-exempt, left unchanged**.

### CC-1 — `disallowed-tools: Write, Edit` on the audit skill
Read-only analysis (already `allowed-tools: Read, Bash, Grep, Glob`); declaring the denial hardens the documented hostile-clone threat model at the harness level. **Not** applied to the report-writing commands (`review`/`audit`/`generate-review-md` legitimately write `.reports/` / `REVIEW.md`).

### CC-4 — "Sandbox users" note rewritten for the process-level sandbox runtime
The built-in **sandboxed Bash tool** restricts *only Bash* — hooks run unconstrained on the host — so the `npx`-trojan-in-hook risk (watch-mode `lint-changed.sh`, documented under "Known limitations") is **outside** that boundary. The note now adds the **sandbox runtime** (`@anthropic-ai/sandbox-runtime`, no Docker, wraps file tools + Bash + hooks): `~/.srt-settings.json` config + `npx @anthropic-ai/sandbox-runtime claude` launch, and **recommends running audits of untrusted checkouts under it** (or a VM / Claude Code on the web for kernel-level separation). Cross-references the **Sandbox Environments** guide. Grounded in the cached guide (2026-05-29 snapshot).

### CC-2 — `--strict` gate in CONVENTIONS
New "Release Hygiene" section names `/plugin-creation-tools:validate --strict` as the pre-PR gate (promotes S-series warnings to gating errors) alongside the lockstep version-bump checklist.

## Bumps
- `plugin.json` 3.7.0 → **3.8.0**; marketplace entry → 3.8.0; `metadata.version` 1.15.12 → 1.15.13; CHANGELOG `[3.8.0]`.
- Skill frontmatter `version` resynced 3.5.0 → 3.8.0 (lagged two releases; this release makes substantive frontmatter changes).

## Validation
- `/plugin-creation-tools:validate ./code-quality-tools --strict`: **S14 cleared** (`model: inherit`, exempt); `disallowed-tools` recognized (S15 ✓). **No new warnings.**
- Only residual `--strict` finding is **S10** (310-line hub-skill body) — the long-accepted carve-out (firing since v3.3.0 at 286–310 lines), **not a v3.8.0 regression**, recorded as an accepted carve-out per the new CONVENTIONS rule + CHANGELOG/roadmap notes. Body-trim is an explicit out-of-scope optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)