### PR TITLE
fix(ai-dev-assistant 5.10.3): actually wire the VR before/after Slider

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.5"
+    "version": "2.0.6"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.10.2",
+      "version": "5.10.3",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.10.3] - 2026-06-16
+
+**Fix: the VR slider documented in 5.10.2 never appeared — no path emitted Playwright's `html` report, so `show-report` had nothing to open.**
+
+5.10.2 documented that `npx playwright show-report` shows Playwright's before/after **Slider** at the diff-classification pause. It didn't, as shipped, on **either** path:
+1. The VR **gate** (`scripts/visual-regression-gate.sh`) ran `npx playwright test --reporter=json`. A CLI `--reporter` **replaces** the config reporter (it does not merge), so only the json reporter ran — no `playwright-report/` was produced by the gate, which is the run that immediately precedes the "open the slider" ask.
+2. The config template set `reporter: process.env.CI ? 'github' : 'list'` — no `html` reporter — so CI and manual `npx playwright test` runs produced no report either.
+
+The Slider is a real Playwright feature (HTML report image-diff view, rendered from the expected/actual/diff attachments a **failed** `toHaveScreenshot` writes); our wiring just never emitted the report that hosts it. Caught in red-team by verifying the gate's actual invocation against the Playwright reporter docs — not by trusting the config change.
+
+### Fixed
+- `scripts/visual-regression-gate.sh` — the gate now runs `npx playwright test --reporter=json,html` with `PLAYWRIGHT_JSON_OUTPUT_NAME` routing the JSON to a temp file (so the html reporter's stdout can't corrupt the parse) and `PLAYWRIGHT_HTML_OPEN=never` (so the html reporter doesn't auto-launch a browser on the failing-screenshot case). **This is the primary fix** — it makes `playwright-report/` exist on the gate path, so the on-demand "open the slider" ask and `--show-diffs` actually render Playwright's **Slider**.
+- `references/visual-review/playwright-base.config.ts` — the config reporter now also includes `html` (`open: 'never'`) alongside the console reporter, covering **CI and manual** runs (which don't pass `--reporter`): `process.env.CI ? [['github'],['html',{open:'never'}]] : [['list'],['html',{open:'never'}]]`. This also fixes a latent CI gap — the GitHub workflow uploads `playwright-report/`, but with the `github`-only reporter that artifact was empty.
+- `playwright-report/` is already gitignored (setup Step 7b) — no gitignore change needed.
+- Docs corrected to match reality on both paths: `commands/validate-visual-regression.md` Step 9 + Step 12, `references/visual-regression-walkthrough.md` §7. The view is named accurately as Playwright's **Slider**, scoped to surfaces that failed `toHaveScreenshot`.
+
+### Migration (existing VR setups)
+The gate-script fix is delivered by the plugin, so existing projects get the slider on the gate path automatically once on 5.10.3. To also get the report from **CI / manual** `npx playwright test` runs, add the `html` reporter to that project's own `playwright.config.*` (the template is copied into codePath at setup, so existing copies carry the old reporter): `reporter: [['list'], ['html', { open: 'never' }]]`.
+
 ## [5.10.2] - 2026-06-16
 
 **`/research` scope-offer floor: close the one path where no scope was offered anywhere.**

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -327,7 +327,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading: it auto-dete
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **5.10.2**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **5.10.3**.
 
 ## License
 

--- a/ai-dev-assistant/commands/validate-visual-regression.md
+++ b/ai-dev-assistant/commands/validate-visual-regression.md
@@ -174,16 +174,18 @@ For every surface in the gate output with `verdict: fail`:
   Emit the `visual-regression-gate-fail` prompt from
   `references/gate-hardening-prompts.md` substituting `{{surface_id}}`,
   `{{viewport}}`, `{{diff_percent}}`, `{{diff_pixels}}`, `{{diff_path}}`.
-  **Slider/side-by-side view is available on request (v5.10.2+):** the static
-  `{{diff_path}}` PNG is the default aid, but if the reviewer asks to *see* the
-  change interactively — e.g. "open the slider", "show baseline vs current
-  side by side", "let me swipe between them" — run `npx playwright show-report`
-  host-side and point them at the failed surface's image-diff view, which
-  offers Playwright's **Diff / Side-by-side / Slider** (drag-to-reveal) modes
-  over expected vs actual. This is an **on-demand** aid the reviewer asks for,
-  not an auto-launch and not a new flag (the pre-run `--show-diffs` flag opens
-  the same report eagerly); the gate still pauses on the same `[r]/[i]/[c]`
-  decision either way.
+  **Slider view is available on request (v5.10.2+; actually wired in v5.10.3):**
+  the static `{{diff_path}}` PNG is the default aid, but if the reviewer asks to
+  *see* the change interactively — e.g. "open the slider", "show baseline vs
+  current side by side", "let me swipe between them" — run `npx playwright
+  show-report` host-side and point them at the failed surface's image-diff view,
+  which offers Playwright's **Slider** (drag-to-reveal baseline↔current) view
+  over expected vs actual. This works because the `html` reporter is always
+  configured (`playwright-base.config.ts`), so the run produced a current
+  `playwright-report/` for `show-report` to open. This is an **on-demand** aid
+  the reviewer asks for, not an auto-launch and not a new flag (the pre-run
+  `--show-diffs` flag opens the same report eagerly); the gate still pauses on
+  the same `[r]/[i]/[c]` decision either way.
   Classify **one surface before moving to the next** (no batched prompts):
   - `[r]` Regression → `verdict: fail`, `classification: "regression"`,
     `baseline_updated: false`.
@@ -263,6 +265,17 @@ string interpolation) and write it via
 If `--show-diffs` was passed, run `npx playwright show-report` host-side from
 `codePath` (default port 9323; if busy, Playwright picks the next free port).
 Print the report URL.
+
+Every VR run produces a current `playwright-report/`, so `show-report` always has
+something to open and its image-diff view carries the **Slider** (drag-to-reveal
+baseline↔current) widget. This holds on **both** paths: the gate
+(`scripts/visual-regression-gate.sh`) runs `npx playwright test --reporter=json,html`
+(a CLI `--reporter` replaces the config one, so the gate requests html itself,
+with `PLAYWRIGHT_HTML_OPEN=never` to avoid auto-launching a browser), and CI /
+manual runs use the `html` reporter configured in `playwright-base.config.ts`.
+(Before v5.10.3 neither path emitted the html report — config was `list`/`github`
+only and the gate passed `--reporter=json` — so `show-report` had nothing to open
+and the slider never appeared. That wiring gap is fixed.)
 
 ## Step 13: Print the summary
 

--- a/ai-dev-assistant/references/visual-regression-walkthrough.md
+++ b/ai-dev-assistant/references/visual-regression-walkthrough.md
@@ -124,17 +124,25 @@ the `visual-regression-gate-fail` prompt:
 
 Each surface is classified before the next — prompts are never batched.
 
-**Seeing the change interactively (v5.10.2+).** The default aid is the static
-`diff_path` PNG, but the reviewer can simply **ask** to view the change — "open
-the slider", "show baseline vs current side by side", "let me swipe between
-them" — and the AI runs `npx playwright show-report` host-side. Playwright's
-HTML report renders the failed surface's image diff with **Diff / Side-by-side /
-Slider** (drag-to-reveal expected vs actual) modes — the same swipe-comparison
-UX as hosted VR tools. It is an **on-demand** action the reviewer requests, not
-an auto-launch and not a new flag (the pre-run `--show-diffs` flag opens the same
-report eagerly). Visual **parity** does not share this view — it compares the
-build against an external reference via `parity-compare.mjs` (CSS property diff),
-not Playwright's `toHaveScreenshot`, so the slider is VR-only.
+**Seeing the change interactively (v5.10.2+; wiring fixed in v5.10.3).** The
+default aid is the static `diff_path` PNG, but the reviewer can simply **ask** to
+view the change — "open the slider", "show baseline vs current side by side",
+"let me swipe between them" — and the AI runs `npx playwright show-report`
+host-side. Playwright writes the expected/actual/diff attachments **only when a
+surface fails `toHaveScreenshot`**, and its HTML report renders that failed
+surface's image diff with a **Slider** (drag-to-reveal expected vs actual) view —
+the same swipe-comparison UX as hosted VR tools. This works because a current
+`playwright-report/` exists: the gate (`scripts/visual-regression-gate.sh`) runs
+`--reporter=json,html` (with `PLAYWRIGHT_HTML_OPEN=never`), and CI / manual runs
+use the `html` reporter in `playwright-base.config.ts`. **Before v5.10.3 neither
+path produced the HTML report (config was `list`/`github` only; the gate passed
+`--reporter=json`), so `show-report` had nothing to open and the slider never
+appeared.** It is an **on-demand** action the reviewer requests, not an
+auto-launch and not a new flag (the pre-run `--show-diffs` flag opens the same
+report eagerly). Visual **parity** does not
+share this view — it compares the build against an external reference via
+`parity-compare.mjs` (CSS property diff), not Playwright's `toHaveScreenshot`, so
+the slider is VR-only.
 
 ## 8. Updating baselines — the trigger catalog
 

--- a/ai-dev-assistant/references/visual-review/playwright-base.config.ts
+++ b/ai-dev-assistant/references/visual-review/playwright-base.config.ts
@@ -47,7 +47,19 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? 'github' : 'list',
+  /* Always emit the `html` reporter alongside the console reporter: it is what
+     produces `playwright-report/`, whose image-diff view carries the **Slider**
+     (drag-to-reveal baseline↔current) widget that `--show-diffs` /
+     `npx playwright show-report` opens. `open: 'never'` keeps it from
+     auto-launching a browser mid-gate (it is opened on demand). Without the html
+     reporter, `show-report` has no report to show. NOTE: this config-level
+     reporter governs CI and manual `npx playwright test` runs; the VR *gate*
+     (`scripts/visual-regression-gate.sh`) passes `--reporter=json,html` on the
+     CLI (a CLI `--reporter` replaces the config one), so it must — and does —
+     request html itself. */
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
 
   use: {
     baseURL: BASE_URL,

--- a/ai-dev-assistant/scripts/visual-regression-gate.sh
+++ b/ai-dev-assistant/scripts/visual-regression-gate.sh
@@ -122,7 +122,24 @@ for p in "${PROJECTS[@]}"; do PROJ_ARGS+=("--project" "$p"); done
 # ─── run the suite ───────────────────────────────────────────────────────────
 
 PW_EXIT=0
-PW_JSON=$(cd "$CODE_PATH" && npx playwright test "${PROJ_ARGS[@]}" --reporter=json 2>/dev/null) || PW_EXIT=$?
+# Run BOTH the json reporter (this gate parses it) AND the html reporter, so
+# `npx playwright show-report` / `--show-diffs` has a CURRENT report whose
+# image-diff Slider the reviewer can open at the Step 9 classification pause. A
+# CLI `--reporter` REPLACES the config reporter (it does not merge), so the html
+# reporter added to playwright.config is NOT enough on this path — we must
+# request it here too. `PLAYWRIGHT_JSON_OUTPUT_NAME` routes the JSON to a file so
+# the html reporter's stdout never corrupts the parse; `PLAYWRIGHT_HTML_OPEN=never`
+# stops the html reporter auto-launching a browser on the failing-screenshot case.
+# (PLAYWRIGHT_JSON_OUTPUT_NAME is honored on all supported @playwright/test; on a
+# version old enough to ignore it the JSON would go to the /dev/null'd stdout and
+# this file stays empty — which degrades fail-safe to the playwright_no_json branch
+# below, never a false pass.)
+PW_JSON_FILE="$(mktemp 2>/dev/null || echo "${TMPDIR:-/tmp}/vr-gate-$$.json")"
+( cd "$CODE_PATH" \
+  && PLAYWRIGHT_HTML_OPEN=never PLAYWRIGHT_JSON_OUTPUT_NAME="$PW_JSON_FILE" \
+     npx playwright test "${PROJ_ARGS[@]}" --reporter=json,html >/dev/null 2>&1 ) || PW_EXIT=$?
+PW_JSON="$(cat "$PW_JSON_FILE" 2>/dev/null || true)"
+rm -f "$PW_JSON_FILE"
 
 if ! jq -e . >/dev/null 2>&1 <<<"$PW_JSON"; then
   add_warning "playwright_no_json: the suite produced no parseable JSON report (exit $PW_EXIT)"


### PR DESCRIPTION
## The bug

5.10.2 documented that the reviewer can ask to "open the slider" at the VR diff-classification pause and get Playwright's before/after **Slider** via `npx playwright show-report`. **It didn't work** — on *either* path:

1. **The gate** (`scripts/visual-regression-gate.sh`) ran `npx playwright test --reporter=json`. A CLI `--reporter` **replaces** the config reporter (it doesn't merge), so only the json reporter ran — **no `playwright-report/` was produced by the gate**, which is the run immediately before the "open the slider" ask.
2. **The config template** reporter was `process.env.CI ? 'github' : 'list'` — **no `html` reporter** — so CI and manual `npx playwright test` runs produced no report either.

The Slider is a real Playwright feature (HTML-report image-diff view, rendered from the expected/actual/diff attachments a **failed** `toHaveScreenshot` writes). Our wiring just never emitted the report that hosts it. I claimed twice it already worked; it didn't. This corrects that.

## Fix

- **`scripts/visual-regression-gate.sh` (primary):** the gate now runs `npx playwright test --reporter=json,html` with `PLAYWRIGHT_JSON_OUTPUT_NAME` routing the JSON to a temp file (so the html reporter's stdout can't corrupt the `jq` parse) and `PLAYWRIGHT_HTML_OPEN=never` (no browser auto-launch on the failing-screenshot case). `playwright-report/` now exists on the gate path, so the on-demand "open the slider" ask and `--show-diffs` render Playwright's **Slider**.
- **`references/visual-review/playwright-base.config.ts`:** config reporter also includes `html` (`open: 'never'`) for **CI / manual** runs (which don't pass `--reporter`). Also fixes a latent CI gap — the workflow uploads `playwright-report/`, but the `github`-only reporter made that artifact empty.
- **Docs corrected on both paths** — `validate-visual-regression.md` Step 9 + Step 12, `visual-regression-walkthrough.md` §7. Named accurately as "Slider", scoped to surfaces that failed `toHaveScreenshot`. `playwright-report/` is already gitignored (setup Step 7b).

## Red-team

Fresh-context critic **with Playwright-doc verification** (because I'd been wrong twice from memory): initial **BLOCK** — caught that the gate's `--reporter=json` override nullified the config fix on the primary path — → fixed in the gate script → re-review **SHIP**, every env-var claim cited to playwright.dev ([reporters](https://playwright.dev/docs/test-reporters), [CLI](https://playwright.dev/docs/test-cli)).

## Migration
Existing projects get the slider on the gate path automatically on 5.10.3. To also get the report from CI/manual `npx playwright test`, add `html` to that project's own `playwright.config.*` (template is copied at setup): `reporter: [['list'], ['html', { open: 'never' }]]`.

## Files
- `scripts/visual-regression-gate.sh`, `references/visual-review/playwright-base.config.ts` (the fix)
- `commands/validate-visual-regression.md`, `references/visual-regression-walkthrough.md` (docs)
- Metadata: `plugin.json` 5.10.2→**5.10.3**; `marketplace.json` entry + `metadata.version` 2.0.5→**2.0.6** (patch); `CHANGELOG.md`; `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)