### PR TITLE
code-quality-tools v3.9.1 — --changed security/dry skip a no-PHP change without DDEV

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2026-06-12
+
+**Fix: `--changed` security/dry gates no longer require DDEV to skip a no-PHP change.** A faithful
+autonomous-loop run surfaced that `security-check.sh` and `dry-check.sh` checked the DDEV precondition
+**before** their no-relevant-files clean-skip — so a CSS-only (or any no-PHP) changed set ERRORed with
+`DDEV is not running` instead of skipping, breaking the static-tier premise (change-scoped gates are meant to
+run in a detached worktree with no running site) and fail-closing `/review` under automation. `solid-check.sh`
+and `lint-check.sh` already skip-before-DDEV; this aligns security + dry to that pattern.
+
+### Fixed
+- **`security-check.sh` `--changed`** — the empty-relevant-set clean-skip now runs **before** the DDEV check;
+  DDEV is required only when there is real SAST work (a PHP/JS/Twig file, or composer.json/lock, in the set).
+  No security scan is bypassed — a PHP- or composer-containing changed set still requires DDEV and runs the
+  full SAST. The standard (no-`--changed`) path is unchanged.
+- **`dry-check.sh` `--changed`** — added a no-PHP early short-circuit: when the changed set contains no
+  PHP-relevant files, there can be zero change-touching clones by definition, so it resolves to a clean PASS
+  and exits 0 **without** running whole-tree phpcpd or requiring DDEV. A PHP-containing changed set keeps the
+  unchanged whole-tree phpcpd + verdict-filter (DDEV required) path.
+
+### Tests
+- `tests/changed-mode.sh` +4 (24–27): assert a CSS-only changed set SKIPS/PASSES with exit 0 for both
+  security and dry when DDEV is unavailable (stubbed), and that a PHP-containing set still requires DDEV.
+
 ## [3.9.0] - 2026-06-12
 
 **`--changed <files>` mode for the Drupal gates — scope a gate run to a changed-files list.** Brings the

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/dry-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/dry-check.sh
@@ -124,7 +124,49 @@ if [ -n "$CHANGED_FILES_PATH" ]; then
 fi
 echo ""
 
-# Check DDEV
+# --changed early skip: no PHP files → zero change-touching clones possible, no DDEV needed.
+# A DRY clone is a PHP construct; if the changed set has no PHP files, there can be no
+# change-touching clones by definition. Mirror the solid/lint pattern: resolve without DDEV.
+if [ -n "$CHANGED_FILES_PATH" ]; then
+    _DRY_PHP_EXTS="\.php$|\.module$|\.inc$|\.install$|\.profile$|\.theme$|\.engine$"
+    _DRY_HAS_PHP=false
+    while IFS= read -r _f; do
+        [ -z "$_f" ] && continue
+        if echo "$_f" | grep -qE "$_DRY_PHP_EXTS"; then
+            _DRY_HAS_PHP=true
+            break
+        fi
+    done < "$CHANGED_FILES_PATH"
+
+    if [ "$_DRY_HAS_PHP" = false ]; then
+        echo -e "${GREEN}[SKIP]${NC} No PHP files in changed set — zero change-touching clones possible."
+        mkdir -p "${REPORT_DIR}/dry"
+        cat > "${REPORT_DIR}/dry-report.json" << EOF
+{
+  "changed_mode": true,
+  "changed_files": "${CHANGED_FILES_PATH}",
+  "duplication_percentage": 0,
+  "total_lines": 0,
+  "duplicated_lines": 0,
+  "clone_count": 0,
+  "failing_clones": 0,
+  "informational_clones": 0,
+  "clones": [],
+  "rating": "excellent",
+  "status": "pass",
+  "skip_reason": "no PHP files in changed set",
+  "settings": {
+    "min_lines": ${MIN_LINES},
+    "min_tokens": ${MIN_TOKENS}
+  },
+  "generated_at": "$(date -Iseconds)"
+}
+EOF
+        exit 0
+    fi
+fi
+
+# Check DDEV (only reached when PHP files are present in --changed mode, or no --changed flag)
 if ! ddev describe &> /dev/null; then
     echo -e "${RED}[ERROR]${NC} DDEV is not running"
     exit 2

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
@@ -18,12 +18,6 @@ DRUPAL_THEMES_PATH="${DRUPAL_THEMES_PATH:-web/themes/custom}"
 echo "=== Security Audit (OWASP + Drupal) ==="
 echo ""
 
-# Check DDEV
-if ! ddev describe &> /dev/null; then
-    echo -e "${RED}[ERROR]${NC} DDEV is not running"
-    exit 2
-fi
-
 # Check jq
 if ! command -v jq &> /dev/null; then
     echo -e "${RED}[ERROR]${NC} jq is required but not installed"
@@ -115,6 +109,12 @@ if [ -n "$CHANGED_FILE" ]; then
                 issues: []
             }' > "${REPORT_DIR}/security-report.json"
         exit 0
+    fi
+
+    # Changed set has real SAST work to do — DDEV is required from here
+    if ! ddev describe &> /dev/null; then
+        echo -e "${RED}[ERROR]${NC} DDEV is not running"
+        exit 2
     fi
 
     echo "Relevant SAST files (${#RELEVANT_FILES[@]}):"
@@ -419,6 +419,12 @@ fi
 # =====================
 # Standard (no --changed) path — byte-identical to original logic
 # =====================
+
+# Check DDEV (standard path always requires a running site)
+if ! ddev describe &> /dev/null; then
+    echo -e "${RED}[ERROR]${NC} DDEV is not running"
+    exit 2
+fi
 
 echo -e "${BLUE}[1/10]${NC} Checking Drupal security advisories..."
 # =====================

--- a/code-quality-tools/tests/changed-mode.sh
+++ b/code-quality-tools/tests/changed-mode.sh
@@ -617,6 +617,120 @@ SECURITY_SCRIPT="${DRUPAL_SCRIPTS}/security-check.sh"
 }
 
 # =====================
+# No-DDEV static-tier gap tests (Tests 24-27)
+# Regression tests for the gap where --changed with a no-PHP changed set
+# errored with "DDEV is not running" instead of skipping cleanly.
+# These tests run with a stub ddev whose `describe` always exits non-zero,
+# simulating a fully detached worktree with no running site.
+# =====================
+make_no_ddev() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "${dir}/ddev" <<'SH'
+#!/bin/bash
+# Stub: DDEV unavailable — describe always exits non-zero
+case "$1" in
+    describe) exit 1 ;;
+    *)        exit 1 ;;
+esac
+SH
+    chmod +x "${dir}/ddev"
+}
+
+NO_DDEV_BIN=$(mktemp -d)
+make_no_ddev "$NO_DDEV_BIN"
+
+# =====================
+# Test 24: security-check.sh --changed CSS-only → exit 0 (SKIP) even without DDEV
+# =====================
+{
+    label="security-check.sh --changed CSS-only → exit 0/SKIP without DDEV"
+    tmpf=$(mktemp)
+    printf '%s\n' "themes/custom/x/scss/styles.scss" "themes/custom/x/css/styles.css" > "$tmpf"
+    RDIR=$(mktemp -d)
+
+    exit_code=0
+    output=$(PATH="${NO_DDEV_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/security-check.sh" --changed "$tmpf" 2>&1) || exit_code=$?
+    rm -f "$tmpf"
+
+    if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qi "skip"; then
+        ok "$label → exit 0, skip message present"
+    else
+        fail "$label → exit_code=${exit_code}; output=${output}"
+    fi
+    rm -rf "$RDIR"
+}
+
+# =====================
+# Test 25: security-check.sh --changed PHP-file → requires DDEV (exit 2 when absent)
+# =====================
+{
+    label="security-check.sh --changed PHP-file → exit 2 (DDEV required)"
+    tmpf=$(mktemp)
+    printf '%s\n' "web/modules/custom/my_module/src/MyService.php" > "$tmpf"
+    RDIR=$(mktemp -d)
+
+    exit_code=0
+    output=$(PATH="${NO_DDEV_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/security-check.sh" --changed "$tmpf" 2>&1) || exit_code=$?
+    rm -f "$tmpf"
+
+    if [ "$exit_code" -eq 2 ] && echo "$output" | grep -qi "ddev"; then
+        ok "$label → exit 2, DDEV error message"
+    else
+        fail "$label → expected exit 2, got ${exit_code}; output=${output}"
+    fi
+    rm -rf "$RDIR"
+}
+
+# =====================
+# Test 26: dry-check.sh --changed CSS-only → exit 0 (SKIP) even without DDEV
+# =====================
+{
+    label="dry-check.sh --changed CSS-only → exit 0/SKIP without DDEV"
+    tmpf=$(mktemp)
+    printf '%s\n' "themes/custom/x/scss/styles.scss" "themes/custom/x/css/styles.css" > "$tmpf"
+    RDIR=$(mktemp -d)
+
+    exit_code=0
+    output=$(PATH="${NO_DDEV_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/dry-check.sh" --changed "$tmpf" 2>&1) || exit_code=$?
+    rm -f "$tmpf"
+
+    if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qi "skip\|no php"; then
+        ok "$label → exit 0, skip/no-php message present"
+    else
+        fail "$label → exit_code=${exit_code}; output=${output}"
+    fi
+    rm -rf "$RDIR"
+}
+
+# =====================
+# Test 27: dry-check.sh --changed PHP-file → requires DDEV (exit 2 when absent)
+# =====================
+{
+    label="dry-check.sh --changed PHP-file → exit 2 (DDEV required)"
+    tmpf=$(mktemp)
+    printf '%s\n' "web/modules/custom/my_module/src/MyService.php" > "$tmpf"
+    RDIR=$(mktemp -d)
+
+    exit_code=0
+    output=$(PATH="${NO_DDEV_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/dry-check.sh" --changed "$tmpf" 2>&1) || exit_code=$?
+    rm -f "$tmpf"
+
+    if [ "$exit_code" -eq 2 ] && echo "$output" | grep -qi "ddev"; then
+        ok "$label → exit 2, DDEV error message"
+    else
+        fail "$label → expected exit 2, got ${exit_code}; output=${output}"
+    fi
+    rm -rf "$RDIR"
+}
+
+rm -rf "$NO_DDEV_BIN"
+
+# =====================
 # Cleanup
 # =====================
 rm -rf "$FINDINGS_BIN"


### PR DESCRIPTION
## What

A bug found by the **faithful autonomous-loop de-risk run** (validating the just-closed `build_gate_correctness` epic). The change-scoped (`--changed`) gates are the **static tier** that the gate architecture runs in a **detached worktree with no running site**. But `security-check.sh` and `dry-check.sh` checked the **DDEV precondition before** their no-relevant-files clean-skip — so a CSS-only (or any no-PHP) changed set ERRORed with `DDEV is not running` instead of skipping. Under automation that fail-closes `/review` → the work-order retries to cap → HALT, on any such change. `solid-check.sh` and `lint-check.sh` already skip-before-DDEV; this aligns security + dry.

## Fix

- **`security-check.sh` `--changed`** — the empty-relevant-set clean-skip now runs **before** the DDEV check. DDEV is required only when there's real SAST work (a PHP/JS/Twig file, or `composer.json|lock`, in the set). **No security scan is bypassed** — a PHP- or composer-containing changed set still requires DDEV and runs the full SAST. Standard (no-`--changed`) path unchanged.
- **`dry-check.sh` `--changed`** — added a no-PHP early short-circuit: a changed set with no PHP-relevant files has zero possible change-touching clones, so it resolves to a clean PASS and exits 0 **without** phpcpd or DDEV. A PHP-containing set keeps the unchanged whole-tree-scan + verdict-filter (DDEV) path.

## Verification

Built by an independent agent + conducted red-team from disk (security-sensitive). With DDEV stubbed unavailable:

| set | security | dry |
|-----|----------|-----|
| CSS-only | **SKIP / exit 0** ✓ | **SKIP / exit 0** ✓ |
| PHP file | ERROR / exit 2 (DDEV required) ✓ | ERROR / exit 2 ✓ |
| composer.lock | ERROR / exit 2 (DDEV required) ✓ | — |

The skip condition is exactly `no-relevant-files AND no-composer` — only the genuine no-op skips; any real PHP/security/composer change still runs the full scan (no scan-bypass).

Suites: `changed-mode.sh` **27/27** (+4 DDEV-down regression tests) · `changed-mode-spec` 22/22 · `dry-check-spec` 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)