### PR TITLE
drupal-ai-contrib v0.4.0: structural fixes (security Task dispatch + review-staleness)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "1.15.21"
+    "version": "1.15.22"
   },
   "plugins": [
     {
@@ -119,8 +119,8 @@
     {
       "name": "drupal-ai-contrib",
       "source": "./drupal-ai-contrib",
-      "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline), a local drupalci-parity gate set plus AI-policy and eval gates inside verify, 3 read-only agents (fresh-context review, external-fact verification, live AI-policy checking), and a PostToolUse re-verification ledger. Authenticated GitLab writes (fork push, MR create, pipeline) delegate to the drupal-gitlab skill (glab); drupalorg-cli covers no-auth reads and the legacy queue. A quality layer outside ai-dev-assistant; cites the camoa/dev-guides contribution guides as its knowledge layer.",
-      "version": "0.3.0",
+      "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline) with a local drupalci-parity gate set plus AI-policy and eval gates, and 3 read-only fresh-context review agents. Authenticated GitLab writes delegate to the drupal-gitlab skill (glab); drupalorg-cli covers no-auth reads and the legacy queue. A quality layer outside ai-dev-assistant, built on the camoa/dev-guides contribution guides.",
+      "version": "0.4.0",
       "author": {
         "name": "camoa"
       },

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-ai-contrib",
   "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "camoa"
   },

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-06-16
+
+Structural fixes at the `review` → `submit` boundary. No gate logic, drupalci-parity,
+AI-policy, eval, or GitLab-ops behavior changed.
+
+### Added
+
+- **`scripts/review-mark.sh`** — a review-staleness marker, the review-stage parallel to
+  the `reverify` ledger. `--set` stamps "review ran now"; piping the contribution's
+  changed files in prints those edited **after** the marker. mtime-based on purpose — it
+  does not depend on the reverify ledger (which `verify` clears), so a `verify` re-run
+  after a post-review edit cannot mask the staleness. Deterministic, zero-model.
+- **Security-critical review is now an explicit Task dispatch** (`contribution-review`
+  §3). When a contribution is security-tagged or its diff touches permission/access
+  callbacks, entity/field access, `#access` form keys, input sanitization / output
+  escaping, input-built queries, file/path handling, or XSS-/injection-adjacent code, the
+  skill **must** dispatch the security sub-review via the Task tool
+  (`/code-quality-tools:security` and/or `code-paper-test`) and **append its findings to
+  the review artifact** before returning a verdict — evidence over assertion, not an
+  advisory "or delegate" aside. Non-security contributions are unaffected.
+- **Submit review-staleness check** (`contribution-submit` Preconditions). `submit` pipes
+  `git diff --name-only <target>...<branch>` to `review-mark.sh`; if any file changed
+  after the last `review`, it surfaces "Review artifact is stale — … re-run review or
+  acknowledge and proceed." Acknowledge path required; **never a hard block**.
+
+### Changed
+
+- **`contribution-review`**: the §2 advisory "or delegate to `code-paper-test`" reworded
+  to route security-critical changes to the mandatory §3 dispatch; steps renumbered
+  (3→4 philosophy, 4→5 synthesize, 5→6 report); §6 now stamps `review-mark.sh --set`
+  after producing the report; Example 2 updated to show the captured sub-review.
+- **`CONVENTIONS.md`**: new "Structural contracts" section documenting both the
+  security-critical Task-dispatch trigger and the review-freshness (warn-not-block) posture.
+
+### Notes
+
+- `commands/review.md` already carried `Task` + `Bash` in `allowed-tools` — no command
+  change needed. `contribution-review` keeps `disallowed-tools: Edit, Write`; it stamps
+  the marker via the script (Bash), in the plugin data dir, never touching contribution
+  files.
+
+### Bumped
+
+- Plugin `0.3.0` → `0.4.0`. Root `marketplace.json` entry `0.3.0` → `0.4.0` and
+  `metadata.version` `1.15.21` → `1.15.22`.
+
 ## [0.3.0] - 2026-06-16
 
 GitLab-operations hybrid swap. Authenticated GitLab writes on migrated projects now

--- a/drupal-ai-contrib/CONVENTIONS.md
+++ b/drupal-ai-contrib/CONVENTIONS.md
@@ -86,6 +86,27 @@ over assertion, so it must apply that candor to itself.
   live for the contribution. If a source is unreachable, the AI-policy gate is UNRUN,
   never silently passed.
 
+## Structural contracts — security review & review freshness
+
+Two contracts govern the `review` → `submit` boundary (v0.4.0):
+
+- **Security-critical reviews are an explicit Task dispatch, not an aside.** When a
+  contribution is security-tagged *or* its diff touches permission / access callbacks,
+  entity or field access, `#access` form keys, input sanitization / output escaping,
+  input-built SQL/db queries, file/path handling, or XSS-/injection-adjacent code,
+  `contribution-review` **must** dispatch the security sub-review via the Task tool
+  (`/code-quality-tools:security` and/or `code-paper-test`) and **append its findings to
+  the review artifact** before returning a verdict. Evidence over assertion: "ran the
+  security sub-review" must be captured in the artifact, never merely claimed. Non-security
+  contributions are unaffected.
+- **Review freshness is checked, never blocked.** `contribution-review` stamps
+  `scripts/review-mark.sh --set` on completion; `contribution-submit` pipes the
+  contribution's changed files to `review-mark.sh` and, if any were edited after the
+  marker, surfaces a stale-review warning with an **acknowledge-and-proceed** path — never
+  a hard block (the arc is detect-driven). This is the review-stage parallel to the
+  reverify ledger's verify-stage check, and is **mtime-based** so a `verify` re-run cannot
+  mask a post-review edit.
+
 ## Release hygiene
 
 - Run `/plugin-creation-tools:validate --strict` before every release. `--strict`

--- a/drupal-ai-contrib/scripts/review-mark.sh
+++ b/drupal-ai-contrib/scripts/review-mark.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# drupal-ai-contrib — review-staleness marker (a review-gate parallel to the reverify
+# ledger that contribution-verify uses).
+#
+# Records WHEN contribution-review last ran, so contribution-submit can detect
+# contribution files edited *after* the last review — closing the gap where a post-review
+# edit slips an unreviewed change into submission. The marker lives in the plugin data
+# dir, never in the contribution tree (so a read-only review skill never mutates code).
+#
+#   review-mark.sh --set       stamp "review ran now" (contribution-review calls this on completion)
+#   review-mark.sh --clear      remove the marker
+#   review-mark.sh < paths      read newline-separated candidate paths on stdin; print the
+#                               subset whose mtime is NEWER than the marker — i.e. files
+#                               changed since the last review. Prints nothing when there is
+#                               no marker (review never run; submit's "review not run"
+#                               surface handles that case).
+#
+# mtime-based on purpose: it does not depend on the reverify ledger, which contribution-
+# verify clears — so a verify run after a post-review edit cannot mask the staleness.
+# Deterministic, zero-model; degrades silently and never blocks the lifecycle.
+set -u
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+data="${CLAUDE_PLUGIN_DATA:-${TMPDIR:-/tmp}}"
+key="$(printf '%s' "$proj" | cksum | cut -d' ' -f1)"
+mark_dir="$data/review"
+marker="$mark_dir/$key.mark"
+
+case "${1:-}" in
+  --set)
+    mkdir -p "$mark_dir" 2>/dev/null || exit 0
+    : > "$marker" 2>/dev/null || true   # touch: the marker's own mtime is the review time
+    exit 0
+    ;;
+  --clear)
+    rm -f "$marker" 2>/dev/null || true
+    exit 0
+    ;;
+  *)
+    # Check mode: read candidate paths on stdin, print those newer than the marker.
+    [ -f "$marker" ] || exit 0          # no review recorded → nothing stale to report
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      case "$f" in
+        /*) p="$f" ;;                   # absolute
+        *)  p="$proj/$f" ;;             # relative to the project (git diff --name-only form)
+      esac
+      [ -e "$p" ] || continue
+      if [ "$p" -nt "$marker" ]; then
+        printf '%s\n' "$f"
+      fi
+    done
+    exit 0
+    ;;
+esac

--- a/drupal-ai-contrib/skills/contribution-review/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-review/SKILL.md
@@ -45,8 +45,9 @@ agent reviews against:
 - **Security** — AI-specific risks (see the security-considerations dev-guide).
 - **AI policy** — is AI use above the "significant portion" threshold disclosed?
 
-For a large or security-critical change, dispatch multiple reviewer agents for
-perspective diversity, or delegate to `code-paper-test` for line-by-line paper testing.
+For a **large** change, dispatch multiple reviewer agents for perspective diversity. For
+a **security-critical** change, the security sub-review in §3 is **mandatory** — an
+explicit Task dispatch whose output is captured in the artifact, not an optional aside.
 
 **Complementary security layer.** The `security-guidance` plugin and this skill cover
 *different* scopes and do not compete. `security-guidance` runs automatically on
@@ -59,24 +60,47 @@ them; the contribution review catches what survives into the diff. Neither repla
 other, and neither blocks — both surface findings as instructions. Install the in-session
 layer with `/plugin install security-guidance@claude-plugins-official`.
 
-### 3. Delegate the philosophy review
+### 3. Security-critical contributions — mandatory Task dispatch
+
+A contribution is **security-critical** when the issue is **security-tagged** *or* the
+diff touches any of: permission / access callbacks, entity or field access, `#access`
+form keys, user-input sanitization or output escaping, SQL / database queries built from
+input, file or path handling, or other XSS-/injection-adjacent code. When **none** of
+these apply, skip this step.
+
+When it applies, the security sub-review is **not advisory** — dispatch it explicitly with
+the **Task tool** (the subagent's isolated context is the evidence, not this skill's
+narrative): run `/code-quality-tools:security` on the diff, and/or the `code-paper-test`
+paper-test skill, passing the diff plus the security checklist from the
+`security-considerations` dev-guide. **Append the Task's returned findings to the review
+artifact (§6) before this skill returns its verdict.** A security-critical review is not
+complete until that sub-review output is captured in the artifact — never on an assertion
+that it "was run".
+
+### 4. Delegate the philosophy review
 
 Hand the SOLID / DRY / architecture review to `code-quality-tools`. This skill owns the
 *honest-validation* concern; `code-quality-tools` owns the philosophy review. Do not
 re-implement it here.
 
-### 4. Synthesize — honest verdicts only
+### 5. Synthesize — honest verdicts only
 
 Collect the agents' verdicts. Report findings by severity (blocker / should-fix /
 suggestion), each tied to a **file:line** and a concrete fix. The verdict is the
 agent's — never soften it because the builder explained the intent. If reviewers
 disagree, surface the disagreement; do not paper over it.
 
-### 5. Report
+### 6. Report
 
-A findings report: per-finding severity, location, fix. State plainly whether the
-contribution is ready for `submit` or needs another development pass. An honest "not
+A findings report: per-finding severity, location, fix. For a security-critical
+contribution, the §3 sub-review findings must already appear here. State plainly whether
+the contribution is ready for `submit` or needs another development pass. An honest "not
 ready" is the correct output when the work is not ready.
+
+After producing the report, record that a review ran against the current tree:
+`${CLAUDE_PLUGIN_ROOT}/scripts/review-mark.sh --set`. `submit` reads this marker to detect
+contribution files edited **after** this review (the review-staleness gate, parallel to
+the `verify` reverify ledger). Re-running `review` after fixes re-stamps it.
 
 ## Examples
 
@@ -88,11 +112,14 @@ ready" is the correct output when the work is not ready.
 **Result:** Logged as a blocker — review burden the maintainer did not ask for.
 
 ### Example 2: a security-critical change
-**Trigger:** `/drupal-ai-contrib:review` on a diff touching access control.
+**Trigger:** `/drupal-ai-contrib:review` on a diff touching access control (`#access`,
+an entity-access callback).
 **Actions:**
-1. Dispatch multiple reviewer agents for perspective diversity.
-2. Delegate line-by-line paper testing to `code-paper-test`.
-**Result:** A synthesized findings report; reviewer disagreement surfaced, not hidden.
+1. Flag it security-critical; dispatch the fresh-context reviewer **and** the §3 Task
+   sub-review (`/code-quality-tools:security` + `code-paper-test`) on the diff.
+2. Append the sub-review findings to the artifact; stamp `review-mark.sh --set`.
+**Result:** A synthesized report with the security sub-review captured in it (not merely
+asserted); reviewer disagreement surfaced, not hidden.
 
 ## Troubleshooting
 

--- a/drupal-ai-contrib/skills/contribution-submit/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-submit/SKILL.md
@@ -27,6 +27,14 @@ Backs `/drupal-ai-contrib:submit`. Load the knowledge layer via `dev-guides-navi
   If it prints any path, those files were edited **after** `verify` last passed — the
   green is stale. Surface the stale paths and recommend re-running `verify` before
   submitting. A pre-edit green is not evidence for the current code (guardrails Rule 3).
+- **Is the `review` still valid?** Pipe the contribution's changed files to the review
+  marker:
+  `git diff --name-only <target-branch>...<issue-fork-branch> | ${CLAUDE_PLUGIN_ROOT}/scripts/review-mark.sh`.
+  If it prints any path, those files were edited **after** `review` last ran — the review
+  artifact is stale. Surface: *"Review artifact is stale — files modified since the last
+  `/drupal-ai-contrib:review`. Re-run review, or acknowledge and proceed."* Require an
+  explicit acknowledgement; **never a hard block**. (If `review` never ran the marker is
+  absent and prints nothing — the "Has `review` been run?" point above covers that case.)
 
 If a precondition is unmet, **report it and let the contributor decide** — do not
 silently block. The contributor may have evidence from another path.
@@ -127,6 +135,7 @@ submission, including copyright and licensing.
 | Situation | Handling |
 |-----------|----------|
 | `verify` / `review` not run | Surface it; report, do not refuse — the contributor decides. |
+| Files changed since the last `review` | `review-mark.sh` prints the stale paths — surface the stale-review warning and require an acknowledgement; never block. Re-running `review` re-stamps the marker. |
 | `drupalorg` not installed | Surface the install steps from `references/drupalorg-cli.md`; do not fabricate an MR URL. |
 | `git push` to the issue fork rejected | The drupal.org SSH key is likely missing/unregistered — point at `setup` §5 and `references/drupalorg-cli.md` §Authentication. No push, no MR. |
 | MR-create call returns `200` + a list (nothing created) | The `glab api` write was misdirected to `git.drupal.org` — it must go to `git.drupalcode.org`. Re-issue and confirm a `201`. See `drupal-gitlab` → `references/merge-requests.md`. |


### PR DESCRIPTION
## Summary

**Final release** of the 2026-05-29 wave. Structural fixes at the `review` → `submit` boundary. No gate logic, drupalci-parity, AI-policy, eval, or GitLab-ops behavior changed.

## Changes

- **Security-critical review → explicit Task dispatch** (`contribution-review` §3). The old advisory "or delegate to `code-paper-test`" becomes mandatory for security-critical contributions — **trigger:** a security-tagged issue, *or* a diff touching permission/access callbacks, entity/field access, `#access` form keys, input sanitization / output escaping, input-built SQL/db queries, file/path handling, or XSS-/injection-adjacent code. On trigger, the skill dispatches the security sub-review via the **Task tool** (`/code-quality-tools:security` and/or `code-paper-test`) and **appends its findings to the review artifact** before returning — evidence over assertion. Non-security contributions unaffected. Steps renumbered (3→4→5→6); §6 stamps the review marker.
- **New `scripts/review-mark.sh`** — review-staleness marker, the review-stage parallel to the `reverify` ledger. `--set` stamps "review ran now"; piping the contribution's changed files in prints those edited *after* the marker. **mtime-based on purpose** — not the reverify ledger, which `verify` clears (that would false-negative when `verify` re-runs after a post-review edit). Zero-model deterministic; unit-tested (no marker→empty; post-`--set` edit→only the edited file; `--clear`→empty).
- **Submit review-staleness check** (`contribution-submit` Preconditions): pipes `git diff --name-only <target>...<branch>` to `review-mark.sh`; if any file changed after the last `review`, surfaces "Review artifact is stale — re-run review or acknowledge and proceed." **Acknowledge required; never a hard block.**
- **`CONVENTIONS.md`**: new "Structural contracts" section documenting both the security-dispatch trigger and the review-freshness (warn-not-block) posture.

## Notes

- `commands/review.md` already carried `Task` + `Bash` in `allowed-tools` — no command change (as the roadmap predicted). `contribution-review` keeps `disallowed-tools: Edit, Write`; it stamps the marker via the script (Bash, plugin-data dir only), never touching contribution files.
- **Also trims the marketplace catalog description** 704 → 550 chars. The overage (X02) was introduced by the v0.3.0 delegation-note edit; the v0.3.0 `--strict` run missed it (forked-validator non-determinism), this run caught it — so v0.4.0 retroactively cleans it.

## Validation

- `/plugin-creation-tools:validate --strict` → **PASS** (only two pre-existing S11 info nudges).
- `review-mark.sh` unit test → **PASS** (no marker → empty; stamp then edit → only edited file flagged; clear → empty).

## Bumps
- `plugin.json` 0.3.0 → **0.4.0**; `marketplace.json` entry 0.4.0; `metadata.version` 1.15.21 → **1.15.22**; CHANGELOG `[0.4.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)