### PR TITLE
drupal-ai-contrib v0.3.0: GitLab-operations hybrid swap (glab/drupal-gitlab)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.20"
+    "version": "1.15.21"
   },
   "plugins": [
     {
@@ -119,8 +119,8 @@
     {
       "name": "drupal-ai-contrib",
       "source": "./drupal-ai-contrib",
-      "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline), a local drupalci-parity gate set plus AI-policy and eval gates inside verify, 3 read-only agents (fresh-context review, external-fact verification, live AI-policy checking), and a PostToolUse re-verification ledger. A quality layer outside ai-dev-assistant; cites the camoa/dev-guides contribution guides as its knowledge layer.",
-      "version": "0.2.0",
+      "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline), a local drupalci-parity gate set plus AI-policy and eval gates inside verify, 3 read-only agents (fresh-context review, external-fact verification, live AI-policy checking), and a PostToolUse re-verification ledger. Authenticated GitLab writes (fork push, MR create, pipeline) delegate to the drupal-gitlab skill (glab); drupalorg-cli covers no-auth reads and the legacy queue. A quality layer outside ai-dev-assistant; cites the camoa/dev-guides contribution guides as its knowledge layer.",
+      "version": "0.3.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-ai-contrib",
   "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-16
+
+GitLab-operations hybrid swap. Authenticated GitLab writes on migrated projects now
+delegate to the `drupal-gitlab` skill (from `ai_best_practices`, driving `glab` against
+`git.drupalcode.org`); `drupalorg-cli` is kept for no-auth public reads, the legacy
+Drupal.org issue queue (which `glab` cannot see), and `skill:*`/`mcp:*` ops. No gate
+logic, drupalci-parity, AI-policy, or eval behavior changed.
+
+### Changed
+
+- **`contribution-setup`** (+ `commands/setup.md`): added a `glab` detect + auth check
+  (`command -v glab`; `glab auth status --hostname git.drupalcode.org`) with a soft
+  report (`glab auth login --hostname git.drupalcode.org`); `glab` status now appears in
+  the §7 report. The `drupal-gitlab` skill itself ships with `ai_best_practices` — no
+  install step for the skill.
+- **`contribution-pipeline`**: CI fetch rewired from a generic "GitLab API" call to
+  `glab ci status` / `glab ci view` / `glab ci trace <job>` (delegated to `drupal-gitlab`).
+  Added the two hard limits on `git.drupalcode.org` — **pipelines fire on push only**
+  (API/CLI triggers blocked; re-run by pushing a commit) and **never WebFetch a
+  JS-rendered job URL** (use `glab ci trace`).
+- **`contribution-issue`**: fork provisioning, branch setup, and push moved to
+  `drupal-gitlab` (`/do:fork` / `/do:access`, never push/API); `drupalorg issue:show` /
+  `issue:search` / `mr:list` kept for no-auth reads. Replaced the `drupalorg`
+  `issue:branch`/`issue:checkout` fork-setup calls. Added the two-host rule and the
+  legacy-queue boundary.
+- **`contribution-submit`**: MR create/update moved to `drupal-gitlab` via
+  **`glab api … /merge_requests`** with `target_project_id` — **`glab mr create` cannot
+  create cross-project (fork→upstream) MRs**, which is Drupal's model. `drupalorg
+  mr:list`/`mr:status` kept for no-auth reads. Added write-token safety (a write token is
+  not project-scoped; never push a protected branch without approval; default to the
+  issue fork) and the API-merge-blocked note (web-UI merge only).
+- **`references/drupalorg-cli.md`**: new "Hybrid model" section — the read/write split
+  table, the two-host rule, and write-token safety. Existing install/auth/safe-invocation
+  docs preserved; the "No `mr:create`" item now defers MR creation to `drupal-gitlab`.
+
+### Notes from v0.3.0
+
+- **Discrepancies surfaced against the live `drupal-gitlab` SKILL.md** (the binding
+  authority; read at `1.0.x`, ~10.9 KB). The rollout prompt's wording was corrected to
+  match the SKILL.md on three points: (1) **URL semantics** — the prompt had the write
+  host inverted; truth is all HTTP/HTTPS (incl. `glab api` writes and HTTPS git push) →
+  `git.drupalcode.org`, only **SSH** push → `git.drupal.org`; a `glab api` write
+  misdirected to `git.drupal.org` silently degrades to a `200`+list. (2) **MR create** —
+  `glab mr create` cannot do cross-project MRs; use `glab api`. (3) **Pipeline** — commands
+  are `glab ci status`/`view`/`trace` (no `glab ci list`); triggers and API merges are
+  blocked (push-only / web-UI-only).
+- **Bonus boundary** that strengthens the hybrid model: `glab` cannot see the legacy
+  Drupal.org issue queue, so `drupalorg`/web UI legitimately remains for legacy-queue
+  projects — not merely a no-auth convenience.
+
+### Bumped
+
+- Plugin `0.2.0` → `0.3.0`. Root `marketplace.json` entry `0.2.0` → `0.3.0` and
+  `metadata.version` `1.15.20` → `1.15.21`.
+
 ## [0.2.0] - 2026-06-16
 
 BUG-1 (model-pin overflow footgun) plus Claude Code hardening. No gate logic, no

--- a/drupal-ai-contrib/commands/setup.md
+++ b/drupal-ai-contrib/commands/setup.md
@@ -24,6 +24,7 @@ Thin entry point. Onboarding is optional, idempotent, and never a gate.
    the resolved path.
 3. Present the skill's result: the detected workflow and issue system, environment
    status, the resolved gate set, AI-skill status, the `drupalorg` CLI status, the
+   `glab` CLI status (installed + authenticated for `git.drupalcode.org`), the
    contribution-credentials (SSH-key) status, and the environment-match result. If the
    SSH key is missing, name registering it as the contributor's first next step.
 

--- a/drupal-ai-contrib/skills/contribution-issue/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribution-issue
-description: "Works the Drupal issue lifecycle — reviews prior work on an issue first, then creates / comments on / claims it, and checks out the issue fork + branch with three-way fork handling. Use when the user runs /drupal-ai-contrib:issue or asks to find, create, claim, or check out a Drupal issue or issue fork. Wraps drupalorg-cli."
+description: "Works the Drupal issue lifecycle — reviews prior work on an issue first, then creates / comments on / claims it, and checks out the issue fork + branch with three-way fork handling. Use when the user runs /drupal-ai-contrib:issue or asks to find, create, claim, or check out a Drupal issue or issue fork. Wraps drupalorg-cli for no-auth reads; delegates authenticated GitLab fork/push to the drupal-gitlab skill."
 version: 0.1.1
 model: inherit
 user-invocable: false
@@ -53,21 +53,29 @@ existing work:
 
 | State | Action |
 |-------|--------|
-| **Your existing fork** | `issue:checkout` — check out your fork's issue branch |
-| **Someone else's fork/branch** | **Surface it. Do not clobber.** Coordinate via an issue comment before proceeding — their work may be ahead of yours |
-| **No fork yet** | `issue:branch` — create the issue fork + branch |
+| **Your existing fork** | Check out your fork's issue branch and continue. |
+| **Someone else's fork/branch** | **Surface it. Do not clobber.** Coordinate via an issue comment before proceeding — their work may be ahead of yours. |
+| **No fork yet** | Provision the fork **first** via `/do:fork` (issue comment) or the Drupal.org management page — a fork is **never** created by pushing or via the API (a push to a non-existent fork 404s). Then add the remote and branch. |
 
-Branch naming **must include the issue number** (per the issue-forks dev-guide). Target
-the most recent development branch (`main` for core; per-project for contrib).
+On a **migrated (GitLab) project**, delegate fork provisioning, remote setup, and push
+to the **`drupal-gitlab`** skill (its `references/merge-requests.md`) — it owns the
+`/do:fork` / `/do:access` flow and the two-host rule: **SSH** push → `git.drupal.org`;
+HTTPS / `glab` → `git.drupalcode.org` (the CDN has no SSH listener). On a **legacy-queue**
+project `glab` cannot see the issue — use `drupalorg` / the web UI. Branch naming **must
+include the issue number** (per the issue-forks dev-guide). Target the most recent
+development branch (`main` for core; per-project for contrib).
 
-### 5. Wrap drupalorg-cli — safely
+### 5. Reads via drupalorg-cli; authenticated writes via drupal-gitlab
 
-Issue/fork operations wrap `mglaman/drupalorg-cli`. The executable on `PATH` is
-**`drupalorg`** (not `drupalorg-cli` — that is only the package name); detect it with
-`command -v drupalorg`. See `${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md`
-for what the tool is, how to install it, authentication, and what it can and cannot do.
-Confirm exact subcommand names with `drupalorg list` — names can drift between
-releases; do not assume them.
+Prior-work review and issue/MR **reads** (`issue:show`, `issue:search`, `mr:list`) use
+`mglaman/drupalorg-cli` — the executable on `PATH` is **`drupalorg`** (not `drupalorg-cli`,
+which is only the package name); detect it with `command -v drupalorg`. These are no-auth
+public reads and work on both the legacy queue and migrated projects. **Authenticated
+GitLab writes — fork provisioning, branch setup, and push — are delegated to the
+`drupal-gitlab` skill** (§4). See
+`${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md` for the tool,
+install, authentication, and the hybrid split (its §Hybrid model). Confirm exact
+subcommand names with `drupalorg list` — names can drift between releases; do not assume.
 
 **Pushing needs credentials.** Reviewing and reading an issue work over public APIs,
 but creating the issue-fork branch and `git push`ing it need an **SSH key registered
@@ -100,7 +108,8 @@ state and what was done. Point the contributor at the development phase, then `v
 **Trigger:** `/drupal-ai-contrib:issue 3456789`
 **Actions:**
 1. Review confirms no prior MR or fork.
-2. Claim the issue, `issue:branch` to create the fork + issue-number branch.
+2. Claim the issue; provision the fork with `/do:fork`, then (via `drupal-gitlab`) add the
+   fork remote and create the issue-number branch.
 **Result:** A clean issue branch checked out, ready for development.
 
 ## Troubleshooting

--- a/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
@@ -26,11 +26,29 @@ state, or ask). Before any API call, validate against an explicit pattern — th
 number must match `^[0-9]+$`, the project path `^[A-Za-z0-9_./-]+$` — and reject
 anything that does not match rather than calling the API with it.
 
-### 2. Fetch the pipeline — via the GitLab API
+### 2. Fetch the pipeline — `glab` via the `drupal-gitlab` skill
 
-Fetch the MR's latest pipeline and its jobs from the GitLab API. This is the produced
-artifact — the actual pipeline result, not a prediction. Credentials are the
-contributor's own; never store or transmit them.
+Fetch the MR's latest pipeline and its jobs with **`glab`**, delegated to the
+`drupal-gitlab` skill (it owns the `git.drupalcode.org` auth + host rules; see its
+`references/ci-cd.md`). This is the produced artifact — the actual pipeline result, not a
+prediction:
+
+```bash
+glab ci status                                    # pipeline status for the MR's branch
+glab ci view                                      # per-job overview
+glab ci trace <job-name>                          # stream a job's full log (debug failures)
+```
+
+Always pass `--repo "git.drupalcode.org/project/<repo>"` (or run inside the configured
+git dir) — never rely on the default host. Credentials are the contributor's own (a
+read-only token suffices for status); never store or transmit them.
+
+**Two hard limits on `git.drupalcode.org`:**
+- **Pipelines fire on push events only** — API/CLI triggers (`glab ci run`,
+  `POST /pipeline`) are blocked. To re-run CI, push a commit (an `--allow-empty` commit
+  works); never claim a re-trigger you cannot perform.
+- **Never WebFetch a GitLab job/MR URL** — the pages are JavaScript-rendered and return
+  no log. Read job logs with `glab ci trace <job>` (or `glab api … /jobs/<id>/trace`).
 
 ### 3. Read the pipeline honestly
 
@@ -78,6 +96,7 @@ is the pipeline's — never assert "should pass".
 | Situation | Handling |
 |-----------|----------|
 | No MR found for the branch | Report it; point at `/drupal-ai-contrib:submit` to create the MR first. |
-| GitLab API unreachable / unauthenticated | Report the failure; never substitute a local-green result for the real pipeline. |
+| `glab` unauthenticated / API unreachable | Report the failure (`glab auth login --hostname git.drupalcode.org`); never substitute a local-green result for the real pipeline. |
 | Pipeline still running | Report in-progress; the gate is not satisfied until jobs finish. |
+| Pipeline needs re-running | Triggers are blocked on `git.drupalcode.org` — push a commit (`--allow-empty` if no code change); pipelines fire on push only. |
 | A blocking job failed | Diagnose against the reproduction dev-guide; route back to development → `verify`. |

--- a/drupal-ai-contrib/skills/contribution-setup/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribution-setup
-description: "Stands up and environment-matches a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config (new-module scaffold or existing-module discovery), the Drupal AI skills, the drupalorg CLI, and a contribution-credentials (SSH-key) check. Use when the user runs /drupal-ai-contrib:setup or asks to set up a Drupal contribution environment. Idempotent and detect-driven — does only what is missing; never a gate, never a prerequisite."
+description: "Stands up and environment-matches a Drupal contribution workspace — DDEV with the workflow-matched add-on, CI gate config (new-module scaffold or existing-module discovery), the Drupal AI skills, the drupalorg CLI, the GitLab CLI (glab) for authenticated git.drupalcode.org operations, and a contribution-credentials (SSH-key) check. Use when the user runs /drupal-ai-contrib:setup or asks to set up a Drupal contribution environment. Idempotent and detect-driven — does only what is missing; never a gate, never a prerequisite."
 version: 0.1.1
 model: inherit
 user-invocable: false
@@ -77,6 +77,24 @@ that reference covers what the tool is, the recommended PHAR install, the deprec
 Composer path, and the subcommand set. Offer to install it; do not block if the
 contributor declines (`issue`/`submit` re-surface the same instructions).
 
+**The GitLab CLI (`glab`)** — authenticated GitLab writes on migrated projects (fork
+push, MR create/update, pipeline status) are delegated to the `drupal-gitlab` skill,
+which drives `glab` against `git.drupalcode.org`. The `drupal-gitlab` skill itself ships
+with `ai_best_practices` (installed above via `drupal_devkit`) — no install step for the
+skill — but `glab` is a separate binary. Detect and report it:
+
+```bash
+command -v glab                                  # installed?
+glab auth status --hostname git.drupalcode.org   # authenticated for Drupal's GitLab?
+```
+
+If `glab` is missing or not authenticated, surface the next step — install `glab`, then
+`glab auth login --hostname git.drupalcode.org` (a write-capable token is needed only for
+pushes / MR creation; reads work read-only — see the `drupal-gitlab` README for token
+scopes). Soft posture, exactly like the `drupalorg` check: report the gap, never block.
+The legacy `drupalorg` reads still work without `glab`; only migrated-project
+authenticated writes need it.
+
 ### 5. Check contribution credentials — and guide, do not assume
 
 The contribution arc needs the contributor's **drupal.org credentials** for its write
@@ -114,7 +132,8 @@ This is the mechanism that makes `verify`'s gates trustworthy — see `contribut
 
 Summarize, and for each item state ready vs. needs-action so the contributor knows
 their exact next step: workflow, issue system, environment status, the resolved gate
-set, AI-skill status, the issue/MR CLI (`drupalorg`) status, the **credentials/SSH-key**
+set, AI-skill status, the issue/MR CLI (`drupalorg`) status, the **GitLab CLI (`glab`)**
+status (installed + authenticated for `git.drupalcode.org`), the **credentials/SSH-key**
 status, the environment-match result. Point the contributor at `issue` (or, if work is
 underway, `verify`) — and if the SSH key is missing, name *that* as the first step.
 
@@ -153,6 +172,7 @@ environment is a no-op that simply reports state.
 |-----------|----------|
 | `drupal_devkit` not installed | Report how to obtain it; do not block setup. |
 | `drupalorg` not on `PATH` | Surface `references/drupalorg-cli.md` (PHAR install); offer to install; do not block. If installed via Composer global, the bin dir may just be off `PATH` — see the reference's Install note. |
+| `glab` missing or not authenticated | Report it as a next step (install `glab`; `glab auth login --hostname git.drupalcode.org`); never block. Only migrated-project authenticated writes need it — `drupalorg` reads and the legacy queue work without it. See `references/drupalorg-cli.md` §Hybrid model. |
 | No SSH key registered on the drupal.org account | Guide the contributor to add one (*drupal.org → My account → SSH keys*); report it as the next step. Read/review still works; `git push` to issue forks does not. Never block. |
 | Workflow cannot be inferred | Ask the contributor — never assume core vs. contrib. |
 | `.gitlab-ci.yml` exists but uses a non-`gitlab_templates` setup | Record what is there; `verify` mirrors the discovered jobs as-is. |

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribution-submit
-description: "Creates or updates a Drupal merge request and generates the AI-disclosure comment at the policy threshold. Use when the user runs /drupal-ai-contrib:submit or asks to submit, open, or update a Drupal merge request or patch. Wraps drupalorg-cli; surfaces status and RTBC guidance."
+description: "Creates or updates a Drupal merge request and generates the AI-disclosure comment at the policy threshold. Use when the user runs /drupal-ai-contrib:submit or asks to submit, open, or update a Drupal merge request or patch. Creates the cross-project MR via the drupal-gitlab skill (glab); wraps drupalorg-cli for no-auth reads; surfaces status and RTBC guidance."
 version: 0.1.1
 model: inherit
 user-invocable: false
@@ -61,20 +61,27 @@ contributor as the responsible author — "the AI wrote it" is never a defense.
 
 ### 4. Create or update the MR
 
-The contribution tool is `mglaman/drupalorg-cli`; the executable on `PATH` is
-**`drupalorg`** (detect with `command -v drupalorg`). See
-`${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md` for what
-it is, how to install it, and the subcommand set.
+**Migrated (GitLab) project** — delegate MR create/update to the **`drupal-gitlab`**
+skill (its `references/merge-requests.md`). Drupal MRs go **from the issue fork to the
+upstream project** (cross-project), which **`glab mr create` cannot do** — `drupal-gitlab`
+creates them via `glab api … /projects/issue%2F<project>-<id>/merge_requests` with an
+explicit `target_project_id`, confirming a `201` (a write misdirected to `git.drupal.org`
+silently degrades to a `200` + list, creating nothing). Reads — confirming and reporting
+an existing MR — stay on `drupalorg mr:list` / `mr:status` (no-auth) or `glab mr view`.
+**Legacy-queue project**: there is no GitLab MR — follow the classic patch/queue flow via
+`drupalorg` / the web UI. See `${CLAUDE_PLUGIN_ROOT}/skills/drupal-ai-contrib/references/drupalorg-cli.md`
+§Hybrid model.
 
-On GitLab there is **no MR-create subcommand** — a merge request is created by
-**pushing the issue-fork branch** (`issue:branch` / `issue:checkout` set up the fork +
-branch; develop, commit, `git push`, and GitLab opens the MR). Use `drupalorg mr:list`
-and `mr:status` to confirm and report the MR. Do not invent an `mr:create` subcommand.
+**Write-token safety (from `drupal-gitlab`, the binding authority):** a GitLab write
+token is **not** project-scoped — it reaches every repo you can write to. Confirm the
+target repo/branch, **never push to a protected branch without explicit human approval**,
+and default to the issue fork even as a maintainer. API/CLI **merges are blocked** on
+`git.drupalcode.org` — merge via the web UI only; never claim a merge you cannot perform.
 
-Wrap the CLI with **fixed, validated subcommands**. Before any shell-out, validate
-identifiers against an explicit pattern — issue IDs `^[0-9]+$`, project machine-names
-`^[a-z][a-z0-9_]*$` — and reject non-matching values; never interpolate unsanitized
-input. Credentials are the contributor's own — never stored or transmitted.
+Before any shell-out, validate identifiers against an explicit pattern — issue IDs
+`^[0-9]+$`, project machine-names `^[a-z][a-z0-9_]*$` — and reject non-matching values;
+never interpolate unsanitized input. Credentials are the contributor's own — never stored
+or transmitted.
 
 The MR description states: what the change does, the issue it resolves, the AI
 disclosure (§2), and how it was verified (cite the captured `verify` artifacts).
@@ -121,6 +128,8 @@ submission, including copyright and licensing.
 |-----------|----------|
 | `verify` / `review` not run | Surface it; report, do not refuse — the contributor decides. |
 | `drupalorg` not installed | Surface the install steps from `references/drupalorg-cli.md`; do not fabricate an MR URL. |
-| `git push` rejected — no MR opens | The drupal.org SSH key is likely missing/unregistered — point at `setup` §5 and `references/drupalorg-cli.md` §Authentication. No push, no MR. |
+| `git push` to the issue fork rejected | The drupal.org SSH key is likely missing/unregistered — point at `setup` §5 and `references/drupalorg-cli.md` §Authentication. No push, no MR. |
+| MR-create call returns `200` + a list (nothing created) | The `glab api` write was misdirected to `git.drupal.org` — it must go to `git.drupalcode.org`. Re-issue and confirm a `201`. See `drupal-gitlab` → `references/merge-requests.md`. |
+| `glab` not installed / unauthenticated for writes | Migrated-project MR creation needs `glab` + a write-scoped token — `glab auth login --hostname git.drupalcode.org`; point at `setup`. Reads/reporting still work via `drupalorg`. |
 | Disclosure threshold ambiguous | Fetch the live policy via `drupal-ai-contrib:ai-policy-checker`; when still unclear, disclose. |
 | Project uses GitLab `state::*` labels | Set the GitLab scoped label, not a classic-queue status. |

--- a/drupal-ai-contrib/skills/drupal-ai-contrib/references/drupalorg-cli.md
+++ b/drupal-ai-contrib/skills/drupal-ai-contrib/references/drupalorg-cli.md
@@ -95,11 +95,40 @@ between releases, so confirm against the install rather than assuming.
    issue queue, or its GitLab issues page if it has migrated. `contribution-issue`
    drafts the issue (title, summary, steps, component, version) and guides the
    contributor to file it, then resumes with the new issue ID.
-2. **No `mr:create`.** On GitLab a merge request is created by **pushing the
-   issue-fork branch** — `issue:branch` / `issue:checkout` set up the fork + branch;
-   the contributor develops, commits, and `git push`es, and GitLab opens the MR (the
-   push output includes a create-MR URL). `submit` then uses `mr:list` / `mr:status`
-   to confirm and report it.
+2. **No `mr:create`.** Every `mr:*` command operates on an *existing* MR (list, status,
+   diff, files, logs). Creating the cross-project (fork→upstream) merge request is
+   delegated to the **`drupal-gitlab`** skill via `glab api` (see §Hybrid model) —
+   `glab mr create` cannot do cross-project MRs. `submit` then uses `drupalorg mr:list` /
+   `mr:status` (or `glab mr view`) to confirm and report it.
+
+## Hybrid model — `drupalorg` for reads, `glab`/`drupal-gitlab` for authenticated writes
+
+As of plugin v0.3.0 the GitLab-operations layer is **hybrid**. `drupalorg` is kept for
+what it does best — no-auth public reads, the **legacy Drupal.org issue queue** (which
+`glab` cannot see), and `skill:*` / `mcp:*` ops — while **authenticated GitLab writes on
+migrated projects are delegated to the `drupal-gitlab` skill** (from `ai_best_practices`,
+already installed via `drupal_devkit`). `drupal-gitlab` encodes the auth-safety knowledge
+`drupalorg` lacks: token scopes, the two-host rule, the issue-fork API gotchas. **Never
+vendor it — reference and delegate.**
+
+| Operation | Tool | Notes |
+|-----------|------|-------|
+| Public reads: `issue:show`, `issue:search`, `mr:list`, `mr:status`, `project:issues` | **`drupalorg`** | No credentials; works on legacy queue **and** GitLab. |
+| Legacy-queue projects (not migrated to GitLab work items) | **`drupalorg`** / web UI | `glab` only sees migrated `git.drupalcode.org` work items. |
+| `skill:*` / `mcp:*` (AI-skill install, MCP server mode) | **`drupalorg`** | No `glab` equivalent. |
+| Fork provisioning + push, branch setup | **`drupal-gitlab`** | `/do:fork` or the Drupal.org UI provisions the fork (never push/API); push then goes to the fork. See `drupal-gitlab` → `references/merge-requests.md`. |
+| Merge-request **create / update** | **`drupal-gitlab`** | Cross-project (fork→upstream) MR via `glab api … /merge_requests` with `target_project_id` — **`glab mr create` cannot do cross-project MRs**. |
+| Pipeline / CI status + logs | **`drupal-gitlab`** | `glab ci status` / `glab ci trace <job>`. Pipelines fire **on push only** — API/CLI triggers (`glab ci run`) and API merges are blocked on `git.drupalcode.org` (web-UI merge only). |
+
+**The two-host rule (per the `drupal-gitlab` SKILL.md, the binding authority):** all
+HTTP/HTTPS — the web UI, `glab` subcommands, `glab api` reads **and writes**, and HTTPS
+`git push` — use **`git.drupalcode.org`** (a Fastly CDN front). Only **SSH** `git push`
+uses the origin host **`git.drupal.org`** (the CDN has no SSH listener; an SSH remote on
+`git.drupalcode.org` hangs on port 22). A `glab api` *write* misdirected to
+`git.drupal.org` is silently downgraded to a GET (`200` + a list, nothing created) — so
+confirm writes by checking for `201`, not a bare `200`. **Write-scoped tokens are not
+project-scoped** — they reach every repo you can write to; never push to a protected
+branch without explicit human approval, and default to the issue fork even as a maintainer.
 
 ## Safe invocation
 


### PR DESCRIPTION
## Summary

Second release of the 2026-05-29 wave. Authenticated GitLab writes on **migrated** projects now delegate to the **`drupal-gitlab`** skill (from `ai_best_practices`, driving `glab` against `git.drupalcode.org`). `drupalorg-cli` is kept for **no-auth public reads**, the **legacy Drupal.org issue queue** (which `glab` cannot see), and `skill:*`/`mcp:*` ops. **Delegation, not vendoring; no command-table duplication.** No gate logic, drupalci-parity, AI-policy, or eval behavior changed.

## ⚠ Followed the binding `drupal-gitlab` SKILL.md over the rollout prompt on 3 points

The prompt's own constraint says the live SKILL.md wins; these are surfaced, not silently reconciled:

1. **URL semantics (prompt had it inverted).** All HTTP/HTTPS — web UI, `glab` subcommands, `glab api` reads **and writes**, HTTPS `git push` → **`git.drupalcode.org`**. **Only SSH `git push` → `git.drupal.org`** (CDN has no SSH listener; SSH-to-CDN hangs on port 22). The real silent-degrade is the reverse: a `glab api` *write* to `git.drupal.org` downgrades to `200`+list — confirm `201`. _(The plugin's existing code already used `git@git.drupal.org` for SSH, so it was correct; only the prompt's wording was off.)_
2. **MR create — wrong command.** `glab mr create` **cannot** create cross-project (fork→upstream) MRs, which is Drupal's model. Use `glab api … /merge_requests` with `target_project_id`.
3. **Pipeline.** Commands are `glab ci status`/`view`/`trace` (no `glab ci list` in the flow). API/CLI **pipeline triggers and merges are blocked** — pipelines fire on push only; merges via web UI only.

**Bonus boundary** strengthening the hybrid: `glab` cannot see the legacy issue queue, so `drupalorg`/web UI legitimately stays for legacy-queue projects.

## Changes

- **`contribution-setup`** (+ `commands/setup.md`): `glab` detect + `glab auth status --hostname git.drupalcode.org` check, soft report; `glab` status in §7. (`drupal-gitlab` ships with `ai_best_practices` — no skill install step.)
- **`contribution-pipeline`**: CI fetch → `glab ci status`/`view`/`trace` via `drupal-gitlab`; push-only-trigger + never-WebFetch-job-URL gotchas.
- **`contribution-issue`**: fork provisioning/branch/push → `drupal-gitlab` (`/do:fork`, never push/API); `drupalorg` reads kept; two-host rule + legacy-queue boundary. Removed the `drupalorg issue:branch`/`issue:checkout` fork-setup calls.
- **`contribution-submit`**: MR create/update → `glab api` cross-project; `drupalorg mr:list`/`mr:status` reads kept; write-token safety (not project-scoped; never protected branch; default to issue fork) + API-merge-blocked note.
- **`references/drupalorg-cli.md`**: new "Hybrid model" section (read/write split, two-host rule, token safety).

## Validation

- `/plugin-creation-tools:validate --strict` → **PASS** (only two pre-existing S11 info nudges).
- Self-test grep: no `drupalorg` `issue:branch`/`issue:checkout`/push/`mr:create` calls remain in skill bodies.
- **Live `glab` smoke against `git.drupalcode.org`** (authenticated as `camoa`): `glab auth status` ✓ (SSH for git, HTTPS for API), `glab api /version` ✓ (GitLab 18.11.5-ee), `glab ci list` ✓ (real pipelines), `glab mr list` ✓ (real MRs).

## Bumps
- `plugin.json` 0.2.0 → **0.3.0**; `marketplace.json` entry 0.3.0; `metadata.version` 1.15.20 → **1.15.21**; CHANGELOG `[0.3.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)