### PR TITLE
ai-dev-assistant 5.16.0: DDEV-aware worktrees + build-in-place for infra/state work-orders (GAP A)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.11"
+    "version": "2.0.14"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.13.1",
+      "version": "5.16.0",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.13.1",
+  "version": "5.16.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.16.0] - 2026-06-22
+
+### Added — GAP A: DDEV-aware worktrees + build-in-place for infra/state work-orders
+Closes GAP A (dogfooded on `adrupalcouple p1_scaffold_enable`): the agent-dispatched build path couldn't build a live-DDEV task — a git worktree is a separate checkout the running DDEV (bound to the main checkout) can't see. Grounded in DDEV's own published git-worktree workflow.
+
+**Part 1 — `/worktree --ddev-up` (opt-in).** Brings up the worktree's **own isolated DDEV** (own web+db) and seeds DB+files from the main checkout (`ddev export-db`/`import-db`/`import-files`) — the supported pattern. The DB is **copied, never shared** (pointing a worktree at the main db container is unsupported and corruption-prone; rejected). Auto-naming via `ddev config global --omit-project-name-by-default`; a pinned `name:` is a hard halt under `--ddev-up`. `/worktree-prune` now `ddev delete --omit-snapshot`s the worktree's DDEV project **before** `git worktree remove` (else an orphaned registry entry blocks the next same-name worktree — a gap DDEV's own blog glosses over). `worktree-conventions.md` → v1.3.
+
+**Part 2 — `/run-work-orders --in-place` (operator-gated, sequential-only).** A **build-in-place** mode for infra/state WOs (composer require + drush en + config import + theme build) whose produced *state* must land on the **canonical** integration env, which an isolated worktree can't reach. Builds on the main checkout's DDEV; file changes still PR-able. Skips the worktree precondition; **refuses to build on the integration base** (no commit-to-`main`); requires `[y]` confirmation and refuses unattended; rejects `--parallel --in-place`. **Critical safety property:** in-place **never `git reset --hard`** — a reset rolls back files but not DB/module-enable/`vendor/` state (split-brain), so both reset sites (crash-recovery + retryable-fail) convert to **HALT+escalate**; a review failure is terminal, never auto-reworked. Per-WO `/review` uses `--base <cp>` (this WO's checkpoint) for an incremental diff. Taxonomy: **code-authoring WO → worktree+PR; infra/state WO → build-in-place** (`references/work-order-lifecycle.md`). First cut: task-level `--in-place`; per-WO `build_mode` is the future granular evolution.
+
+### Tests
+New `tests/ddev-worktree-spec.sh` (17 assertions): the `--ddev-up` bring-up/seed/auto-naming, the prune teardown ordering, the `--in-place` gate (operator-confirm + base-refusal + `--parallel` rejection), and the never-reset / `--base <cp>` loop branches.
+
 ## [5.13.1] - 2026-06-19
 
 ### Changed — docs

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -327,7 +327,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading: it auto-dete
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **5.13.1**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **5.16.0**.
 
 ## License
 

--- a/ai-dev-assistant/commands/run-work-orders.md
+++ b/ai-dev-assistant/commands/run-work-orders.md
@@ -1,7 +1,7 @@
 ---
 description: "Run all compiled work-orders for a /design-complete ai-dev-assistant task end-to-end via the autonomous work-order loop. Validates preconditions (compiled WOs exist, a code worktree is available), then invokes the work-order-loop skill INLINE (never Task-dispatched) to drive the ready-queue, build, gate-review, and PR-open pipeline. Pass --parallel to run independent work-orders concurrently under the same gates via the work-order-loop-parallel skill (also inline-only). Trigger: 'run work orders', 'execute work orders', 'start work order loop'."
 allowed-tools: Read, Bash, Skill
-argument-hint: <task-name> [--parallel [--max N]]
+argument-hint: <task-name> [--parallel [--max N]] [--in-place]
 ---
 
 # Run Work-Orders
@@ -23,7 +23,10 @@ skill **inline** via the Skill tool; it does NOT loop, dispatch, or re-implement
 /ai-dev-assistant:run-work-orders <task-name>                       # sequential (default)
 /ai-dev-assistant:run-work-orders <task-name> --parallel            # concurrent, disjoint-file batches
 /ai-dev-assistant:run-work-orders <task-name> --parallel --max 4    # cap the concurrent batch size (default 8)
+/ai-dev-assistant:run-work-orders <task-name> --in-place            # infra/state task: build on the canonical env, no worktree (operator-gated)
 ```
+
+`--in-place` is the **build-in-place** mode for **infra/state** tasks (composer require + drush en + config import + theme build) whose produced *state* — DB schema, enabled-module config, built theme — must land on the **canonical** integration env, which a per-WO isolated worktree can't reach. It is **mutually exclusive with `--parallel`** (build-in-place is sequential-only) and is **operator-gated** (it mutates the running site directly; failures HALT for human inspection — no auto-rework). The default (no `--in-place`) is the unchanged **code-authoring** worktree+PR path.
 
 `<task-name>` must match `^[a-z0-9_-]+$`. Reject path traversal (`..`, `/`) and special chars →
 exit 2. Missing arg AND no session-context task → exit 2 with usage. `--parallel` is an optional
@@ -42,21 +45,45 @@ batch size. The **default (no `--parallel`) is unchanged** — the sequential `w
 
    > "No compiled work-orders found — run `/ai-dev-assistant:compile-work-orders <task>` first."
 
-3. **Precondition — a worktree is set.** Read `codePath` from the `project-state-read.sh` JSON.
-   The `work-order-loop` builds in a code worktree and owns its lifecycle. If no worktree is set or
-   available → **offer** `/ai-dev-assistant:worktree <task>` and stop. Do NOT silently proceed
-   without a worktree; do NOT hardcode `codePath`.
+   **Reject `--parallel --in-place`** — build-in-place is sequential-only (concurrent writes to one
+   checkout + one DB are an unisolatable race; infra state flows forward and cannot be batched). Exit 2
+   with: "`--in-place` cannot be combined with `--parallel` — build-in-place is sequential-only."
 
-4. **Invoke the loop conductor INLINE via the Skill tool.** **Without `--parallel`** (default):
+3. **Precondition — build path (mode-dependent).**
+   - **Default (`worktree` mode):** Read `codePath` from the `project-state-read.sh` JSON. The
+     `work-order-loop` builds in a code worktree and owns its lifecycle. If no worktree is set or
+     available → **offer** `/ai-dev-assistant:worktree <task>` and stop. Do NOT silently proceed
+     without a worktree; do NOT hardcode `codePath`.
+   - **`--in-place`:** **skip the worktree precondition** — build on the main checkout (`codePath` from
+     `project-state-read.sh`, where the canonical DDEV is bound). Reject if no `codePath` resolves (a
+     docs-only project has nothing to build in-place). **Branch safety (refuse-on-base):** in-place commits
+     land on the main checkout's **current branch** (the env state applies regardless of branch). Run
+     `git -C <codePath> branch --show-current`; if it equals the integration `<base>` (default `main`) →
+     **refuse**: "in-place would commit directly to `<base>` — create/checkout a feature branch in
+     `<codePath>` first (e.g. `git -C <codePath> checkout -b feature/<task>`), then re-run." This keeps file
+     changes PR-able and never commits to `<base>`. **Operator gate (build-in-place mutates the
+     canonical environment):** print this confirmation and block —
+     > "`--in-place` builds these work-orders directly on the canonical environment at `<codePath>`:
+     > state (DB schema, enabled modules, built theme) is applied to the running site, there is **no
+     > worktree isolation and no PR-staged rollback**, and any review failure **HALTs for manual
+     > inspection (no auto-rework)**. Proceed? `[y]/[N]`"
+
+     Default `[N]`; proceed only on `[y]`. In an **unattended/headless** run do NOT auto-confirm — refuse
+     with the gate message (build-in-place needs a human gate).
+
+4. **Invoke the loop conductor INLINE via the Skill tool.** **Without `--parallel`/`--in-place`** (default):
    invoke the `work-order-loop` skill with the resolved task folder and worktree. **With
    `--parallel`** (optionally `--max N`): invoke the `work-order-loop-parallel` skill instead,
    passing the same task folder + the worktree as the **integration worktree**, plus the `--max N`
-   batch cap when supplied. Both paths are routed **identically**: an inline invocation (Skill
-   tool, depth-0) — **NEVER via the Task tool.** The build atom (dispatched by either loop inside)
-   is the single supported depth-1 spawn; the parallel loop only issues **N** atoms in one message
-   (still depth-1). A Task-dispatched loop would push the atoms to depth-2 (unsupported). Do NOT
-   re-implement either loop here. The parallel path is **additive** — it does not change the
-   default sequential behavior.
+   batch cap when supplied. **With `--in-place`** (mutually exclusive with `--parallel`): invoke the
+   `work-order-loop` skill with `<worktree>` = `codePath` (the main checkout) and `<build_mode>` =
+   `in-place`, so the loop runs its in-place branches (no worktree create/teardown; every `reset --hard`
+   site becomes HALT+escalate; per-WO `/review --base <cp>` for incremental diffs). All paths are routed
+   **identically**: an inline invocation (Skill tool, depth-0) — **NEVER via the Task tool.** The build
+   atom (dispatched by either loop inside) is the single supported depth-1 spawn; the parallel loop only
+   issues **N** atoms in one message (still depth-1). A Task-dispatched loop would push the atoms to
+   depth-2 (unsupported). Do NOT re-implement either loop here. The parallel and in-place paths are
+   **additive** — they do not change the default sequential worktree behavior.
 
 5. **Emit the `/goal` string.** The loop prints a ready-to-paste `/goal` line; surface it to the
    user. Do NOT run `/goal` yourself — the user pastes it to launch the next attended turn.
@@ -69,9 +96,11 @@ batch size. The **default (no `--parallel`) is unchanged** — the sequential `w
 
 It does **not** build, dispatch, loop, review, or open a PR itself — all of that is owned by the
 `work-order-loop` skill (or `work-order-loop-parallel` under `--parallel`). It does NOT auto-create
-a worktree silently (offer `/worktree` when absent). It does NOT invoke either loop via the Task
-tool (hard inline-only constraint — the parallel loop is just as inline-only as the sequential
-one). It does NOT run `/goal` itself — the user pastes it.
+a worktree silently (offer `/worktree` when absent). Under `--in-place` it does NOT create a worktree
+(builds on the canonical env at `codePath`, operator-gated) and does NOT auto-rework a failing WO (a
+fail HALTs for human inspection — infra state isn't safely resettable). It does NOT invoke either loop
+via the Task tool (hard inline-only constraint — every path is inline-only). It does NOT run `/goal`
+itself — the user pastes it.
 
 ## Related
 

--- a/ai-dev-assistant/commands/worktree-prune.md
+++ b/ai-dev-assistant/commands/worktree-prune.md
@@ -1,5 +1,5 @@
 ---
-description: "Clean up abandoned worktrees in the current project. Lists each worktree with state (branch merged? task completed?). Per-worktree confirm; never bulk-removes silently. Honors git's refusal on uncommitted changes. Introduced v3.16.0."
+description: "Clean up abandoned worktrees in the current project. Lists each worktree with state (branch merged? task completed?). Per-worktree confirm; never bulk-removes silently. Honors git's refusal on uncommitted changes. Tears down a worktree's DDEV project (`ddev delete --omit-snapshot`) before removing the dir so no orphaned DDEV registry entry is left. Introduced v3.16.0."
 allowed-tools: Read, Bash, Skill
 ---
 
@@ -60,7 +60,7 @@ Order: candidates first, then active. For each:
 Remove? [y]es / [n]o / [q]uit
 ```
 
-- `[y]` → run `git worktree remove "<path>"`. If git refuses (uncommitted changes, locked):
+- `[y]` → **first, if `<path>/.ddev/config.yaml` exists, tear the worktree's DDEV project down BEFORE removing the dir:** `( cd "<path>" && ddev delete --omit-snapshot --yes )`. This is mandatory ordering — `git worktree remove` alone leaves an **orphaned DDEV registry entry** (the dir is gone but DDEV still has the project root registered, so the next worktree of the same name fails `ddev start` with `project root is already set … refusing to change it`). `--omit-snapshot` skips the slow auto-snapshot (the worktree DB is a throwaway copy). If `ddev delete` fails, surface the error and ask `[c]ontinue removal anyway / [s]kip`; on `[c]` proceed to the `git worktree remove`, on `[s]` skip this worktree. Then run `git worktree remove "<path>"`. If git refuses (uncommitted changes, locked):
   - Print git's error verbatim
   - Offer `[f]orce / [n]o`
   - On `[f]` → run `git worktree remove --force "<path>"` (ONLY on explicit user confirmation)
@@ -89,6 +89,8 @@ Run `git worktree list` to verify.
 | Single worktree (only main) | Print "No worktrees to prune"; exit 0 |
 | `git worktree remove` fails on uncommitted changes | Honor refusal; offer `[f]orce`; require explicit user confirm |
 | Branch deletion fails (unmerged) | Honor git's refusal; print message; continue with worktree-only removal |
+| Worktree has `.ddev/` (created via `/worktree --ddev-up`) | `ddev delete --omit-snapshot --yes` in the worktree BEFORE `git worktree remove` — else an orphaned DDEV registry entry blocks the next same-name worktree |
+| `ddev delete` fails | Surface the error; ask `[c]ontinue removal anyway / [s]kip`; never silently leave a half-torn-down project |
 
 ## Soft-nudge posture
 

--- a/ai-dev-assistant/commands/worktree.md
+++ b/ai-dev-assistant/commands/worktree.md
@@ -1,7 +1,7 @@
 ---
-description: "Create a git worktree for parallel task execution. Sets up `.worktrees/<task>/` on `feature/<task>` branch, runs auto-detect setup (composer install, npm install), pre-seeds session-context. Framework-aware. Soft-nudge — never auto-creates without confirmation. Introduced v3.16.0."
+description: "Create a git worktree for parallel task execution. Sets up `.worktrees/<task>/` on `feature/<task>` branch, runs auto-detect setup (composer install, npm install), pre-seeds session-context. Framework-aware. Opt-in `--ddev-up` brings up an isolated DDEV instance for the worktree and seeds its DB/files from the main checkout (the official DDEV git-worktree workflow) so an agent has a live env to build/verify against. Soft-nudge — never auto-creates without confirmation; never spins up DDEV implicitly. Introduced v3.16.0."
 allowed-tools: Read, Write, Edit, Bash, Skill
-argument-hint: <task-name> [--base <ref>] [--branch <name>] [--with-baseline] [--no-ddev-check]
+argument-hint: <task-name> [--base <ref>] [--branch <name>] [--with-baseline] [--no-ddev-check] [--ddev-up] [--ddev-no-seed]
 ---
 
 # Worktree
@@ -16,7 +16,11 @@ Create a git worktree at `.worktrees/<task_name>/` on branch `feature/<task_name
 /ai-dev-assistant:worktree <task-name> --branch task/<custom>       # custom branch name
 /ai-dev-assistant:worktree <task-name> --with-baseline              # opt-in baseline tests
 /ai-dev-assistant:worktree <task-name> --no-ddev-check              # skip dev-environment name-conflict check
+/ai-dev-assistant:worktree <task-name> --ddev-up                    # bring up an isolated DDEV for the worktree + seed DB/files from main
+/ai-dev-assistant:worktree <task-name> --ddev-up --ddev-no-seed     # bring up the isolated DDEV but DON'T copy the DB/files (empty env)
 ```
+
+`--ddev-up` is opt-in (default OFF — DDEV spin-up is expensive). It gives the worktree its **own isolated DDEV project** so an agent has a live env to `composer`/`drush`/`npm`/verify against — the official DDEV git-worktree workflow (<https://ddev.com/blog/git-worktree-contributor-training/>). `--ddev-no-seed` brings the instance up empty (skips the DB/files copy). This is the **code-authoring** worktree path; **infra/state** work-orders that must mutate the canonical env build in-place instead (see `references/work-order-lifecycle.md`).
 
 See `references/worktree-conventions.md` v1.2 for the full convention, including how this command relates to Claude Code's native `claude --worktree` flag, PR-based worktrees, `.worktreeinclude`, `worktree.baseRef`, and `worktree.bgIsolation`.
 
@@ -68,6 +72,8 @@ On `[c]` → continue (user knows the risk).
 
 If `--no-ddev-check` was passed, skip this step entirely.
 
+**Under `--ddev-up`, a pinned `name:` is a HARD blocker, not a warning.** Auto-naming (the worktree dir → the DDEV project name) is what keeps the worktree's instance distinct from the main project's; a pinned `name:` makes both projects share one name and `ddev start` refuses the second (`project root is already set … refusing to change it`). So with `--ddev-up` and a `name:` set: do NOT offer `[c]ontinue` — halt and instruct the user to either remove the `name:` line and commit, OR run `ddev config global --omit-project-name-by-default` once (the recommended global default), then re-run. `--no-ddev-check` does not bypass this (you cannot bring up a correctly-named isolated instance with a pinned name).
+
 ### Step 6 — Create worktree
 
 Determine BASE:
@@ -97,6 +103,37 @@ If creation fails (existing branch with different HEAD, dirty tree blocking, etc
 | `package.json` | `npm install` (or `pnpm install` / `yarn install` per lockfile) |
 
 Setup runs sequentially. Failures print but don't auto-rollback (user can fix and re-run).
+
+### Step 7b — DDEV bring-up + seed (opt-in, `--ddev-up`)
+
+Runs **only** when `--ddev-up` was passed AND `<codePath>/.ddev/config.yaml` exists. Skip silently otherwise. This brings up the worktree's **own isolated DDEV project** (its own web + db containers) and copies the main site's state into it — the official DDEV git-worktree pattern. The DB is **copied, never shared**: each worktree gets its own DB (the supported, isolation-safe path; pointing a worktree at the main project's db container is explicitly NOT used — it resets on restart and risks concurrent-write corruption).
+
+**Auto-naming** is already guaranteed by Step 5 (a pinned `name:` halted there under `--ddev-up`). The worktree at `.worktrees/<task>/` becomes `https://<task>.ddev.site` (non-alphanumerics in the dir name normalise to `-`). Recommend the global default once so every future worktree auto-names: `ddev config global --omit-project-name-by-default`.
+
+**Bring up the isolated instance** (cwd is the worktree from Step 7):
+
+```bash
+ddev start
+```
+
+If `ddev start` fails (commonly a stale same-name project still registered), surface the error verbatim; the fix is `ddev stop --unlist <name>` then re-run. Do NOT auto-`--unlist` — it mutates the user's DDEV project registry.
+
+**Seed DB + files from the main checkout** (skip entirely when `--ddev-no-seed`). Warn first: a DB export/import can take **minutes** on a large site and the worktree keeps its own DB volume (disk cost).
+
+```bash
+TARBALLS="<codePath>/.worktrees/.tarballs"; mkdir -p "$TARBALLS"
+# DB — stack-agnostic + cross-project portable (text SQL dump):
+( cd "<codePath>" && ddev export-db --file="$TARBALLS/db.sql.gz" )   # from the MAIN project's running DDEV
+ddev import-db --file="$TARBALLS/db.sql.gz"                          # into the worktree (cwd = the worktree)
+# Files — best-effort; derive the docroot from .ddev/config.yaml (default empty = repo root):
+DOCROOT=$(grep -E '^docroot:' "<codePath>/.ddev/config.yaml" | head -1 | sed -E 's/^docroot:[[:space:]]*//; s/["'"'"']//g')
+FILES="<codePath>/${DOCROOT:+$DOCROOT/}sites/default/files"
+if [ -d "$FILES" ]; then
+  ( cd "<codePath>" && tar -C "$FILES" -czf "$TARBALLS/files.tgz" . ) && ddev import-files --source="$TARBALLS/files.tgz"
+fi
+```
+
+The two `ddev export-db` / `tar` reads run in a `( cd … )` subshell against the **main** checkout (a subshell `cd` does not change the command's working directory); the `import-*` run in the worktree. On any seed failure, leave the worktree's DDEV up (empty/partial) and surface the error — never abort the whole worktree over a seed hiccup; the user can re-seed or build against an empty DB.
 
 ### Step 8 — Optional baseline
 
@@ -133,14 +170,17 @@ This ensures the worktree's session-context file exists; the user's first `/rese
 ✓ Worktree created at .worktrees/<task-name>
   Branch:  feature/<task-name> from <BASE-ref>
   Setup:   composer install ✓ | npm install ✓
+  DDEV:    https://<task-name>.ddev.site  (seeded: db ✓ | files ✓)   # only when --ddev-up
   Session: pre-seeded for project <name>
 
 Next:
   cd .worktrees/<task-name>
   /ai-dev-assistant:implement <task-name>
 
-Or run /worktree-prune later to clean up when done.
+Or run /worktree-prune later to clean up when done (it tears the worktree's DDEV down first).
 ```
+
+Print the `DDEV:` line only when `--ddev-up` brought an instance up; show `seeded: skipped` under `--ddev-no-seed`.
 
 ## Error cases
 
@@ -154,12 +194,16 @@ Or run /worktree-prune later to clean up when done.
 | Branch already exists pointing at a different ref | Surface error; suggest `--branch` or branch deletion; exit 1 |
 | Setup fails (composer install error, npm install error) | Print error; leave worktree created; exit 0 (user resumes manually) |
 | Baseline fails AND no `--ignore-baseline` | Refuse to declare ready; exit 1; user can `--ignore-baseline` |
+| `--ddev-up` AND `.ddev/config.yaml` has `name:` set | **Hard halt** (Step 5) — no `[c]ontinue`; instruct remove `name:` + commit OR `ddev config global --omit-project-name-by-default`, then re-run |
+| `--ddev-up` and `ddev start` fails (stale same-name project) | Surface git/ddev error verbatim; suggest `ddev stop --unlist <name>`; leave the worktree created; do NOT auto-`--unlist` |
+| `--ddev-up` seed (export/import) fails | Leave the worktree + its DDEV instance up (empty/partial); surface the error; user re-seeds or builds against an empty DB |
 
 ## Soft-nudge posture
 
 - Never creates without explicit confirmation when there's a dev-environment name-conflict warning
 - Never auto-edits `.ddev/config.yaml`
 - Never `--force` removes anything
+- `--ddev-up` is opt-in (default OFF) — DDEV is never spun up implicitly; never auto-`--unlist`s a registered project
 - User can decline at every interactive step
 
 ## Related

--- a/ai-dev-assistant/references/work-order-lifecycle.md
+++ b/ai-dev-assistant/references/work-order-lifecycle.md
@@ -47,11 +47,24 @@ where you want per-WO review before integrating.
 When to use: large sliced tasks where you want the loop to run unattended, with the
 human reviewing the flagged PR before any merge.
 
+## Build-mode taxonomy: code-authoring vs infra/state
+
+`/run-work-orders` has two build modes, chosen by the **nature of the work-order's output**:
+
+| WO kind | Durable output | Mode | How |
+|---|---|---|---|
+| **Code-authoring** (SDC, templates, services, theme SCSS) | **files** (PR-able, isolatable) | **worktree+PR** (default) | builds in an isolated worktree; optional `/worktree --ddev-up` gives it a live DDEV to verify against; opens a flagged PR |
+| **Infra/state** (composer require, drush en, config import, recipe apply, theme build) | **environment state** (DB schema, enabled modules, built theme) | **build-in-place** (`--in-place`) | builds on the **canonical** env (the main checkout's DDEV) so the produced state lands where later tasks verify against it |
+
+Why two modes: an infra/state WO's product is env state a per-WO isolated worktree builds where **nothing downstream sees it** (the gap that surfaced live on `adrupalcouple p1_scaffold_enable`). So those WOs build in-place on the canonical env. File changes (composer.json, config/sync, the generated theme) still go through a PR; the **state** is already on the integration env.
+
+**`--in-place` is operator-gated and sequential-only.** It mutates the running site directly (no worktree isolation, no PR-staged rollback), so `/run-work-orders --in-place` requires an explicit `[y]` confirmation and refuses in unattended/headless runs. A review failure is **terminal (HALT for human inspection), never auto-reworked** — the loop never `git reset --hard`s in-place (a reset rolls back files but not DB/module state → split-brain). It cannot combine with `--parallel` (concurrent writes to one DB are an unisolatable race). *(First cut: mode is task-level via the `--in-place` flag; a per-WO `build_mode` field is the future granular evolution.)*
+
 ## Key invariants
 
 - **All paths are opt-in.** No WO machinery fires automatically.
 - **The in-session path is always available**, even when work-orders exist.
-- **`/run-work-orders` requires a worktree** — it will prompt to create one if absent.
+- **`/run-work-orders` requires a worktree** in the default (code-authoring) mode — it will prompt to create one if absent. **`--in-place` lifts this** for infra/state tasks: it builds on the canonical env (`codePath`), operator-gated, no worktree.
 - **The loop never auto-merges** — it opens a flagged PR and stops.
 - **`/next` surfaces WO status** when `work-orders/wo-*.md` are present (count by
   `status:` field), pointing to `/run-work-orders` as an alternative action.
@@ -61,7 +74,7 @@ human reviewing the flagged PR before any merge.
 ## Related
 
 - `/ai-dev-assistant:compile-work-orders` — produce work-orders from architecture
-- `/ai-dev-assistant:run-work-orders` — autonomous loop (requires worktree)
+- `/ai-dev-assistant:run-work-orders` — autonomous loop (worktree by default; `--in-place` for infra/state)
 - `/ai-dev-assistant:worktree` — isolate a WO build in its own worktree
 - `/ai-dev-assistant:review` — post-implementation review gate
 - `/ai-dev-assistant:complete` — close the task

--- a/ai-dev-assistant/references/worktree-conventions.md
+++ b/ai-dev-assistant/references/worktree-conventions.md
@@ -1,4 +1,4 @@
-# Worktree Conventions v1.2
+# Worktree Conventions v1.3
 
 **Introduced:** ai-dev-assistant v3.16.0
 **Owner:** `commands/worktree.md`, `commands/worktree-prune.md`, `commands/implement.md` (recommendation), `commands/complete.md` (lifecycle)
@@ -103,18 +103,35 @@ Lists existing worktrees with their state:
 
 Per worktree: `[y]es remove / [n]o keep / [q]uit`. Never bulk-removes silently. Refuses to remove worktrees with uncommitted changes (honors git's refusal); user resolves manually.
 
-## 8. Dev-environment tool compatibility
+## 8. DDEV-aware worktrees (`--ddev-up`)
 
-For projects with a `.ddev/config.yaml` in `codePath`:
+For Drupal projects with a `.ddev/config.yaml` in `codePath`, `/worktree --ddev-up` gives the worktree its **own isolated DDEV project** (own web + db containers) and seeds it from the main site — the official DDEV git-worktree workflow (<https://ddev.com/blog/git-worktree-contributor-training/>). This is what makes the worktree+PR agent loop viable for **code-authoring** Drupal WOs that need a live env to verify against. (DDEV is optional Drupal-flavored wiring; the engine stays stack-agnostic — a non-`.ddev` project simply skips this.)
 
-- **Requires the `name:` key removed from `.ddev/config.yaml`** — the tool will then derive the project name from each worktree's directory automatically (`.worktrees/feature-foo/` → `https://feature-foo.ddev.site`)
-- Framework detects `.ddev/config.yaml` presence + parses for `name:` key + warns user before creation if set; never auto-edits the config
+### 8.1 Auto-naming (the name-conflict guard)
 
-If `name:` is set, `/worktree` warns:
+A DDEV project name **must be unique**; two projects sharing a `name:` collide — `ddev start` on the second refuses with `project root is already set … refusing to change it`. The fix is **auto-naming**: with no pinned `name:`, each worktree's directory becomes its project name (`.worktrees/feature-foo/` → `https://feature-foo.ddev.site`).
 
-> `.ddev/config.yaml` has `name: <x>` set. Multiple worktrees with the same name will conflict at dev-environment startup. Recommended: remove the `name:` line and commit, OR use `/worktree --no-ddev-check` to proceed anyway.
+- **Recommended global default:** `ddev config global --omit-project-name-by-default` (once) — every future worktree auto-names with no per-project edit.
+- **Or** remove the `name:` line from `.ddev/config.yaml` and commit.
+- `/worktree` detects a pinned `name:` and warns; **under `--ddev-up` a pinned `name:` is a hard halt** (no `[c]ontinue`, and `--no-ddev-check` does not bypass it) — you cannot bring up a correctly-named isolated instance with a pinned name. Never auto-edits the config.
 
-User chooses [c]ontinue / [a]bort / [s]how-instructions.
+### 8.2 Seeding (copy, never share)
+
+Each worktree gets its **own** DB — the state is **copied** from the main project, never shared. (Pointing a worktree at the main project's db container is explicitly NOT used: DDEV resets the DB host on restart, and two web containers writing one DB risks cache/schema/lock corruption — see the DDEV research in `aida-gaps.md`.) `/worktree --ddev-up` (without `--ddev-no-seed`):
+
+1. `ddev start` in the worktree (its own containers).
+2. From the **main** checkout: `ddev export-db --file=<shared>/db.sql.gz` (+ `tar` the files dir, docroot derived from `.ddev/config.yaml`).
+3. In the worktree: `ddev import-db` (+ `ddev import-files`).
+
+`--ddev-no-seed` brings the instance up empty. A DB export/import is minutes on a large site and each worktree holds its own DB volume (disk) — hence `--ddev-up` is opt-in (default OFF), never implicit.
+
+### 8.3 Teardown ordering (mandatory)
+
+`/worktree-prune` **must `ddev delete --omit-snapshot --yes` the worktree's DDEV project BEFORE `git worktree remove`.** Removing the dir first leaves an **orphaned DDEV registry entry** (DDEV still has the project root registered → the next same-name worktree fails `ddev start`). The DB is a throwaway copy, so `--omit-snapshot` skips the slow auto-snapshot.
+
+### 8.4 Infra/state WOs build in-place, NOT in a worktree
+
+The ephemeral worktree above is for **code-authoring** WOs (durable output = files, PR-able). An **infra/state** WO (composer require + drush en + config import + theme build) produces env state — DB schema, enabled modules, built theme — that must land on the **canonical** integration env. A per-worktree isolated DDEV builds it where nothing downstream sees it. Those WOs use **build-in-place** mode instead (see `references/work-order-lifecycle.md`): build on the main checkout's DDEV, operator-gated. The taxonomy: **code-authoring WO → ephemeral-worktree (`--ddev-up`) + PR; infra/state WO → build-in-place.**
 
 ## 9. Refusal cases
 
@@ -240,7 +257,7 @@ task-completed), the native sweep is not.
 
 - **Major bumps** (`2.0`) are breaking: changes to directory priority semantics, branch-naming default, signal-strength thresholds, lifecycle path order.
 - **Minor bumps** (`1.1`) are additive: new optional signal types, new lifecycle paths, additional refusal cases, new flags, new documentation sections.
-- v1.0 committed for v3.16.0; v1.1 (additive, native worktree support) for v4.7.0; v1.2 (session-ID-salted session files) for v4.9.0.
+- v1.0 committed for v3.16.0; v1.1 (additive, native worktree support) for v4.7.0; v1.2 (session-ID-salted session files) for v4.9.0; v1.3 (additive, DDEV-aware worktrees `--ddev-up` + teardown ordering + infra/state build-in-place taxonomy) for v5.16.0.
 
 ## 13. Non-goals (deferred to v2)
 

--- a/ai-dev-assistant/skills/work-order-loop/SKILL.md
+++ b/ai-dev-assistant/skills/work-order-loop/SKILL.md
@@ -26,13 +26,25 @@ rules 1–5) — never parse builder prose for control flow. Detail lives in `re
 ## Inputs
 
 - `<task-folder>` — the leaf ai-dev-assistant task whose `work-orders/` you run.
-- `<worktree>` — the code worktree to build in. **You own its lifecycle** (create/attach on entry, tear
+- `<worktree>` — the code worktree to build in (**`worktree` mode**). **You own its lifecycle** (create/attach on entry, tear
   down on clean completion; keep on HALT for inspection). The build atom presupposes a handed worktree.
 - `<base>` — the integration branch the worktree was cut from and the PR targets (**default `main`**).
   Thread it to BOTH `/review --base <base>` (so its merge-base diff is the actual change, not the whole
   branch-vs-`main` divergence — on a non-`main` base, `merge-base main HEAD` is an ancient fork point and
   every PHP file in the divergence false-triggers the gate floor) AND `wo-pr-open.sh --base <base>` (so the
   PR targets the right branch). A non-`main` base that is not passed silently breaks both.
+- `<build_mode>` — `worktree` (default) | `in-place`. **`in-place` is operator-gated** (passed by
+  `run-work-orders --in-place`) for **infra/state** WOs that must mutate the **canonical** environment
+  (composer/drush/config/theme on the main checkout's DDEV), where a per-WO isolated worktree would build
+  state nothing downstream sees. Under `in-place`: `<worktree>` **is** the main checkout (`codePath`); the
+  loop does **NOT** create or tear down a worktree, and — critically — **never `git reset --hard`**. A reset
+  rolls back tracked files but NOT DB / module-enable (DB-stored in Drupal 10+) / `vendor/` state, so it
+  would leave a silent **split-brain** (filesystem at `$cp`, environment at the post-build state). Every
+  `reset --hard` site below therefore becomes **HALT + escalate**, and a review failure is **terminal (no
+  requeue)** — infra operations aren't idempotent like code edits, so a human inspects the accumulated state
+  before any re-dispatch. `in-place` is **sequential-only** (`run-work-orders` rejects `--parallel
+  --in-place`; the parallel conductor's per-WO ephemeral worktrees are structurally incompatible with shared
+  canonical state).
 
 ## Terminal-HALT — the highest-precedence predicate (check FIRST, everywhere)
 
@@ -73,10 +85,14 @@ ref:
   next `dispatch` (step 5) re-increments the attempt (the cap may HALT). **No reset needed** (nothing was
   committed). `ready` + `checkpoint_after` is structurally impossible (the sidecar gets `checkpoint_after`
   only at step 7, by which point the builder has already flipped to `in_progress`).
-- **`in_progress`, sidecar, no `checkpoint_after`** ⇒ crashed mid-build (the builder had flipped): validate
-  `git -C <worktree> merge-base --is-ancestor "$cp" HEAD`, then `git -C <worktree> reset --hard "$cp"`,
-  `set-status <wo> needs_rework` (`in_progress→needs_rework`, legal); the unconditional requeue (step 2)
-  promotes it next pass. This is the row that rolls back a committed-but-uncollected build.
+- **`in_progress`, sidecar, no `checkpoint_after`** ⇒ crashed mid-build (the builder had flipped).
+  **`worktree` mode:** validate `git -C <worktree> merge-base --is-ancestor "$cp" HEAD`, then
+  `git -C <worktree> reset --hard "$cp"`, `set-status <wo> needs_rework` (`in_progress→needs_rework`, legal);
+  the unconditional requeue (step 2) promotes it next pass. This is the row that rolls back a
+  committed-but-uncollected build. **`in-place` mode: do NOT reset** (the reset can't undo the DB/infra state
+  a crashed mid-build may already have applied → split-brain). Instead write `wo-NN.HALT` reason
+  `in_place_crash_manual_recovery`, mark the sidecar halted (`wo-run-state.sh halt`), and escalate — a human
+  reconciles the half-applied canonical state before any re-run.
 - **`in_progress`, `checkpoint_after`, no `wo-NN._review.json`** ⇒ build done, review never ran: resume at
   the review step (step 8) onward WITHOUT a rebuild and WITHOUT a second `dispatch` (no attempt
   re-increment).
@@ -140,7 +156,11 @@ deps are all `done`, or a `needs_rework` WO — step 2 promotes both to `ready`)
 8. **Per-WO review (run for EVERY dispatched WO).** Run `/review --headless --dry-run --base <base> <task-folder>`
    **inline from cwd=`<worktree>`** (command-prose, not a callable; `/review` derives the change from
    `git diff $(git merge-base main HEAD)..HEAD` in its cwd, so it MUST run in the worktree where the build
-   was committed — otherwise it assesses the unchanged main checkout), then
+   was committed — otherwise it assesses the unchanged main checkout). **`in-place` mode:** cwd is the main
+   checkout (`codePath`, already correct for `gh`), but pass **`--base <cp>`** (this WO's `checkpoint_before`
+   sha from the run-state sidecar) instead of the integration `<base>` — with no per-WO worktree isolation,
+   `merge-base <base> HEAD` would fold every prior WO's commits into this WO's diff (false positives);
+   `--base <cp>` scopes the review to this WO's incremental change. Then
    `wo-review-snapshot.sh <task-folder> <wo-NN>` → `wo-NN._review.json`. Forward the review's stdout verdict
    lines to the transcript.
 9. **Critique rung.** Invoke the `work-order-critique` skill **inline** → `wo-NN._critique.json`
@@ -158,12 +178,15 @@ deps are all `done`, or a `needs_rework` WO — step 2 promotes both to `ready`)
     - **clean** ⇒ `_review.json .gate_specific.overall_verdict=="pass"` AND `_critique.json
       blocking==false` AND no `wo-NN.HALT` ⇒ `set-status <wo-file> done` (`in_progress→done`).
     - **failing (retryable)** ⇒ a plain review fail (`.gate_specific.overall_verdict != "pass"`, **no**
-      blocking critique, **no** `wo-NN.HALT`): validate
+      blocking critique, **no** `wo-NN.HALT`). **`worktree` mode:** validate
       `git -C <worktree> merge-base --is-ancestor "$cp" HEAD` (else HALT `reset_target_invalid`), then
       `git -C <worktree> reset --hard "$cp"`, `set-status <wo-file> needs_rework`
       (`in_progress→needs_rework`). The next pass requeues it **unconditionally** (step 2 — a **blind**
       re-dispatch; no feedback injection at L1, see `loop-contract.md`); the cap is enforced **only** at
-      `dispatch` (step 5), which HALTs the WO once `attempts ≥ cap`.
+      `dispatch` (step 5), which HALTs the WO once `attempts ≥ cap`. **`in-place` mode: a review fail is
+      TERMINAL, not retryable** — do NOT `reset --hard` (it can't undo the infra state the build applied) and
+      do NOT requeue. Write `wo-NN.HALT` reason `in_place_review_fail`, mark the sidecar halted, escalate. A
+      human inspects the accumulated canonical-env state and re-dispatches from there if appropriate.
 
 11. **Observability append (non-fatal, ⑤ telemetry lane).** Once step 10 has settled the WO's
     disposition, record it for off-line failure-pattern mining. Run, **once per WO**:

--- a/ai-dev-assistant/skills/work-order-loop/references/loop-contract.md
+++ b/ai-dev-assistant/skills/work-order-loop/references/loop-contract.md
@@ -25,6 +25,13 @@ HALT (`ready→needs_rework` is ILLEGAL, so it is never set), and a blocking-cri
 `in_progress` WITH a HALT; both are terminal-by-marker and only escalate. The kernel rejects any other
 transition fail-closed.
 
+**`build_mode == in-place` (operator-gated infra/state runs):** the `in_progress → needs_rework` retryable
+transition does **not** fire and **no `git reset --hard` occurs**. A reset rolls back tracked files but not
+DB/module-enable/`vendor/` state, so it would leave a split-brain; instead a review fail (and a mid-build
+crash) is made **TERMINAL** — write `wo-NN.HALT` (`in_place_review_fail` / `in_place_crash_manual_recovery`)
+and escalate for human reconciliation of the accumulated canonical state. No requeue, no blind re-dispatch.
+The `done`/`blocked→ready`/`ready→in_progress` transitions are unchanged.
+
 ## Bounded verify→fix (D3 — crash-safe)
 
 `wo-run-state.sh dispatch` does **read-increment-write** on `attempts` and checks the cap **before**
@@ -79,7 +86,10 @@ reset row.
 
 **Worktree (carry #4).** The loop owns create/teardown. `git reset` always targets the **handed
 worktree** (`git -C <worktree>`), never the user's main tree, to the **sidecar** `checkpoint_before`
-(③-captured pre-spawn), and only after `merge-base --is-ancestor` validates it.
+(③-captured pre-spawn), and only after `merge-base --is-ancestor` validates it. **In `build_mode ==
+in-place` the loop owns NO worktree lifecycle (the handed path IS the canonical `codePath`) and issues NO
+`git reset` at all** — the reset rows convert to HALT (above), so this carry's reset never runs in-place;
+this is also why in-place is sequential-only and refuses `--parallel`.
 
 ## Compact-line forwarding (G3 — format-stable, mechanical)
 

--- a/ai-dev-assistant/tests/ddev-worktree-spec.sh
+++ b/ai-dev-assistant/tests/ddev-worktree-spec.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Wiring/contract test for GAP-A: DDEV-aware worktrees (--ddev-up) + the build-in-place mode for
+# infra/state work-orders (v5.16.0).
+#
+# GAP A (dogfooded on adrupalcouple p1_scaffold_enable): run-work-orders hard-requires a git worktree
+# and opens a PR, but a worktree is a separate checkout DDEV (bound to the main checkout) can't see —
+# so the only agent-dispatched build path couldn't build a live-DDEV task. Fix has two parts:
+#   PART 1 — /worktree --ddev-up brings up an ISOLATED DDEV against the worktree + seeds DB/files from
+#            main (DB copied, never shared); /worktree-prune tears that DDEV down BEFORE git worktree
+#            remove (else an orphaned registry entry blocks the next same-name worktree).
+#   PART 2 — infra/state WOs declare build_mode:in-place and build on the canonical env (no worktree),
+#            operator-gated, distinct from the code-authoring worktree+PR mode.
+#
+# Greppable wiring assertions (these are prose commands/docs, not scripts).
+# Exit: 0 = all pass; 1 = a failure.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$DIR/.."
+WT="$ROOT/commands/worktree.md"
+PRUNE="$ROOT/commands/worktree-prune.md"
+CONV="$ROOT/references/worktree-conventions.md"
+fail=0
+pass() { echo "PASS: $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+for f in "$WT" "$PRUNE" "$CONV"; do [ -f "$f" ] || bad "missing required file: $f"; done
+
+# ── PART 1: DDEV-aware worktree ──────────────────────────────────────────────
+
+# (1) the opt-in flag exists in the argument-hint + usage.
+if grep -Fq -- '--ddev-up' "$WT" && grep -Fq -- '--ddev-no-seed' "$WT"; then
+  pass "worktree.md exposes --ddev-up / --ddev-no-seed"
+else
+  bad  "worktree.md missing the --ddev-up / --ddev-no-seed flags"
+fi
+
+# (2) the bring-up brings an isolated instance up AND seeds via export/import (the official pattern).
+if grep -Fq -- 'ddev start' "$WT" && grep -Fq -- 'ddev export-db' "$WT" && grep -Fq -- 'ddev import-db' "$WT"; then
+  pass "worktree.md brings up (ddev start) + seeds the DB (export-db → import-db)"
+else
+  bad  "worktree.md does NOT bring up + seed an isolated DDEV (export-db/import-db missing)"
+fi
+
+# (3) auto-naming via --omit-project-name-by-default (so the worktree dir names the project).
+if grep -Fq -- 'omit-project-name-by-default' "$WT"; then
+  pass "worktree.md uses --omit-project-name-by-default for auto-naming"
+else
+  bad  "worktree.md does NOT reference --omit-project-name-by-default (name-collision risk)"
+fi
+
+# (4) under --ddev-up a pinned name: is a HARD halt (no [c]ontinue) — the collision can't be waved through.
+if grep -Fiq -- 'hard' "$WT" && grep -Fiq -- 'pinned `name:`' "$WT"; then
+  pass "worktree.md makes a pinned name: a hard halt under --ddev-up"
+else
+  bad  "worktree.md does NOT hard-halt on a pinned name: under --ddev-up (silent collision)"
+fi
+
+# (5) DB is COPIED, never shared (idea (b) explicitly rejected).
+if grep -Fiq -- 'copied, never shared' "$WT" || grep -Fiq -- 'copied' "$WT" && grep -Fiq -- 'NOT used' "$WT"; then
+  pass "worktree.md states the DB is copied, not a shared container (idea (b) rejected)"
+else
+  bad  "worktree.md does NOT state DB-copied-not-shared (risk of the unsupported shared-db hack)"
+fi
+
+# (6) /worktree-prune tears the DDEV project down BEFORE git worktree remove (orphan-registry guard).
+if grep -Fq -- 'ddev delete' "$PRUNE" && grep -Fq -- 'git worktree remove' "$PRUNE" \
+   && grep -Fiq -- 'before' "$PRUNE" && grep -Fiq -- 'orphaned' "$PRUNE"; then
+  pass "worktree-prune.md ddev-deletes BEFORE git worktree remove (orphaned-registry guard)"
+else
+  bad  "worktree-prune.md does NOT order ddev delete before git worktree remove (orphan risk)"
+fi
+if grep -Fq -- 'omit-snapshot' "$PRUNE"; then
+  pass "worktree-prune.md uses --omit-snapshot on the throwaway worktree DB"
+else
+  bad  "worktree-prune.md ddev delete lacks --omit-snapshot (slow snapshot of a throwaway DB)"
+fi
+
+# (7) conventions doc bumped to v1.3 and documents the DDEV-aware section + teardown ordering + taxonomy.
+if grep -Fq -- 'Worktree Conventions v1.3' "$CONV"; then
+  pass "worktree-conventions bumped to v1.3"
+else
+  bad  "worktree-conventions not bumped to v1.3"
+fi
+if grep -Fiq -- 'teardown ordering' "$CONV" && grep -Fiq -- 'build-in-place' "$CONV" && grep -Fiq -- 'copy, never share' "$CONV"; then
+  pass "worktree-conventions §8 documents teardown ordering + build-in-place taxonomy + copy-not-share"
+else
+  bad  "worktree-conventions §8 missing teardown ordering / build-in-place taxonomy / copy-not-share"
+fi
+
+# ── PART 2: build-in-place for infra/state WOs ───────────────────────────────
+RWO="$ROOT/commands/run-work-orders.md"
+LOOP="$ROOT/skills/work-order-loop/SKILL.md"
+LOOPC="$ROOT/skills/work-order-loop/references/loop-contract.md"
+LIFE="$ROOT/references/work-order-lifecycle.md"
+for f in "$RWO" "$LOOP" "$LOOPC" "$LIFE"; do [ -f "$f" ] || bad "missing required file: $f"; done
+
+# (8) run-work-orders exposes --in-place and rejects --parallel --in-place (sequential-only).
+if grep -Fq -- '--in-place' "$RWO" && grep -Fiq -- 'cannot be combined with' "$RWO"; then
+  pass "run-work-orders exposes --in-place + rejects --parallel --in-place (sequential-only)"
+else
+  bad  "run-work-orders missing --in-place or the --parallel mutual-exclusion"
+fi
+
+# (9) --in-place is OPERATOR-GATED: explicit confirm + refuses unattended.
+if grep -Fiq -- 'canonical environment' "$RWO" && grep -Fq -- '[y]/[N]' "$RWO" \
+   && grep -Fiq -- 'unattended' "$RWO"; then
+  pass "run-work-orders --in-place is operator-gated ([y]/[N] confirm + refuses unattended)"
+else
+  bad  "run-work-orders --in-place is NOT operator-gated (missing confirm / unattended refusal)"
+fi
+
+# (10) --in-place skips the worktree precondition (builds on codePath).
+if grep -Fiq -- 'skip the worktree precondition' "$RWO"; then
+  pass "run-work-orders --in-place skips the worktree precondition (builds on codePath)"
+else
+  bad  "run-work-orders --in-place does NOT skip the worktree precondition"
+fi
+
+# (10b) BRANCH SAFETY (red-team fix): in-place refuses when codePath is on the integration base, so it
+#       never commits directly to main (file changes must land on a PR-able feature branch).
+if grep -Fq -- 'branch --show-current' "$RWO" && grep -Fiq -- 'refuse' "$RWO" \
+   && grep -Fiq -- 'feature branch' "$RWO"; then
+  pass "run-work-orders --in-place refuses building on the integration base (no commit-to-main)"
+else
+  bad  "run-work-orders --in-place lacks the branch-safety guard (could commit directly to main)"
+fi
+
+# (11) THE CRITICAL SAFETY PROPERTY: in-place NEVER resets — both reset sites become HALT.
+if grep -Fiq -- 'never `git reset --hard`' "$LOOP" \
+   && grep -Fq -- 'in_place_review_fail' "$LOOP" && grep -Fq -- 'in_place_crash_manual_recovery' "$LOOP"; then
+  pass "work-order-loop in-place NEVER resets — reset sites convert to HALT (split-brain guard)"
+else
+  bad  "work-order-loop in-place may still reset --hard (split-brain risk — the killer coupling)"
+fi
+
+# (12) in-place per-WO review scopes the diff to this WO (--base <cp>, not the integration base).
+if grep -Fq -- '--base <cp>' "$LOOP"; then
+  pass "work-order-loop in-place per-WO review uses --base <cp> (incremental diff, no prior-WO bleed)"
+else
+  bad  "work-order-loop in-place review does NOT use --base <cp> (cumulative-diff false positives)"
+fi
+
+# (13) loop-contract records the in-place no-reset / terminal-on-fail transition rule.
+if grep -Fq -- 'in_place_review_fail' "$LOOPC" && grep -Fiq -- 'no `git reset' "$LOOPC"; then
+  pass "loop-contract documents the in-place no-reset / terminal-on-fail rule"
+else
+  bad  "loop-contract missing the in-place no-reset / terminal-on-fail rule"
+fi
+
+# (14) lifecycle doc carries the code-authoring vs infra/state taxonomy + lifts the worktree invariant.
+if grep -Fiq -- 'taxonomy' "$LIFE" && grep -Fiq -- 'code-authoring' "$LIFE" \
+   && grep -Fiq -- 'build-in-place' "$LIFE" && grep -Fq -- '--in-place' "$LIFE"; then
+  pass "work-order-lifecycle documents the build-mode taxonomy + --in-place lifting the worktree invariant"
+else
+  bad  "work-order-lifecycle missing the build-mode taxonomy / --in-place invariant lift"
+fi
+
+echo
+[ "$fail" -eq 0 ] && { echo "ddev-worktree-spec: ALL PASS"; exit 0; } || { echo "ddev-worktree-spec: FAILURES"; exit 1; }


### PR DESCRIPTION
## GAP A — the agent-dispatched build path can't build a live-DDEV task

Found dogfooding **`adrupalcouple p1_scaffold_enable`** (recorded in `aida-gaps.md`). `run-work-orders` → `work-order-loop` hard-requires a **git worktree** and opens a PR, but a worktree is a *separate checkout* the running **DDEV** (bound to the main checkout) can't see — so AIDA's only agent-dispatched build path structurally couldn't build a live-DDEV task on the running environment. Grounded in **DDEV's own published git-worktree workflow** (<https://ddev.com/blog/git-worktree-contributor-training/>) and research that ruled out a shared DB container as unsupported/corruption-prone.

## Part 1 — DDEV-aware worktree (`/worktree --ddev-up`, opt-in)

- Brings up the worktree's **own isolated DDEV** (own web+db) and seeds DB+files from the main checkout via `ddev export-db`/`import-db`/`import-files`. The DB is **copied, never shared** (pointing a worktree at the main db container resets on restart + risks concurrent-write corruption — rejected).
- Auto-naming via `ddev config global --omit-project-name-by-default`; a pinned `name:` is a **hard halt** under `--ddev-up`.
- `/worktree-prune` now `ddev delete --omit-snapshot`s the worktree's DDEV project **before** `git worktree remove` — fixes the **orphaned-registry** teardown gap (DDEV's own blog only shows `git worktree remove`, leaving a registered project root that blocks the next same-name worktree).
- `worktree-conventions.md` → **v1.3** (§8 rewritten: auto-naming, copy-not-share, teardown ordering, the taxonomy).

## Part 2 — build-in-place for infra/state WOs (`/run-work-orders --in-place`)

An **operator-gated, sequential-only** mode for infra/state WOs (composer require + drush en + config import + theme build) whose produced **state** must land on the **canonical** integration env, which an isolated worktree can't reach. Builds on the main checkout's DDEV; file changes still PR-able.

- Skips the worktree precondition; **refuses to build on the integration base** (no commit-to-`main`); requires `[y]` confirmation and **refuses unattended**; rejects `--parallel --in-place`.
- **Critical safety property:** in-place **never `git reset --hard`** — a reset rolls back tracked files but *not* DB/module-enable/`vendor/` state (split-brain). Both reset sites (crash-recovery + retryable-fail) convert to **HALT+escalate**; a review failure is terminal, never auto-reworked. Per-WO `/review` uses `--base <cp>` (this WO's checkpoint) for an incremental diff.
- Taxonomy: **code-authoring WO → worktree+PR; infra/state WO → build-in-place** (`references/work-order-lifecycle.md`); `loop-contract.md` records the no-reset / terminal-on-fail transition.
- First cut is task-level `--in-place`; a per-WO `build_mode` field is the documented future evolution.

### Red-team fix included
The in-place loop commits to `codePath`'s **current branch** — on `main` it would commit directly to `main` (and PR `main→main`). Added a **branch-safety guard**: `--in-place` refuses when `codePath` is on the integration base, instructing the operator to create a feature branch first.

## Tests
New `tests/ddev-worktree-spec.sh` — **17 assertions** (the `--ddev-up` bring-up/seed/auto-naming, the prune teardown ordering, the `--in-place` gate + base-refusal + `--parallel` rejection, and the never-reset / `--base <cp>` loop branches). Sibling `wo-*` specs pass.

## Scope note
The change is **additive** — default worktree+PR behavior is untouched; the in-place branches are guards keyed on `build_mode == in-place`. The red-teamed sequential/parallel loops are not restructured.

## Metadata
aida **5.16.0**, marketplace `metadata.version` **2.0.14**. `5.14.0`/`2.0.12` are reserved for open **#224**, `5.15.0`/`2.0.13` for **#225** — expect one-line marketplace.json/CHANGELOG conflicts at merge (routine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)