### PR TITLE
drupal-ai-contrib v0.2.0: BUG-1 model-pin fix + CC hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.19"
+    "version": "1.15.20"
   },
   "plugins": [
     {
@@ -120,7 +120,7 @@
       "name": "drupal-ai-contrib",
       "source": "./drupal-ai-contrib",
       "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline), a local drupalci-parity gate set plus AI-policy and eval gates inside verify, 3 read-only agents (fresh-context review, external-fact verification, live AI-policy checking), and a PostToolUse re-verification ledger. A quality layer outside ai-dev-assistant; cites the camoa/dev-guides contribution guides as its knowledge layer.",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-ai-contrib",
   "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-ai-contrib/.claude/rules/skill-conventions.md
+++ b/drupal-ai-contrib/.claude/rules/skill-conventions.md
@@ -10,7 +10,13 @@ globs: skills/**
 - `version` — semver
 
 ## Optional Frontmatter
-- `model` — matched to complexity (sonnet for balanced tasks)
+- `model` — use `inherit` on inline skills. A skill's `model:` is a current-turn
+  override with no context isolation, so pinning a sub-1M tier (`sonnet`/`haiku`)
+  overflows when the skill activates from a large conversation (validator S14). Pin a
+  specific tier only on a Task-dispatched agent (fresh context), never on a SKILL.md.
+- `disallowed-tools` (kebab-case on skills — distinct from the agent `disallowedTools`
+  camelCase field) — declare `Edit, Write` on read-only worker skills that only dispatch
+  agents, run gate commands, or read status and never mutate contribution files.
 - `user-invocable: false` — umbrella + the six worker skills (invoked by command or
   routed to by the umbrella, never from the `/` menu)
 

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-06-16
+
+BUG-1 (model-pin overflow footgun) plus Claude Code hardening. No gate logic, no
+drupalci-parity, no AI-policy/eval behavior changed — this wave is frontmatter + advisory
+guidance only.
+
+### Fixed
+
+- **BUG-1 / S14 — inline model-pin overflow.** All 8 SKILL.md files pinned
+  `model: sonnet`. A skill `model:` is an inline, current-turn override with no context
+  isolation, so a sub-1M pin overflows when the skill activates from a large conversation.
+  Changed to `model: inherit` on every skill (`contribution-guardrails`, `-issue`,
+  `-pipeline`, `-review`, `-setup`, `-submit`, `-verify`, and the `drupal-ai-contrib`
+  umbrella). The 3 agents keep `model: sonnet` — they run in fresh subagent contexts and
+  are S14-exempt.
+
+### Added
+
+- **Read-only tool restriction.** `disallowed-tools: Edit, Write` (kebab-case skill field)
+  on the 4 read-only worker skills: `contribution-review` (dispatches agents),
+  `contribution-verify` (runs gates, captures artifacts), `contribution-pipeline` (reads
+  status), `contribution-guardrails` (enforces discipline). `-setup`, `-issue`, `-submit`,
+  and the umbrella keep full access (they scaffold / run git ops / create MRs).
+- **Sandbox guidance for untrusted code execution** (`contribution-verify`). `verify`
+  runs the contributor's own `composer install` / `phpunit` / `eslint` at CI strictness —
+  untrusted code. Added a note recommending the process-level `@anthropic-ai/sandbox-runtime`
+  (constrains the whole process — Bash, file tools, MCP, hooks — not only Bash) for
+  unreviewed contributions, with a VM / Claude Code on the web pointer for fully untrusted
+  repos.
+- **Large-codebase scoping note** (`contribution-verify`) — for core / large-suite
+  contributions, scope `verify` to the changed subtree; cites the Large Codebases and
+  Monorepos guide.
+- **Complementary security layer** (`contribution-review` + `README.md`) — documents that
+  the `security-guidance` plugin (auto, watches Claude's own in-session edits) is a
+  complementary defense-in-depth layer to the per-contribution, explicitly-dispatched
+  `fresh-context-reviewer` agent — different scopes, never a replacement. Install pointer
+  included.
+
+### Changed
+
+- **`CONVENTIONS.md` release hygiene** — documents `/plugin-creation-tools:validate --strict`
+  as a required pre-release gate (promotes S14 to an error so the overflow footgun cannot
+  ship as a tolerated warning), plus the model / `disallowed-tools` skill conventions.
+- **`.claude/rules/skill-conventions.md`** — corrected the optional-frontmatter guidance
+  that recommended `sonnet` on skills (the S14 root cause) to mandate `inherit` on inline
+  skills and document the `disallowed-tools` field.
+
+### Notes
+
+- `capabilities: [...]` on the 3 agents was checked against `--strict`: **not flagged**
+  (the validator tolerates extra YAML keys), so per the rollout decision rule it was left
+  in place. It is harmless prose, though not a documented agent frontmatter field.
+
+### Bumped
+
+- Plugin `0.1.2` → `0.2.0`. All 8 skill versions unchanged at this layer (frontmatter-only
+  change). Root `marketplace.json` entry `0.1.2` → `0.2.0` and `metadata.version`
+  `1.15.19` → `1.15.20`.
+
 ## [0.1.2] - 2026-06-13
 
 Prose patch — track the `drupal-dev-framework` → `ai-dev-assistant` rename.

--- a/drupal-ai-contrib/CONVENTIONS.md
+++ b/drupal-ai-contrib/CONVENTIONS.md
@@ -22,6 +22,15 @@ component; the plugin eats its own dog food.
 - The umbrella skill (`drupal-ai-contrib`) and the six worker skills are
   `user-invocable: false` — invoked by their command or routed to by the umbrella.
 - `contribution-guardrails` is user-invocable — a contributor may pull it up directly.
+- `model: inherit` on every SKILL.md. A skill `model:` is an inline, current-turn
+  override with no context isolation — pinning a sub-1M tier (`sonnet`/`haiku`) overflows
+  when the skill activates from a large conversation (validator S14). Pin a tier only on
+  a Task-dispatched **agent** (fresh context), never on a skill.
+- Read-only worker skills carry `disallowed-tools: Edit, Write` (kebab-case on skills —
+  distinct from the agent `disallowedTools` camelCase field): `contribution-review`,
+  `-verify`, `-pipeline`, and `-guardrails` dispatch agents / run gates / read status and
+  never mutate contribution files. `-setup`, `-issue`, `-submit`, and the umbrella write
+  or run git ops, so they keep full tool access.
 - Body uses imperative voice — instructions for Claude, not documentation.
 - Under 500 lines per SKILL.md; push detail into `references/`.
 
@@ -76,3 +85,13 @@ over assertion, so it must apply that candor to itself.
   *illustrative*. The binding state is whatever the `ai-policy-checker` agent fetches
   live for the contribution. If a source is unreachable, the AI-policy gate is UNRUN,
   never silently passed.
+
+## Release hygiene
+
+- Run `/plugin-creation-tools:validate --strict` before every release. `--strict`
+  promotes S14 (sub-1M `model:` pins on a skill) and other warnings to errors, so the
+  inline-overflow footgun cannot slip into a release as a tolerated warning. A release is
+  clean only when `--strict` passes.
+- Bump `.claude-plugin/plugin.json`, sync the root `.claude-plugin/marketplace.json`
+  entry **and** `metadata.version`, add a `CHANGELOG.md` entry, and update `README.md` in
+  the same change. One minor bump per PR; one release = one PR.

--- a/drupal-ai-contrib/README.md
+++ b/drupal-ai-contrib/README.md
@@ -179,4 +179,6 @@ adds contribution-quality commands and gates on top, without forking or modifyin
 `code-quality-tools` (philosophy / standards review) · `code-paper-test` (paper
 testing) · `mglaman/drupalorg-cli` (issue / MR / pipeline CLI — executable `drupalorg`)
 · `drupal_devkit` (Drupal AI skill install) · `ai_best_practices` (the canonical AI
-policy + evals).
+policy + evals) · `security-guidance` (a *complementary* in-session security layer that
+auto-reviews Claude's own edits — not a replacement for the fresh-context contribution
+review; install `/plugin install security-guidance@claude-plugins-official`).

--- a/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-guardrails/SKILL.md
@@ -2,9 +2,10 @@
 name: contribution-guardrails
 description: "Enforces the development discipline for AI-assisted Drupal contributions — evidence over assertion, the no-guessing rule for external facts, the verification-gate artifact contracts, and re-verification on post-gate change. Use PROACTIVELY during any development between claiming an issue and verifying it. Use when user says 'guardrails', 'evidence over assertion', 'no guessing', 'verify this fact', 'is this actually tested', or whenever AI-assisted code is being written for a Drupal contribution. MUST apply before claiming any gate passed."
 version: 0.1.0
-model: sonnet
+model: inherit
 user-invocable: true
 allowed-tools: Read, Grep, Glob, Task
+disallowed-tools: Edit, Write
 ---
 
 # Contribution Guardrails

--- a/drupal-ai-contrib/skills/contribution-issue/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-issue/SKILL.md
@@ -2,7 +2,7 @@
 name: contribution-issue
 description: "Works the Drupal issue lifecycle — reviews prior work on an issue first, then creates / comments on / claims it, and checks out the issue fork + branch with three-way fork handling. Use when the user runs /drupal-ai-contrib:issue or asks to find, create, claim, or check out a Drupal issue or issue fork. Wraps drupalorg-cli."
 version: 0.1.1
-model: sonnet
+model: inherit
 user-invocable: false
 ---
 

--- a/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
@@ -2,8 +2,9 @@
 name: contribution-pipeline
 description: "Fetches the real GitLab merge-request pipeline for a Drupal contribution and gates on it — the authoritative final check. Use when the user runs /drupal-ai-contrib:pipeline or asks to check the real pipeline, the CI status, or whether a Drupal contribution is done. A contribution is not complete until the real drupalci pipeline is green."
 version: 0.1.0
-model: sonnet
+model: inherit
 user-invocable: false
+disallowed-tools: Edit, Write
 ---
 
 # Contribution Pipeline (worker skill)

--- a/drupal-ai-contrib/skills/contribution-review/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-review/SKILL.md
@@ -2,8 +2,9 @@
 name: contribution-review
 description: "Runs honest fresh-context review of a Drupal contribution — dispatches isolated reviewer agents with no session narrative to check the work against scope, coding standards, security, and the AI policy. Use when the user runs /drupal-ai-contrib:review or asks for an honest review, a fresh-eyes review, or a pre-submission review of a Drupal contribution. A builder cannot objectively review its own work."
 version: 0.1.0
-model: sonnet
+model: inherit
 user-invocable: false
+disallowed-tools: Edit, Write
 ---
 
 # Contribution Review (worker skill)
@@ -46,6 +47,17 @@ agent reviews against:
 
 For a large or security-critical change, dispatch multiple reviewer agents for
 perspective diversity, or delegate to `code-paper-test` for line-by-line paper testing.
+
+**Complementary security layer.** The `security-guidance` plugin and this skill cover
+*different* scopes and do not compete. `security-guidance` runs automatically on
+**Claude's own in-session edits** — a deterministic per-edit string match (no model
+involved) plus a fresh-context, security-focused review of the diff at end-of-turn and on
+commit. The `fresh-context-reviewer` agent here is **per-contribution** and **explicitly
+dispatched**, reviewing the whole contribution diff against scope, standards, security,
+and the AI policy. Run both: in-session guidance catches vulnerabilities as Claude writes
+them; the contribution review catches what survives into the diff. Neither replaces the
+other, and neither blocks — both surface findings as instructions. Install the in-session
+layer with `/plugin install security-guidance@claude-plugins-official`.
 
 ### 3. Delegate the philosophy review
 

--- a/drupal-ai-contrib/skills/contribution-setup/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: contribution-setup
 description: "Stands up and environment-matches a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config (new-module scaffold or existing-module discovery), the Drupal AI skills, the drupalorg CLI, and a contribution-credentials (SSH-key) check. Use when the user runs /drupal-ai-contrib:setup or asks to set up a Drupal contribution environment. Idempotent and detect-driven — does only what is missing; never a gate, never a prerequisite."
 version: 0.1.1
-model: sonnet
+model: inherit
 user-invocable: false
 ---
 

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -2,7 +2,7 @@
 name: contribution-submit
 description: "Creates or updates a Drupal merge request and generates the AI-disclosure comment at the policy threshold. Use when the user runs /drupal-ai-contrib:submit or asks to submit, open, or update a Drupal merge request or patch. Wraps drupalorg-cli; surfaces status and RTBC guidance."
 version: 0.1.1
-model: sonnet
+model: inherit
 user-invocable: false
 ---
 

--- a/drupal-ai-contrib/skills/contribution-verify/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-verify/SKILL.md
@@ -2,8 +2,9 @@
 name: contribution-verify
 description: "Runs the local verification inner loop for a Drupal contribution — the drupalci-parity gate set at CI strictness, the AI-policy gate, and the eval gate, every gate passing only on a captured artifact. Use when the user runs /drupal-ai-contrib:verify or asks to verify, check, or locally test a Drupal contribution before submitting. This is the centerpiece — evidence over assertion, never a bare 'passes'."
 version: 0.1.0
-model: sonnet
+model: inherit
 user-invocable: false
+disallowed-tools: Edit, Write
 ---
 
 # Contribution Verify (worker skill)
@@ -137,3 +138,24 @@ passed.
 | `evals.json` absent or schema changed | Degrade silently — the eval gate is best-effort, never a hard dependency. |
 | A gate cannot run locally (e.g. `_MAX_PHP`) | Report UNRUN and defer to `contribution-pipeline`; never imply it passed. |
 | `phpstan` reports errors | It is `allow_failure: true` by default — report FAIL flagged non-blocking, per the project's config. |
+
+## Sandbox users — untrusted code execution
+
+`verify` runs the **contributor's own code** at CI strictness — `composer install`,
+`phpunit`, `eslint`, `phpstan` — which is untrusted-code execution against an unreviewed
+contribution (Composer scripts and a test suite both run arbitrary PHP). When verifying
+a contribution you have not yet reviewed, run it under the process-level sandbox runtime
+(`@anthropic-ai/sandbox-runtime`): unlike the built-in Bash sandbox, it wraps the
+**whole Claude Code process** — Bash, file tools, MCP servers, and hooks — in the same
+Seatbelt / bubblewrap isolation, so a malicious `composer.json` script or test fixture
+cannot reach beyond the workspace. (The attack surface here is PHPUnit / Composer,
+parallel to the `npx`-trojan risk in JS tooling.) For a *fully* untrusted repository,
+the guide steers stronger isolation — a dedicated VM or Claude Code on the web. See the
+**Sandbox Environments** guide.
+
+## Large host codebases
+
+For Drupal **core** or large-suite contributions, scope `verify` to the contribution's
+**changed subtree** rather than the entire host codebase — point the gates at the paths
+the diff actually touches so a multi-gigabyte monorepo does not dilute the signal or
+blow the time budget. See the **Large Codebases and Monorepos** guide.

--- a/drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md
+++ b/drupal-ai-contrib/skills/drupal-ai-contrib/SKILL.md
@@ -2,7 +2,7 @@
 name: drupal-ai-contrib
 description: "Routes Drupal contribution work to the right contribution-quality stage and supplies the contribution knowledge layer. Use when user says 'contribute to Drupal', 'Drupal contribution', 'submit a Drupal patch', 'Drupal merge request', 'fix a Drupal core issue', 'contribute a module', 'AI-assisted Drupal contribution', or works a drupal.org / GitLab Drupal issue. Use PROACTIVELY whenever AI-assisted code is headed for a Drupal contribution — drupalci and maintainer review are unforgiving."
 version: 0.1.1
-model: sonnet
+model: inherit
 user-invocable: false
 ---
 


### PR DESCRIPTION
## Summary

First release of the 2026-05-29 feature wave. **Frontmatter + advisory guidance only — no gate logic, drupalci-parity, AI-policy, or eval behavior changed.**

### BUG-1 / S14 — inline model-pin overflow (the headline fix)
All 8 worker skills pinned `model: sonnet`. A skill `model:` is an inline, current-turn override with **no context isolation**, so a sub-1M pin overflows when the skill activates from a large conversation. Changed to **`model: inherit`** on all 8 (`contribution-{guardrails,issue,pipeline,review,setup,submit,verify}` + `drupal-ai-contrib` umbrella). The 3 `agents/` keep `model: sonnet` — fresh subagent context, **S14-exempt**.

### CC hardening
- **CC-1** `disallowed-tools: Edit, Write` on the 4 read-only skills (`-review`, `-verify`, `-pipeline`, `-guardrails`). `-setup`/`-issue`/`-submit`/umbrella keep full access (scaffold / git ops / MR create).
- **CC-2** `/plugin-creation-tools:validate --strict` documented as a pre-release gate in `CONVENTIONS.md`.
- **CC-3** "Complementary security layer" note in `contribution-review` + README one-liner — `security-guidance` (auto, watches Claude's own edits) is complementary to the `fresh-context-reviewer` agent, never a replacement.
- **CC-4** Process-level `@anthropic-ai/sandbox-runtime` note in `contribution-verify` — `verify` runs the contributor's PHPUnit/Composer/eslint = untrusted code execution.
- **CC-5** Large-codebase changed-subtree scoping note in `contribution-verify`.

### Root-cause fix (beyond the literal task list, approved)
`--strict` flagged the plugin's own `.claude/rules/skill-conventions.md` (and a gap in `CONVENTIONS.md`) for recommending `sonnet` on skills — the very S14 anti-pattern. Both corrected to mandate `inherit` on inline skills + document `disallowed-tools`, so future skill additions start S14-clean.

### `capabilities` verdict (rollout item 1)
The pre-edit `--strict` run **did NOT flag** `capabilities: […]` (present on all 3 agents). The validator tolerates unknown YAML keys, so per the rollout decision rule the field was **left in place**. Honest caveat: it's not a documented agent frontmatter field, just harmless prose.

### Bumps
- `plugin.json` 0.1.2 → **0.2.0**
- `marketplace.json` entry 0.1.2 → 0.2.0; `metadata.version` 1.15.19 → **1.15.20**
- `CHANGELOG.md` [0.2.0] entry added

### Validation
`/plugin-creation-tools:validate --strict` → **PASS** (S14 cleared on all 8 skills; `disallowed-tools` on the 4 read-only skills; only two pre-existing S11 info nudges, not promoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)