### PR TITLE
code-paper-test v0.10.0: behavioral contract verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.1"
+    "version": "2.0.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.0"
+    "version": "2.0.1"
   },
   "plugins": [
     {
@@ -175,8 +175,8 @@
     {
       "name": "code-paper-test",
       "source": "./code-paper-test",
-      "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase single agent (50–300 lines), or 3-agent competing team with isolated worktrees (300+ lines, security-critical, skills). Supports `--json` output for CI integration. v0.9.0 honors ${CLAUDE_EFFORT} as a floor across scenario depth and per-teammate effort, and trims SKILL.md into references.",
-      "version": "0.9.0",
+      "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase (50–300), or 3-agent competing team in isolated worktrees (300+, security-critical, skills). Supports `--json` for CI. v0.10.0 adds behavioral contract verification (B1 code, B2 plugin/MCP/skill) on top of existence checks: return-shape/nullability diffing, chained-object tracing, taint-stance closed-source fallback.",
+      "version": "0.10.0",
       "author": {
         "name": "camoa"
       },

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-16
+
+### Added
+- **Behavioral contract verification — the second pass after existence verification.** New `references/behavioral-verification.md` holds the canonical procedures: **B1** (code/library calls) enumerates every caller assumption about a return, locates the declared contract (type stub → OpenAPI → docs → docblock → changelog), diffs assumption vs contract, and applies a **chained-object rule** (trace every property/method invoked on a returned object, not just the first return type); **B2** (plugin/MCP/hook/skill references) checks that a referenced capability *produces* what the calling step consumes, not merely that the reference resolves. Closed-source / no-contract targets get a **taint stance** (assume the return could be null, hostile, or malformed; require a validation wrapper) and the explicit label `EXISTENCE VERIFIED / BEHAVIOR UNVERIFIED`.
+- `references/dependency-verification.md` — renamed Option 3 to "Closed-Source / No-Contract — Taint Stance" and added a "Chained-Object Rule" section. The existence-layer `UNVERIFIED RISK` label is preserved; the behavioral-layer `BEHAVIOR UNVERIFIED` label is new and distinct.
+- `references/skill-and-config-testing.md` — new "§8 Behavioral Output Verification (B2)" procedure and a `tool-reference-behavior` row in the JSON category table.
+- `commands/test-team.md` — Happy Path Validator spawn gains a behavioral step 5b (B1) and a skill-mode B2 check.
+
+### Changed
+- **Report columns now distinguish existence from behavior** (the previous single `Verified?` column was a false-confidence trap). The Happy Path Analysis `## Dependency Verification` table gains `Behavior verified?` + `Contract source`; the lead synthesis splits its single Dependency Verification table into `## Existence Verification` and `## Behavioral Contract Verification` (the latter renamed from the rollout's `## Contract Verification` to avoid colliding with the pre-existing relational `## Contract Verification` table).
+- **JSON schema 1.0 → 1.1 (additive only).** Optional `behavior_verified` boolean on dependency-type findings; `behaviors_verified` in the summary envelope; `tool-reference-behavior` category. CI gates pinning `^1\.` are unaffected.
+- SKILL.md — new workflow step 6b, a behavioral distinction in "Critical: Never Assume", a skill-mode B2 note, and the new reference in the References list.
+
+### Notes
+- Existence-verification discipline is unchanged — behavioral verification is added on top, never a replacement.
+
 ## [0.9.0] - 2026-05-21
 
 ### Added

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -18,15 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JSON schema 1.0 → 1.1 (additive only).** Optional `behavior_verified` boolean on dependency-type findings; `behaviors_verified` in the summary envelope; `tool-reference-behavior` category. CI gates pinning `^1\.` are unaffected.
 - SKILL.md — new workflow step 6b, a behavioral distinction in "Critical: Never Assume", a skill-mode B2 note, and the new reference in the References list.
 
+### Fixed (pre-existing)
+- **Slash-command namespace corrected everywhere.** 21 references used `/code-paper:test-team`, but the plugin name is `code-paper-test`, so the command actually resolves as `/code-paper-test:test-team` — every documented invocation previously pointed at a non-existent command. Corrected across `SKILL.md` (incl. the routing table and `--json` examples), `commands/test-team.md`, `README.md`, `CHANGELOG.md`, and four `references/*.md`.
+- **S14 (BUG-1) — `skills/paper-test/SKILL.md` frontmatter `model: sonnet` → `model: inherit`.** The skill runs inline with no context isolation, so a pinned sub-1M model overflows when the skill activates from a large conversation. `inherit` runs on the session model. The `**Model:** sonnet` markers in `commands/test-team.md` are fresh-context agent spawns and are intentionally left unchanged (S14 does not apply to spawns).
+
 ### Notes
 - Existence-verification discipline is unchanged — behavioral verification is added on top, never a replacement.
 
 ## [0.9.0] - 2026-05-21
 
 ### Added
-- **`${CLAUDE_EFFORT}` honored as a floor.** `/paper-test` (SKILL.md, "Effort-Adaptive Scenario Depth") scales scenarios per phase with the active effort level — `low` = happy path + one error case, `medium` = 2 per phase, `high`/`xhigh`/`max` = 3+. Effort never lowers the verification bar; every external call is still verified. `/code-paper:test-team` treats caller effort as a **floor-raiser**: each teammate runs at `max(${CLAUDE_EFFORT}, role floor)` — floors are `medium` (Happy Path Validator) and `high` (Edge Case Hunter, Red Team Attacker). A `low`/`medium` caller still gets the adversarial lenses at `high`; an `xhigh`/`max` caller bumps the whole team.
+- **`${CLAUDE_EFFORT}` honored as a floor.** `/paper-test` (SKILL.md, "Effort-Adaptive Scenario Depth") scales scenarios per phase with the active effort level — `low` = happy path + one error case, `medium` = 2 per phase, `high`/`xhigh`/`max` = 3+. Effort never lowers the verification bar; every external call is still verified. `/code-paper-test:test-team` treats caller effort as a **floor-raiser**: each teammate runs at `max(${CLAUDE_EFFORT}, role floor)` — floors are `medium` (Happy Path Validator) and `high` (Edge Case Hunter, Red Team Attacker). A `low`/`medium` caller still gets the adversarial lenses at `high`; an `xhigh`/`max` caller bumps the whole team.
 - README documentation for `teammateDefaultModel` / `teammateMode` settings as an alternative to the per-spawn `Model:` lines in `/test-team`.
-- **`references/fork-vs-fresh.md`** — decision record for why `/code-paper:test-team` spawns its three testers in fresh contexts rather than forked subagents (`CLAUDE_CODE_FORK_SUBAGENT=1`): the fresh-vs-forked tradeoff table, why fresh is the default (independent reasoning is what makes the cross-challenge debate meaningful), the re-evaluation criteria, and how to opt in. Cross-linked from `references/ai-code-auditing.md` and the SKILL.md references list.
+- **`references/fork-vs-fresh.md`** — decision record for why `/code-paper-test:test-team` spawns its three testers in fresh contexts rather than forked subagents (`CLAUDE_CODE_FORK_SUBAGENT=1`): the fresh-vs-forked tradeoff table, why fresh is the default (independent reasoning is what makes the cross-challenge debate meaningful), the re-evaluation criteria, and how to opt in. Cross-linked from `references/ai-code-auditing.md` and the SKILL.md references list.
 
 ### Changed
 - **SKILL.md conciseness pass** (494 → 126 body lines, no behavior change). The full 8-step workflow, verification procedures, flaw-catalog summary, module strategy, and output template moved to the new `references/workflow.md`; SKILL.md keeps the routing, the condensed workflow, the effort guidance, and the references list.
@@ -55,13 +59,13 @@ Closes the 2026-04-25 Claude Code doc-refresh deltas affecting this plugin (snap
 ## [0.7.0] - 2026-04-22
 
 ### Added
-- **`--json` output mode** on both `/paper-test` and `/code-paper:test-team` for CI integration and programmatic consumption. Versioned schema (`schema_version: "1.0"`) matching the camoa-skills ecosystem convention established by code-quality-tools. Severity rubric preserved (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO`) — no new terms introduced.
+- **`--json` output mode** on both `/paper-test` and `/code-paper-test:test-team` for CI integration and programmatic consumption. Versioned schema (`schema_version: "1.0"`) matching the camoa-skills ecosystem convention established by code-quality-tools. Severity rubric preserved (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO`) — no new terms introduced.
 - **New reference:** `skills/paper-test/references/json-output-schema.md` — full schema, finding-object shape, team-report extensions, skill/config category vocabulary, optional `rubric_score` block, CI gate patterns, and schema-versioning contract (match `^1\.`, never exact).
 - **Deterministic + Agentic pairing section** in `skill-and-config-testing.md` — documents running `plugin-creation-tools:skill-quality-reviewer` before paper-test when testing skills/commands/agents, so mechanical issues (stale SDK refs, missing imperatives, frontmatter gaps) clear cheaply before semantic analysis.
 - **SKILL.md trigger phrases** expanded: `"test this agent"`, `"walk through this code"`, `"step through this"`, `"dry run"`, `"sanity check"`, `"red team this"`, `"poke holes in this"` — cover natural phrasings the prior list missed.
 
 ### Changed
-- **`/code-paper:test-team` command** — new `--json` argument handling. Each teammate writes `{role}-analysis.json` alongside the markdown report when the flag is set; the lead aggregates per the schema into `paper-test-team-report.json` with per-teammate breakdowns (`team.happy_path` / `team.edge_case` / `team.red_team`), cross-challenge outcomes (`confirmed_by_multiple`, `disputed`, `unanimous_clean_areas`), and per-finding `found_by` / `disputed` fields.
+- **`/code-paper-test:test-team` command** — new `--json` argument handling. Each teammate writes `{role}-analysis.json` alongside the markdown report when the flag is set; the lead aggregates per the schema into `paper-test-team-report.json` with per-teammate breakdowns (`team.happy_path` / `team.edge_case` / `team.red_team`), cross-challenge outcomes (`confirmed_by_multiple`, `disputed`, `unanimous_clean_areas`), and per-finding `found_by` / `disputed` fields.
 - **PreCompact hook** now surfaces both `.md` and `.json` reports in `.reports/`.
 - **SKILL.md** frontmatter `version: 0.5.0` → `0.7.0` (corrects the intentional drift left during the v0.6.0 hook-only bump).
 

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -278,7 +278,13 @@ Specific checks for AI-generated code:
 
 ## Version
 
-**0.9.0** (Current) — effort-adaptive depth + hygiene
+**0.10.0** (Current) — behavioral contract verification
+- New `references/behavioral-verification.md` — B1 (code/library) and B2 (plugin/MCP/hook/skill) behavioral-contract procedures, layered on top of the existing existence checks (not a replacement)
+- Existence vs behavior is now surfaced distinctly: SKILL.md step 6b, the Happy Path table gains a `Behavior verified?` column, and the lead synthesis splits into Existence / Behavioral Contract tables
+- Closed-source/no-contract fallback applies a taint stance; chained-object rule traces every property/method on a returned object
+- JSON schema 1.0 → 1.1 (additive): optional `behavior_verified`, summary `behaviors_verified`, new `tool-reference-behavior` category
+
+**0.9.0** — effort-adaptive depth + hygiene
 - `${CLAUDE_EFFORT}` honored as a floor across `/paper-test` (scenario depth) and `/code-paper:test-team` (per-teammate effort)
 - SKILL.md conciseness pass — workflow detail extracted to `references/workflow.md`
 - `teammateDefaultModel` / `teammateMode` documentation for `/test-team`

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -90,7 +90,7 @@ Or use it explicitly:
 For complex or security-critical code, use the agent team command:
 
 ```
-/code-paper:test-team src/Service/PaymentService.php
+/code-paper-test:test-team src/Service/PaymentService.php
 ```
 
 Spawns 3 competing testers — Happy Path Validator, Edge Case Hunter, and Red Team Attacker — who independently analyze the code in isolated worktrees and then debate findings. Each tester has a 15-turn limit for cost control.
@@ -98,7 +98,7 @@ Spawns 3 competing testers — Happy Path Validator, Edge Case Hunter, and Red T
 Also works with skills and configs:
 
 ```
-/code-paper:test-team skills/paper-test/SKILL.md
+/code-paper-test:test-team skills/paper-test/SKILL.md
 ```
 
 Auto-detects skill files and switches to instruction tracing mode.
@@ -112,7 +112,7 @@ honest about cost in CI and smoke runs:
   path plus one error case, `medium` traces two per phase, `high`/`xhigh`/`max`
   go to full edge and adversarial coverage. Effort never lowers the
   verification bar — every external call is still verified.
-- **`/code-paper:test-team`** treats caller effort as a **floor-raiser**: each
+- **`/code-paper-test:test-team`** treats caller effort as a **floor-raiser**: each
   teammate runs at `max(caller effort, role floor)`. Role floors are `medium`
   for the Happy Path Validator and `high` for the Edge Case Hunter and Red Team
   Attacker — so the adversarial lenses are never cheapened, and a caller at
@@ -120,7 +120,7 @@ honest about cost in CI and smoke runs:
 
 ### Teammate model configuration
 
-`/code-paper:test-team` spawn prompts set `Model: sonnet` per teammate. If you
+`/code-paper-test:test-team` spawn prompts set `Model: sonnet` per teammate. If you
 prefer a single setting, set `teammateDefaultModel` in `settings.json` (e.g.
 `"sonnet"`, or `null` to inherit the lead's `/model`) — it applies to any
 teammate whose spawn prompt doesn't name a model. `teammateMode` (`auto` /
@@ -285,7 +285,7 @@ Specific checks for AI-generated code:
 - JSON schema 1.0 → 1.1 (additive): optional `behavior_verified`, summary `behaviors_verified`, new `tool-reference-behavior` category
 
 **0.9.0** — effort-adaptive depth + hygiene
-- `${CLAUDE_EFFORT}` honored as a floor across `/paper-test` (scenario depth) and `/code-paper:test-team` (per-teammate effort)
+- `${CLAUDE_EFFORT}` honored as a floor across `/paper-test` (scenario depth) and `/code-paper-test:test-team` (per-teammate effort)
 - SKILL.md conciseness pass — workflow detail extracted to `references/workflow.md`
 - `teammateDefaultModel` / `teammateMode` documentation for `/test-team`
 - Plugin-root conventions file, manifest `$schema`, exec-form hook

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -177,6 +177,13 @@ Trace the code with ideal inputs and document expected behavior. Your lens: "Doe
 5. For EVERY external call (methods, services, APIs):
    - Use Read tool to verify method exists and check signature
    - DO NOT assume — read actual source or mark as UNVERIFIED RISK
+5b. **Behavioral verification** — for each dependency confirmed to exist in step 5, run the B1 procedure:
+   - Enumerate every assumption the CALLER makes about the return: fields accessed, assumed type (required vs optional), null-checked?, error modes handled, side effects relied on.
+   - Locate the declared contract in priority order: type stub (.d.ts / .pyi / typeshed) → OpenAPI `responses` for the endpoint+status → official method docs → `@returns` / docblock → changelog as observed-behavior proxy.
+   - Extract declared outputs (required vs optional, nullable, exact types, documented errors).
+   - DIFF caller assumption vs declared: field declared? required not optional? type matches? nullable but unchecked? error mode handled? Each miss = flagged behavioral gap.
+   - **Chained-object rule:** when a call returns an object, trace EVERY property/method the caller invokes on it and verify each against the contract. Do not stop at the first return type.
+   - **Closed-source fallback:** mark "postcondition unknown — EXISTENCE VERIFIED / BEHAVIOR UNVERIFIED"; apply taint stance (assume return could be null/hostile/malformed — does code fail safely?); require a validation wrapper; flag as behavioral gap if none exists.
 6. For code contracts (extends, implements, uses, injects):
    - Read parent/base classes and interfaces
    - Verify all abstract methods implemented, signatures match
@@ -217,8 +224,8 @@ OUTPUT: {return value, side effects}
 ```
 
 ## Dependency Verification
-| # | External Call | File | Method Exists? | Signature Correct? | Issue |
-|---|-------------|------|----------------|-------------------|-------|
+| # | External Call | File | Exists? | Behavior verified? | Contract source | Issue |
+|---|-------------|------|---------|-------------------|----------------|-------|
 
 ## Contract Verification
 | # | Relationship | Base/Interface | Verified? | Issue |
@@ -240,6 +247,8 @@ If target files are skills, commands, or agents (.md with frontmatter):
 - Design 2-3 scenarios with different user messages
 - Trace what Claude would do at each step
 - Verify all tool/file/skill references exist
+- Verify each referenced capability PRODUCES what the calling step consumes — run the B2 procedure:
+  Enumerate what the calling step assumes the capability produces (fields, types, success handling). Locate the capability's declared output: MCP tool output schema, SKILL.md declared outputs, hook event payload schema. DIFF assumptions vs declaration. False-confidence check: does the gate verify production or only existence? If existence only, flag behavioral gap.
 - Check frontmatter completeness and consistency
 - Test trigger phrases (will Claude invoke this?)
 
@@ -477,9 +486,13 @@ Source files: [happy-path-analysis.md] | [edge-case-analysis.md] | [red-team-ana
 | # | Flaw | Claimed By | Disputed By | Resolution |
 |---|------|-----------|-------------|------------|
 
-## Dependency Verification
-| # | External Call | Verified? | Issue |
-|---|-------------|-----------|-------|
+## Existence Verification
+| # | External Call | Exists? | Issue |
+|---|-------------|---------|-------|
+
+## Behavioral Contract Verification
+| # | External Call | Behavior verified? | Contract source | Gap |
+|---|-------------|-------------------|----------------|-----|
 
 ## Contract Verification
 | # | Relationship | Verified? | Issue |

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -11,7 +11,7 @@ Paper test code from 3 competing perspectives using an agent team. A Happy Path 
 ## Usage
 
 ```
-/code-paper:test-team [--json] <file-path> [file-path...]
+/code-paper-test:test-team [--json] <file-path> [file-path...]
 ```
 
 Pass `--json` to emit a CI-consumable JSON report alongside the markdown report. Schema: `skills/paper-test/references/json-output-schema.md` (`schema_version: "1.0"`).
@@ -38,7 +38,7 @@ Verify each file exists using the Read tool.
 If no arguments provided:
 > What code should the team test? Provide one or more file paths:
 > ```
-> /code-paper:test-team src/Service/PaymentService.php
+> /code-paper-test:test-team src/Service/PaymentService.php
 > ```
 
 If a file doesn't exist:

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -2,7 +2,7 @@
 name: paper-test
 description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "test this agent", "validate this implementation", "review this logic", "check dependencies", "check this config", "walk through this code", "step through this", "dry run", "sanity check", "red team this", "poke holes in this". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
 version: 0.10.0
-model: sonnet
+model: inherit
 allowed-tools: Read, Glob, Grep, Bash
 user-invocable: true
 ---
@@ -17,8 +17,8 @@ Systematically test code by mentally executing it line-by-line with concrete val
 |-------------|----------|-----|
 | **< 50 lines** | Quick trace (workflow below) | Fast, inline, sufficient for small code |
 | **50–300 lines** | Structured 3-phase | One agent, all 3 perspectives, sequential — thorough without coordination overhead |
-| **300+ lines or security-critical** | `/code-paper:test-team` (3 agents) | Context pressure justifies splitting. Cross-challenge debate catches what one agent misses. |
-| **Skill/command/agent files** | `/code-paper:test-team` | Different lenses genuinely find different things for instruction-based testing |
+| **300+ lines or security-critical** | `/code-paper-test:test-team` (3 agents) | Context pressure justifies splitting. Cross-challenge debate catches what one agent misses. |
+| **Skill/command/agent files** | `/code-paper-test:test-team` | Different lenses genuinely find different things for instruction-based testing |
 
 If the user asks for "paper test" without specifying, read the target files, count lines, and recommend the appropriate approach. For 50–300 lines, use Structured 3-Phase mode. Only recommend `/test-team` for 300+ lines, explicit "test team" requests, or security-critical code.
 
@@ -100,7 +100,7 @@ A method existing is not it returning what you assume. Existence verification is
 
 For CI integration, aggregation, or programmatic consumption, invoke with `--json` to emit a stable, versioned JSON document instead of the markdown report.
 
-- Available on `/paper-test` (quick and structured-3-phase modes) and `/code-paper:test-team` (lead synthesis).
+- Available on `/paper-test` (quick and structured-3-phase modes) and `/code-paper-test:test-team` (lead synthesis).
 - Schema is pinned at `schema_version: "1.0"` with an additive-only minor-version contract. CI should pin `^1\.`, not exact match.
 - Severity values match the existing rubric exactly: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`.
 - `findings` is always an array — `[]` when clean, never `null` or omitted.
@@ -110,7 +110,7 @@ For CI integration, aggregation, or programmatic consumption, invoke with `--jso
 
 ```
 /paper-test --json src/Service/UserService.php
-/code-paper:test-team --json src/Service/PaymentService.php
+/code-paper-test:test-team --json src/Service/PaymentService.php
 ```
 
 ## Pairing with `skill-quality-reviewer` for Skill Testing

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-test
 description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "test this agent", "validate this implementation", "review this logic", "check dependencies", "check this config", "walk through this code", "step through this", "dry run", "sanity check", "red team this", "poke holes in this". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
-version: 0.9.0
+version: 0.10.0
 model: sonnet
 allowed-tools: Read, Glob, Grep, Bash
 user-invocable: true
@@ -76,6 +76,7 @@ Trace the target with concrete values. The 8-step workflow:
 4. **Follow every branch** — note which branch each conditional takes and why
 5. **Track loop iterations** — trace each iteration with index and values
 6. **Verify external dependencies** — for EVERY external call, Read/Grep the actual source; never assume
+6b. **Verify behavioral contracts** — for every dependency confirmed to exist, enumerate caller assumptions about the return and diff against the declared contract. Procedures: `references/behavioral-verification.md` §B1 (code/library calls) and §B2 (plugin/MCP/hook/skill references). Closed-source fallback: apply taint stance; flag as behavioral gap if no validation wrapper exists. Chained-object rule: trace every property/method invoked on the return object, not just the return type.
 7. **Verify code contracts** — extends/implements/uses/injects — all abstract methods, signatures, services
 8. **Note output and flaws** — return value, side effects, state changes; then **untested path analysis** (branches never exercised)
 
@@ -92,6 +93,8 @@ rather than assuming it works. This is the single highest-value discipline of
 paper testing, especially for AI-generated code. Procedures: `references/workflow.md`
 (verification section), `references/dependency-verification.md`,
 `references/contract-patterns.md`.
+
+A method existing is not it returning what you assume. Existence verification is the first pass; behavioral verification is the second: locate the declared contract (type stub → OpenAPI → docs → docblock), enumerate every assumption the caller makes about the return, and diff. For closed-source targets with no contract: apply the taint stance — assume the return could be null, hostile, or malformed. See `references/behavioral-verification.md`.
 
 ## JSON Output Mode (`--json`)
 
@@ -112,7 +115,7 @@ For CI integration, aggregation, or programmatic consumption, invoke with `--jso
 
 ## Pairing with `skill-quality-reviewer` for Skill Testing
 
-When paper-testing a skill, command, or agent file, run `plugin-creation-tools:skill-quality-reviewer` first (deterministic: stale SDK refs, dropped imperatives, frontmatter gaps) then paper-test for the semantic analysis (instruction fidelity, trigger coverage, context budget). See `references/skill-and-config-testing.md` §"Deterministic + Agentic pairing".
+When paper-testing a skill, command, or agent file, run `plugin-creation-tools:skill-quality-reviewer` first (deterministic: stale SDK refs, dropped imperatives, frontmatter gaps) then paper-test for the semantic analysis (instruction fidelity, trigger coverage, context budget). See `references/skill-and-config-testing.md` §"Deterministic + Agentic pairing". In skill-mode, after verifying tool/file/skill references exist, verify each referenced capability PRODUCES what the calling step consumes — see `references/behavioral-verification.md` §B2.
 
 ## References
 
@@ -133,3 +136,4 @@ All detailed guides are in the `references/` directory:
 - `references/rubric-scoring.md` — structured grading for code quality assessment
 - `references/skill-and-config-testing.md` — testing skills, commands, agents, and configs
 - `references/json-output-schema.md` — stable JSON schema for `--json` mode (CI integration)
+- `references/behavioral-verification.md` — B1 (code/library behavioral contracts) and B2 (plugin/MCP/hook/skill output contracts)

--- a/code-paper-test/skills/paper-test/references/ai-code-auditing.md
+++ b/code-paper-test/skills/paper-test/references/ai-code-auditing.md
@@ -6,7 +6,7 @@ AI (LLMs) generates code based on patterns, not actual knowledge of your codebas
 
 ## Forked subagents (experimental upstream)
 
-Paper-test team mode (`/code-paper:test-team`) currently spawns 3 agents in fresh contexts. Claude Code 2.1.117+ ships **forked subagents** as an experimental opt-in (`CLAUDE_CODE_FORK_SUBAGENT=1`) — a subagent that inherits the full conversation history (system prompt, tools, model, messages) instead of starting fresh. For paper-test, this is a strong fit: the Happy Path Validator, Edge Case Hunter, and Red Team Attacker all benefit from the same loaded codebase context (the target file's dependencies, config, and contracts) without each one re-reading them.
+Paper-test team mode (`/code-paper-test:test-team`) currently spawns 3 agents in fresh contexts. Claude Code 2.1.117+ ships **forked subagents** as an experimental opt-in (`CLAUDE_CODE_FORK_SUBAGENT=1`) — a subagent that inherits the full conversation history (system prompt, tools, model, messages) instead of starting fresh. For paper-test, this is a strong fit: the Happy Path Validator, Edge Case Hunter, and Red Team Attacker all benefit from the same loaded codebase context (the target file's dependencies, config, and contracts) without each one re-reading them.
 
 **Why not enabled by default in v0.8.0:**
 - Experimental upstream — schema and behavior may shift before stable.

--- a/code-paper-test/skills/paper-test/references/behavioral-verification.md
+++ b/code-paper-test/skills/paper-test/references/behavioral-verification.md
@@ -1,0 +1,89 @@
+# Behavioral Contract Verification
+
+The second pass after existence verification: confirm the call produces what the caller assumes.
+
+## Why existence is not enough
+
+A method existing and resolving is zero evidence it behaves as assumed. The caller makes assumptions about every field it accesses, every type it coerces, every error mode it handles (or doesn't). Existence verification catches AI hallucinations of method names. Behavioral verification catches the larger category: wrong assumptions about what the method produces.
+
+Cross-discipline grounding: consumer-driven contract testing (Pact), Design-by-Contract postconditions, OpenAPI response validation, and security taint analysis all share the same unifying principle — *demand a declared contract as the minimum evidence; treat anything without a verified contract as untrusted.*
+
+---
+
+## B1 — Code / Library Calls
+
+Run after existence verification for every external call.
+
+**Step 1.** Enumerate every assumption the CALLER makes about the return:
+- Fields accessed on the return value (e.g., `$response->status`, `result['id']`)
+- Assumed type of each field (string? int? object? array?)
+- Presence assumption: required (always present) vs optional (may be absent)
+- Value shape: non-empty? in a specific enum? within a numeric range?
+- Null-checked? (`if ($result !== null)` before access — or not?)
+- Error / exception modes: does the caller handle exceptions? wrap in try/catch? check return for error sentinel?
+- Side effects the caller relies on (cache warm, DB write, email sent)
+
+**Step 2.** Locate the declared contract, in priority order:
+1. Type stub (`.d.ts` / `.pyi` / typeshed) — the strongest machine-verifiable contract
+2. OpenAPI `responses` object for the endpoint + status code being consumed
+3. Official method docs / SDK reference
+4. `@returns` / `@throws` docblock in the source
+5. Changelog or release notes as an observed-behavior proxy (weakest; note when used)
+
+**Step 3.** Extract declared output:
+- Required vs optional fields (use `?` / `nullable` / `Optional[T]` markers)
+- Exact types for each field
+- Documented exceptions and when they are thrown
+- Documented error sentinels (returns `false`, `null`, empty array on failure)
+
+**Step 4.** DIFF caller assumption vs declared contract — flag each miss:
+- Field accessed but NOT declared → behavioral gap
+- Field declared optional but accessed without null check → behavioral gap
+- Type assumed as non-null but declared nullable → behavioral gap
+- Error mode handled differently from what docs declare → behavioral gap
+- Exception documented as thrown but no try/catch in caller → behavioral gap
+
+**Step 5. Chained-object rule.** When a call returns an object, trace EVERY property and method the caller invokes on it and verify each against the contract. Do not stop at the first return type. Example: `$response->getBody()->getContents()` — verify `getBody()` return type, then verify `getContents()` on THAT type. Each link in the chain is a separate behavioral assumption.
+
+**Step 6. Closed-source / no-contract fallback.**
+- Mark: "postcondition unknown — behavioral contract unverified."
+- Apply the **TAINT STANCE**: assume the return could be null, hostile, or malformed. Ask: does the code fail safely if the return is null? An empty array? An unexpected object? If no validation wrapper exists, the answer is usually no.
+- Require a validation wrapper before the return is consumed.
+- Flag the dependency as a **behavioral gap** if no wrapper exists.
+- Use this label: `EXISTENCE VERIFIED / BEHAVIOR UNVERIFIED — taint stance applied`.
+
+---
+
+## B2 — Plugin / MCP / Hook / Skill References
+
+Run in skill-mode (when the target is a skill, command, agent, or config file).
+
+**Step 1.** Enumerate what the calling plugin assumes the capability PRODUCES:
+- Output fields the calling step reads from the capability's response
+- Types assumed for each field
+- Success-vs-failure handling: does the calling step check whether the capability succeeded?
+- Assumed side effects (file written, DB updated, message sent)
+
+**Step 2.** Locate the capability's declared output contract, in priority order:
+1. MCP tool `inputSchema` + declared output (read `.mcp.json` for the server + tool definition)
+2. Referenced SKILL.md: check `description`, output format sections, declared return behavior
+3. Agent `description` field in the agent definition file
+4. Hook event payload schema (check `hooks.json` + any referenced hook documentation)
+
+**Step 3.** Extract declared outputs from the contract source.
+
+**Step 4.** DIFF caller assumption vs declaration (same checks as B1 step 4):
+- Field consumed but not declared in capability output → behavioral gap
+- Capability declared as potentially returning nothing (no match, empty) but calling step doesn't handle that case → behavioral gap
+- Type mismatch between declared output and caller's assumed input type → behavioral gap
+
+**Step 5. False-confidence check.**
+- Does the calling step verify the capability PRODUCES the expected output, or only that the reference RESOLVES?
+- A check like "skill exists in the plugin" is an existence gate, not a behavioral gate.
+- Also check: cross-plugin skill resolution (is the skill installed?) and MCP server configuration existence (`.mcp.json` present with the server configured?).
+- Flag any gate that checks availability only.
+
+**Step 6. No-contract fallback.**
+- Mark: "capability drift risk — behavioral conformance unverified."
+- The capability could silently change its output format without the calling plugin knowing.
+- Flag as a behavioral gap.

--- a/code-paper-test/skills/paper-test/references/dependency-verification.md
+++ b/code-paper-test/skills/paper-test/references/dependency-verification.md
@@ -60,15 +60,16 @@ Line 15: $user = $userService->loadByEmail($email);
          → VERIFIED: Safe to assume User|null
 ```
 
-### Option 3: Mark as Unknown Risk
+### **Option 3: Closed-Source / No-Contract — Taint Stance**
 
-If you can't verify, flag it as a potential flaw source.
+If source and docs are unavailable:
 
-```php
-Line 15: $user = $userService->loadByEmail($email);
-         → UNKNOWN: Need to verify return type when not found
-         → RISK: Line 16 assumes $user is object, might be null
-```
+- Mark: `EXISTENCE VERIFIED / BEHAVIOR UNVERIFIED — taint stance applied`
+- Apply the **taint stance**: assume the return could be null, hostile, or malformed. Ask: does the code fail safely if the return is null? An empty array? An unexpected object? Check whether a validation wrapper exists between the return and the consuming code.
+- If no validation wrapper exists, flag the dependency as a **behavioral gap** (not just an unknown risk — the code actively trusts an unverifiable return).
+- Require: add a validation wrapper before trusting the return.
+
+The "UNVERIFIED RISK" label is preserved for the existence layer (method might not exist). Use "BEHAVIOR UNVERIFIED" as the distinct label for the behavioral layer (method exists but output contract unknown).
 
 ---
 
@@ -176,6 +177,32 @@ VERIFIED BEHAVIOR:
   - Empty array: when no results
   - Throws: HttpException on failure
 ```
+
+---
+
+## Chained-Object Rule
+
+When a call returns an object, trace EVERY property and method the caller invokes on that object and verify each one against the declared contract. Do not stop at the first return type.
+
+Example: `$client->request('GET', $url)->getBody()->getContents()`
+
+```
+DEPENDENCY CHECK: HttpClient::request()
+  Returns: Psr\Http\Message\ResponseInterface
+  Verified: YES (PSR-7 type stub)
+
+CHAINED: ResponseInterface::getBody()
+  Returns: Psr\Http\Message\StreamInterface
+  Verified: YES (PSR-7 type stub)
+
+CHAINED: StreamInterface::getContents()
+  Returns: string
+  Verified: YES
+  Behavioral assumption: string is valid JSON → NOT declared — behavioral gap
+  Caller does: json_decode($contents) with no error check → behavioral gap
+```
+
+Each link in the chain is a separate behavioral assumption. An unchecked assumption on the third link is as dangerous as one on the first.
 
 ---
 

--- a/code-paper-test/skills/paper-test/references/fork-vs-fresh.md
+++ b/code-paper-test/skills/paper-test/references/fork-vs-fresh.md
@@ -1,6 +1,6 @@
 # Decision: Forked vs Fresh Subagents for `/test-team`
 
-**Decision:** `/code-paper:test-team` spawns its three testers in **fresh
+**Decision:** `/code-paper-test:test-team` spawns its three testers in **fresh
 contexts**. This is the default and the recommended posture. Forked subagents
 are a documented opt-in, not the default.
 
@@ -47,7 +47,7 @@ or behavior changes.
 If you have a specific reason to fork (e.g. a very large target where three
 independent reads are prohibitively expensive, and you accept the weaker
 debate), set `CLAUDE_CODE_FORK_SUBAGENT=1` in the environment before invoking
-`/code-paper:test-team`. The command itself is unchanged — the env var is read
+`/code-paper-test:test-team`. The command itself is unchanged — the env var is read
 by Claude Code, not the plugin. Treat the resulting report's "Disputed
 Findings" and "Blind Spots" sections with extra skepticism: shared context
 makes unanimous agreement less meaningful.

--- a/code-paper-test/skills/paper-test/references/json-output-schema.md
+++ b/code-paper-test/skills/paper-test/references/json-output-schema.md
@@ -1,6 +1,6 @@
 # JSON Output Schema (`--json` mode)
 
-Stable, versioned schema for CI integration, aggregation, and programmatic consumption. Emitted by `/paper-test --json <file>` and `/code-paper:test-team --json <file>`.
+Stable, versioned schema for CI integration, aggregation, and programmatic consumption. Emitted by `/paper-test --json <file>` and `/code-paper-test:test-team --json <file>`.
 
 Shape follows the camoa-skills ecosystem convention established by `code-quality-tools/skills/code-quality-audit/references/json-schemas.md` — the same envelope fields (`schema_version`, `timestamp`, `target`, `status`, `summary`, `findings`) so downstream tooling can treat reports from both plugins uniformly.
 
@@ -125,7 +125,7 @@ Example for a passing trace with one low-severity finding:
 }
 ```
 
-## `/code-paper:test-team --json` output
+## `/code-paper-test:test-team --json` output
 
 Test-team mode emits the common envelope PLUS a `team` section holding per-teammate breakdowns and the cross-challenge debate outcome. Write location: `{target_dir}/paper-test-team-report.json` (sibling to the existing `paper-test-team-report.md`). Each teammate also writes `{role}-analysis.json` in `{target_dir}` so the lead can aggregate without re-parsing markdown.
 

--- a/code-paper-test/skills/paper-test/references/json-output-schema.md
+++ b/code-paper-test/skills/paper-test/references/json-output-schema.md
@@ -14,6 +14,9 @@ Shape follows the camoa-skills ecosystem convention established by `code-quality
    > ```bash
    > echo "$result" | jq -e '.schema_version | test("^1\\.")' >/dev/null || exit 1
    > ```
+
+   **v1.1 (this release):** Added optional `behavior_verified` boolean on dependency-type findings; added `behaviors_verified` to the summary envelope; added `tool-reference-behavior` category. All changes are additive. CI gates pinning `^1\.` are unaffected.
+
 4. **String fields are JSON-escaped.** Newlines, quotes, and backslashes in `title`, `description`, `fix_suggestion`, and file excerpts must not corrupt the document. Validate with `echo "$OUTPUT" | jq .` before trusting it in a gate.
 5. **Severity values match the existing rubric exactly** — `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO` (uppercase). Do not introduce new terms. See `severity-scoring.md`.
 
@@ -23,7 +26,7 @@ All paper-test JSON reports share this shape:
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "tool": "paper-test | test-team",
   "mode": "quick | structured-3-phase | test-team",
   "target_type": "code | skill | config",
@@ -39,6 +42,7 @@ All paper-test JSON reports share this shape:
     "total_findings": 0,
     "scenarios_traced": 0,
     "dependencies_verified": 0,
+    "behaviors_verified": 0,
     "contracts_verified": 0
   },
   "findings": []
@@ -64,7 +68,8 @@ Every entry in `findings[]`:
     "impact": 3,
     "reversibility": 3,
     "exploitability": 3
-  }
+  },
+  "behavior_verified": false
 }
 ```
 
@@ -75,6 +80,7 @@ Every entry in `findings[]`:
 - **`line_end`** — equals `line_start` for single-line findings. Always present.
 - **`fix_suggestion`** — one-line actionable fix. May include code snippets (remember invariant 4).
 - **`scoring_factors`** — all four keys required (`reach`, `impact`, `reversibility`, `exploitability`), each `1`, `2`, or `3`. Omit the object only for `INFO` findings where scoring doesn't apply.
+- **`behavior_verified`** — optional boolean. Present (and `false`) on findings of category `dependency-verification` or `tool-reference-behavior` when behavioral contract was not checked. Present and `true` when the behavioral contract was located and diffed with no gap. Absent on all other finding categories.
 
 ## `/paper-test --json` output
 
@@ -84,7 +90,7 @@ Example for a passing trace with one low-severity finding:
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "tool": "paper-test",
   "mode": "structured-3-phase",
   "target_type": "code",
@@ -100,6 +106,7 @@ Example for a passing trace with one low-severity finding:
     "total_findings": 1,
     "scenarios_traced": 7,
     "dependencies_verified": 4,
+    "behaviors_verified": 0,
     "contracts_verified": 2
   },
   "findings": [
@@ -126,7 +133,7 @@ The example below shows the shape only — the individual counts (`confirmed_by_
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "tool": "test-team",
   "mode": "test-team",
   "target_type": "code",
@@ -142,6 +149,7 @@ The example below shows the shape only — the individual counts (`confirmed_by_
     "total_findings": 10,
     "scenarios_traced": 18,
     "dependencies_verified": 7,
+    "behaviors_verified": 0,
     "contracts_verified": 3
   },
   "team": {
@@ -203,6 +211,7 @@ When `target_type` is `"skill"` or `"config"`, `findings[].category` uses instru
 - `frontmatter-verification` — declared `allowed-tools` / `model` / `description` match the body's actual tool use and claims.
 - `context-budget` — instruction/reference size vs. likely context window at invocation time.
 - `tool-reference-existence` — does every tool, file, skill, or agent named in the body actually exist?
+- `tool-reference-behavior` — Does each referenced capability PRODUCE what the calling step consumes? Behavioral contract check for MCP output schemas, SKILL.md declared outputs, hook event payloads (§B2 in `behavioral-verification.md`)
 - `dependency-verification` — for configs, do the keys the consuming code reads actually exist and have the expected types?
 
 Example skill finding:

--- a/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
+++ b/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
@@ -20,7 +20,7 @@ Use the plugin-creation-tools:skill-quality-reviewer agent on <skill/command/age
 # Step 2 — semantic pass
 /paper-test <skill/command/agent file>
 # or for skills ≥ 300 lines or agent definitions:
-/code-paper:test-team <skill/command/agent file>
+/code-paper-test:test-team <skill/command/agent file>
 ```
 
 The reviewer typically clears within a single turn; paper-test then focuses on the harder semantic problems it cannot detect. Skipping step 1 means paper-test wastes effort flagging things a grep could have caught.

--- a/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
+++ b/code-paper-test/skills/paper-test/references/skill-and-config-testing.md
@@ -331,6 +331,39 @@ ROUTING CHECK (routing.yml):
 
 ---
 
+## 8. Behavioral Output Verification (B2)
+
+For every capability reference (skill, MCP tool, agent, hook) found during existence verification in §3 / §5:
+
+```
+BEHAVIORAL CHECK: [capability name / skill / MCP tool]
+
+STEP 1 — Caller assumptions:
+  Calling step N reads: [field names from the capability's output]
+  Assumed types: [string? array? object?]
+  Success handling: [does the calling step check for failure?]
+  Assumed side effects: [file written? DB updated?]
+
+STEP 2 — Declared output contract:
+  Source: [MCP inputSchema / SKILL.md description / agent description / hook payload]
+  Declared outputs: [fields, types, optional vs required]
+
+STEP 3 — DIFF:
+  Field consumed but not declared: [YES/NO → if YES, behavioral gap]
+  Optional field accessed without null check: [YES/NO → if YES, behavioral gap]
+  Type mismatch: [YES/NO → if YES, behavioral gap]
+  Failure case handled: [YES/NO → if NO, behavioral gap]
+
+FALSE-CONFIDENCE CHECK:
+  Caller gate checks: [existence only / behavioral / both]
+  If existence only: flag as behavioral gap
+
+NO-CONTRACT FALLBACK:
+  If no declared output found: "CAPABILITY DRIFT RISK — behavioral conformance unverified"
+```
+
+---
+
 ## Quick Reference: Code vs Skill Testing
 
 | What You're Testing | Trace Method | Key Checks |
@@ -400,6 +433,7 @@ When paper-testing a skill/command/agent/config with `--json`, the schema's `tar
 | `frontmatter-verification` | `allowed-tools` / `model` / `description` match the body's actual claims (§3) |
 | `context-budget` | Skill + references vs. likely window size at invocation (§5) |
 | `tool-reference-existence` | Does every tool, file, skill, or agent named in the body exist? (§4) |
+| `tool-reference-behavior` | Does the referenced capability PRODUCE what the calling step consumes? Checks MCP output schema, SKILL.md declared outputs, hook payload shape (§8 above) |
 | `dependency-verification` | For configs: do keys the consuming code reads exist with expected types? |
 
 Severity stays on the same `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO` rubric. Full schema: `references/json-output-schema.md`.


### PR DESCRIPTION
## Summary

Adds **behavioral contract verification** — the second pass after existence verification — to code-paper-test, layered **on top of** (never replacing) the existing existence-verification discipline.

**Diagnosis:** the plugin verified that external calls *exist* (signature/existence: strong) but conflated "the call resolves" with "the call produces what the caller assumes." Behavioral verification was **partial for code (B1)** — the right questions lived in `dependency-verification.md` but were not enforced in the `/test-team` spawn prompts, the closed-source fallback applied an existence stance rather than a taint stance, and chained-object tracing was absent — and **absent for plugin/MCP/hook/skill targets (B2)**, where skill-mode only verified that references resolve. The lead synthesis report's single `Verified?` column was a false-confidence trap.

## Changes (behavioral verification)
- **NEW** `references/behavioral-verification.md` — canonical **B1** (code/library) and **B2** (plugin/MCP/hook/skill) procedures.
- `SKILL.md` — workflow step **6b**; existence-vs-behavior distinction in *Critical: Never Assume*; skill-mode B2 note; new reference listed.
- `references/dependency-verification.md` — Option 3 renamed to **taint stance**; new **Chained-Object Rule** section; `UNVERIFIED RISK` (existence) vs `BEHAVIOR UNVERIFIED` (behavioral) labels kept distinct.
- `references/skill-and-config-testing.md` — new **§8 Behavioral Output Verification (B2)**; `tool-reference-behavior` category row.
- `commands/test-team.md` — Happy Path spawn gains behavioral **step 5b** (B1) + skill-mode B2 check; Happy Path table gains `Behavior verified?`/`Contract source`; lead synthesis splits into **Existence Verification** + **Behavioral Contract Verification** tables.
- `references/json-output-schema.md` — schema **1.0 → 1.1 (additive only)**: `behavior_verified` finding field, `behaviors_verified` summary count, `tool-reference-behavior` category. CI gates pinning `^1\.` unaffected.

## Pre-existing defects also fixed in this PR
1. **Slash-command namespace corrected everywhere.** 21 references used `/code-paper:test-team`, but the plugin name is `code-paper-test`, so the command resolves as **`/code-paper-test:test-team`** — every documented invocation previously pointed at a non-existent command. Corrected across `SKILL.md` (incl. routing table + `--json` examples), `commands/test-team.md`, `README.md`, `CHANGELOG.md`, and four `references/*.md` (0 wrong refs remain, 21 now correct).
2. **S14 (BUG-1):** `skills/paper-test/SKILL.md` frontmatter `model: sonnet` → **`model: inherit`**. The skill runs inline with no context isolation, so a pinned sub-1M model overflows when activated from a large conversation. The `**Model:** sonnet` markers in `commands/test-team.md` are fresh-context agent spawns and are intentionally unchanged.

> Note: the rollout originally scoped S14 to v0.11.0; pulled forward here at reviewer request. The v0.11.0 work (Synthesizer teammate, `disallowed-tools`, `--strict` in CONVENTIONS, security-guidance positioning) remains for its own release; its S14 task is now a no-op.

## Deviation from the rollout (surfaced, not silently reconciled)
The rollout's lead-synthesis split named the new behavioral table `## Contract Verification`, but that heading **already existed** in the synthesis section (the relational `Relationship | Verified? | Issue` table). To avoid two identical headings, the new behavioral table was renamed **`## Behavioral Contract Verification`** and the pre-existing relational `## Contract Verification` left unchanged (also keeping it consistent with the Happy Path output's relational table name).

## Self-tests (Task 7)
- **B1** (Stripe/PSR-7 chained call): flagged **6** behavioral gaps an existence-only pass would have returned clean (bar: ≥1).
- **B2** (skill assuming a `guides` array from dev-guides-navigator): produced **3** `tool-reference-behavior` findings after reading the navigator's actual SKILL.md, which declares no `guides` field in any mode (bar: ≥1).
- All six `json` blocks in `json-output-schema.md` validate with `jq` after the 1.1 edits.

## Validation
`/plugin-creation-tools:validate code-paper-test --strict` → **PASS** (zero errors, zero warnings on a clean re-run; S14 cleared, X02 description-length within cap, marketplace entry version matches).

## Scope / housekeeping
- Branch merged up to current `main` (includes #214 / ai-dev-assistant 5.8.0); catalog `metadata.version` bumped to **2.0.2** (resolving the 2.0.1 collision #214 introduced).
- Metadata synced across plugin.json (0.10.0), SKILL.md, marketplace entry (0.10.0), CHANGELOG, and README.
- Existence-verification language untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)