### PR TITLE
fix(cqt): Drupal tdd phpunit bootstrap + consistent missing-analyzer skips (3.9.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.17"
+    "version": "1.15.18"
   },
   "plugins": [
     {
@@ -144,7 +144,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.2] - 2026-06-14
+
+**Fix: two real defects in the Drupal gate floor, surfaced by running the gates live against a real site (idexx).**
+
+### Fixed
+- **F1 — `tdd-workflow.sh` (and `coverage-report.sh`) omitted Drupal's phpunit bootstrap.** The gate ran
+  `ddev exec vendor/bin/phpunit <test>` with **no** `-c <config>`. Drupal Unit tests extend
+  `Drupal\Tests\UnitTestCase`, which only autoloads under core's phpunit config, so a bare invocation
+  load-errored with `Class "Drupal\Tests\UnitTestCase" not found` (proven: the same test passes 4/4 with
+  `-c docroot/core/phpunit.xml.dist`, load-errors without). Added a host-side resolver
+  (`resolve_phpunit_config`) that detects the Drupal phpunit config — trying, in order,
+  `web/core/phpunit.xml.dist`, `docroot/core/phpunit.xml.dist`, `core/phpunit.xml.dist`, `phpunit.xml`,
+  `phpunit.xml.dist` (project-root-relative, since `ddev exec` cwd is the mounted project root) — and passes
+  `-c "$cfg"` to phpunit at every call site in **both** scripts (`tdd-workflow.sh` `_run_changed_mode` +
+  `run_test`; `coverage-report.sh` `--changed` + no-flag). If no config is found it prints a clear WARN and
+  runs without `-c` (preserving the old behavior as a fallback).
+- **F2 — a missing analyzer degraded inconsistently across the gates.** With analyzers absent,
+  `dry-check.sh` **ERRORed** (`[ERROR] PHPCPD not found`, non-zero) while `solid`/`security` printed PASS on
+  grep-only fallbacks. A missing tool now degrades **consistently and honestly** — run what is available, mark
+  each absent analyzer with an explicit `[SKIP] <tool> not installed (tool absent)` line, and never ERROR
+  purely because a tool is absent:
+  - `dry-check.sh` — phpcpd absent now emits `[SKIP] phpcpd not installed — DRY gate skipped (tool absent)`
+    and **exits 0** (benign skip), with `status`/`mode` = `skipped` and `skip_reason` = `tool_absent` in
+    `dry-report.json`.
+  - `solid-check.sh` / `security-check.sh` — absent analyzers (phpstan, phpmd / semgrep, php-security-linter,
+    psalm, trivy, gitleaks, security_review) now print `[SKIP] <tool> ... (tool absent)` and are recorded in
+    the JSON report (`skipped_tools` / `tools_absent`, plus `analyzers_ran`). The gate stays PASS when the
+    checks that DID run found nothing (absence ≠ failure); if **every** analyzer is absent (no real check ran)
+    the verdict is `skipped` (exit 0), never a hollow PASS. Pass↔fail is never inverted.
+
+### Tests
+- `tests/changed-mode.sh` +7 (28–34): F1 — tdd/coverage pass `-c <core-config>` when present, the resolver
+  prefers `web/core` over `docroot/core`, and falls back (no `-c` + WARN) when no config exists; F2 —
+  phpcpd-absent → dry SKIP-clean (exit 0, `status=skipped`/`tool_absent`), phpstan+phpmd-absent → solid exit 0
+  with `tools_absent` recorded, php-security-linter-absent → security exit 0 with `tools_absent` recorded.
+- Validated live against idexx (DDEV up): tdd now reports `Configuration: docroot/core/phpunit.xml.dist` and
+  4/4 OK; dry/solid/security SKIP-clean with explicit `[SKIP] ... (tool absent)` lines, all exit 0.
+
 ## [3.9.1] - 2026-06-12
 
 **Fix: `--changed` security/dry gates no longer require DDEV to skip a no-PHP change.** A faithful

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/coverage-report.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/coverage-report.sh
@@ -28,6 +28,29 @@ DRUPAL_MODULES_PATH="${DRUPAL_MODULES_PATH:-web/modules/custom}"
 COVERAGE_MINIMUM="${COVERAGE_MINIMUM:-70}"
 COVERAGE_TARGET="${COVERAGE_TARGET:-80}"
 
+# ── Drupal phpunit config resolver ────────────────────────────────────────────
+# Drupal Unit tests extend Drupal\Tests\UnitTestCase, which only autoloads under
+# core's phpunit config. A bare `phpunit <test>` fails with "Class
+# Drupal\Tests\UnitTestCase not found", so phpunit MUST be invoked with -c
+# <core-config>. Paths are project-root-relative (ddev exec cwd = mounted root).
+# Tries: web/core, docroot/core, core, then project-root phpunit.xml[.dist].
+# Echoes the first match; returns 1 (empty output) if none found.
+resolve_phpunit_config() {
+    local cfg
+    for cfg in \
+        web/core/phpunit.xml.dist \
+        docroot/core/phpunit.xml.dist \
+        core/phpunit.xml.dist \
+        phpunit.xml \
+        phpunit.xml.dist; do
+        if [ -f "$cfg" ]; then
+            echo "$cfg"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # ── --changed guard ───────────────────────────────────────────────────────────
 # Intercept --changed before main script body; no-flag path is byte-identical.
 if [[ "${1:-}" == "--changed" ]]; then
@@ -115,6 +138,14 @@ if [[ "${1:-}" == "--changed" ]]; then
   echo ""
 
   PHPUNIT_CMD="php ${PCOV_FLAGS} vendor/bin/phpunit"
+  # Drupal core phpunit config (autoloads Drupal\Tests\UnitTestCase)
+  _COV_CFG=$(resolve_phpunit_config || true)
+  if [ -n "$_COV_CFG" ]; then
+    echo -e "${GREEN}[CONFIG]${NC} Using Drupal phpunit config: $_COV_CFG"
+    PHPUNIT_CMD+=" -c $_COV_CFG"
+  else
+    echo -e "${YELLOW}[WARN]${NC} No Drupal phpunit config found; running without -c (Unit tests may fail to autoload)."
+  fi
   # Add mapped test paths (instead of --testsuite)
   for tp in "${_test_paths[@]}"; do
     PHPUNIT_CMD+=" $tp"
@@ -231,6 +262,14 @@ echo ""
 
 # Build PHPUnit command
 PHPUNIT_CMD="php ${PCOV_FLAGS} vendor/bin/phpunit"
+# Drupal core phpunit config (autoloads Drupal\Tests\UnitTestCase)
+_COV_CFG=$(resolve_phpunit_config || true)
+if [ -n "$_COV_CFG" ]; then
+    echo -e "${GREEN}[CONFIG]${NC} Using Drupal phpunit config: $_COV_CFG"
+    PHPUNIT_CMD+=" -c $_COV_CFG"
+else
+    echo -e "${YELLOW}[WARN]${NC} No Drupal phpunit config found; running without -c (Unit tests may fail to autoload)."
+fi
 PHPUNIT_CMD+=" --testsuite unit,kernel"
 PHPUNIT_CMD+=" --coverage-clover /var/www/html/${REPORT_DIR}/coverage/clover.xml"
 PHPUNIT_CMD+=" --coverage-text"

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/dry-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/dry-check.sh
@@ -173,10 +173,37 @@ if ! ddev describe &> /dev/null; then
 fi
 
 # Check for PHPCPD
+# A missing analyzer is a benign SKIP, not an error: phpcpd is the only analyzer
+# this gate runs, so if it is absent there is no real DRY check to perform. Degrade
+# honestly (verdict = skipped, reason = tool_absent) and exit 0 — do NOT exit non-zero
+# purely because the tool is not installed.
 if ! ddev exec vendor/bin/phpcpd --version &> /dev/null; then
-    echo -e "${RED}[ERROR]${NC} PHPCPD not found"
+    echo -e "${YELLOW}[SKIP]${NC} phpcpd not installed — DRY gate skipped (tool absent)"
     echo "  Install with: ddev composer require --dev systemsdk/phpcpd"
-    exit 2
+    mkdir -p "${REPORT_DIR}/dry"
+    cat > "${REPORT_DIR}/dry-report.json" << EOF
+{
+  "mode": "skipped",
+  "changed_mode": $([ -n "$CHANGED_FILES_PATH" ] && echo "true" || echo "false"),
+  "duplication_percentage": 0,
+  "total_lines": 0,
+  "duplicated_lines": 0,
+  "clone_count": 0,
+  "clones": [],
+  "rating": "skipped",
+  "status": "skipped",
+  "skip_reason": "tool_absent",
+  "tools_absent": ["phpcpd"],
+  "settings": {
+    "min_lines": ${MIN_LINES},
+    "min_tokens": ${MIN_TOKENS}
+  },
+  "generated_at": "$(date -Iseconds)"
+}
+EOF
+    echo ""
+    echo "Report saved: ${REPORT_DIR}/dry-report.json"
+    exit 0
 fi
 
 # Get PHPCPD version

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
@@ -15,6 +15,15 @@ REPORT_DIR="${REPORT_DIR:-.reports}"
 DRUPAL_MODULES_PATH="${DRUPAL_MODULES_PATH:-web/modules/custom}"
 DRUPAL_THEMES_PATH="${DRUPAL_THEMES_PATH:-web/themes/custom}"
 
+# Serialise a bash array to a JSON string array (empty array → []).
+to_json_array() {
+    if [ "$#" -eq 0 ]; then
+        echo "[]"
+    else
+        printf '%s\n' "$@" | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null || echo "[]"
+    fi
+}
+
 echo "=== Security Audit (OWASP + Drupal) ==="
 echo ""
 
@@ -126,6 +135,11 @@ if [ -n "$CHANGED_FILE" ]; then
     CUSTOM_ISSUES="[]"
     COMPOSER_VIOLATIONS="[]"
 
+    # Tool-availability tracking: which SAST analyzers ran vs were absent.
+    # absence ≠ failure; if NO analyzer runs the gate verdict is "skipped" (exit 0).
+    SKIPPED_TOOLS=()
+    RAN_ANALYZERS=0
+
     # =====================
     # [1] Semgrep SAST — changed files only
     # =====================
@@ -134,6 +148,7 @@ if [ -n "$CHANGED_FILE" ]; then
 
     if [ "${#RELEVANT_FILES[@]}" -gt 0 ]; then
         if ddev exec semgrep --version &> /dev/null || command -v semgrep &> /dev/null; then
+            RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
             set +e
             if ddev describe &> /dev/null; then
                 # shellcheck disable=SC2046
@@ -172,7 +187,8 @@ if [ -n "$CHANGED_FILE" ]; then
                 fi
             fi
         else
-            echo -e "  ${YELLOW}Semgrep not installed (optional)${NC}"
+            echo -e "  ${YELLOW}[SKIP]${NC} semgrep not installed (tool absent)"
+            SKIPPED_TOOLS+=("semgrep")
         fi
     else
         echo -e "  ${YELLOW}No SAST-eligible files — skipping Semgrep${NC}"
@@ -187,6 +203,7 @@ if [ -n "$CHANGED_FILE" ]; then
 
     if [ "${#RELEVANT_FILES[@]}" -gt 0 ]; then
         if ddev exec test -f vendor/bin/php-security-linter &> /dev/null; then
+            RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
             set +e
             # shellcheck disable=SC2046
             ddev exec vendor/bin/php-security-linter scan \
@@ -222,7 +239,8 @@ if [ -n "$CHANGED_FILE" ]; then
                 PHPCS_ISSUES="[]"
             fi
         else
-            echo -e "  ${YELLOW}PHPCS security linter not installed (optional)${NC}"
+            echo -e "  ${YELLOW}[SKIP]${NC} php-security-linter not installed (tool absent)"
+            SKIPPED_TOOLS+=("php-security-linter")
         fi
     else
         echo -e "  ${YELLOW}No SAST-eligible files — skipping php-security-linter${NC}"
@@ -235,6 +253,8 @@ if [ -n "$CHANGED_FILE" ]; then
     echo -e "${BLUE}[SAST 3/3]${NC} Checking custom Drupal security patterns (changed files)..."
 
     if [ "${#RELEVANT_FILES[@]}" -gt 0 ]; then
+        # grep-based pattern scan is always available — a real check that runs.
+        RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
         # Unsafe db_query usage
         DB_QUERY_UNSAFE=$(grep -n "db_query.*\$" "${RELEVANT_FILES[@]}" 2>/dev/null || true)
         if [ -n "$DB_QUERY_UNSAFE" ]; then
@@ -299,6 +319,7 @@ if [ -n "$CHANGED_FILE" ]; then
     echo ""
     if [ "$HAS_COMPOSER" = true ]; then
         echo -e "${BLUE}[ADVISORY]${NC} composer.json|lock changed — running composer audit..."
+        RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
         COMPOSER_AUDIT_JSON="${REPORT_DIR}/security/composer-audit.json"
         set +e
         ddev composer audit --format=json > "$COMPOSER_AUDIT_JSON" 2>/dev/null
@@ -343,14 +364,23 @@ if [ -n "$CHANGED_FILE" ]; then
         --argjson custom "$CUSTOM_ISSUES" \
         '$composer + $phpcs + $semgrep + $custom')
 
-    OVERALL_STATUS="pass"
-    if [ "$CRITICAL_COUNT" -gt 0 ]; then
-        OVERALL_STATUS="fail"
-    elif [ "$HIGH_COUNT" -gt 3 ]; then
-        OVERALL_STATUS="fail"
-    elif [ "$HIGH_COUNT" -gt 0 ] || [ "$MEDIUM_COUNT" -gt 10 ]; then
-        OVERALL_STATUS="warning"
+    # Status. If NO SAST analyzer ran (every analyzer absent + no eligible files),
+    # degrade to "skipped" (exit 0) rather than a hollow PASS. Otherwise the verdict
+    # comes from the checks that DID run — tool absence never inverts pass↔fail.
+    if [ "$RAN_ANALYZERS" -eq 0 ]; then
+        OVERALL_STATUS="skipped"
+    else
+        OVERALL_STATUS="pass"
+        if [ "$CRITICAL_COUNT" -gt 0 ]; then
+            OVERALL_STATUS="fail"
+        elif [ "$HIGH_COUNT" -gt 3 ]; then
+            OVERALL_STATUS="fail"
+        elif [ "$HIGH_COUNT" -gt 0 ] || [ "$MEDIUM_COUNT" -gt 10 ]; then
+            OVERALL_STATUS="warning"
+        fi
     fi
+
+    SKIPPED_TOOLS_JSON=$(to_json_array "${SKIPPED_TOOLS[@]+"${SKIPPED_TOOLS[@]}"}")
 
     REPORT_FILE="${REPORT_DIR}/security-report.json"
     jq -n \
@@ -361,13 +391,17 @@ if [ -n "$CHANGED_FILE" ]; then
         --argjson medium "$MEDIUM_COUNT" \
         --argjson low "$LOW_COUNT" \
         --argjson issues "$ISSUES" \
+        --argjson analyzers_ran "$RAN_ANALYZERS" \
+        --argjson tools_absent "$SKIPPED_TOOLS_JSON" \
         --arg advisory_note "$ADVISORY_SKIP_NOTE" \
         '{
             meta: {
                 timestamp: $timestamp,
                 scan_type: "security_audit_changed",
                 mode: "changed",
+                analyzers_ran: $analyzers_ran,
                 tools_run: ["semgrep","phpcs_security_linter","custom_patterns","composer_audit_on_lock_change"],
+                tools_absent: $tools_absent,
                 tools_skipped: ["drush_pm_security","psalm_taint","security_review","trivy","gitleaks","roave"]
             },
             summary: {
@@ -402,7 +436,11 @@ if [ -n "$CHANGED_FILE" ]; then
     echo -e "Low:      ${LOW_COUNT}"
     echo ""
 
-    if [ "$OVERALL_STATUS" = "pass" ]; then
+    if [ "$OVERALL_STATUS" = "skipped" ]; then
+        echo -e "${YELLOW}[SKIP]${NC} No security SAST analyzers available (all tools absent) — gate skipped"
+        echo -e "Report: ${REPORT_FILE}"
+        exit 0
+    elif [ "$OVERALL_STATUS" = "pass" ]; then
         echo -e "${GREEN}[PASS]${NC} Security SAST passed"
         exit 0
     elif [ "$OVERALL_STATUS" = "warning" ]; then
@@ -425,6 +463,9 @@ if ! ddev describe &> /dev/null; then
     echo -e "${RED}[ERROR]${NC} DDEV is not running"
     exit 2
 fi
+
+# Track absent optional analyzers (honest, consistent skip reporting).
+SKIPPED_TOOLS=()
 
 echo -e "${BLUE}[1/10]${NC} Checking Drupal security advisories..."
 # =====================
@@ -546,7 +587,8 @@ if ddev exec test -f vendor/bin/php-security-linter &> /dev/null; then
         PHPCS_ISSUES="[]"
     fi
 else
-    echo -e "  ${YELLOW}PHPCS security linter not installed (optional)${NC}"
+    echo -e "  ${YELLOW}[SKIP]${NC} php-security-linter not installed (tool absent)"
+    SKIPPED_TOOLS+=("php-security-linter")
     PHPCS_ISSUES="[]"
 fi
 
@@ -619,7 +661,8 @@ EOF
         PSALM_ISSUES="[]"
     fi
 else
-    echo -e "  ${YELLOW}Psalm not installed (optional but recommended)${NC}"
+    echo -e "  ${YELLOW}[SKIP]${NC} psalm not installed (tool absent)"
+    SKIPPED_TOOLS+=("psalm")
     PSALM_ISSUES="[]"
 fi
 
@@ -729,7 +772,8 @@ if ddev drush pm:list --filter=security_review --format=json 2>/dev/null | jq -e
         SECREVIEW_ISSUES="[]"
     fi
 else
-    echo -e "  ${YELLOW}Security Review module not installed (optional)${NC}"
+    echo -e "  ${YELLOW}[SKIP]${NC} security_review module not installed (tool absent)"
+    SKIPPED_TOOLS+=("security_review")
     SECREVIEW_ISSUES="[]"
 fi
 
@@ -783,7 +827,8 @@ if ddev exec semgrep --version &> /dev/null || command -v semgrep &> /dev/null; 
         fi
     fi
 else
-    echo -e "  ${YELLOW}Semgrep not installed (optional)${NC}"
+    echo -e "  ${YELLOW}[SKIP]${NC} semgrep not installed (tool absent)"
+    SKIPPED_TOOLS+=("semgrep")
 fi
 
 echo ""
@@ -845,7 +890,8 @@ if command -v trivy &> /dev/null; then
         fi
     fi
 else
-    echo -e "  ${YELLOW}Trivy not installed (optional)${NC}"
+    echo -e "  ${YELLOW}[SKIP]${NC} trivy not installed (tool absent)"
+    SKIPPED_TOOLS+=("trivy")
 fi
 
 echo ""
@@ -885,7 +931,8 @@ if command -v gitleaks &> /dev/null; then
         fi
     fi
 else
-    echo -e "  ${YELLOW}Gitleaks not installed (optional)${NC}"
+    echo -e "  ${YELLOW}[SKIP]${NC} gitleaks not installed (tool absent)"
+    SKIPPED_TOOLS+=("gitleaks")
 fi
 
 echo ""
@@ -950,6 +997,8 @@ fi
 # =====================
 REPORT_FILE="${REPORT_DIR}/security-report.json"
 
+SKIPPED_TOOLS_JSON=$(to_json_array "${SKIPPED_TOOLS[@]+"${SKIPPED_TOOLS[@]}"}")
+
 jq -n \
     --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg status "$OVERALL_STATUS" \
@@ -958,11 +1007,13 @@ jq -n \
     --argjson medium "$MEDIUM_COUNT" \
     --argjson low "$LOW_COUNT" \
     --argjson issues "$ISSUES" \
+    --argjson tools_absent "$SKIPPED_TOOLS_JSON" \
     '{
         meta: {
             timestamp: $timestamp,
             scan_type: "security_audit",
-            tools: ["drush_pm_security", "composer_audit", "phpcs_security_linter", "psalm_taint", "custom_patterns", "security_review", "semgrep", "trivy", "gitleaks", "roave"]
+            tools: ["drush_pm_security", "composer_audit", "phpcs_security_linter", "psalm_taint", "custom_patterns", "security_review", "semgrep", "trivy", "gitleaks", "roave"],
+            tools_absent: $tools_absent
         },
         summary: {
             overall_status: $status,

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/solid-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/solid-check.sh
@@ -14,6 +14,23 @@ REPORT_DIR="${REPORT_DIR:-.reports}"
 DRUPAL_MODULES_PATH="${DRUPAL_MODULES_PATH:-web/modules/custom}"
 COMPLEXITY_MAX="${COMPLEXITY_MAX:-10}"
 
+# Probe whether a vendor analyzer binary is installed in the container.
+# A missing analyzer is a benign SKIP (tool absent), not an error or a failure —
+# the gate runs what IS available and records absences in the report. Only called
+# after DDEV availability has been confirmed.
+tool_present() {
+    ddev exec test -f "vendor/bin/$1" &> /dev/null
+}
+
+# Serialise a bash array to a JSON string array (empty array → []).
+to_json_array() {
+    if [ "$#" -eq 0 ]; then
+        echo "[]"
+    else
+        printf '%s\n' "$@" | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null || echo "[]"
+    fi
+}
+
 echo "=== SOLID Principles Analysis ==="
 echo ""
 
@@ -95,6 +112,11 @@ EOF
     WARNING_COUNT=0
     SUGGESTION_COUNT=0
 
+    # Tool-availability tracking: which analyzers actually ran vs were absent.
+    # absence ≠ failure; if NO analyzer runs, the gate verdict is "skipped" (exit 0).
+    SKIPPED_TOOLS=()
+    RAN_ANALYZERS=0
+
     echo "Relevant files (${#RELEVANT_FILES[@]}):"
     printf '  %s\n' "${RELEVANT_FILES[@]}"
     echo ""
@@ -102,65 +124,71 @@ EOF
     # =====================
     # PHPStan Analysis (LSP, DIP) — changed files only
     # =====================
-    echo "Running PHPStan (type safety, LSP, DIP)..."
-
-    PHPSTAN_JSON="${REPORT_DIR}/solid/phpstan.json"
-    set +e
-    # shellcheck disable=SC2046
-    ddev exec vendor/bin/phpstan analyse \
-        "${RELEVANT_FILES[@]}" \
-        --error-format=json \
-        --no-progress \
-        --memory-limit=1500M \
-        2>/dev/null > "$PHPSTAN_JSON"
-    PHPSTAN_EXIT=$?
-    set -e
-
     PHPSTAN_ERRORS=0
     PHPSTAN_VIOLATIONS="[]"
-    if [ -f "$PHPSTAN_JSON" ] && [ -s "$PHPSTAN_JSON" ]; then
-        PHPSTAN_ERRORS=$(jq '.totals.errors // 0' "$PHPSTAN_JSON" 2>/dev/null || echo "0")
-        echo "  PHPStan errors: ${PHPSTAN_ERRORS}"
+    PHPSTAN_JSON="${REPORT_DIR}/solid/phpstan.json"
+    if tool_present phpstan; then
+        echo "Running PHPStan (type safety, LSP, DIP)..."
+        RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
+        set +e
+        # shellcheck disable=SC2046
+        ddev exec vendor/bin/phpstan analyse \
+            "${RELEVANT_FILES[@]}" \
+            --error-format=json \
+            --no-progress \
+            --memory-limit=1500M \
+            2>/dev/null > "$PHPSTAN_JSON"
+        PHPSTAN_EXIT=$?
+        set -e
 
-        if [ "$PHPSTAN_ERRORS" -gt 0 ]; then
-            PHPSTAN_VIOLATIONS=$(jq '[.files | to_entries[] | .key as $file | .value.messages[] | {
-                principle: "LSP",
-                severity: "warning",
-                file: $file,
-                line: .line,
-                message: .message,
-                metric: "phpstan",
-                value: 1,
-                threshold: 0
-            }]' "$PHPSTAN_JSON" 2>/dev/null || echo "[]")
+        if [ -f "$PHPSTAN_JSON" ] && [ -s "$PHPSTAN_JSON" ]; then
+            PHPSTAN_ERRORS=$(jq '.totals.errors // 0' "$PHPSTAN_JSON" 2>/dev/null || echo "0")
+            echo "  PHPStan errors: ${PHPSTAN_ERRORS}"
 
-            WARNING_COUNT=$((WARNING_COUNT + PHPSTAN_ERRORS))
+            if [ "$PHPSTAN_ERRORS" -gt 0 ]; then
+                PHPSTAN_VIOLATIONS=$(jq '[.files | to_entries[] | .key as $file | .value.messages[] | {
+                    principle: "LSP",
+                    severity: "warning",
+                    file: $file,
+                    line: .line,
+                    message: .message,
+                    metric: "phpstan",
+                    value: 1,
+                    threshold: 0
+                }]' "$PHPSTAN_JSON" 2>/dev/null || echo "[]")
+
+                WARNING_COUNT=$((WARNING_COUNT + PHPSTAN_ERRORS))
+            fi
+        else
+            echo -e "${YELLOW}[WARN]${NC} PHPStan output not available"
         fi
     else
-        echo -e "${YELLOW}[WARN]${NC} PHPStan output not available"
+        echo -e "${YELLOW}[SKIP]${NC} phpstan not installed (tool absent)"
+        SKIPPED_TOOLS+=("phpstan")
     fi
 
     # =====================
     # PHPMD Analysis (SRP) — changed files (comma-separated)
     # =====================
-    echo "Running PHPMD (complexity, SRP)..."
-
-    PHPMD_JSON="${REPORT_DIR}/solid/phpmd.json"
-    # PHPMD takes a comma-separated list as the first positional arg
-    PHPMD_TARGETS=$(IFS=,; echo "${RELEVANT_FILES[*]}")
-    set +e
-    ddev exec vendor/bin/phpmd \
-        "$PHPMD_TARGETS" \
-        json \
-        cleancode,codesize,design,naming \
-        --exclude "*/tests/*" \
-        2>/dev/null > "$PHPMD_JSON"
-    PHPMD_EXIT=$?
-    set -e
-
     PHPMD_VIOLATIONS_COUNT=0
     PHPMD_VIOLATIONS="[]"
-    if [ -f "$PHPMD_JSON" ] && [ -s "$PHPMD_JSON" ]; then
+    PHPMD_JSON="${REPORT_DIR}/solid/phpmd.json"
+    if tool_present phpmd; then
+        echo "Running PHPMD (complexity, SRP)..."
+        RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
+        # PHPMD takes a comma-separated list as the first positional arg
+        PHPMD_TARGETS=$(IFS=,; echo "${RELEVANT_FILES[*]}")
+        set +e
+        ddev exec vendor/bin/phpmd \
+            "$PHPMD_TARGETS" \
+            json \
+            cleancode,codesize,design,naming \
+            --exclude "*/tests/*" \
+            2>/dev/null > "$PHPMD_JSON"
+        PHPMD_EXIT=$?
+        set -e
+
+        if [ -f "$PHPMD_JSON" ] && [ -s "$PHPMD_JSON" ]; then
         PHPMD_VIOLATIONS_COUNT=$(jq '[.files[].violations[]] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
         echo "  PHPMD violations: ${PHPMD_VIOLATIONS_COUNT}"
 
@@ -184,8 +212,12 @@ EOF
             WARNING_COUNT=$((WARNING_COUNT + PHPMD_WARNINGS))
             SUGGESTION_COUNT=$((SUGGESTION_COUNT + PHPMD_SUGGESTIONS))
         fi
+        else
+            echo -e "${YELLOW}[WARN]${NC} PHPMD output not available"
+        fi
     else
-        echo -e "${YELLOW}[WARN]${NC} PHPMD output not available"
+        echo -e "${YELLOW}[SKIP]${NC} phpmd not installed (tool absent)"
+        SKIPPED_TOOLS+=("phpmd")
     fi
 
     # =====================
@@ -195,12 +227,15 @@ EOF
 
     # =====================
     # Check for static \Drupal:: calls (DIP violation) — changed files only
+    # grep is always available (not an external analyzer), so this is a real check
+    # that runs regardless of phpstan/phpmd presence.
     # =====================
     echo "Checking for static \\Drupal:: calls (DIP)..."
 
     STATIC_CALLS=0
     STATIC_VIOLATIONS="[]"
     if [ "${#RELEVANT_FILES[@]}" -gt 0 ]; then
+        RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
         STATIC_CALLS=$(ddev exec grep -l "\\\\Drupal::" "${RELEVANT_FILES[@]}" \
             2>/dev/null | wc -l || echo "0")
 
@@ -231,8 +266,16 @@ EOF
 
     TOTAL_VIOLATIONS=$(echo "$ALL_VIOLATIONS" | jq 'length' 2>/dev/null || echo "0")
 
-    # Determine overall status
-    if [ "$CRITICAL_COUNT" -gt 0 ]; then
+    SKIPPED_TOOLS_JSON=$(to_json_array "${SKIPPED_TOOLS[@]+"${SKIPPED_TOOLS[@]}"}")
+
+    # Determine overall status.
+    # If NO analyzer ran at all (every analyzer absent), degrade to "skipped" (exit 0)
+    # rather than reporting a hollow PASS. Otherwise the verdict comes from the
+    # checks that DID run (absence of a tool never inverts pass↔fail).
+    if [ "$RAN_ANALYZERS" -eq 0 ]; then
+        SOLID_STATUS="skipped"
+        echo -e "${YELLOW}[SKIP]${NC} No SOLID analyzers available (all tools absent) — gate skipped"
+    elif [ "$CRITICAL_COUNT" -gt 0 ]; then
         SOLID_STATUS="fail"
         echo -e "${RED}[FAIL]${NC} Found ${CRITICAL_COUNT} critical SOLID violations"
     elif [ "$WARNING_COUNT" -gt 10 ]; then
@@ -258,6 +301,9 @@ EOF
   "mode": "changed",
   "changed_file": "${CHANGED_FILE}",
   "relevant_files": ${#RELEVANT_FILES[@]},
+  "analyzers_ran": ${RAN_ANALYZERS},
+  "skipped_tools": ${SKIPPED_TOOLS_JSON},
+  "tools_absent": ${SKIPPED_TOOLS_JSON},
   "status": "${SOLID_STATUS}",
   "thresholds": {
     "complexity_max": ${COMPLEXITY_MAX}
@@ -270,6 +316,7 @@ EOF
     echo "Report saved: ${REPORT_DIR}/solid-report.json"
 
     case "$SOLID_STATUS" in
+        skipped) exit 0 ;;
         pass) exit 0 ;;
         warning) exit 1 ;;
         fail) exit 2 ;;
@@ -292,99 +339,117 @@ WARNING_COUNT=0
 SUGGESTION_COUNT=0
 VIOLATIONS="[]"
 
+# Tool-availability tracking (see --changed path for rationale).
+SKIPPED_TOOLS=()
+RAN_ANALYZERS=0
+PHPSTAN_ERRORS=0
+PHPMD_VIOLATIONS_COUNT=0
+
 # Create temp directory for individual reports
 mkdir -p "${REPORT_DIR}/solid"
 
 # =====================
 # PHPStan Analysis (LSP, DIP)
 # =====================
-echo "Running PHPStan (type safety, LSP, DIP)..."
-
+PHPSTAN_VIOLATIONS="[]"
 PHPSTAN_JSON="${REPORT_DIR}/solid/phpstan.json"
-set +e
-ddev exec vendor/bin/phpstan analyse \
-    "${DRUPAL_MODULES_PATH}" \
-    --error-format=json \
-    --no-progress \
-    --memory-limit=1500M \
-    2>/dev/null > "$PHPSTAN_JSON"
-PHPSTAN_EXIT=$?
-set -e
+if tool_present phpstan; then
+    echo "Running PHPStan (type safety, LSP, DIP)..."
+    RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
+    set +e
+    ddev exec vendor/bin/phpstan analyse \
+        "${DRUPAL_MODULES_PATH}" \
+        --error-format=json \
+        --no-progress \
+        --memory-limit=1500M \
+        2>/dev/null > "$PHPSTAN_JSON"
+    PHPSTAN_EXIT=$?
+    set -e
 
-if [ -f "$PHPSTAN_JSON" ] && [ -s "$PHPSTAN_JSON" ]; then
-    PHPSTAN_ERRORS=$(jq '.totals.errors // 0' "$PHPSTAN_JSON" 2>/dev/null || echo "0")
-    echo "  PHPStan errors: ${PHPSTAN_ERRORS}"
+    if [ -f "$PHPSTAN_JSON" ] && [ -s "$PHPSTAN_JSON" ]; then
+        PHPSTAN_ERRORS=$(jq '.totals.errors // 0' "$PHPSTAN_JSON" 2>/dev/null || echo "0")
+        echo "  PHPStan errors: ${PHPSTAN_ERRORS}"
 
-    # Convert PHPStan errors to violations
-    if [ "$PHPSTAN_ERRORS" -gt 0 ]; then
-        PHPSTAN_VIOLATIONS=$(jq '[.files | to_entries[] | .key as $file | .value.messages[] | {
-            principle: "LSP",
-            severity: "warning",
-            file: $file,
-            line: .line,
-            message: .message,
-            metric: "phpstan",
-            value: 1,
-            threshold: 0
-        }]' "$PHPSTAN_JSON" 2>/dev/null || echo "[]")
+        # Convert PHPStan errors to violations
+        if [ "$PHPSTAN_ERRORS" -gt 0 ]; then
+            PHPSTAN_VIOLATIONS=$(jq '[.files | to_entries[] | .key as $file | .value.messages[] | {
+                principle: "LSP",
+                severity: "warning",
+                file: $file,
+                line: .line,
+                message: .message,
+                metric: "phpstan",
+                value: 1,
+                threshold: 0
+            }]' "$PHPSTAN_JSON" 2>/dev/null || echo "[]")
 
-        # Count by severity
-        ((WARNING_COUNT += PHPSTAN_ERRORS))
+            # Count by severity
+            ((WARNING_COUNT += PHPSTAN_ERRORS))
+        else
+            PHPSTAN_VIOLATIONS="[]"
+        fi
     else
+        echo -e "${YELLOW}[WARN]${NC} PHPStan output not available"
         PHPSTAN_VIOLATIONS="[]"
     fi
 else
-    echo -e "${YELLOW}[WARN]${NC} PHPStan output not available"
-    PHPSTAN_VIOLATIONS="[]"
+    echo -e "${YELLOW}[SKIP]${NC} phpstan not installed (tool absent)"
+    SKIPPED_TOOLS+=("phpstan")
 fi
 
 # =====================
 # PHPMD Analysis (SRP)
 # =====================
-echo "Running PHPMD (complexity, SRP)..."
-
+PHPMD_VIOLATIONS="[]"
 PHPMD_JSON="${REPORT_DIR}/solid/phpmd.json"
-set +e
-ddev exec vendor/bin/phpmd \
-    "${DRUPAL_MODULES_PATH}" \
-    json \
-    cleancode,codesize,design,naming \
-    --exclude "*/tests/*" \
-    2>/dev/null > "$PHPMD_JSON"
-PHPMD_EXIT=$?
-set -e
+if tool_present phpmd; then
+    echo "Running PHPMD (complexity, SRP)..."
+    RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
+    set +e
+    ddev exec vendor/bin/phpmd \
+        "${DRUPAL_MODULES_PATH}" \
+        json \
+        cleancode,codesize,design,naming \
+        --exclude "*/tests/*" \
+        2>/dev/null > "$PHPMD_JSON"
+    PHPMD_EXIT=$?
+    set -e
 
-if [ -f "$PHPMD_JSON" ] && [ -s "$PHPMD_JSON" ]; then
-    PHPMD_VIOLATIONS_COUNT=$(jq '[.files[].violations[]] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
-    echo "  PHPMD violations: ${PHPMD_VIOLATIONS_COUNT}"
+    if [ -f "$PHPMD_JSON" ] && [ -s "$PHPMD_JSON" ]; then
+        PHPMD_VIOLATIONS_COUNT=$(jq '[.files[].violations[]] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
+        echo "  PHPMD violations: ${PHPMD_VIOLATIONS_COUNT}"
 
-    if [ "$PHPMD_VIOLATIONS_COUNT" -gt 0 ]; then
-        # Convert PHPMD violations
-        PHPMD_VIOLATIONS=$(jq '[.files[] | .file as $file | .violations[] | {
-            principle: (if .rule | test("Complexity|NPath|Methods") then "SRP" else "design" end),
-            severity: (if .priority <= 2 then "critical" elif .priority <= 3 then "warning" else "suggestion" end),
-            file: $file,
-            line: .beginLine,
-            message: .description,
-            metric: .rule,
-            value: (.priority // 3),
-            threshold: 3
-        }]' "$PHPMD_JSON" 2>/dev/null || echo "[]")
+        if [ "$PHPMD_VIOLATIONS_COUNT" -gt 0 ]; then
+            # Convert PHPMD violations
+            PHPMD_VIOLATIONS=$(jq '[.files[] | .file as $file | .violations[] | {
+                principle: (if .rule | test("Complexity|NPath|Methods") then "SRP" else "design" end),
+                severity: (if .priority <= 2 then "critical" elif .priority <= 3 then "warning" else "suggestion" end),
+                file: $file,
+                line: .beginLine,
+                message: .description,
+                metric: .rule,
+                value: (.priority // 3),
+                threshold: 3
+            }]' "$PHPMD_JSON" 2>/dev/null || echo "[]")
 
-        # Count by severity
-        PHPMD_CRITICAL=$(jq '[.files[].violations[] | select(.priority <= 2)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
-        PHPMD_WARNINGS=$(jq '[.files[].violations[] | select(.priority == 3)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
-        PHPMD_SUGGESTIONS=$(jq '[.files[].violations[] | select(.priority > 3)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
+            # Count by severity
+            PHPMD_CRITICAL=$(jq '[.files[].violations[] | select(.priority <= 2)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
+            PHPMD_WARNINGS=$(jq '[.files[].violations[] | select(.priority == 3)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
+            PHPMD_SUGGESTIONS=$(jq '[.files[].violations[] | select(.priority > 3)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
 
-        ((CRITICAL_COUNT += PHPMD_CRITICAL))
-        ((WARNING_COUNT += PHPMD_WARNINGS))
-        ((SUGGESTION_COUNT += PHPMD_SUGGESTIONS))
+            ((CRITICAL_COUNT += PHPMD_CRITICAL)) || true
+            ((WARNING_COUNT += PHPMD_WARNINGS)) || true
+            ((SUGGESTION_COUNT += PHPMD_SUGGESTIONS)) || true
+        else
+            PHPMD_VIOLATIONS="[]"
+        fi
     else
+        echo -e "${YELLOW}[WARN]${NC} PHPMD output not available"
         PHPMD_VIOLATIONS="[]"
     fi
 else
-    echo -e "${YELLOW}[WARN]${NC} PHPMD output not available"
-    PHPMD_VIOLATIONS="[]"
+    echo -e "${YELLOW}[SKIP]${NC} phpmd not installed (tool absent)"
+    SKIPPED_TOOLS+=("phpmd")
 fi
 
 # =====================
@@ -397,8 +462,11 @@ echo "  For auto-fixes: Run rector-fix.sh"
 
 # =====================
 # Check for static Drupal:: calls (DIP violation)
+# grep is always available (not an external analyzer) — this real check runs
+# regardless of phpstan/phpmd presence.
 # =====================
 echo "Checking for static \\Drupal:: calls (DIP)..."
+RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
 
 STATIC_CALLS=$(ddev exec grep -r "\\\\Drupal::" "${DRUPAL_MODULES_PATH}" \
     --include="*.php" \
@@ -407,7 +475,7 @@ STATIC_CALLS=$(ddev exec grep -r "\\\\Drupal::" "${DRUPAL_MODULES_PATH}" \
 
 if [ "$STATIC_CALLS" -gt 0 ]; then
     echo -e "  ${YELLOW}[WARN]${NC} Found ${STATIC_CALLS} files with static \\Drupal:: calls"
-    ((WARNING_COUNT += STATIC_CALLS))
+    ((WARNING_COUNT += STATIC_CALLS)) || true
 
     # Create DIP violations for static calls
     STATIC_VIOLATIONS=$(ddev exec grep -rn "\\\\Drupal::" "${DRUPAL_MODULES_PATH}" \
@@ -437,8 +505,14 @@ ALL_VIOLATIONS=$(echo "$PHPSTAN_VIOLATIONS $PHPMD_VIOLATIONS $STATIC_VIOLATIONS"
 # Calculate metrics
 TOTAL_VIOLATIONS=$(echo "$ALL_VIOLATIONS" | jq 'length' 2>/dev/null || echo "0")
 
-# Determine overall status
-if [ "$CRITICAL_COUNT" -gt 0 ]; then
+SKIPPED_TOOLS_JSON=$(to_json_array "${SKIPPED_TOOLS[@]+"${SKIPPED_TOOLS[@]}"}")
+
+# Determine overall status. All analyzers absent → "skipped" (exit 0), never a
+# hollow PASS. Absence of a tool never inverts pass↔fail.
+if [ "$RAN_ANALYZERS" -eq 0 ]; then
+    SOLID_STATUS="skipped"
+    echo -e "${YELLOW}[SKIP]${NC} No SOLID analyzers available (all tools absent) — gate skipped"
+elif [ "$CRITICAL_COUNT" -gt 0 ]; then
     SOLID_STATUS="fail"
     echo -e "${RED}[FAIL]${NC} Found ${CRITICAL_COUNT} critical SOLID violations"
 elif [ "$WARNING_COUNT" -gt 10 ]; then
@@ -462,6 +536,9 @@ cat > "${REPORT_DIR}/solid-report.json" << EOF
     "phpstan_errors": ${PHPSTAN_ERRORS:-0},
     "phpmd_violations": ${PHPMD_VIOLATIONS_COUNT:-0}
   },
+  "analyzers_ran": ${RAN_ANALYZERS},
+  "skipped_tools": ${SKIPPED_TOOLS_JSON},
+  "tools_absent": ${SKIPPED_TOOLS_JSON},
   "status": "${SOLID_STATUS}",
   "thresholds": {
     "complexity_max": ${COMPLEXITY_MAX}
@@ -475,6 +552,7 @@ echo "Report saved: ${REPORT_DIR}/solid-report.json"
 
 # Exit based on status
 case "$SOLID_STATUS" in
+    skipped) exit 0 ;;
     pass) exit 0 ;;
     warning) exit 1 ;;
     fail) exit 2 ;;

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/tdd-workflow.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/tdd-workflow.sh
@@ -24,6 +24,30 @@ NC='\033[0m'
 
 DRUPAL_MODULES_PATH="${DRUPAL_MODULES_PATH:-web/modules/custom}"
 
+# ── Drupal phpunit config resolver ────────────────────────────────────────────
+# Drupal Unit tests extend Drupal\Tests\UnitTestCase, which only autoloads under
+# core's phpunit config. A bare `phpunit <test>` fails with:
+#   Class "Drupal\Tests\UnitTestCase" not found
+# So phpunit MUST be invoked with -c <core-config>. Paths are project-root-relative
+# because `ddev exec` runs with cwd = the mounted project root (same layout on host).
+# Tries, in order: web/core, docroot/core, core, then a project-root phpunit.xml[.dist].
+# Echoes the first match (relative path); returns 1 (empty output) if none found.
+resolve_phpunit_config() {
+    local cfg
+    for cfg in \
+        web/core/phpunit.xml.dist \
+        docroot/core/phpunit.xml.dist \
+        core/phpunit.xml.dist \
+        phpunit.xml \
+        phpunit.xml.dist; do
+        if [ -f "$cfg" ]; then
+            echo "$cfg"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # ── --changed guard ───────────────────────────────────────────────────────────
 # Intercept --changed before any existing argument parsing; no-flag path is
 # byte-identical to pre-change behaviour.
@@ -101,8 +125,18 @@ if [[ "${1:-}" == "--changed" ]]; then
       exit 1
     fi
 
+    local _cfg
+    _cfg=$(resolve_phpunit_config || true)
+
     set +e
-    ddev exec vendor/bin/phpunit "${test_paths[@]}"
+    if [ -n "$_cfg" ]; then
+      echo -e "${BLUE}[CONFIG]${NC} Using Drupal phpunit config: $_cfg"
+      ddev exec vendor/bin/phpunit -c "$_cfg" "${test_paths[@]}"
+    else
+      echo -e "${YELLOW}[WARN]${NC} No Drupal phpunit config found (web/core, docroot/core, core, phpunit.xml[.dist])."
+      echo "  Running phpunit without -c; Drupal Unit tests may fail to autoload Drupal\\Tests\\UnitTestCase."
+      ddev exec vendor/bin/phpunit "${test_paths[@]}"
+    fi
     local rc=$?
     set -e
     exit $rc
@@ -169,11 +203,21 @@ run_test() {
         filter="--filter $(basename "$TEST_FILE" .php)"
     fi
 
-    echo "Running: ddev exec vendor/bin/phpunit $filter"
+    local cfg cfg_flag=""
+    cfg=$(resolve_phpunit_config || true)
+    if [ -n "$cfg" ]; then
+        cfg_flag="-c $cfg"
+        echo -e "${BLUE}[CONFIG]${NC} Using Drupal phpunit config: $cfg"
+    else
+        echo -e "${YELLOW}[WARN]${NC} No Drupal phpunit config found (web/core, docroot/core, core, phpunit.xml[.dist])."
+        echo "  Running phpunit without -c; Drupal Unit tests may fail to autoload Drupal\\Tests\\UnitTestCase."
+    fi
+
+    echo "Running: ddev exec vendor/bin/phpunit $cfg_flag $filter"
     echo ""
 
     set +e
-    ddev exec vendor/bin/phpunit $filter
+    ddev exec vendor/bin/phpunit $cfg_flag $filter
     local exit_code=$?
     set -e
 

--- a/code-quality-tools/tests/changed-mode.sh
+++ b/code-quality-tools/tests/changed-mode.sh
@@ -731,6 +731,264 @@ make_no_ddev "$NO_DDEV_BIN"
 rm -rf "$NO_DDEV_BIN"
 
 # =====================
+# F1: Drupal phpunit-bootstrap config resolver (tdd-workflow.sh + coverage-report.sh)
+# Tests 28-31. A fake ddev logs the phpunit invocation so we can assert -c <cfg>.
+# Drupal Unit tests extend Drupal\Tests\UnitTestCase which only autoloads under
+# core's phpunit config; without -c phpunit load-errors. The resolver must pass
+# -c when a core config exists and fall back (no -c + WARN) when none is found.
+# =====================
+make_phpunit_log_ddev() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "${dir}/ddev" <<'SH'
+#!/bin/bash
+# Fake ddev that logs the phpunit command line to $DDEV_PHPUNIT_LOG.
+LOG="${DDEV_PHPUNIT_LOG:-/dev/null}"
+case "$1" in
+    describe) exit 0 ;;
+    exec)
+        shift
+        case "$1" in
+            php)
+                # Either `php -m` (pcov probe) or `php ... vendor/bin/phpunit ...` (coverage run)
+                if printf '%s ' "$@" | grep -q 'vendor/bin/phpunit'; then
+                    printf 'PHPUNIT_RUN: %s\n' "$*" >> "$LOG"
+                    echo "Lines: 100.00% (1/1)"; echo "Tests: 1"; echo "OK (1 test, 1 assertion)"
+                    exit 0
+                fi
+                echo "Core"; exit 0     # `php -m` → no pcov line
+                ;;
+            vendor/bin/phpunit)
+                if [ "${2:-}" = "--version" ]; then echo "PHPUnit 11"; exit 0; fi
+                printf 'PHPUNIT_RUN: %s\n' "$*" >> "$LOG"   # tdd run
+                echo "OK (4 tests, 4 assertions)"
+                exit 0
+                ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac
+SH
+    chmod +x "${dir}/ddev"
+}
+
+PHPUNIT_BIN=$(mktemp -d)
+make_phpunit_log_ddev "$PHPUNIT_BIN"
+TDD_SCRIPT="${DRUPAL_SCRIPTS}/tdd-workflow.sh"
+COV_SCRIPT="${DRUPAL_SCRIPTS}/coverage-report.sh"
+
+# Build a fixture project with a module (src + mapped Unit test on disk).
+make_phpunit_fixture() {
+    local root="$1"
+    mkdir -p "${root}/docroot/modules/custom/m/src"
+    mkdir -p "${root}/docroot/modules/custom/m/tests/src/Unit"
+    printf '<?php\n' > "${root}/docroot/modules/custom/m/src/Service.php"
+    printf '<?php\n' > "${root}/docroot/modules/custom/m/tests/src/Unit/ServiceTest.php"
+}
+
+# ── Test 28: tdd --changed passes -c docroot/core/phpunit.xml.dist when present ──
+{
+    label="tdd --changed: phpunit invoked with -c docroot/core/phpunit.xml.dist"
+    WORKDIR=$(mktemp -d); make_phpunit_fixture "$WORKDIR"
+    mkdir -p "${WORKDIR}/docroot/core"; touch "${WORKDIR}/docroot/core/phpunit.xml.dist"
+    LOG=$(mktemp)
+    ( cd "$WORKDIR" && PATH="${PHPUNIT_BIN}:${ORIG_PATH}" DDEV_PHPUNIT_LOG="$LOG" \
+        bash "$TDD_SCRIPT" --changed "docroot/modules/custom/m/src/Service.php" >/dev/null 2>&1 ) || true
+    RUN=$(grep '^PHPUNIT_RUN:' "$LOG" | head -1 || echo "")
+    if echo "$RUN" | grep -q -- '-c docroot/core/phpunit.xml.dist'; then
+        ok "$label"
+    else
+        fail "$label → PHPUNIT_RUN='${RUN}'"
+    fi
+    rm -rf "$WORKDIR"; rm -f "$LOG"
+}
+
+# ── Test 29: resolver prefers web/core over docroot/core ─────────────────────
+{
+    label="tdd --changed: resolver prefers web/core/phpunit.xml.dist over docroot/core"
+    WORKDIR=$(mktemp -d); make_phpunit_fixture "$WORKDIR"
+    mkdir -p "${WORKDIR}/web/core" "${WORKDIR}/docroot/core"
+    touch "${WORKDIR}/web/core/phpunit.xml.dist" "${WORKDIR}/docroot/core/phpunit.xml.dist"
+    LOG=$(mktemp)
+    ( cd "$WORKDIR" && PATH="${PHPUNIT_BIN}:${ORIG_PATH}" DDEV_PHPUNIT_LOG="$LOG" \
+        bash "$TDD_SCRIPT" --changed "docroot/modules/custom/m/src/Service.php" >/dev/null 2>&1 ) || true
+    RUN=$(grep '^PHPUNIT_RUN:' "$LOG" | head -1 || echo "")
+    if echo "$RUN" | grep -q -- '-c web/core/phpunit.xml.dist'; then
+        ok "$label"
+    else
+        fail "$label → PHPUNIT_RUN='${RUN}'"
+    fi
+    rm -rf "$WORKDIR"; rm -f "$LOG"
+}
+
+# ── Test 30: no config present → no -c flag, WARN, phpunit still runs (fallback) ─
+{
+    label="tdd --changed: no core config → fallback (no -c, WARN, still runs)"
+    WORKDIR=$(mktemp -d); make_phpunit_fixture "$WORKDIR"
+    LOG=$(mktemp)
+    out=$( cd "$WORKDIR" && PATH="${PHPUNIT_BIN}:${ORIG_PATH}" DDEV_PHPUNIT_LOG="$LOG" \
+        bash "$TDD_SCRIPT" --changed "docroot/modules/custom/m/src/Service.php" 2>&1 ) || true
+    RUN=$(grep '^PHPUNIT_RUN:' "$LOG" | head -1 || echo "")
+    if [ -n "$RUN" ] && ! echo "$RUN" | grep -q -- '-c ' && echo "$out" | grep -qi "No Drupal phpunit config found"; then
+        ok "$label"
+    else
+        fail "$label → RUN='${RUN}'; warn=$(echo "$out" | grep -ci 'No Drupal phpunit config')"
+    fi
+    rm -rf "$WORKDIR"; rm -f "$LOG"
+}
+
+# ── Test 31: coverage-report.sh --changed passes -c when a core config exists ──
+{
+    label="coverage-report.sh --changed: phpunit invoked with -c docroot/core/phpunit.xml.dist"
+    WORKDIR=$(mktemp -d); make_phpunit_fixture "$WORKDIR"
+    mkdir -p "${WORKDIR}/docroot/core"; touch "${WORKDIR}/docroot/core/phpunit.xml.dist"
+    LOG=$(mktemp); RDIR=$(mktemp -d)
+    ( cd "$WORKDIR" && PATH="${PHPUNIT_BIN}:${ORIG_PATH}" DDEV_PHPUNIT_LOG="$LOG" REPORT_DIR="$RDIR" \
+        bash "$COV_SCRIPT" --changed "docroot/modules/custom/m/src/Service.php" >/dev/null 2>&1 ) || true
+    RUN=$(grep '^PHPUNIT_RUN:' "$LOG" | head -1 || echo "")
+    if echo "$RUN" | grep -q -- '-c docroot/core/phpunit.xml.dist'; then
+        ok "$label"
+    else
+        fail "$label → PHPUNIT_RUN='${RUN}'"
+    fi
+    rm -rf "$WORKDIR" "$RDIR"; rm -f "$LOG"
+}
+
+rm -rf "$PHPUNIT_BIN"
+
+# =====================
+# F2: missing analyzer degrades to a benign SKIP (not an ERROR/FAIL)
+# Tests 32-34. A fake ddev reports the analyzer as absent; the gate must exit 0,
+# print an explicit "[SKIP] <tool> ... (tool absent)", and record the absence in
+# its JSON report — never ERROR purely because a tool is not installed.
+# =====================
+
+# ── Test 32: dry-check.sh --changed, phpcpd absent → SKIP-clean exit 0 ──────────
+make_no_phpcpd_ddev() {
+    local dir="$1"; mkdir -p "$dir"
+    cat > "${dir}/ddev" <<'SH'
+#!/bin/bash
+case "$1" in
+    describe) exit 0 ;;
+    exec)
+        shift
+        case "$1" in
+            vendor/bin/phpcpd) exit 127 ;;   # absent: --version fails
+            *) exit 0 ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac
+SH
+    chmod +x "${dir}/ddev"
+}
+{
+    label="dry-check.sh --changed: phpcpd absent → SKIP-clean (exit 0, not ERROR)"
+    NOPCPD_BIN=$(mktemp -d); make_no_phpcpd_ddev "$NOPCPD_BIN"
+    tmpf=$(mktemp); printf '%s\n' "web/modules/custom/m/src/A.php" > "$tmpf"
+    RDIR=$(mktemp -d)
+    exit_code=0
+    output=$(PATH="${NOPCPD_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/dry-check.sh" --changed "$tmpf" 2>&1) || exit_code=$?
+    STATUS=$(jq -r '.status // ""' "${RDIR}/dry-report.json" 2>/dev/null || echo "")
+    REASON=$(jq -r '.skip_reason // ""' "${RDIR}/dry-report.json" 2>/dev/null || echo "")
+    if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qi "SKIP.*phpcpd" \
+        && [ "$STATUS" = "skipped" ] && [ "$REASON" = "tool_absent" ]; then
+        ok "$label (status=${STATUS}, reason=${REASON})"
+    else
+        fail "$label → exit=${exit_code}, status='${STATUS}', reason='${REASON}', out=$(echo "$output" | tr '\n' '|')"
+    fi
+    rm -rf "$NOPCPD_BIN" "$RDIR"; rm -f "$tmpf"
+}
+
+# ── Test 33: solid-check.sh --changed, phpstan+phpmd absent → exit 0, tools_absent ──
+make_no_analyzers_ddev() {
+    local dir="$1"; mkdir -p "$dir"
+    cat > "${dir}/ddev" <<'SH'
+#!/bin/bash
+# Analyzers absent: `test -f vendor/bin/<tool>` fails; grep still works.
+case "$1" in
+    describe) exit 0 ;;
+    exec)
+        shift
+        case "$1" in
+            test) exit 1 ;;                  # tool_present → absent
+            grep) shift; grep "$@" 2>/dev/null; exit 0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac
+SH
+    chmod +x "${dir}/ddev"
+}
+{
+    label="solid-check.sh --changed: phpstan+phpmd absent → exit 0, tools_absent recorded"
+    NOAN_BIN=$(mktemp -d); make_no_analyzers_ddev "$NOAN_BIN"
+    tmpf=$(mktemp); printf '%s\n' "web/modules/custom/m/src/A.php" > "$tmpf"
+    RDIR=$(mktemp -d)
+    exit_code=0
+    output=$(PATH="${NOAN_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/solid-check.sh" --changed "$tmpf" 2>&1) || exit_code=$?
+    ABSENT=$(jq -c '.tools_absent // []' "${RDIR}/solid-report.json" 2>/dev/null || echo "[]")
+    if [ "$exit_code" -eq 0 ] \
+        && echo "$output" | grep -qi "SKIP.*phpstan.*tool absent" \
+        && echo "$output" | grep -qi "SKIP.*phpmd.*tool absent" \
+        && echo "$ABSENT" | grep -q "phpstan" && echo "$ABSENT" | grep -q "phpmd"; then
+        ok "$label (tools_absent=${ABSENT})"
+    else
+        fail "$label → exit=${exit_code}, tools_absent='${ABSENT}', out=$(echo "$output" | tr '\n' '|')"
+    fi
+    rm -rf "$NOAN_BIN" "$RDIR"; rm -f "$tmpf"
+}
+
+# ── Test 34: security-check.sh --changed, php-security-linter absent → exit 0, recorded ──
+make_psl_absent_ddev() {
+    local dir="$1"; mkdir -p "$dir"
+    cat > "${dir}/ddev" <<'SH'
+#!/bin/bash
+# semgrep present-but-clean; php-security-linter absent (test -f fails).
+case "$1" in
+    describe) exit 0 ;;
+    exec)
+        shift
+        case "$1" in
+            semgrep)
+                if [ "${2:-}" = "--version" ]; then exit 0; fi
+                echo '{"results":[]}'; exit 0 ;;
+            test) exit 1 ;;                  # `test -f vendor/bin/php-security-linter` → absent
+            grep) shift; grep "$@" 2>/dev/null; exit 0 ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac
+SH
+    chmod +x "${dir}/ddev"
+}
+{
+    label="security-check.sh --changed: php-security-linter absent → exit 0, tools_absent recorded"
+    PSL_BIN=$(mktemp -d); make_psl_absent_ddev "$PSL_BIN"
+    WORKDIR=$(mktemp -d); mkdir -p "${WORKDIR}/web/modules/custom/m/src"
+    printf '<?php\n' > "${WORKDIR}/web/modules/custom/m/src/A.php"
+    tmpf=$(mktemp); printf '%s\n' "web/modules/custom/m/src/A.php" > "$tmpf"
+    RDIR=$(mktemp -d)
+    exit_code=0
+    output=$( cd "$WORKDIR" && PATH="${PSL_BIN}:${ORIG_PATH}" REPORT_DIR="$RDIR" \
+        bash "${DRUPAL_SCRIPTS}/security-check.sh" --changed "$tmpf" 2>&1 ) || exit_code=$?
+    ABSENT=$(jq -c '.meta.tools_absent // []' "${RDIR}/security-report.json" 2>/dev/null || echo "[]")
+    if [ "$exit_code" -eq 0 ] \
+        && echo "$output" | grep -qi "SKIP.*php-security-linter.*tool absent" \
+        && echo "$ABSENT" | grep -q "php-security-linter"; then
+        ok "$label (tools_absent=${ABSENT})"
+    else
+        fail "$label → exit=${exit_code}, tools_absent='${ABSENT}', out=$(echo "$output" | tr '\n' '|')"
+    fi
+    rm -rf "$PSL_BIN" "$WORKDIR" "$RDIR"; rm -f "$tmpf"
+}
+
+# =====================
 # Cleanup
 # =====================
 rm -rf "$FINDINGS_BIN"


### PR DESCRIPTION
## Summary
Fixes two real defects in the **code-quality-tools** Drupal gate floor, surfaced by running it live against a real Drupal 11 site (idexx) during the ddf_autonomy breadth runs.

### F1 — tdd gate omitted Drupal's phpunit bootstrap (high impact)
`tdd-workflow.sh` (and `coverage-report.sh`) ran `vendor/bin/phpunit <test>` with **no** `-c <config>`, so `Drupal\Tests\UnitTestCase` never autoloaded → **every Drupal Unit test false-failed** (`Class "Drupal\Tests\UnitTestCase" not found`). Now resolves the Drupal phpunit config (`web|docroot|.`/`core/phpunit.xml.dist`) and passes `-c` at both call sites (`--changed` + no-flag), with a WARN fallback when none exists. Proven: same test = **4/4 pass** with `-c`, load-error without.

### F2 — inconsistent missing-analyzer degradation
With an analyzer binary absent, `dry-check.sh` **ERRORed** while `solid`/`security` printed a silent partial **PASS** (masking that the heavy analyzer never ran). Now consistent + honest: each absent tool → `[SKIP] <tool> not installed (tool absent)` recorded in `tools_absent[]`; `dry` phpcpd-absent → **skip-clean exit 0**; all-analyzers-absent → `skipped` (not a green pass, not an error). No pass↔fail semantics inverted.

## Tests
+258 lines of hermetic (fake-ddev) tests for F1 (`-c` passed when a core config exists; resolver prefers web/core; fallback when none) and F2 (phpcpd-absent skip-clean exit 0; solid/security tool-absent skips). Suite green (34/34 + 16/16 + 22/22).

## Version
cqt 3.9.1 → 3.9.2; marketplace cqt entry + `metadata.version` 1.15.17 → 1.15.18; CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)