### PR TITLE
docs: temporary rename transition banner on root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Custom plugins and tools for Claude Code.
 > has been renamed to **`ai-dev-assistant`** (same workflow, broader scope, command
 > names unchanged). If you already have the old plugin installed: install
 > `ai-dev-assistant`, run `/drupal-dev-framework:upgrade` once to migrate your project
-> store and per-project wiring, then uninstall the old shell. The shell exposes only
+> store and per-project wiring, then uninstall `drupal-dev-framework`
+> (`/plugin uninstall drupal-dev-framework@camoa-skills`). The shell exposes only
 > `/drupal-dev-framework:upgrade`; everything else now lives under the
 > `ai-dev-assistant:` namespace. A few other plugins got minor description and tone
 > cleanups in the same pass. Full steps:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Custom plugins and tools for Claude Code.
 
+> **Heads up (transition notice, kept through ~August 2026).** `drupal-dev-framework`
+> has been renamed to **`ai-dev-assistant`** (same workflow, broader scope, command
+> names unchanged). If you already have the old plugin installed: install
+> `ai-dev-assistant`, run `/drupal-dev-framework:upgrade` once to migrate your project
+> store and per-project wiring, then uninstall the old shell. The shell exposes only
+> `/drupal-dev-framework:upgrade`; everything else now lives under the
+> `ai-dev-assistant:` namespace. A few other plugins got minor description and tone
+> cleanups in the same pass. Full steps:
+> [drupal-dev-framework/README.md](drupal-dev-framework/README.md).
+
 ## Background
 
 I started building what I called "frameworks" over a year before Claude officially released Skills. Same concept, different name.


### PR DESCRIPTION
Adds a short, time-boxed transition notice to the top of the root `README.md` for the `drupal-dev-framework` → `ai-dev-assistant` rename.

**What it tells readers:**
- The plugin was renamed (same workflow, command names unchanged, only the namespace moved).
- If they have the old plugin: install `ai-dev-assistant`, run `/drupal-dev-framework:upgrade` once to migrate the store + per-project wiring, then uninstall the shell.
- A few other plugins got minor description/tone cleanups in the same pass.
- Links to `drupal-dev-framework/README.md` for full steps.

**Scope:** root README only. Doc-only, no plugin content or version change. Catalog `metadata.version` stays held at 1.15.15.

**Lifecycle:** marked as a transition notice to keep through ~August 2026, then remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)