### PR TITLE
ai-dev-assistant 5.8.0: consume verification in /goal bridge + work-order-loop observability reader

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.0"
+    "version": "2.0.1"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.0] - 2026-06-16
+
+**Closes the consumption half of the two 5.7.0 PAI adoptions: verification now drives the `/goal` clause, and the observability log is now mineable.**
+
+### Added — `/goal` bridge consumes the per-criterion `verification` note
+- `references/goal-from-scope.md` now uses a success criterion's ` — verify: <how>` note (grammar v1.1) as the concrete transcript-confirmable signal the `/goal` completion clause anchors that criterion to — turning capture-at-scope-time into an actual gate input rather than a display-only aid. A criterion without a note falls back to gate-anchored prose. The non-negotiable anchoring rule is unchanged: a gate (`/review` or `/validate:all`) must still run and surface its verdict inline; a restate-only `verify:` note never becomes a rubber-stamp. Contract §11 cross-references the bridge as the field's first consumer.
+
+### Added — work-order-loop observability reader
+- `scripts/wo-obs-report.sh` — a read-only zero-model miner over `work-orders/loop-obs.ndjson` (the 5.7.0 sidecar's output). Aggregates latest-per-WO disposition / review / critique histograms, a `halt_reasons` histogram, a `per_wo[]` summary (attempts, rework_count, ever_halted), and a **`flagged[]`** list surfacing the recurring failure patterns (terminal WOs + WOs reworked ≥ threshold, `--rework-threshold N`). `--format json|text`; empty/missing log → valid empty report (exit 0); malformed lines skipped defensively. Pointed to from the loop's Exit branches (ESCALATION + LOOP_COMPLETE) and `/run-work-orders` Related — read-only, never part of the gate/merge decision. New `tests/wo-obs-report-spec.sh` (14 cases).
+
 ## [5.7.0] - 2026-06-15
 
 **Two PAI-inspired additions: verification-strategy-per-criterion (scope) and a work-order-loop observability sidecar.**

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -27,9 +27,9 @@ Phases apply per task, not per project. A project can have tasks at different ph
 
 **Project codePath metadata (v3.11.0+):** projects declare where their code lives (distinct from the memory folder) via `/set-code-path` or during `/new`. Used by the analysis-agent and future code-aware features.
 
-**Verification per success criterion (v5.7.0+):** an `alignment.md` success criterion may carry an optional ` — verify: <how>` suffix, capturing how it will be checked up-front at scope time. Parsed into an additive `verification` field (backward compatible) and surfaced in the design/implement/research traceability walkthroughs.
+**Verification per success criterion (v5.7.0+):** an `alignment.md` success criterion may carry an optional ` — verify: <how>` suffix, capturing how it will be checked up-front at scope time. Parsed into an additive `verification` field (backward compatible) and surfaced in the design/implement/research traceability walkthroughs. **(v5.8.0+)** the `/scope` → `/goal` bridge consumes the note as the transcript-confirmable signal each completion-clause criterion anchors to — so the verification strategy drives the autonomy condition, not just documentation.
 
-**Work-order-loop observability (v5.7.0+):** the autonomous loop appends one compact per-WO record (disposition, attempts, review/critique outcome, HALT state) to `work-orders/loop-obs.ndjson` via a zero-model kernel — read-only on WO artifacts, non-fatal, disk-only — so recurring failure patterns can be mined.
+**Work-order-loop observability (v5.7.0+):** the autonomous loop appends one compact per-WO record (disposition, attempts, review/critique outcome, HALT state) to `work-orders/loop-obs.ndjson` via a zero-model kernel — read-only on WO artifacts, non-fatal, disk-only. **(v5.8.0+)** `scripts/wo-obs-report.sh` mines that log: per-WO disposition/halt histograms and a `flagged[]` list of recurring failure patterns (terminal + repeatedly-reworked WOs), pointed to from the loop's Exit branches and `/run-work-orders`.
 
 ## Installation
 

--- a/ai-dev-assistant/commands/run-work-orders.md
+++ b/ai-dev-assistant/commands/run-work-orders.md
@@ -73,3 +73,6 @@ does NOT run `/goal` itself — the user pastes it.
 - `skills/work-order-loop/references/loop-contract.md` — the ready-queue, legal-transition table,
   compact-line discipline, and `/goal` template the loop honors.
 - `skills/work-order-loop/references/merge-contract.md` — the honest no-auto-merge guarantee.
+- `scripts/wo-obs-report.sh <task>/work-orders` — read-only miner that summarizes a completed or
+  aborted run from `work-orders/loop-obs.ndjson` (per-WO dispositions + flagged terminal/repeated-rework
+  WOs). Optional triage/learning aid; never part of the gate or merge decision.

--- a/ai-dev-assistant/references/alignment-contract.md
+++ b/ai-dev-assistant/references/alignment-contract.md
@@ -249,3 +249,4 @@ Research note citing 2–3 framework-core examples and one ecosystem pattern if 
 - `scripts/alignment-read.sh` — parser
 - `references/analysis-agent-schema.md` (the "Signal codes" section) — `scope_contract_recommended` signal fires when an `alignment.md` is recommended
 - `commands/scope.md` — primary authoring command
+- `references/goal-from-scope.md` — the `/scope` → `/goal` bridge; consumes the per-criterion `verification` note (§5.2) as the anchor signal for each completion clause

--- a/ai-dev-assistant/references/goal-from-scope.md
+++ b/ai-dev-assistant/references/goal-from-scope.md
@@ -18,6 +18,14 @@ fields into a `/goal` condition:
 - **Success criteria** (`success_criteria[]`) → the **completion clause**. These must
   already be gate-anchored — a criterion the evaluator can confirm from a verdict in
   the transcript, not loose prose.
+  - When a criterion carries a `verification` note (grammar v1.1 — the parsed
+    `{text, checked, verification}` item has a non-null `verification`), the bridge
+    uses that note as the concrete signal the completion clause anchors that criterion
+    to: it tells the evaluator precisely which inline gate output / observable to look
+    for. A criterion *without* a verification note (`verification: null`) falls back to
+    today's behavior — it must still be gate-anchored from its prose. The verification
+    note **refines which signal each criterion maps to; it does NOT replace** the
+    non-negotiable requirement (below) that a gate ran and surfaced its verdict inline.
 - **Non-goals** (`non_goals[]`) → a **guard clause**: "…and nothing outside the listed
   scope was modified (`git status` clean outside the named areas)."
 
@@ -34,6 +42,13 @@ and prints per-gate verdicts to the transcript) or `/ai-dev-assistant:validate:a
 (which prints a per-gate summary table). Anchor the completion clause to that
 surfaced verdict, add the Non-goals guard, and bound the run with a turn clause.
 
+A criterion's `verification` note (v1.1) is the **preferred** anchor when it names a
+confirmable inline signal — e.g. "`/review`'s e2e gate prints a passing Playwright
+run for the route" — because it makes the anchor explicit rather than leaving the
+bridge to infer it from prose. But a `verify:` note that merely restates the
+criterion ("verify: the component works") names no inline signal, so it still needs a
+real gate verdict to anchor to: never let a verification note become a rubber-stamp.
+
 ### Worked example
 
 Given a Phase-3 contract like:
@@ -41,20 +56,25 @@ Given a Phase-3 contract like:
 ```
 Success criteria:
 - [ ] /review reports all hard-block gates green for this task
-- [ ] The new component renders on its route with no console/log errors
+- [ ] The new component renders on its route with no console errors — verify: /review's e2e gate prints a passing Playwright run for the route
 Non-goals:
 - Do not touch framework core or third-party dependencies under vendor/
 - Do not change the theme's style build pipeline
 ```
 
-the bridge emits:
+the second criterion carries a `verification` note; the first does not. The bridge
+emits:
 
 ```
-/goal /ai-dev-assistant:review <task> reports overall_verdict "pass" in _review.json (all hard-block gates green) printed inline AND the Phase-3 Success criteria hold AND nothing outside the Non-goals was modified — git status shows no changes under framework core, vendor/, or the style build pipeline — or stop after 20 turns
+/goal /ai-dev-assistant:review <task> reports overall_verdict "pass" in _review.json (all hard-block gates green) printed inline AND /review's e2e gate prints a passing Playwright run for the route AND nothing outside the Non-goals was modified — git status shows no changes under framework core, vendor/, or the style build pipeline — or stop after 20 turns
 ```
 
-The condition references the `/review` verdict that lands in the transcript, folds in
-the Non-goals as a `git status` guard, and turn-bounds the loop.
+The first criterion has no `verify:` note, so it falls back to its gate-anchored prose
+— the inline `/review` `overall_verdict "pass"`. The second criterion's verification
+note becomes the specific anchored check ("`/review`'s e2e gate prints a passing
+Playwright run for the route") instead of a generic "Success criteria hold". The
+condition references the `/review` verdicts that land in the transcript, folds in the
+Non-goals as a `git status` guard, and turn-bounds the loop.
 
 ## Limits — state these plainly
 

--- a/ai-dev-assistant/scripts/wo-obs-report.sh
+++ b/ai-dev-assistant/scripts/wo-obs-report.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# wo-obs-report.sh (⑤ telemetry, READER) — the off-line failure-pattern miner.
+#
+# Owner: observability lane (sibling of wo-obs-append.sh, the WRITER). The writer appends one
+# compact NDJSON record per WO to <work-orders-dir>/loop-obs.ndjson as the loop processes each WO;
+# THIS kernel READS that log and aggregates it into a single report so recurring failure patterns
+# (terminal HALTs, repeated rework) can be mined for triage/learning. It is a passive, READ-ONLY
+# consumer: it NEVER writes/renames a *.HALT marker, never touches run.json / a WO status, never
+# calls git/gh/merge/PR, and is NEVER part of the gate or merge decision.
+#
+# A WO can have MULTIPLE records across a run (re-dispatches); the LATEST record (by line order,
+# which also tracks recorded_at) is its current state. Latest-per-WO drives the disposition /
+# verdict histograms + per_wo; the halt_reasons histogram spans ALL records.
+#
+# Usage:
+#   wo-obs-report.sh <work-orders-dir> [--format json|text] [--rework-threshold N]
+#       reads <work-orders-dir>/loop-obs.ndjson. Default --format json, default --rework-threshold 2.
+#
+# Report (schema_version "1.0"), built EXCLUSIVELY via jq (slurped NDJSON), injection-inert:
+#   { schema_version, records, skipped_lines, work_orders, dispositions{...}, halt_reasons{...},
+#     review_verdicts{...}, critique_overall{...}, per_wo[], flagged[] }
+#   flagged[] = the recurring failure patterns: latest disposition terminal_halt/terminal_escalated
+#   (reason "terminal") OR rework_count >= threshold (reason "repeated_rework").
+#
+# Exit: 0 in all normal cases (incl. a MISSING log — an empty-but-valid report, safe to call always).
+# Exit 2 ONLY on a hard usage error (missing/nonexistent <work-orders-dir>) — even then a best-effort
+# JSON {schema_version, error} is emitted to stdout + a stderr line. Malformed/blank NDJSON lines are
+# skipped defensively (counted in skipped_lines), never crash. One compact stderr summary line always.
+
+set -uo pipefail
+
+DIR=""; FORMAT="json"; THRESH="2"
+# --- parse args (positional dir first, then flags) -------------------------
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --format)           FORMAT="${2:-json}"; shift 2 || shift ;;
+    --rework-threshold) THRESH="${2:-2}"; shift 2 || shift ;;
+    --) shift ;;
+    -*) shift ;;                       # ignore unknown flags (non-fatal)
+    *)  [ -z "$DIR" ] && DIR="$1"; shift ;;
+  esac
+done
+case "$FORMAT" in json|text) ;; *) FORMAT="json" ;; esac          # garbage => json
+case "$THRESH" in ''|*[!0-9]*) THRESH=2 ;; esac                   # non-int => default 2
+
+# --- usage error (the ONLY exit-2 path) ------------------------------------
+USAGE_ERR=""
+if   [ -z "$DIR" ];   then USAGE_ERR="missing_work_orders_dir"
+elif [ ! -d "$DIR" ]; then USAGE_ERR="work_orders_dir_missing"
+fi
+if [ -n "$USAGE_ERR" ]; then
+  jq -nc --arg e "$USAGE_ERR" '{schema_version:"1.0", error:$e}'
+  printf 'wo-obs-report error=%s\n' "$USAGE_ERR" >&2
+  exit 2
+fi
+
+LOG="$DIR/loop-obs.ndjson"
+
+# --- pre-filter the NDJSON: keep only valid JSON objects, count the rest ----
+# jq -s would abort the whole file on a single malformed line, so we validate line-by-line and
+# slurp ONLY the clean lines. A missing log simply yields an empty set ⇒ an empty-but-valid report.
+VALID="$(mktemp)"; trap 'rm -f "$VALID"' EXIT
+SKIPPED=0
+if [ -f "$LOG" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    # blank / whitespace-only line ⇒ skip + count
+    if [ -z "${line//[[:space:]]/}" ]; then SKIPPED=$((SKIPPED+1)); continue; fi
+    if printf '%s' "$line" | jq -e 'type=="object"' >/dev/null 2>&1; then
+      printf '%s\n' "$line" >> "$VALID"
+    else
+      SKIPPED=$((SKIPPED+1))               # malformed / non-object ⇒ skip + count
+    fi
+  done < "$LOG"
+fi
+
+# --- aggregate (ALL JSON built by jq; latest-per-WO = last in input order) --
+REPORT="$(jq -n \
+  --slurpfile recs "$VALID" \
+  --argjson skipped "$SKIPPED" \
+  --argjson thresh "$THRESH" \
+  '
+  ($recs) as $all
+  | ($all | group_by(.wo_id // "")) as $groups
+  | ($groups | map(.[-1])) as $latest
+  | ($latest
+     | reduce .[] as $r ({done:0,needs_rework:0,terminal_halt:0,terminal_escalated:0,unknown:0};
+         (($r.disposition // "unknown") | tostring) as $d
+         | (if (["done","needs_rework","terminal_halt","terminal_escalated","unknown"] | index($d))
+            then $d else "unknown" end) as $dd
+         | .[$dd] += 1)) as $disp
+  | {
+      schema_version: "1.0",
+      records: ($all | length),
+      skipped_lines: $skipped,
+      work_orders: ($latest | length),
+      dispositions: $disp,
+      halt_reasons: (
+        reduce $all[] as $r ({};
+          ($r.halt_reason) as $h
+          | if $h == null then . else (($h | tostring) as $k | .[$k] = ((.[$k] // 0) + 1)) end)),
+      review_verdicts: (
+        reduce $latest[] as $r ({};
+          (($r.review_verdict // "missing") | tostring) as $k | .[$k] = ((.[$k] // 0) + 1))),
+      critique_overall: (
+        reduce $latest[] as $r ({};
+          (($r.critique_overall // "missing") | tostring) as $k | .[$k] = ((.[$k] // 0) + 1))),
+      per_wo: (
+        $groups | map(
+          . as $g | ($g[-1]) as $last
+          | {
+              wo_id: ($last.wo_id // null),
+              last_disposition: (($last.disposition // "unknown") | tostring),
+              attempts: ([ $g[] | (.attempts // 0) ] | max),
+              records: ($g | length),
+              ever_halted: ([ $g[] | ((.halt_marker_present == true) or (.halted == true)) ] | any),
+              rework_count: ([ $g[] | select(.disposition == "needs_rework") ] | length)
+            }) | sort_by(.wo_id)),
+      flagged: (
+        $groups | map(
+          . as $g | ($g[-1]) as $last
+          | (($last.disposition // "unknown") | tostring) as $dispo
+          | ([ $g[] | select(.disposition == "needs_rework") ] | length) as $rc
+          | ([ $g[] | (.attempts // 0) ] | max) as $att
+          | (if ($dispo == "terminal_halt" or $dispo == "terminal_escalated") then "terminal"
+             elif ($rc >= $thresh) then "repeated_rework"
+             else null end) as $reason
+          | select($reason != null)
+          | {
+              wo_id: ($last.wo_id // null),
+              reason: $reason,
+              attempts: $att,
+              rework_count: $rc,
+              last_disposition: $dispo,
+              halt_reason: ($last.halt_reason // null)
+            }) | sort_by(.wo_id))
+    }')"
+
+# defensive: if jq somehow produced nothing, emit a minimal empty-but-valid report (non-fatal)
+[ -n "$REPORT" ] || REPORT="$(jq -nc --argjson s "$SKIPPED" \
+  '{schema_version:"1.0", records:0, skipped_lines:$s, work_orders:0,
+    dispositions:{done:0,needs_rework:0,terminal_halt:0,terminal_escalated:0,unknown:0},
+    halt_reasons:{}, review_verdicts:{}, critique_overall:{}, per_wo:[], flagged:[]}')"
+
+# --- output ----------------------------------------------------------------
+if [ "$FORMAT" = "text" ]; then
+  printf '%s\n' "$REPORT" | jq -r '
+    "wo-obs-report: \(.records) records, \(.work_orders) work-orders (skipped \(.skipped_lines))",
+    "dispositions: done=\(.dispositions.done) needs_rework=\(.dispositions.needs_rework) terminal_halt=\(.dispositions.terminal_halt) terminal_escalated=\(.dispositions.terminal_escalated) unknown=\(.dispositions.unknown)",
+    (if (.flagged | length) == 0 then "Flagged WOs: none"
+     else ("Flagged WOs (\(.flagged | length)):"),
+          (.flagged[] | "  \(.wo_id)  \(.reason)  rework=\(.rework_count) attempts=\(.attempts) last=\(.last_disposition)"
+             + (if .halt_reason then " halt_reason=\(.halt_reason)" else "" end))
+     end),
+    (if (.halt_reasons | length) == 0 then "halt reasons: none"
+     else "top halt reasons: " + ([.halt_reasons | to_entries[] | "\(.key)=\(.value)"] | join(" "))
+     end)'
+else
+  printf '%s\n' "$REPORT"
+fi
+
+# --- one compact stderr summary line ---------------------------------------
+printf 'wo-obs-report wos=%s done=%s rework=%s terminal=%s flagged=%s\n' \
+  "$(jq -r '.work_orders' <<<"$REPORT" 2>/dev/null)" \
+  "$(jq -r '.dispositions.done' <<<"$REPORT" 2>/dev/null)" \
+  "$(jq -r '.dispositions.needs_rework' <<<"$REPORT" 2>/dev/null)" \
+  "$(jq -r '(.dispositions.terminal_halt + .dispositions.terminal_escalated)' <<<"$REPORT" 2>/dev/null)" \
+  "$(jq -r '.flagged | length' <<<"$REPORT" 2>/dev/null)" >&2
+
+exit 0

--- a/ai-dev-assistant/skills/work-order-loop/SKILL.md
+++ b/ai-dev-assistant/skills/work-order-loop/SKILL.md
@@ -182,6 +182,10 @@ TERMINAL WO — `wo-NN.HALT` / sidecar `halted:true` — is never processable an
   STOP. Do **not** run the merge step; do **not** print `LOOP_COMPLETE`. **Escalation keys off TERMINAL
   residue, NOT off status** — a HALTed-but-`ready` WO (cap exhausted at step 5) still escalates here and
   **never** reaches the `LOOP_COMPLETE` branch, so /goal cannot fire on a failed run.
+  *(Optional, read-only triage:* `bash "${CLAUDE_PLUGIN_ROOT}/scripts/wo-obs-report.sh"
+  "<task-folder>/work-orders"` *summarizes the run's per-WO dispositions + flagged WOs (terminal /
+  repeated-rework) from the ⑤ telemetry log for triage/learning. It is a passive consumer — never part
+  of the gate or escalation decision.)*
 - **Else (every WO `done`):**
   1. Run `/review --headless --base <base> <task-folder>` **inline from cwd=`<worktree>`** (the
      authoritative task-level PR-gate; it derives the change from the worktree's
@@ -198,7 +202,10 @@ TERMINAL WO — `wo-NN.HALT` / sidecar `halted:true` — is never processable an
      Forward the `merge_gate` compact line.
   3. Print a `LOOP_COMPLETE` summary, then the composed **/goal** string for the user to paste (see
      `loop-contract.md` (/goal section — turn bound `min(20 × N_WOs, 80)`). **Never run /goal yourself** (degrade
-     = an attended sequential loop with the same compact lines).
+     = an attended sequential loop with the same compact lines). *(Optional, read-only:*
+     `bash "${CLAUDE_PLUGIN_ROOT}/scripts/wo-obs-report.sh" "<task-folder>/work-orders"` *summarizes the
+     run's per-WO dispositions + any flagged WOs from the ⑤ telemetry log for learning — passive consumer,
+     never part of the merge decision.)*
 
 ## Boundaries
 

--- a/ai-dev-assistant/tests/wo-obs-report-spec.sh
+++ b/ai-dev-assistant/tests/wo-obs-report-spec.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# TDD spec for scripts/wo-obs-report.sh (⑤ telemetry, READER) — the off-line failure-pattern miner.
+# Verifies: latest-per-WO disposition histogram, flagged (terminal + repeated_rework), halt_reasons,
+# per_wo correctness, --rework-threshold, empty/missing-log safety, usage error, malformed-line skip,
+# --format text, and structural read-only posture.
+set -uo pipefail
+HERE="$(dirname "$(readlink -f "$0")")"; ROOT="$(dirname "$HERE")"
+export CLAUDE_PLUGIN_ROOT="$ROOT"
+SUT="$ROOT/scripts/wo-obs-report.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+# krun: run the SUT, capture OUT (stdout) and RC (exit code). stderr is suppressed.
+krun() { OUT="$(bash "$SUT" "$@" 2>/dev/null)"; RC=$?; }
+
+fail_check() {
+  FAIL=$((FAIL+1))
+  echo "FAIL $1: $2"
+  [ -n "${OUT:-}" ] && echo "  out: $OUT"
+}
+pass_check() { PASS=$((PASS+1)); }
+
+# mkwo: fresh per-test work-orders dir
+mkwo() { local d="$TMP/$1"; mkdir -p "$d"; echo "$d"; }
+
+# rec: emit one NDJSON record line. $1=wo $2=disposition $3=attempts $4=halt_reason(null|str) $5=halt_marker(true|false) $6=review $7=critique
+rec() {
+  jq -nc --arg wo "$1" --arg d "$2" --argjson a "$3" \
+    --arg hr "$4" --argjson hm "$5" --arg rv "$6" --arg co "$7" \
+    '{schema_version:"1.0", wo_id:$wo, recorded_at:"2026-01-01T00:00:00Z", disposition:$d,
+      attempts:$a, dispatched_at:null, checkpoint_before:null, checkpoint_after:null,
+      override_used:null, build_returned:null, halted:($hm),
+      halt_reason:(if $hr=="null" then null else $hr end), halt_marker_present:$hm,
+      review_verdict:$rv, critique_overall:$co, critique_blocking:false, critique_tier:"low"}'
+}
+
+# seed_fixture: a representative loop-obs.ndjson:
+#   wo-01: clean done (1 record)
+#   wo-02: needs_rework, needs_rework, done (3 records; rework_count 2)
+#   wo-03: terminal_halt with halt_reason retry_cap_exhausted (1 record)
+seed_fixture() { # $1=dir
+  {
+    rec wo-01 done           1 null false pass    pass
+    rec wo-02 needs_rework    1 null false fail    pass
+    rec wo-02 needs_rework    2 null false fail    pass
+    rec wo-02 done            3 null false pass    pass
+    rec wo-03 terminal_halt   3 retry_cap_exhausted true missing critical
+  } > "$1/loop-obs.ndjson"
+}
+
+# ---------------------------------------------------------------------------
+# T1: disposition histogram = latest-per-WO. wo-02 (rework→rework→done) counts as done.
+D="$(mkwo t1)"; seed_fixture "$D"
+krun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.records'                       <<<"$OUT")" = "5" ] \
+  && [ "$(jq -r '.work_orders'                   <<<"$OUT")" = "3" ] \
+  && [ "$(jq -r '.dispositions.done'             <<<"$OUT")" = "2" ] \
+  && [ "$(jq -r '.dispositions.needs_rework'     <<<"$OUT")" = "0" ] \
+  && [ "$(jq -r '.dispositions.terminal_halt'    <<<"$OUT")" = "1" ] \
+  && [ "$(jq -r '.dispositions.terminal_escalated' <<<"$OUT")" = "0" ]; then
+  pass_check "T1 disposition histogram latest-per-WO (rework→done counts done)"
+else
+  fail_check "T1 disposition histogram latest-per-WO" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# T2: flagged contains terminal WO (reason terminal) AND repeated-rework WO (reason repeated_rework).
+D="$(mkwo t2)"; seed_fixture "$D"
+krun "$D"
+TERM_REASON="$(jq -r '.flagged[] | select(.wo_id=="wo-03") | .reason' <<<"$OUT")"
+REWORK_REASON="$(jq -r '.flagged[] | select(.wo_id=="wo-02") | .reason' <<<"$OUT")"
+FLAG_N="$(jq -r '.flagged | length' <<<"$OUT")"
+if [ "$RC" -eq 0 ] \
+  && [ "$TERM_REASON" = "terminal" ] \
+  && [ "$REWORK_REASON" = "repeated_rework" ] \
+  && [ "$FLAG_N" = "2" ]; then
+  pass_check "T2 flagged: terminal + repeated_rework, count 2"
+else
+  fail_check "T2 flagged: terminal + repeated_rework" "rc=$RC term=$TERM_REASON rework=$REWORK_REASON n=$FLAG_N"
+fi
+
+# ---------------------------------------------------------------------------
+# T3: halt_reasons histogram has the terminal WO's halt reason.
+D="$(mkwo t3)"; seed_fixture "$D"
+krun "$D"
+if [ "$RC" -eq 0 ] && [ "$(jq -r '.halt_reasons.retry_cap_exhausted' <<<"$OUT")" = "1" ]; then
+  pass_check "T3 halt_reasons histogram counts retry_cap_exhausted"
+else
+  fail_check "T3 halt_reasons histogram" "rc=$RC halt_reasons=$(jq -c '.halt_reasons' <<<"$OUT")"
+fi
+
+# ---------------------------------------------------------------------------
+# T4: per_wo last_disposition + rework_count + attempts(max) + records correct for wo-02.
+D="$(mkwo t4)"; seed_fixture "$D"
+krun "$D"
+W2="$(jq -c '.per_wo[] | select(.wo_id=="wo-02")' <<<"$OUT")"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.last_disposition' <<<"$W2")" = "done" ] \
+  && [ "$(jq -r '.rework_count'     <<<"$W2")" = "2" ] \
+  && [ "$(jq -r '.attempts'         <<<"$W2")" = "3" ] \
+  && [ "$(jq -r '.records'          <<<"$W2")" = "3" ] \
+  && [ "$(jq -r '.per_wo[] | select(.wo_id=="wo-03") | .ever_halted' <<<"$OUT")" = "true" ]; then
+  pass_check "T4 per_wo latest_disposition/rework_count/attempts/records + ever_halted"
+else
+  fail_check "T4 per_wo fields" "rc=$RC w2=$W2"
+fi
+
+# ---------------------------------------------------------------------------
+# T5: --rework-threshold 3 drops the rework WO (rework_count 2 < 3); terminal WO still flagged.
+D="$(mkwo t5)"; seed_fixture "$D"
+krun "$D" --rework-threshold 3
+HAS_W2="$(jq -r '[.flagged[] | select(.wo_id=="wo-02")] | length' <<<"$OUT")"
+HAS_W3="$(jq -r '[.flagged[] | select(.wo_id=="wo-03")] | length' <<<"$OUT")"
+if [ "$RC" -eq 0 ] && [ "$HAS_W2" = "0" ] && [ "$HAS_W3" = "1" ]; then
+  pass_check "T5 --rework-threshold 3 drops repeated_rework WO, keeps terminal"
+else
+  fail_check "T5 --rework-threshold 3" "rc=$RC w2=$HAS_W2 w3=$HAS_W3"
+fi
+
+# ---------------------------------------------------------------------------
+# T6: empty log file → records 0, empty arrays, exit 0.
+D="$(mkwo t6)"; : > "$D/loop-obs.ndjson"
+krun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.records'           <<<"$OUT")" = "0" ] \
+  && [ "$(jq -r '.work_orders'       <<<"$OUT")" = "0" ] \
+  && [ "$(jq -r '.flagged | length'  <<<"$OUT")" = "0" ] \
+  && [ "$(jq -r '.per_wo | length'   <<<"$OUT")" = "0" ] \
+  && [ "$(jq -r '.dispositions.done' <<<"$OUT")" = "0" ]; then
+  pass_check "T6 empty log: records 0, empty arrays, exit 0"
+else
+  fail_check "T6 empty log" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# T7: MISSING log (no runs yet) → empty-but-valid report, exit 0 (safe to call always).
+D="$(mkwo t7)"   # no loop-obs.ndjson created
+krun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.schema_version' <<<"$OUT")" = "1.0" ] \
+  && [ "$(jq -r '.records'        <<<"$OUT")" = "0" ]; then
+  pass_check "T7 missing log: empty-but-valid report, exit 0"
+else
+  fail_check "T7 missing log" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# T8: missing dir arg → exit 2 + best-effort JSON {schema_version, error}.
+krun
+if [ "$RC" -eq 2 ] \
+  && [ "$(jq -r '.schema_version' <<<"$OUT" 2>/dev/null)" = "1.0" ] \
+  && [ -n "$(jq -r '.error' <<<"$OUT" 2>/dev/null)" ]; then
+  pass_check "T8 missing dir arg: exit 2 + best-effort JSON"
+else
+  fail_check "T8 missing dir arg" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# T8b: nonexistent dir → exit 2.
+krun "$TMP/does-not-exist"
+if [ "$RC" -eq 2 ] && [ "$(jq -r '.error' <<<"$OUT" 2>/dev/null)" = "work_orders_dir_missing" ]; then
+  pass_check "T8b nonexistent dir: exit 2"
+else
+  fail_check "T8b nonexistent dir" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# T9: malformed + blank lines skipped (skipped_lines incremented), valid records still counted, no crash.
+D="$(mkwo t9)"
+{
+  rec wo-01 done 1 null false pass pass
+  printf '{ not json\n'      # malformed
+  printf '\n'                # blank
+  printf '   \n'             # whitespace-only
+  printf '[1,2,3]\n'         # valid JSON but not an object
+  rec wo-02 done 1 null false pass pass
+} > "$D/loop-obs.ndjson"
+krun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.records'       <<<"$OUT")" = "2" ] \
+  && [ "$(jq -r '.skipped_lines' <<<"$OUT")" = "4" ] \
+  && [ "$(jq -r '.work_orders'   <<<"$OUT")" = "2" ]; then
+  pass_check "T9 malformed/blank/non-object lines skipped (skipped_lines=4), no crash"
+else
+  fail_check "T9 malformed-line skip" "rc=$RC records=$(jq -r '.records' <<<"$OUT" 2>/dev/null) skipped=$(jq -r '.skipped_lines' <<<"$OUT" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# T10: --format text prints a summary containing "Flagged".
+D="$(mkwo t10)"; seed_fixture "$D"
+OUT="$(bash "$SUT" "$D" --format text 2>/dev/null)"; RC=$?
+if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'Flagged' && printf '%s' "$OUT" | grep -q 'dispositions:'; then
+  pass_check "T10 --format text: human summary containing 'Flagged'"
+else
+  fail_check "T10 --format text" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# T11 (structural): report built via jq; kernel is grep-clean of WO mutations (read-only posture).
+JQ_BUILD=0; HALT_WRITE=0; GH_PR=0; GIT_RESET=0; SET_STATUS=0
+grep -Eq 'jq -n' "$SUT" && JQ_BUILD=1
+grep -Eq '(>|>>|mv|cp|touch|tee)[^|]*\.HALT' "$SUT" && HALT_WRITE=1
+grep -Eq 'gh[[:space:]]+pr' "$SUT" && GH_PR=1
+grep -Eq 'git[[:space:]].*reset' "$SUT" && GIT_RESET=1
+grep -Eq 'set-status' "$SUT" && SET_STATUS=1
+if [ "$JQ_BUILD" -eq 1 ] && [ "$HALT_WRITE" -eq 0 ] && [ "$GH_PR" -eq 0 ] && [ "$GIT_RESET" -eq 0 ] && [ "$SET_STATUS" -eq 0 ]; then
+  pass_check "T11 structural: jq-built + no HALT-write/gh-pr/git-reset/set-status"
+else
+  fail_check "T11 structural" "jq=$JQ_BUILD halt=$HALT_WRITE gh=$GH_PR reset=$GIT_RESET status=$SET_STATUS"
+fi
+
+# ---------------------------------------------------------------------------
+# T11b (runtime): running the report NEVER writes into the work-orders dir (no new files, log byte-identical).
+D="$(mkwo t11b)"; seed_fixture "$D"
+BEFORE_LS="$(ls -1 "$D" | sort)"; BEFORE_LOG="$(cat "$D/loop-obs.ndjson")"
+krun "$D"
+AFTER_LS="$(ls -1 "$D" | sort)"; AFTER_LOG="$(cat "$D/loop-obs.ndjson")"
+HALT_COUNT="$(find "$D" -name '*.HALT' 2>/dev/null | wc -l)"
+if [ "$RC" -eq 0 ] && [ "$BEFORE_LS" = "$AFTER_LS" ] && [ "$BEFORE_LOG" = "$AFTER_LOG" ] && [ "$HALT_COUNT" -eq 0 ]; then
+  pass_check "T11b runtime: read-only on work-orders dir (no new files, log unchanged, no HALT)"
+else
+  fail_check "T11b runtime read-only" "rc=$RC ls_changed=$([[ "$BEFORE_LS" != "$AFTER_LS" ]] && echo yes || echo no) log_changed=$([[ "$BEFORE_LOG" != "$AFTER_LOG" ]] && echo yes || echo no) halt=$HALT_COUNT"
+fi
+
+# ---------------------------------------------------------------------------
+# T12: terminal_escalated WO is flagged with reason terminal.
+D="$(mkwo t12)"
+rec wo-09 terminal_escalated 2 null false missing critical > "$D/loop-obs.ndjson"
+krun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.dispositions.terminal_escalated' <<<"$OUT")" = "1" ] \
+  && [ "$(jq -r '.flagged[] | select(.wo_id=="wo-09") | .reason' <<<"$OUT")" = "terminal" ]; then
+  pass_check "T12 terminal_escalated flagged with reason terminal"
+else
+  fail_check "T12 terminal_escalated" "rc=$RC out=$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+echo "----"
+echo "wo-obs-report-spec: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Follow-up to #213. The two 5.7.0 PAI adoptions each shipped their *capture/write* half; this closes their *consumption/read* half — the part that turns "recorded" into "acted on" (raised in the post-merge review of #213).

## F2 — verification now drives the `/goal` clause (was: parsed + displayed only)
`references/goal-from-scope.md` (the `/scope` → `/goal` bridge) now consumes a success criterion's ` — verify: <how>` note (alignment grammar v1.1) as the **transcript-confirmable signal the completion clause anchors that criterion to**. The verification strategy you capture at scope time becomes an actual input to the autonomy condition instead of a documentation aid.
- A criterion **without** a note falls back to today's gate-anchored-prose behavior.
- **Anchoring rule unchanged:** a gate (`/review` or `/validate:all`) must still run and surface its verdict inline; a restate-only `verify:` note (names no inline signal) never becomes a rubber-stamp.
- Worked example updated to show one suffixed + one bare criterion. Contract §11 cross-refs the bridge as the field's first consumer.

## F3 — the observability log is now mineable (was: write-only)
`scripts/wo-obs-report.sh` — a read-only zero-model miner over `work-orders/loop-obs.ndjson` (the 5.7.0 sidecar's output, which nothing read until now).
- Latest-per-WO **disposition / review / critique** histograms, a **`halt_reasons`** histogram, `per_wo[]` (attempts, rework_count, ever_halted), and **`flagged[]`** — the recurring failure patterns: terminal WOs + WOs reworked ≥ threshold (`--rework-threshold N`).
- `--format json|text`; empty/missing log → valid empty report (exit 0); malformed lines skipped defensively (`skipped_lines`).
- Pointed to from the loop's Exit branches (ESCALATION + LOOP_COMPLETE) and `/run-work-orders` — **read-only, never part of the gate/merge decision; no loop/gate/invariant touched.**
- This is also the instrument the open Beads token-economy A/B needs to *measure* state-reload cost rather than argue it.

## Marketplace
`metadata.version` 2.0.0 → **2.0.1** (patch — plugin pointer update).

## Verification
- Tests: `wo-obs-report` **14/14**, `wo-obs-append` **11/11**, `alignment-read` **7/7**.
- No plugin.json↔marketplace version drift; containment scan clean (errors=0) on ai-dev-assistant.

## Not in this PR (deliberate)
- F1 (containment) auto-enforcement pre-publish remains opt-in via `/validate` — a separate design decision, not a gap. (I'm separately dogfooding the `/validate` fork→kernel wiring and will report.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)