### PR TITLE
oracle-integrity invariant — drupal-dev-framework v4.21.0 (epic build_gate_correctness, 2/4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "Systematic 3-phase Drupal development workflow (Research \u2192 Architecture \u2192 Implementation) with enforced SOLID, TDD, DRY, and security gates. Covers epic/sub-task hierarchy, scope contracts, a Phase 4 /review gate with change-impact dispatch, two-stage dev-guides detection, the Playbook System, git-worktree parallel-task awareness, agent-team validation, per-project session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (/setup-atk, /setup-visual-regression, /setup-visual-parity).",
-      "version": "4.20.0",
+      "version": "4.21.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-dev-framework",
   "description": "Systematic 3-phase Drupal development workflow with agents, skills, and commands. Implements Research → Architecture → Implementation phases with enforced SOLID, TDD, DRY, and security principles.",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.21.0] - 2026-06-12
+
+**Oracle-integrity invariant — a builder can never pass a gate by altering the gate's oracle.** The
+autonomous builder must fix the code, not weaken the check: VR baselines never auto-recreate, and a work-order
+diff that writes a VR baseline, deletes a test/spec, or adds/modifies `phpstan-baseline.neon` is an
+oracle-tamper signal that HALTs and escalates — unless the work-order's explicit human-authored `oracle_update`
+scope covers it (and even then it ships flagged). Closes the most visceral autonomy hole (rubber-stamping any
+visual change by regenerating the baseline) and its siblings (snapshots, phpstan-baseline, coverage thresholds,
+test deletion).
+
+### Added
+- **`scripts/wo-oracle-check.sh`** — a deterministic kernel that scans a work-order's `git diff --name-status`
+  against a fixed oracle watch-table and emits `{tamper_detected, signals[], halt_reason}`. Halts on the
+  unambiguous oracle-weakening signals (VR baseline write, VR-spec/test **deletion** — including a rename that
+  relocates a test out of `tests/`, the rename-evasion case — and `phpstan-baseline.neon` add/modify); flags
+  (advisory, non-halting) on ambiguous config modifies (`phpstan.neon`, coverage config, registry). A
+  human-authored `oracle_update: {classes, reason, by}` work-order field downgrades an in-scope halt to a flag
+  (the work-order ships, the PR opens flagged). Hermetic suite `tests/wo-oracle-check-spec.sh` (120 cases).
+- **Critique-rung integration** (`skills/work-order-critique/SKILL.md`) — the §16.2 critique rung now derives a
+  name-status diff and runs the oracle check **before spawning any critic**; on tamper it writes a
+  `wo-NN.HALT` (reason `oracle_tamper`) and returns, so the loop's existing terminal-HALT path escalates to the
+  human (no reset, no requeue, no merge). Contract spec `tests/critique-oracle-contract-spec.sh`.
+
+### Changed
+- **`work-order-contract.md`** — the invariant is stated (Honest scope boundary), `oracle_tamper` is added to
+  the build-and-collect handle's `halt_reason` enum **additively** (`schema_version` stays `1.0`), and the
+  `oracle_update` seam field (① authored, ② consumed) is documented in the ownership table.
+- **`work-order-builder/SKILL.md`** — a `Never modify an oracle` hard-boundary rule.
+- **`work-order-loop/references/merge-contract.md`** — states that under automation the loop runs VR but never
+  regenerates the baseline (consistent with `/review --headless` `--ci`); a VR diff or `oracle_tamper` HALT is
+  terminal escalation.
+
 ## [4.20.0] - 2026-06-12
 
 **Change-scoped gate floor — assess the diff, not the whole codebase.** The v4.19.1 F2 band-aid (a

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -322,7 +322,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading — it auto-d
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.20.0**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **4.21.0**.
 
 ## License
 

--- a/drupal-dev-framework/scripts/wo-oracle-check.sh
+++ b/drupal-dev-framework/scripts/wo-oracle-check.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# wo-oracle-check.sh — Deterministic oracle tamper-detection kernel.
+#
+# Scans a WO diff (--name-status format) against the oracle watch-table and emits a JSON verdict.
+# Mirrors the shape of wo-risk-classify.sh: shebang, set -euo pipefail, positional WO-file arg +
+# --diff-from flag, safe frontmatter read (never eval/source), all JSON via jq, verdict on stdout.
+#
+# Usage:
+#   wo-oracle-check.sh <wo-file> --diff-from <name-status-file>
+#
+#   <wo-file>           positional; oracle_update.classes extracted safely via awk (no eval).
+#   --diff-from         file holding `git diff --name-status` output:
+#                       TAB-separated lines "STATUS\tpath"; rename "R###\told\tnew" → treat new as M.
+#
+# Stdout JSON:
+#   { "schema_version": "1.0",
+#     "tamper_detected": <bool>,
+#     "signals": [ { "type": <str>, "path": <str>, "change": "A|M|D",
+#                    "oracle_class": <str>, "severity": "halt|flag",
+#                    "allowed_by_scope": <bool> } ],
+#     "halt_reason": "oracle_tamper" | null }
+#
+# Exit: 0 on well-formed run (verdict in JSON). Exit 2 on bad args / unreadable inputs.
+#
+# Watch-table:
+#   baseline_write    tests/visual/*.spec.ts-snapshots/{*.png,*.meta.json}   A,M  baseline           halt
+#   vr_spec_delete    tests/visual/*.spec.ts                                  D    test-delete        halt
+#   test_delete       tests/**/*Test.php                                      D    test-delete        halt
+#                     tests/e2e/**/*.spec.ts                                  D    test-delete        halt
+#                     tests/atk/**/*.spec.ts                                  D    test-delete        halt
+#   phpstan_baseline  phpstan-baseline.neon                                  A,M  phpstan-baseline   halt
+#   phpstan_config    phpstan.neon  phpstan.neon.dist                         M    phpstan-baseline   flag
+#   registry_shrink   .visual-review/registry.yml                             M    baseline           flag
+#   coverage_threshold jest.config.*  phpunit.xml  phpunit.xml.dist           M    coverage-threshold flag
+
+set -euo pipefail
+
+# --- arg parsing -------------------------------------------------------------
+WO_FILE=""
+DIFF_FROM=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --diff-from) DIFF_FROM="${2:-}"; shift 2 || shift ;;
+    --*)         shift ;;
+    *)
+      if [ -z "$WO_FILE" ]; then
+        WO_FILE="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# --- validate inputs (exit 2 on bad args / unreadable files) ----------------
+if [ -z "$WO_FILE" ] || [ ! -f "$WO_FILE" ]; then
+  printf 'wo-oracle-check: wo-file missing or unreadable: %s\n' "${WO_FILE:-<none>}" >&2
+  exit 2
+fi
+if [ -z "$DIFF_FROM" ] || [ ! -f "$DIFF_FROM" ]; then
+  printf 'wo-oracle-check: --diff-from file missing or unreadable: %s\n' "${DIFF_FROM:-<none>}" >&2
+  exit 2
+fi
+
+# --- safe oracle_update parser (never eval/source the WO file) ---------------
+# Reads oracle_update.classes from the WO's YAML frontmatter. Output: comma-separated
+# class names (e.g. "baseline,phpstan-baseline"), or empty string when absent.
+#
+# Robustness requirements (security-critical — a parse miss either false-HALTs legit
+# work OR fail-opens a tamper bypass):
+#   L1  honor oracle_update ONLY inside a properly TERMINATED `---`…`---` frontmatter
+#       block — a file with no closing `---` => NO frontmatter => NO exemption (never
+#       fail-open by reading body prose).
+#   M2  strip quotes (both " and ') from class names.
+#   M3  parse BOTH the inline flow list (`classes: [a, b]`) AND the block-style YAML
+#       list (`classes:` then indented `- a` / `- b` lines).
+#   (d) ignore commented / body-prose / differently-keyed occurrences (case-sensitive,
+#       frontmatter-scoped, top-level `oracle_update:` key only).
+
+# extract_frontmatter — prints the frontmatter body ONLY if a CLOSING `---` exists (L1).
+# No leading `---` on line 1, or no closing `---`, => prints nothing.
+extract_frontmatter() {
+  awk '
+    NR==1 { if ($0 ~ /^---[[:space:]]*$/) { started=1; next } else { exit } }
+    started && $0 ~ /^---[[:space:]]*$/ { closed=1; exit }
+    started { buf = buf $0 "\n" }
+    END { if (closed) printf "%s", buf }
+  ' "$WO_FILE"
+}
+
+parse_oracle_classes() {
+  local _fm
+  _fm="$(extract_frontmatter)"
+  [ -z "$_fm" ] && return 0
+  printf '%s' "$_fm" | awk '
+    BEGIN { in_ou=0; in_classes=0; out="" }
+    # top-level oracle_update mapping key (case-sensitive, column 0, no leading #)
+    /^oracle_update:[[:space:]]*$/ { in_ou=1; in_classes=0; next }
+    # any other top-level key (non-space, non-#) ends the oracle_update block
+    in_ou && /^[^[:space:]#]/ { in_ou=0; in_classes=0 }
+    # inline flow list: classes: [a, b]
+    in_ou && /^[[:space:]]+classes:[[:space:]]*\[/ {
+      line=$0
+      sub(/^[[:space:]]*classes:[[:space:]]*/, "", line)
+      sub(/#.*/, "", line)            # strip a trailing inline comment
+      gsub(/[\[\]]/, "", line)
+      gsub(/"/, "", line)             # M2: strip double quotes
+      gsub(/\047/, "", line)          # M2: strip single quotes (octal 047)
+      gsub(/[[:space:]]/, "", line)
+      if (line != "") out = (out == "" ? line : out "," line)
+      in_classes=0
+      next
+    }
+    # block-style list header: classes: (value continues on indented `- item` lines)
+    in_ou && /^[[:space:]]+classes:[[:space:]]*$/ { in_classes=1; next }
+    # block-style list item: `- baseline`
+    in_classes && /^[[:space:]]+-[[:space:]]*/ {
+      item=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", item)
+      sub(/#.*/, "", item)            # strip a trailing inline comment
+      gsub(/"/, "", item)             # M2: strip double quotes
+      gsub(/\047/, "", item)          # M2: strip single quotes
+      gsub(/[[:space:]]/, "", item)
+      if (item != "") out = (out == "" ? item : out "," item)
+      next
+    }
+    # a sibling key under oracle_update (reason:, by:) ends the classes list
+    in_classes && /^[[:space:]]+[^[:space:]-]/ { in_classes=0 }
+    END { print out }
+  '
+}
+
+ORACLE_CLASSES="$(parse_oracle_classes || true)"
+
+# --- glob-to-regex converter -------------------------------------------------
+# Converts a file glob pattern to a bash ERE regex anchored at start and end.
+#   *  matches any string within one path segment (no slash)  → [^/]*
+#   ** matches any string across path segments               → .*
+#   .  is literal in a path                                  → \.
+# Input:  glob pattern string (e.g. "tests/**/*Test.php")
+# Output: ERE regex string  (e.g. "^tests/(.*/)?[^/]*Test\.php$")
+glob_to_regex() {
+  local _g="$1" _r
+  # 1. Escape literal dots
+  _r="$(printf '%s' "$_g" | sed -e 's/[.]/\\./g')"
+  # 2. Replace **/ and ** with placeholders (no * chars) to prevent the
+  #    single-* pass from re-processing the .* introduced by these replacements
+  _r="$(printf '%s' "$_r" | sed -e 's|\*\*/|__GLOBSTAR_SLASH__|g')"
+  _r="$(printf '%s' "$_r" | sed -e 's|\*\*|__GLOBSTAR__|g')"
+  # 3. Replace remaining single * with one-segment wildcard
+  _r="$(printf '%s' "$_r" | sed -e 's|\*|[^/]*|g')"
+  # 4. Restore placeholders to their ERE regex equivalents
+  _r="$(printf '%s' "$_r" \
+    | sed -e 's|__GLOBSTAR_SLASH__|(.*/)?|g' \
+    | sed -e 's|__GLOBSTAR__|.*|g')"
+  printf '^%s$' "$_r"
+}
+
+# path_matches <path> <glob-pattern>  — returns 0 if the path matches the glob, 1 otherwise
+path_matches() {
+  local _pm_path="$1" _pm_pat="$2" _pm_rx
+  _pm_rx="$(glob_to_regex "$_pm_pat")"
+  [[ "$_pm_path" =~ $_pm_rx ]]
+}
+
+# is_in_oracle_classes <oracle-class>  — returns 0 if class is in ORACLE_CLASSES, 1 if not
+is_in_oracle_classes() {
+  local _cls="$1"
+  if [ -z "$ORACLE_CLASSES" ]; then
+    return 1
+  fi
+  # ORACLE_CLASSES is comma-separated; wrap with commas to avoid partial matches
+  case ",$ORACLE_CLASSES," in
+    *,"$_cls",*) return 0 ;;
+  esac
+  return 1
+}
+
+# classify_path <status> <path>
+# Sets _CLS_TYPE, _CLS_ORACLE_CLASS, _CLS_SEVERITY on match and returns 0.
+# Returns 1 if the path+status combination matches no watch-table row.
+classify_path() {
+  local _cp_st="$1" _cp_p="$2"
+  _CLS_TYPE=""; _CLS_ORACLE_CLASS=""; _CLS_SEVERITY=""
+
+  # --- A or M changes ----------------------------------------------------------
+  case "$_cp_st" in
+    A|M)
+      # baseline_write: visual snapshot images and meta files (** => nested baselines
+      # under the snapshots dir still match; the **/ => (.*/)? regex keeps flat matching)
+      if path_matches "$_cp_p" "tests/visual/*.spec.ts-snapshots/**/*.png" ||
+         path_matches "$_cp_p" "tests/visual/*.spec.ts-snapshots/**/*.meta.json"; then
+        _CLS_TYPE="baseline_write"
+        _CLS_ORACLE_CLASS="baseline"
+        _CLS_SEVERITY="halt"
+        return 0
+      fi
+      # phpstan_baseline: baseline neon file written or modified
+      if path_matches "$_cp_p" "phpstan-baseline.neon"; then
+        _CLS_TYPE="phpstan_baseline"
+        _CLS_ORACLE_CLASS="phpstan-baseline"
+        _CLS_SEVERITY="halt"
+        return 0
+      fi
+      ;;
+  esac
+
+  # --- D (delete) changes only -------------------------------------------------
+  case "$_cp_st" in
+    D)
+      # vr_spec_delete: visual spec file deleted
+      if path_matches "$_cp_p" "tests/visual/*.spec.ts"; then
+        _CLS_TYPE="vr_spec_delete"
+        _CLS_ORACLE_CLASS="test-delete"
+        _CLS_SEVERITY="halt"
+        return 0
+      fi
+      # test_delete: PHPUnit test, e2e spec, or ATK spec deleted
+      if path_matches "$_cp_p" "tests/**/*Test.php" ||
+         path_matches "$_cp_p" "tests/e2e/**/*.spec.ts" ||
+         path_matches "$_cp_p" "tests/atk/**/*.spec.ts"; then
+        _CLS_TYPE="test_delete"
+        _CLS_ORACLE_CLASS="test-delete"
+        _CLS_SEVERITY="halt"
+        return 0
+      fi
+      ;;
+  esac
+
+  # --- M (modify) only — flag-severity rows ------------------------------------
+  case "$_cp_st" in
+    M)
+      # phpstan_config: phpstan config files modified
+      if path_matches "$_cp_p" "phpstan.neon" ||
+         path_matches "$_cp_p" "phpstan.neon.dist"; then
+        _CLS_TYPE="phpstan_config"
+        _CLS_ORACLE_CLASS="phpstan-baseline"
+        _CLS_SEVERITY="flag"
+        return 0
+      fi
+      # registry_shrink: visual review registry modified
+      if path_matches "$_cp_p" ".visual-review/registry.yml"; then
+        _CLS_TYPE="registry_shrink"
+        _CLS_ORACLE_CLASS="baseline"
+        _CLS_SEVERITY="flag"
+        return 0
+      fi
+      # coverage_threshold: test runner config files modified
+      if path_matches "$_cp_p" "jest.config.*" ||
+         path_matches "$_cp_p" "phpunit.xml" ||
+         path_matches "$_cp_p" "phpunit.xml.dist"; then
+        _CLS_TYPE="coverage_threshold"
+        _CLS_ORACLE_CLASS="coverage-threshold"
+        _CLS_SEVERITY="flag"
+        return 0
+      fi
+      ;;
+  esac
+
+  return 1
+}
+
+# --- process diff lines -------------------------------------------------------
+SIGNALS_JSON="[]"
+N_HALT=0
+_CLS_TYPE=""; _CLS_ORACLE_CLASS=""; _CLS_SEVERITY=""
+
+# process_change <status A|M|D> <path>
+# Classifies ONE (status, path) pair against the watch table; on a match appends the
+# signal to SIGNALS_JSON and bumps N_HALT for an un-exempted halt. No-op on no match.
+# Mutates globals SIGNALS_JSON / N_HALT. Returns 0 always (no match is not an error).
+process_change() {
+  local _pc_status="$1" _pc_path="$2"
+  [ -z "$_pc_path" ] && return 0
+
+  _CLS_TYPE=""; _CLS_ORACLE_CLASS=""; _CLS_SEVERITY=""
+  classify_path "$_pc_status" "$_pc_path" || return 0
+
+  # allowed_by_scope via oracle_update.classes
+  local _sig_allowed="false"
+  if is_in_oracle_classes "$_CLS_ORACLE_CLASS"; then
+    _sig_allowed="true"
+  fi
+
+  # Effective severity: downgrade halt -> flag when allowed by oracle_update
+  local _sig_severity="$_CLS_SEVERITY"
+  if [ "$_CLS_SEVERITY" = "halt" ] && [ "$_sig_allowed" = "true" ]; then
+    _sig_severity="flag"
+  fi
+
+  # Append signal to JSON array (all JSON built with jq — no string concatenation)
+  SIGNALS_JSON="$(jq -c \
+    --arg   type          "$_CLS_TYPE" \
+    --arg   path          "$_pc_path" \
+    --arg   change        "$_pc_status" \
+    --arg   oracle_class  "$_CLS_ORACLE_CLASS" \
+    --arg   severity      "$_sig_severity" \
+    --argjson allowed_by_scope "$_sig_allowed" \
+    '. + [{"type":$type,"path":$path,"change":$change,
+           "oracle_class":$oracle_class,"severity":$severity,
+           "allowed_by_scope":$allowed_by_scope}]' \
+    <<< "$SIGNALS_JSON")"
+
+  # Count un-exempted halt signals on ORIGINAL severity (drives tamper_detected)
+  if [ "$_CLS_SEVERITY" = "halt" ] && [ "$_sig_allowed" = "false" ]; then
+    N_HALT=$((N_HALT + 1))
+  fi
+  return 0
+}
+
+while IFS=$'\t' read -r _f1 _f2 _f3 || [ -n "${_f1:-}" ]; do
+  # Strip carriage returns (Windows line endings)
+  _f1="${_f1%$'\r'}"; _f2="${_f2%$'\r'}"; _f3="${_f3%$'\r'}"
+
+  # Skip empty lines
+  [ -z "$_f1" ] && continue
+
+  case "$_f1" in
+    # RENAME (R###, or bare R): the OLD path (_f2) is classified as D against the
+    # D-watched rows (C1 evasion — git mv of a test OUT of tests/ deletes its coverage),
+    # AND the NEW path (_f3) as A against the A-watched rows (rename INTRODUCES a baseline).
+    R*)
+      process_change "D" "$_f2"
+      process_change "A" "$_f3"
+      ;;
+    # COPY (C###, or bare C): only the NEW path (_f3) is new => classify as A
+    # (the original is untouched, so no delete signal for the old path).
+    C*)
+      process_change "A" "$_f3"
+      ;;
+    # Plain single-path status: path is in _f2, _f3 empty.
+    A|M|D)
+      process_change "$_f1" "$_f2"
+      ;;
+    *)
+      continue
+      ;;
+  esac
+done < "$DIFF_FROM"
+
+# --- verdict -----------------------------------------------------------------
+TAMPER_DETECTED="false"
+if [ "$N_HALT" -gt 0 ]; then
+  TAMPER_DETECTED="true"
+fi
+
+HALT_REASON="null"
+if [ "$TAMPER_DETECTED" = "true" ]; then
+  HALT_REASON='"oracle_tamper"'
+fi
+
+# --- emit verdict on stdout (always exit 0 from here) -----------------------
+jq -nc \
+  --argjson tamper      "$TAMPER_DETECTED" \
+  --argjson signals     "$SIGNALS_JSON" \
+  --argjson halt_reason "$HALT_REASON" \
+  '{"schema_version":"1.0","tamper_detected":$tamper,"signals":$signals,"halt_reason":$halt_reason}'

--- a/drupal-dev-framework/skills/work-order-builder/SKILL.md
+++ b/drupal-dev-framework/skills/work-order-builder/SKILL.md
@@ -65,6 +65,10 @@ L-1). You never read the transcript to decide anything.
   checkpoint + any reset happen in the **code worktree** (the project `codePath`, a different repo). The
   atom mutates the code worktree freely and the memory-repo WO file **only** for the single `ready →
   in_progress` flip.
+- **Never modify an oracle.** The build MUST NOT delete or weaken a test, VR baseline/snapshot,
+  `phpstan-baseline.*`, or coverage threshold to pass a gate — only ADD tests / fix code. A diff touching
+  an oracle artifact without the WO's explicit `oracle_update` scope is a tamper signal, caught at the
+  critique rung (`oracle_tamper` HALT) and escalated — never auto-applied.
 
 ## Preconditions (set by ③, not by the atom)
 

--- a/drupal-dev-framework/skills/work-order-compiler/references/work-order-contract.md
+++ b/drupal-dev-framework/skills/work-order-compiler/references/work-order-contract.md
@@ -106,6 +106,12 @@ coverage_override: { reason: <str>, by: <str>, at: <iso8601> } | null   # RESERV
                                     #   dispatch a verified:false WO. Honored like a recorded bypass ⇒ ③ MUST NOT auto-merge.
                                     #   Default null. Resolves the "proceed on verified:false" path the prose promised but the
                                     #   hard precondition forbade (the dispatch gate now checks verified OR override).
+oracle_update: { classes: [baseline|snapshot|phpstan-baseline|coverage-threshold|test-delete], reason: <str>, by: <str> } | null
+                                    #   SEAM: ① AUTHORED in the WO (human); ② CONSUMED at the critique rung.
+                                    #   Default null. When present and a tamper signal’s oracle_class ∈ classes, the signal is
+                                    #   downgraded HALT→flag (the WO ships, the PR opens flagged); a signal outside classes,
+                                    #   or the field absent, HALTs (oracle_tamper). Shape:
+                                    #   oracle_update: {classes:[baseline|snapshot|phpstan-baseline|coverage-threshold|test-delete], reason:<str>, by:<str>} | null
 
 # ── provenance ──
 compiled_from:
@@ -260,6 +266,7 @@ mirror that records only its minted id back into `external_ids.beads`. Detail:
 | `gate_floor` | compiler (here) | ② reads (tiering + which gates) |
 | `review_ref` / `critique_ref` / `risk_tier` | reserved — compiler emits null; ② populates (sidecars + realized tier) | ② §16.2 critique |
 | `size_estimate` / WO count | compiler (here) | ④ budget governor |
+| `oracle_update` | ② / human (authored in the WO; null by default) | ② critique rung — `oracle_class ∈ classes` downgrades HALT→flag; absent or mismatch → `oracle_tamper` HALT |
 
 **OCP note:** the reserved fields (`review_ref` / `risk_tier` / `size_estimate` / `critique_ref` /
 `coverage_override`) absorb new sibling needs **additively**, the way `external_ids: {}` reserves
@@ -278,7 +285,7 @@ fields: ③ reads it to drive sequencing + status; ② reads the tree it points 
 { "wo_id": "local:<task>#wo-NN", "dispatched": true|false, "override_used": true|false,
   "halt_reason": null | "verified_false" | "poisoned" | "uncovered" | "unpinned_ref"
                | "drift_skipped" | "drift_unresolved" | "acceptance_not_runnable"
-               | "sequencing_error" | "frontmatter_unreadable" | "spawn_failed",   # §17: "autonomy_unsafe" retired
+               | "sequencing_error" | "frontmatter_unreadable" | "spawn_failed" | "oracle_tamper",   # §17: "autonomy_unsafe" retired; "oracle_tamper" added 2026-06-12
   "tree": "<worktree path>", "checkpoint_before": "<sha>", "checkpoint_after": "<sha>|null",
   "produced_changes": true|false,
   "artifacts": ["<path>", "..."], "build_returned": true|false }
@@ -295,7 +302,9 @@ fields: ③ reads it to drive sequencing + status; ② reads the tree it points 
 
 (The `halt_reason` enum was **widened 2026-06-08** alongside the dispatch-gate strengthening — the new
 `unpinned_ref` / `drift_skipped` / `drift_unresolved` / `acceptance_not_runnable` grounding reasons
-plus the mapped `sequencing_error` / `frontmatter_unreadable`; additive within `schema_version: "1.0"`.)
+plus the mapped `sequencing_error` / `frontmatter_unreadable`; additive within `schema_version: "1.0"`.
+**Widened again 2026-06-12** to add `oracle_tamper` — a WO diff touched an un-exempted oracle artifact
+(VR baseline / test deletion / phpstan-baseline); also additive within `schema_version: "1.0"`.)
 
 ---
 
@@ -311,4 +320,11 @@ plus the mapped `sequencing_error` / `frontmatter_unreadable`; additive within `
   itself attacker-authored, so the critic stays a semantic-injection target — a probabilistic
   mitigation, not a structural close.** **Unattended operation on high-`risk_tier` / security-touching
   work-orders is below the §14.5/§16.2 bar until ② ships.**
+- **Oracle-integrity invariant.** The contract's `oracle_tamper` HALT reason enforces that the builder
+  must never delete or weaken a test, VR baseline/snapshot, `phpstan-baseline.*`, or coverage threshold
+  to pass a gate — only ADD tests / fix code. *Deterministic* enforcement is the path-level oracle-tamper
+  check at the critique rung: an add/modify of a VR baseline, delete of a test or VR spec, or add/modify
+  of `phpstan-baseline.neon` ⇒ `oracle_tamper` HALT (unless the WO's `oracle_update` field explicitly
+  exempts that class). *Semantic* oracle weakening inside a kept file remains the critics' probabilistic
+  lane — it is not structurally closed here.
 - See `injection-boundary.md` for the mechanical-vs-semantic split in full.

--- a/drupal-dev-framework/skills/work-order-critique/SKILL.md
+++ b/drupal-dev-framework/skills/work-order-critique/SKILL.md
@@ -33,9 +33,32 @@ CRIT_REF="<task>/work-orders/${WO_ID}._critique.json"
 mkdir -p "$CDIR"
 ```
 
-**1 — risk tier (fail-closed kernel).**
+**1 — risk tier inputs + oracle-tamper guard (runs BEFORE critics).**
 ```bash
 git -C "<worktree>" diff <before>..<after> --name-only > "$CDIR/files.txt"
+```
+
+The oracle-tamper guard runs **before the risk classifier and before any critic is spawned** — catching tamper
+before any critic budget is spent. It needs `--name-status` (so deletions are visible); this is a SEPARATE
+diff alongside `files.txt`.
+```bash
+# derive NAME-STATUS diff — --name-only hides deletions (D); the oracle check needs them
+git -C "<worktree>" diff <before>..<after> --name-status > "$CDIR/name-status.txt"
+
+# invoke wo-01's kernel; pass the WO file PATH (safe read for oracle_update field, H1 — never paste diff content)
+ORACLE=$(bash "$KERNEL/wo-oracle-check.sh" "<wo-file>" --diff-from "$CDIR/name-status.txt")
+
+# on tamper_detected → write oracle_tamper HALT (jq-built; NEVER string-concatenated) and RETURN — critics NOT spawned
+if [ "$(printf '%s' "$ORACLE" | jq -r '.tamper_detected')" = "true" ]; then
+  jq -nc --arg wo "$WO_ID" --arg r "oracle_tamper" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '{wo_id:$wo, reason:$r, at:$at}' > "<task>/work-orders/${WO_ID}.HALT"
+  # emit the compact line (forward oracle signals[]), RETURN — the loop's terminal-HALT path escalates
+else
+  # severity:flag signals → record into the compact line; proceed to risk tier + critics below
+fi
+```
+
+```bash
 # pass the WO FILE PATH — the kernel reads verified/gate_floor/collapsed_scc via the safe parser (H1)
 TIER=$(bash "$KERNEL/wo-risk-classify.sh" "<wo-file>" --files-from "$CDIR/files.txt" | jq -r '.risk_tier')
 ```

--- a/drupal-dev-framework/skills/work-order-loop/references/merge-contract.md
+++ b/drupal-dev-framework/skills/work-order-loop/references/merge-contract.md
@@ -34,6 +34,24 @@ itself **re-runs** `wo-ship-gate.sh` from disk (never a cached verdict — TOCTO
   {in_progress,done,needs_rework}) ⇒ `missing_run_state` ⇒ `merge_ok=false`. A missing `PR_BODY.md` ⇒
   `wo-pr-open.sh` refuses (`pr_body_absent`).
 
+## VR and oracle-integrity (terminal escalation — never silent)
+
+Under automation the loop **runs** VR (compares current output to the baseline) but **NEVER regenerates
+the baseline** — consistent with `/review --headless` passing `--ci` to VR tooling (no baseline-write
+path in CI mode). This is load-bearing: an auto-rebaseline would silently pass a visual regression,
+defeating the gate.
+
+- A **VR diff** (baseline exists, current output diverges) is **terminal escalation** — the human
+  decides whether the change is a regression to fix or an intended change requiring a deliberate
+  I-rebaseline. The loop never resolves this silently.
+- An **`oracle_tamper` HALT** (a WO diff touched an un-exempted oracle artifact — VR baseline / test
+  deletion / `phpstan-baseline.*`) joins the set of terminal-HALT reasons the loop already escalates
+  on (alongside `verified_false`, `unpinned_ref`, etc.). Neither is auto-merged; both require human
+  decision before the PR can proceed.
+- The `oracle_update` WO field is the **sole exemption path**: when present and the tamper signal's
+  `oracle_class ∈ oracle_update.classes`, the signal is downgraded HALT→flag (PR opens flagged, not
+  blocked). Absent or mismatched ⇒ `oracle_tamper` HALT (terminal).
+
 ## PR-open posture + token (D6, R-2, H2)
 
 - v1 PR body source = `<task>/PR_BODY.md`, written by the task-level `/review --headless` on green

--- a/drupal-dev-framework/tests/critique-oracle-contract-spec.sh
+++ b/drupal-dev-framework/tests/critique-oracle-contract-spec.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Contract spec for the oracle-tamper wiring in work-order-critique (WO-03, task: oracle_integrity).
+#
+# work-order-critique/SKILL.md is command-prose (Claude executes it), so this is a doc-contract test:
+# it asserts the SKILL.md carries each wiring point required by WO-03. Guards against prose regressions
+# that would silently let a tampered WO reach the critic fan-out.
+#
+# Exit: 0 = all wiring points present; 1 = a wiring point is missing / file not found.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL="$DIR/../skills/work-order-critique/SKILL.md"
+fail=0
+
+if [ ! -f "$SKILL" ]; then
+  echo "FAIL: SKILL.md not found at $SKILL"
+  exit 1
+fi
+
+check() { # <description> <grep -E pattern>
+  if grep -Eq "$2" "$SKILL"; then
+    echo "PASS: $1"
+  else
+    echo "FAIL: $1  (missing pattern: $2)"
+    fail=1
+  fi
+}
+
+# --- Wiring point 1: name-status diff derived alongside files.txt ---
+check "git diff --name-status produces name-status.txt" '\-\-name-status.*name-status\.txt'
+
+# --- Wiring point 2: wo-oracle-check.sh invoked with --diff-from name-status.txt ---
+check "wo-oracle-check.sh kernel invoked"                 'wo-oracle-check\.sh'
+check "oracle check receives --diff-from name-status.txt" '\-\-diff-from.*name-status\.txt'
+
+# --- Wiring point 3: oracle_tamper HALT written on tamper_detected (jq-built, never string-concatenated) ---
+check "tamper_detected condition branch present"          'tamper_detected'
+check "oracle_tamper reason value in jq --arg"            '\-\-arg r .oracle_tamper.'
+check "HALT write uses jq -nc (never string-concatenated)" 'jq -nc.*\-\-arg.*oracle_tamper'
+
+# --- Wiring point 4: flag-only / clean proceed path documented in else branch ---
+check "flag-only proceed path documented (else branch)"   'severity:flag'
+
+# --- Wiring point 5: oracle check positioned BEFORE the critic spawn ---
+oracle_line=$(grep -n 'wo-oracle-check\.sh' "$SKILL" | head -1 | cut -d: -f1)
+critics_line=$(grep -n 'wo-critic.*Task\|Task.*wo-critic' "$SKILL" | head -1 | cut -d: -f1)
+if [ -n "$oracle_line" ] && [ -n "$critics_line" ] && [ "$oracle_line" -lt "$critics_line" ]; then
+  echo "PASS: oracle-check invocation (line $oracle_line) precedes critic spawn (line $critics_line)"
+else
+  echo "FAIL: oracle-check not confirmed before critic spawn (oracle_line=${oracle_line:-unset} critics_line=${critics_line:-unset})"
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "ALL PASS — oracle-tamper wiring present in work-order-critique/SKILL.md"
+  exit 0
+else
+  echo "CONTRACT FAILED — SKILL.md missing one or more oracle-tamper wiring points"
+  exit 1
+fi

--- a/drupal-dev-framework/tests/oracle-invariant-doc-spec.sh
+++ b/drupal-dev-framework/tests/oracle-invariant-doc-spec.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Doc-contract spec for the oracle-integrity invariant (task: oracle_integrity, epic: build_gate_correctness).
+#
+# Three canonical homes must state the invariant:
+#   1. work-order-contract.md  — halt_reason enum gains oracle_tamper; oracle_update field documented;
+#                                invariant clause in Honest scope boundary.
+#   2. work-order-builder/SKILL.md — "Never modify an oracle" bullet in Hard boundaries.
+#   3. merge-contract.md       — VR runs-but-never-regenerates; oracle_tamper → terminal escalation.
+#
+# Exit: 0 = all clauses present; 1 = a clause is missing / file not found.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTRACT="$DIR/../skills/work-order-compiler/references/work-order-contract.md"
+BUILDER="$DIR/../skills/work-order-builder/SKILL.md"
+MERGE="$DIR/../skills/work-order-loop/references/merge-contract.md"
+fail=0
+
+for f in "$CONTRACT" "$BUILDER" "$MERGE"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: file not found: $f"
+    fail=1
+  fi
+done
+[ "$fail" -eq 1 ] && exit 1
+
+check() { # <description> <file> <grep -E pattern>
+  if grep -Eq "$3" "$2"; then
+    echo "PASS: $1"
+  else
+    echo "FAIL: $1  (missing pattern: $3)"
+    fail=1
+  fi
+}
+
+# ── work-order-contract.md ──────────────────────────────────────────────────
+
+check "halt_reason enum includes oracle_tamper"           "$CONTRACT" '"oracle_tamper"'
+check "oracle_tamper 2026-06-12 widening note present"    "$CONTRACT" 'oracle_tamper.*2026-06-12|2026-06-12.*oracle_tamper'
+check "oracle_update seam field with classes shape"       "$CONTRACT" 'oracle_update.*classes'
+check "oracle_update AUTHORED/CONSUMED annotation"        "$CONTRACT" 'SEAM.*AUTHORED.*CONSUMED'
+check "oracle_update in seam-field ownership table"       "$CONTRACT" 'oracle_update.*critique rung'
+check "Oracle-integrity invariant clause present"         "$CONTRACT" 'Oracle-integrity invariant'
+check "Invariant bullet references oracle_tamper HALT"    "$CONTRACT" 'oracle_tamper.*HALT'
+check "Invariant notes semantic lane stays probabilistic" "$CONTRACT" 'probabilistic'
+
+# ── work-order-builder/SKILL.md ─────────────────────────────────────────────
+
+check "Never-modify-an-oracle bullet present"             "$BUILDER"  'Never modify an oracle'
+check "Builder bullet names oracle_tamper HALT"           "$BUILDER"  'oracle_tamper.*HALT'
+check "Builder bullet cites oracle_update exemption"      "$BUILDER"  'oracle_update'
+
+# ── merge-contract.md ───────────────────────────────────────────────────────
+
+check "VR/oracle section heading present"                 "$MERGE"    'VR and oracle-integrity'
+check "Loop NEVER regenerates baseline"                   "$MERGE"    'NEVER regenerates'
+check "VR diff is terminal escalation"                    "$MERGE"    'terminal escalation'
+check "oracle_tamper joins terminal-HALT reasons"         "$MERGE"    'oracle_tamper.*HALT'
+check "oracle_update sole exemption path stated"          "$MERGE"    'oracle_update.*sole exemption|sole exemption.*oracle_update'
+
+if [ "$fail" -eq 0 ]; then
+  echo "ALL PASS ($(grep -c 'check ' "$0" | head -1) checks) — oracle-integrity invariant present in all three contract homes"
+  exit 0
+else
+  echo "CONTRACT FAILED — one or more oracle-invariant clauses missing"
+  exit 1
+fi

--- a/drupal-dev-framework/tests/wo-oracle-check-spec.sh
+++ b/drupal-dev-framework/tests/wo-oracle-check-spec.sh
@@ -1,0 +1,701 @@
+#!/usr/bin/env bash
+# Hermetic spec for scripts/wo-oracle-check.sh
+# No real git invoked — feeds name-status fixtures + WO-file fixtures.
+# Run: bash tests/wo-oracle-check-spec.sh
+set -uo pipefail
+HERE="$(dirname "$(readlink -f "$0")")"
+ROOT="$(dirname "$HERE")"
+KERNEL="$ROOT/scripts/wo-oracle-check.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+DIFF_N=0
+
+# ============================================================
+# Fixture WO files (safe YAML frontmatter; never eval'd)
+# ============================================================
+
+# Minimal WO with NO oracle_update
+cat > "$TMP/wo-no-exempt.md" <<'WOEOF'
+---
+id: local:test#wo-00
+kind: work-order
+schema_version: '1.0'
+title: Test WO no exemption
+status: ready
+gate_floor: [tdd, solid, dry, security, guides]
+verified: false
+---
+# Test WO — no oracle_update block
+WOEOF
+
+# WO with oracle_update exempting: baseline, phpstan-baseline
+cat > "$TMP/wo-exempt-baseline.md" <<'WOEOF'
+---
+id: local:test#wo-01
+kind: work-order
+schema_version: '1.0'
+title: Test WO with oracle_update
+status: ready
+oracle_update:
+  classes: [baseline, phpstan-baseline]
+  reason: "updating visual baselines after intentional redesign"
+  by: "carlos"
+---
+# Test WO — oracle_update: baseline + phpstan-baseline
+WOEOF
+
+# WO with oracle_update exempting: test-delete
+cat > "$TMP/wo-exempt-test-delete.md" <<'WOEOF'
+---
+id: local:test#wo-02
+kind: work-order
+schema_version: '1.0'
+title: Test WO with test-delete exempt
+status: ready
+oracle_update:
+  classes: [test-delete]
+  reason: "removing deprecated integration tests"
+  by: "carlos"
+---
+WOEOF
+
+# M2: oracle_update with QUOTED class names (double quotes) — must still match
+cat > "$TMP/wo-exempt-quoted.md" <<'WOEOF'
+---
+id: local:test#wo-03
+kind: work-order
+schema_version: '1.0'
+title: Test WO with quoted classes
+status: ready
+oracle_update:
+  classes: ["baseline", "test-delete"]
+  reason: "intentional redesign"
+  by: "carlos"
+---
+# Test WO — quoted inline classes
+WOEOF
+
+# M2b: single-quoted class names — must still match
+cat > "$TMP/wo-exempt-squoted.md" <<'WOEOF'
+---
+id: local:test#wo-03b
+oracle_update:
+  classes: ['baseline', 'phpstan-baseline']
+  reason: "x"
+  by: "carlos"
+---
+WOEOF
+
+# M3: oracle_update with BLOCK-STYLE YAML list — must parse `- item` lines
+cat > "$TMP/wo-exempt-block.md" <<'WOEOF'
+---
+id: local:test#wo-04
+kind: work-order
+status: ready
+oracle_update:
+  classes:
+    - baseline
+    - test-delete
+  reason: "block-style list update"
+  by: "carlos"
+---
+# Test WO — block-style classes
+WOEOF
+
+# M3b: block-style with QUOTED items — both robustness features combined
+cat > "$TMP/wo-exempt-block-quoted.md" <<'WOEOF'
+---
+id: local:test#wo-04b
+oracle_update:
+  classes:
+    - "baseline"
+    - 'phpstan-baseline'
+  reason: "x"
+  by: "y"
+---
+WOEOF
+
+# L1: UNTERMINATED frontmatter (no closing ---) carrying an oracle_update.
+# Per L1 the exemption must NOT be honored (no closing --- => no frontmatter).
+cat > "$TMP/wo-unterminated.md" <<'WOEOF'
+---
+id: local:test#wo-05
+oracle_update:
+  classes: [baseline, test-delete]
+  reason: "looks legit but frontmatter never closes"
+  by: "attacker"
+
+# This file has NO closing --- delimiter. The body just continues.
+Some prose here that should never be parsed as frontmatter.
+WOEOF
+
+# L1b: oracle_update appears ONLY in the body (after a terminated, empty frontmatter)
+cat > "$TMP/wo-body-oracle.md" <<'WOEOF'
+---
+id: local:test#wo-06
+status: ready
+---
+# Body
+
+A malicious note trying to look like config:
+oracle_update:
+  classes: [baseline, test-delete]
+WOEOF
+
+WO="$TMP/wo-no-exempt.md"
+WO_EX="$TMP/wo-exempt-baseline.md"
+WO_EX_TD="$TMP/wo-exempt-test-delete.md"
+WO_QUOTED="$TMP/wo-exempt-quoted.md"
+WO_SQUOTED="$TMP/wo-exempt-squoted.md"
+WO_BLOCK="$TMP/wo-exempt-block.md"
+WO_BLOCK_QUOTED="$TMP/wo-exempt-block-quoted.md"
+WO_UNTERM="$TMP/wo-unterminated.md"
+WO_BODY="$TMP/wo-body-oracle.md"
+
+# ============================================================
+# Helpers to create diff fixtures
+# ============================================================
+
+# mk_diff STATUS path — writes name-status fixture, prints path
+mk_diff() {
+  DIFF_N=$((DIFF_N + 1))
+  printf '%s\t%s\n' "$1" "$2" > "$TMP/d${DIFF_N}.txt"
+  echo "$TMP/d${DIFF_N}.txt"
+}
+
+# mk_rename old new — writes rename fixture (R100), prints path
+mk_rename() {
+  DIFF_N=$((DIFF_N + 1))
+  printf 'R100\t%s\t%s\n' "$1" "$2" > "$TMP/d${DIFF_N}.txt"
+  echo "$TMP/d${DIFF_N}.txt"
+}
+
+# mk_copy old new — writes copy fixture (C100), prints path
+mk_copy() {
+  DIFF_N=$((DIFF_N + 1))
+  printf 'C100\t%s\t%s\n' "$1" "$2" > "$TMP/d${DIFF_N}.txt"
+  echo "$TMP/d${DIFF_N}.txt"
+}
+
+# mk_line raw — writes a single raw name-status line verbatim, prints path
+mk_line() {
+  DIFF_N=$((DIFF_N + 1))
+  printf '%s\n' "$1" > "$TMP/d${DIFF_N}.txt"
+  echo "$TMP/d${DIFF_N}.txt"
+}
+
+# mk_multi — writes a multi-line diff fixture and prints path
+mk_multi() {
+  DIFF_N=$((DIFF_N + 1))
+  printf '%s\n' "$@" > "$TMP/d${DIFF_N}.txt"
+  echo "$TMP/d${DIFF_N}.txt"
+}
+
+# ============================================================
+# Assert helpers
+# ============================================================
+
+# assert_verdict label want_tamper want_halt_reason kernel_args...
+# want_tamper: true | false
+# want_halt_reason: null | oracle_tamper
+assert_verdict() {
+  local label="$1" e_tamper="$2" e_halt="$3"; shift 3
+  local out tamper halt
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  tamper="$(printf '%s' "$out" | jq -r '.tamper_detected')"
+  halt="$(printf '%s' "$out" | jq -r '.halt_reason // "null"')"
+  if [ "$tamper" = "$e_tamper" ] && [ "$halt" = "$e_halt" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: tamper=%s halt=%s (want tamper=%s halt=%s)\n' \
+      "$label" "$tamper" "$halt" "$e_tamper" "$e_halt"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# assert_no_signals label kernel_args...
+assert_no_signals() {
+  local label="$1"; shift
+  local out count
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  count="$(printf '%s' "$out" | jq '.signals | length')"
+  if [ "$count" = "0" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: expected 0 signals, got %s\n' "$label" "$count"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# assert_signal label want_type want_severity want_oracle_class kernel_args...
+assert_signal() {
+  local label="$1" e_type="$2" e_sev="$3" e_class="$4"; shift 4
+  local out type sev cls
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  type="$(printf '%s' "$out" | jq -r '.signals[0].type // "null"')"
+  sev="$(printf '%s' "$out" | jq -r '.signals[0].severity // "null"')"
+  cls="$(printf '%s' "$out" | jq -r '.signals[0].oracle_class // "null"')"
+  if [ "$type" = "$e_type" ] && [ "$sev" = "$e_sev" ] && [ "$cls" = "$e_class" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: type=%s sev=%s class=%s (want %s / %s / %s)\n' \
+      "$label" "$type" "$sev" "$cls" "$e_type" "$e_sev" "$e_class"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# assert_signal_count label want_count kernel_args...
+assert_signal_count() {
+  local label="$1" e_count="$2"; shift 2
+  local out count
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  count="$(printf '%s' "$out" | jq '.signals | length')"
+  if [ "$count" = "$e_count" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: signal count=%s (want %s)\n' "$label" "$count" "$e_count"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# assert_has_signal label want_type want_change want_severity kernel_args...
+# Passes if ANY signal in signals[] matches type+change+severity (order-independent).
+assert_has_signal() {
+  local label="$1" e_type="$2" e_change="$3" e_sev="$4"; shift 4
+  local out found
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  found="$(printf '%s' "$out" | jq --arg t "$e_type" --arg c "$e_change" --arg s "$e_sev" \
+    '[.signals[] | select(.type==$t and .change==$c and .severity==$s)] | length')"
+  if [ "$found" != "0" ] && [ -n "$found" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: no signal type=%s change=%s sev=%s\n' "$label" "$e_type" "$e_change" "$e_sev"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# assert_allowed_by_scope label want_allowed kernel_args...
+assert_allowed_by_scope() {
+  local label="$1" e_allowed="$2"; shift 2
+  local out allowed
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  allowed="$(printf '%s' "$out" | jq -r '.signals[0].allowed_by_scope')"
+  if [ "$allowed" = "$e_allowed" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: allowed_by_scope=%s (want %s)\n' "$label" "$allowed" "$e_allowed"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# assert_signal_change label want_change kernel_args...
+assert_signal_change() {
+  local label="$1" e_change="$2"; shift 2
+  local out change
+  out="$(bash "$KERNEL" "$@" 2>/dev/null)"
+  change="$(printf '%s' "$out" | jq -r '.signals[0].change // "null"')"
+  if [ "$change" = "$e_change" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s: change=%s (want %s)\n' "$label" "$change" "$e_change"
+    printf '     out: %s\n' "$out"
+  fi
+}
+
+# ============================================================
+# TC-01: Clean diff (no watched paths) => tamper=false, signals=[], halt_reason=null
+# ============================================================
+diff_clean="$(mk_diff "M" "src/some/file.php")"
+assert_verdict    "TC-01a clean tamper=false"   false null "$WO" --diff-from "$diff_clean"
+assert_no_signals "TC-01b clean no signals"             "$WO" --diff-from "$diff_clean"
+
+# ============================================================
+# TC-02: baseline_write — A on .png => halt, tamper=true, change=A
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/homepage.spec.ts-snapshots/screenshot.png")"
+assert_verdict       "TC-02a baseline_write A tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal        "TC-02b baseline_write A signal"      baseline_write halt baseline "$WO" --diff-from "$diff"
+assert_signal_change "TC-02c baseline_write A change=A"    A "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-03: baseline_write — M on .meta.json => halt, tamper=true, change=M
+# ============================================================
+diff="$(mk_diff "M" "tests/visual/homepage.spec.ts-snapshots/test.meta.json")"
+assert_verdict       "TC-03a baseline_write M tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal        "TC-03b baseline_write M signal"      baseline_write halt baseline "$WO" --diff-from "$diff"
+assert_signal_change "TC-03c baseline_write M change=M"    M "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-04: baseline_write — D on .png => NO signal (D not in watched changes)
+# ============================================================
+diff="$(mk_diff "D" "tests/visual/homepage.spec.ts-snapshots/screenshot.png")"
+assert_verdict    "TC-04a baseline_write D no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-04b baseline_write D no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-05: vr_spec_delete — D on tests/visual/*.spec.ts => halt, tamper=true, change=D
+# ============================================================
+diff="$(mk_diff "D" "tests/visual/homepage.spec.ts")"
+assert_verdict       "TC-05a vr_spec_delete D tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal        "TC-05b vr_spec_delete D signal"      vr_spec_delete halt test-delete "$WO" --diff-from "$diff"
+assert_signal_change "TC-05c vr_spec_delete D change=D"    D "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-06: vr_spec_delete — A on tests/visual/*.spec.ts => NO signal (only D watched)
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/homepage.spec.ts")"
+assert_verdict    "TC-06a vr_spec_delete A no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-06b vr_spec_delete A no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-07: test_delete — D on tests/**/*Test.php => halt, tamper=true
+# ============================================================
+diff="$(mk_diff "D" "tests/Unit/SomeTest.php")"
+assert_verdict "TC-07a test_delete php D tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-07b test_delete php D signal"      test_delete halt test-delete "$WO" --diff-from "$diff"
+
+# TC-07b: nested path (tests/src/Unit/SomeTest.php) — tests ** across multiple segments
+diff="$(mk_diff "D" "tests/src/Unit/SomeTest.php")"
+assert_verdict "TC-07c test_delete nested php D" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-07d test_delete nested php D signal" test_delete halt test-delete "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-08: test_delete — D on tests/e2e/**/*.spec.ts => halt
+# ============================================================
+diff="$(mk_diff "D" "tests/e2e/navigation.spec.ts")"
+assert_verdict "TC-08a test_delete e2e D tamper=true"  true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-08b test_delete e2e D signal"       test_delete halt test-delete "$WO" --diff-from "$diff"
+
+# TC-08b: nested e2e path
+diff="$(mk_diff "D" "tests/e2e/auth/login.spec.ts")"
+assert_verdict "TC-08c test_delete e2e nested D" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-08d test_delete e2e nested D signal" test_delete halt test-delete "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-09: test_delete — D on tests/atk/**/*.spec.ts => halt
+# ============================================================
+diff="$(mk_diff "D" "tests/atk/user-login.spec.ts")"
+assert_verdict "TC-09a test_delete atk D tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-09b test_delete atk D signal"      test_delete halt test-delete "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-10: test_delete — A on *Test.php => NO signal (only D watched)
+# ============================================================
+diff="$(mk_diff "A" "tests/Unit/SomeTest.php")"
+assert_verdict    "TC-10a test_delete A no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-10b test_delete A no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-11: phpstan_baseline — A => halt, tamper=true
+# ============================================================
+diff="$(mk_diff "A" "phpstan-baseline.neon")"
+assert_verdict "TC-11a phpstan_baseline A tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-11b phpstan_baseline A signal"      phpstan_baseline halt phpstan-baseline "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-12: phpstan_baseline — M => halt, tamper=true
+# ============================================================
+diff="$(mk_diff "M" "phpstan-baseline.neon")"
+assert_verdict "TC-12a phpstan_baseline M tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "TC-12b phpstan_baseline M signal"      phpstan_baseline halt phpstan-baseline "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-13: phpstan_baseline — D => NO signal (only A,M watched)
+# ============================================================
+diff="$(mk_diff "D" "phpstan-baseline.neon")"
+assert_verdict    "TC-13a phpstan_baseline D no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-13b phpstan_baseline D no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-14: phpstan_config — M phpstan.neon => flag signal, tamper=false
+# ============================================================
+diff="$(mk_diff "M" "phpstan.neon")"
+assert_verdict "TC-14a phpstan_config neon M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-14b phpstan_config neon M signal"       phpstan_config flag phpstan-baseline "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-15: phpstan_config — M phpstan.neon.dist => flag
+# ============================================================
+diff="$(mk_diff "M" "phpstan.neon.dist")"
+assert_verdict "TC-15a phpstan_config neon.dist M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-15b phpstan_config neon.dist M signal"       phpstan_config flag phpstan-baseline "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-16: phpstan_config — A phpstan.neon => NO signal (only M watched)
+# ============================================================
+diff="$(mk_diff "A" "phpstan.neon")"
+assert_verdict    "TC-16a phpstan_config A no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-16b phpstan_config A no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-17: registry_shrink — M => flag signal, tamper=false
+# ============================================================
+diff="$(mk_diff "M" ".visual-review/registry.yml")"
+assert_verdict "TC-17a registry_shrink M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-17b registry_shrink M signal"       registry_shrink flag baseline "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-18: registry_shrink — A => NO signal (only M watched)
+# ============================================================
+diff="$(mk_diff "A" ".visual-review/registry.yml")"
+assert_verdict    "TC-18a registry_shrink A no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-18b registry_shrink A no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-19: coverage_threshold — M jest.config.js => flag
+# ============================================================
+diff="$(mk_diff "M" "jest.config.js")"
+assert_verdict "TC-19a coverage_threshold jest.config.js M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-19b coverage_threshold jest.config.js M signal"       coverage_threshold flag coverage-threshold "$WO" --diff-from "$diff"
+
+# TC-19b: jest.config.ts
+diff="$(mk_diff "M" "jest.config.ts")"
+assert_verdict "TC-19c coverage_threshold jest.config.ts M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-19d coverage_threshold jest.config.ts M signal"       coverage_threshold flag coverage-threshold "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-20: coverage_threshold — M phpunit.xml => flag
+# ============================================================
+diff="$(mk_diff "M" "phpunit.xml")"
+assert_verdict "TC-20a coverage_threshold phpunit.xml M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-20b coverage_threshold phpunit.xml M signal"       coverage_threshold flag coverage-threshold "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-21: coverage_threshold — M phpunit.xml.dist => flag
+# ============================================================
+diff="$(mk_diff "M" "phpunit.xml.dist")"
+assert_verdict "TC-21a coverage_threshold phpunit.xml.dist M tamper=false" false null "$WO" --diff-from "$diff"
+assert_signal  "TC-21b coverage_threshold phpunit.xml.dist M signal"       coverage_threshold flag coverage-threshold "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-22: coverage_threshold — A phpunit.xml => NO signal (only M watched)
+# ============================================================
+diff="$(mk_diff "A" "phpunit.xml")"
+assert_verdict    "TC-22a coverage_threshold A no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-22b coverage_threshold A no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-23: oracle_update exemption — in-class halt (baseline) => flag, allowed=true, tamper=false
+# WO has oracle_update.classes: [baseline, phpstan-baseline]
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/page.spec.ts-snapshots/screen.png")"
+assert_verdict         "TC-23a exempt baseline in-class tamper=false" false null "$WO_EX" --diff-from "$diff"
+assert_signal          "TC-23b exempt baseline in-class severity=flag" baseline_write flag baseline "$WO_EX" --diff-from "$diff"
+assert_allowed_by_scope "TC-23c exempt baseline in-class allowed=true" true "$WO_EX" --diff-from "$diff"
+
+# ============================================================
+# TC-24: oracle_update exemption — out-of-class halt (test-delete) stays halt, tamper=true
+# WO has oracle_update.classes: [baseline, phpstan-baseline] — test-delete is NOT in scope
+# ============================================================
+diff="$(mk_diff "D" "tests/visual/homepage.spec.ts")"
+assert_verdict         "TC-24a exempt out-of-class tamper=true"    true oracle_tamper "$WO_EX" --diff-from "$diff"
+assert_allowed_by_scope "TC-24b exempt out-of-class allowed=false" false "$WO_EX" --diff-from "$diff"
+assert_signal          "TC-24c exempt out-of-class severity=halt"  vr_spec_delete halt test-delete "$WO_EX" --diff-from "$diff"
+
+# ============================================================
+# TC-25: absent oracle_update — nothing exempt (phpstan_baseline stays halt)
+# ============================================================
+diff="$(mk_diff "A" "phpstan-baseline.neon")"
+assert_verdict         "TC-25a absent oracle_update tamper=true"    true oracle_tamper "$WO" --diff-from "$diff"
+assert_allowed_by_scope "TC-25b absent oracle_update allowed=false" false "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-26: oracle_update exemption — test-delete in-class => flag, allowed=true, tamper=false
+# WO has oracle_update.classes: [test-delete]
+# ============================================================
+diff="$(mk_diff "D" "tests/Unit/SomeTest.php")"
+assert_verdict         "TC-26a exempt test-delete in-class tamper=false" false null "$WO_EX_TD" --diff-from "$diff"
+assert_signal          "TC-26b exempt test-delete in-class severity=flag" test_delete flag test-delete "$WO_EX_TD" --diff-from "$diff"
+assert_allowed_by_scope "TC-26c exempt test-delete allowed=true" true "$WO_EX_TD" --diff-from "$diff"
+
+# ============================================================
+# TC-27: Rename line (R100) — OLD path D against D-rows; here OLD is phpstan-baseline.neon
+# which is NOT a D-row (only A,M watched) => no D signal; NEW path A is the baseline => halt.
+# ============================================================
+diff="$(mk_rename "old/phpstan-baseline.neon" "phpstan-baseline.neon")"
+assert_verdict "TC-27a rename new=phpstan_baseline tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "TC-27b rename new phpstan_baseline A" phpstan_baseline A halt "$WO" --diff-from "$diff"
+
+# TC-27c: rename of a non-watched file => no signal (neither old-D nor new-A matches)
+diff="$(mk_rename "old/src/Foo.php" "src/Bar.php")"
+assert_verdict    "TC-27c rename non-watched no tamper" false null "$WO" --diff-from "$diff"
+assert_no_signals "TC-27d rename non-watched no signal"       "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-28: Multiple signals in one diff (a halt + a flag) => tamper=true
+# ============================================================
+diff="$(mk_multi \
+  "A	tests/visual/p.spec.ts-snapshots/s.png" \
+  "M	phpunit.xml")"
+assert_verdict "TC-28a multi halt+flag tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-29: flag-only signals do NOT set tamper_detected
+# (phpstan_config M is flag; even with no oracle_update, tamper stays false)
+# ============================================================
+diff="$(mk_diff "M" "phpstan.neon")"
+assert_verdict "TC-29 flag-only tamper=false" false null "$WO" --diff-from "$diff"
+
+# ============================================================
+# TC-30: schema_version is "1.0" in the JSON output
+# ============================================================
+diff="$(mk_diff "M" "src/SomeClass.php")"
+out30="$(bash "$KERNEL" "$WO" --diff-from "$diff" 2>/dev/null)"
+sv30="$(printf '%s' "$out30" | jq -r '.schema_version')"
+if [ "$sv30" = "1.0" ]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  printf 'FAIL TC-30 schema_version: got "%s" (want "1.0")\n' "$sv30"
+fi
+
+# ============================================================
+# TC-31: phpstan_baseline in-class exemption (oracle_update has phpstan-baseline)
+# ============================================================
+diff="$(mk_diff "M" "phpstan-baseline.neon")"
+assert_verdict         "TC-31a phpstan_baseline exempt tamper=false" false null "$WO_EX" --diff-from "$diff"
+assert_signal          "TC-31b phpstan_baseline exempt severity=flag" phpstan_baseline flag phpstan-baseline "$WO_EX" --diff-from "$diff"
+assert_allowed_by_scope "TC-31c phpstan_baseline exempt allowed=true" true "$WO_EX" --diff-from "$diff"
+
+# ============================================================
+# ===== RED-TEAM CORRECTION COVERAGE (C1 / M1 / M2 / M3 / L1 / L2) =====
+# ============================================================
+
+# ============================================================
+# C1 — RENAME-EVASION (the ship-blocker): git mv a *Test.php OUT of tests/ must
+# be caught as a test_delete on the OLD path (change:"D", halt), tamper=true.
+# `git mv tests/Unit/CriticalTest.php disabled/CriticalTest.php`
+# ============================================================
+diff="$(mk_rename "tests/Unit/CriticalTest.php" "disabled/CriticalTest.php")"
+assert_verdict    "C1-01a rename test out-of-tests tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "C1-01b rename old=test_delete D halt" test_delete D halt "$WO" --diff-from "$diff"
+assert_signal     "C1-01c rename signals[0]=test_delete (old path first)" test_delete halt test-delete "$WO" --diff-from "$diff"
+assert_signal_change "C1-01d rename signals[0].change=D" D "$WO" --diff-from "$diff"
+
+# C1 — vr_spec_delete via rename out of tests/visual/
+diff="$(mk_rename "tests/visual/home.spec.ts" "archive/home.spec.ts")"
+assert_verdict    "C1-02a rename vr spec out tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "C1-02b rename old=vr_spec_delete D halt" vr_spec_delete D halt "$WO" --diff-from "$diff"
+
+# C1 — e2e spec deletion via rename out of tests/e2e/
+diff="$(mk_rename "tests/e2e/login.spec.ts" "disabled/login.spec.ts")"
+assert_verdict    "C1-03a rename e2e spec out tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "C1-03b rename old=test_delete (e2e) D halt" test_delete D halt "$WO" --diff-from "$diff"
+
+# C1 — atk spec deletion via rename out of tests/atk/
+diff="$(mk_rename "tests/atk/checkout.spec.ts" "old/checkout.spec.ts")"
+assert_verdict    "C1-04a rename atk spec out tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "C1-04b rename old=test_delete (atk) D halt" test_delete D halt "$WO" --diff-from "$diff"
+
+# C1 — rename that INTRODUCES a baseline png on the NEW path => baseline_write A halt
+diff="$(mk_rename "stash/screen.png" "tests/visual/home.spec.ts-snapshots/screen.png")"
+assert_verdict    "C1-05a rename introduces baseline tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "C1-05b rename new=baseline_write A halt" baseline_write A halt "$WO" --diff-from "$diff"
+
+# C1 — rename of a test BOTH out of tests/ AND landing as nothing watched on new:
+# old=test_delete (D), new=disabled/... no A-row => exactly ONE signal.
+diff="$(mk_rename "tests/Unit/CriticalTest.php" "disabled/CriticalTest.php")"
+assert_signal_count "C1-06 rename test-out single signal" 1 "$WO" --diff-from "$diff"
+
+# C1 — bare R (no score) handled the same: old->D, new->A
+diff="$(mk_line "R	tests/Unit/CriticalTest.php	disabled/CriticalTest.php")"
+assert_verdict    "C1-07a bare R rename tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "C1-07b bare R old=test_delete D halt" test_delete D halt "$WO" --diff-from "$diff"
+
+# ============================================================
+# M1 — COPY (C###): the NEW path is classified as A; the OLD path is untouched (no D).
+# A copy that INTRODUCES a baseline png => baseline_write A halt, tamper=true.
+# ============================================================
+diff="$(mk_copy "templates/screen.png" "tests/visual/home.spec.ts-snapshots/screen.png")"
+assert_verdict    "M1-01a copy introduces baseline tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "M1-01b copy new=baseline_write A halt" baseline_write A halt "$WO" --diff-from "$diff"
+assert_signal_count "M1-01c copy single signal (old untouched)" 1 "$WO" --diff-from "$diff"
+
+# M1 — copy of a test FILE: old path is NOT a delete (copy keeps original) => no test_delete.
+# new=disabled/... is not under a watched A-row => NO signal at all, tamper=false.
+diff="$(mk_copy "tests/Unit/CriticalTest.php" "disabled/CriticalTest.php")"
+assert_verdict    "M1-02a copy test no delete tamper=false" false null "$WO" --diff-from "$diff"
+assert_no_signals "M1-02b copy test no signal"                    "$WO" --diff-from "$diff"
+
+# M1 — bare C (no score) handled the same: new->A only
+diff="$(mk_line "C	templates/screen.png	tests/visual/home.spec.ts-snapshots/screen.png")"
+assert_verdict    "M1-03a bare C copy tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_has_signal "M1-03b bare C new=baseline_write A halt" baseline_write A halt "$WO" --diff-from "$diff"
+
+# ============================================================
+# M2 — QUOTED class names in oracle_update must still match (no false-HALT).
+# WO_QUOTED has classes: ["baseline","test-delete"]
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/page.spec.ts-snapshots/s.png")"
+assert_verdict          "M2-01a quoted baseline exempt tamper=false" false null "$WO_QUOTED" --diff-from "$diff"
+assert_allowed_by_scope "M2-01b quoted baseline allowed=true" true "$WO_QUOTED" --diff-from "$diff"
+# test-delete is also in the quoted list => exempt
+diff="$(mk_diff "D" "tests/Unit/SomeTest.php")"
+assert_verdict          "M2-02a quoted test-delete exempt tamper=false" false null "$WO_QUOTED" --diff-from "$diff"
+assert_allowed_by_scope "M2-02b quoted test-delete allowed=true" true "$WO_QUOTED" --diff-from "$diff"
+# single-quoted variant
+diff="$(mk_diff "M" "phpstan-baseline.neon")"
+assert_verdict          "M2-03a single-quoted phpstan exempt tamper=false" false null "$WO_SQUOTED" --diff-from "$diff"
+assert_allowed_by_scope "M2-03b single-quoted phpstan allowed=true" true "$WO_SQUOTED" --diff-from "$diff"
+
+# ============================================================
+# M3 — BLOCK-STYLE YAML list in oracle_update must parse (no false-HALT).
+# WO_BLOCK has classes:\n  - baseline\n  - test-delete
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/page.spec.ts-snapshots/s.png")"
+assert_verdict          "M3-01a block baseline exempt tamper=false" false null "$WO_BLOCK" --diff-from "$diff"
+assert_allowed_by_scope "M3-01b block baseline allowed=true" true "$WO_BLOCK" --diff-from "$diff"
+diff="$(mk_diff "D" "tests/Unit/SomeTest.php")"
+assert_verdict          "M3-02a block test-delete exempt tamper=false" false null "$WO_BLOCK" --diff-from "$diff"
+assert_allowed_by_scope "M3-02b block test-delete allowed=true" true "$WO_BLOCK" --diff-from "$diff"
+# block-style item NOT in the list stays HALT (out-of-class): phpstan-baseline not in WO_BLOCK
+diff="$(mk_diff "A" "phpstan-baseline.neon")"
+assert_verdict          "M3-03a block out-of-class phpstan tamper=true" true oracle_tamper "$WO_BLOCK" --diff-from "$diff"
+assert_allowed_by_scope "M3-03b block out-of-class allowed=false" false "$WO_BLOCK" --diff-from "$diff"
+# block-style WITH quoted items (combined M2+M3)
+diff="$(mk_diff "A" "tests/visual/page.spec.ts-snapshots/s.png")"
+assert_verdict          "M3-04a block-quoted baseline exempt tamper=false" false null "$WO_BLOCK_QUOTED" --diff-from "$diff"
+assert_allowed_by_scope "M3-04b block-quoted baseline allowed=true" true "$WO_BLOCK_QUOTED" --diff-from "$diff"
+
+# ============================================================
+# L1 — UNTERMINATED frontmatter (no closing ---) => exemption NOT honored.
+# WO_UNTERM has an oracle_update with [baseline,test-delete] but the frontmatter
+# never closes, so it is NOT frontmatter => baseline write stays HALT, tamper=true.
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/page.spec.ts-snapshots/s.png")"
+assert_verdict          "L1-01a unterminated fm exemption NOT honored tamper=true" true oracle_tamper "$WO_UNTERM" --diff-from "$diff"
+assert_allowed_by_scope "L1-01b unterminated fm allowed=false" false "$WO_UNTERM" --diff-from "$diff"
+
+# L1b — oracle_update only in the BODY (terminated empty frontmatter) => NOT honored.
+diff="$(mk_diff "A" "tests/visual/page.spec.ts-snapshots/s.png")"
+assert_verdict          "L1-02a body oracle_update NOT honored tamper=true" true oracle_tamper "$WO_BODY" --diff-from "$diff"
+assert_allowed_by_scope "L1-02b body oracle_update allowed=false" false "$WO_BODY" --diff-from "$diff"
+
+# ============================================================
+# L2 — NESTED baseline (…-snapshots/dark/x.png) must still match (** glob), halt.
+# Also confirm the flat case still matches (regression guard for the ** widening).
+# ============================================================
+diff="$(mk_diff "A" "tests/visual/home.spec.ts-snapshots/dark/screen.png")"
+assert_verdict "L2-01a nested baseline png tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "L2-01b nested baseline png signal" baseline_write halt baseline "$WO" --diff-from "$diff"
+# nested meta.json
+diff="$(mk_diff "M" "tests/visual/home.spec.ts-snapshots/mobile/x.meta.json")"
+assert_verdict "L2-02a nested baseline meta tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+assert_signal  "L2-02b nested baseline meta signal" baseline_write halt baseline "$WO" --diff-from "$diff"
+# flat case STILL matches after ** widening (regression)
+diff="$(mk_diff "A" "tests/visual/home.spec.ts-snapshots/flat.png")"
+assert_verdict "L2-03 flat baseline still matches tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+# deeply nested
+diff="$(mk_diff "A" "tests/visual/home.spec.ts-snapshots/a/b/c/deep.png")"
+assert_verdict "L2-04 deeply nested baseline tamper=true" true oracle_tamper "$WO" --diff-from "$diff"
+
+echo "----"
+echo "wo-oracle-check-spec: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Bake the **oracle-integrity invariant** into the work-order machinery: *the autonomous builder must never pass a gate by altering the gate's oracle instead of fixing the code.* Second child (2 of 4) of the **build_gate_correctness** epic.

**drupal-dev-framework 4.20.0 → 4.21.0.**

## Changes

- **`scripts/wo-oracle-check.sh`** (NEW) — deterministic kernel scanning a WO's `git diff --name-status` against a fixed oracle watch-table → `{tamper_detected, signals[], halt_reason}`. **Halts** on: VR baseline write, VR-spec/test **deletion** (incl. the rename-evasion `git mv` out of `tests/`), `phpstan-baseline.neon` add/modify. **Flags** (advisory) on ambiguous config modifies. A human-authored `oracle_update: {classes, reason, by}` WO field downgrades an in-scope halt to a flag (ships flagged). Hermetic suite **120 cases**.
- **Critique-rung wiring** (`work-order-critique/SKILL.md`) — runs the oracle check **before spawning any critic**; on tamper writes `wo-NN.HALT` (reason `oracle_tamper`) → the loop's existing terminal-HALT path escalates (no reset/requeue/merge). Contract spec.
- **Invariant stated** in `work-order-contract.md` (+ `oracle_tamper` added to the `halt_reason` enum **additively**, `schema_version` stays `1.0`; `oracle_update` seam field documented), `work-order-builder/SKILL.md` (`Never modify an oracle` rule), and `merge-contract.md` (VR runs-but-never-regenerates).

## Verification

Built by 3 independent work-order agents (manual-conduct DDF model). The fresh-context **red-team caught a real CRITICAL** the builder's own 120 tests missed: rename-evasion (`git mv tests/Unit/CriticalTest.php disabled/` deletes a test's coverage but passed as clean — defeating the kernel's purpose). The builder built exactly to spec; the **spec rule itself** was the hole. Corrected the spec, fixed C1 + 5 lower defects, re-verified each from disk via independent adversarial probes.

Integration on the merged branch — **all green, zero regression**:
- `wo-oracle-check-spec` 120/120 · `oracle-invariant-doc-spec` 17/17 · `critique-oracle-contract-spec` 8/8
- existing `wo-compile` / `wo-risk-classify` / `wo-critique-aggregate` / `headless-review-contract` suites: all PASS

## ⚠ Flagged — recorded coverage_override (no auto-merge)

Framework/plugin work grounded in the epic's design doc §4 + the audited DDF machinery, not the upstream guide/recipe catalog — WOs compiled `verified:false`, dispatched via a recorded `coverage_override`. Load-bearing gates = plugin-validate + skill-review + the bash hermetic suites (all green). **Please merge with eyes open.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)