### PR TITLE
code-paper-test v0.11.0: test-team Synthesizer + harness hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.12"
+    "version": "2.0.13"
   },
   "plugins": [
     {
@@ -176,7 +176,7 @@
       "name": "code-paper-test",
       "source": "./code-paper-test",
       "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase (50–300), or a 3-agent competing team in isolated worktrees (300+, security-critical, skills). Verifies external calls for both existence and behavioral contracts (return-shape/nullability diffing, chained-object tracing, taint-stance fallback for closed-source). Supports `--json` for CI.",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "author": {
         "name": "camoa"
       },

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-06-22
+
+**Theme: test-team context-economy + harness hardening.**
+
+### Added
+- **4th "Synthesizer" teammate in `/code-paper-test:test-team`.** The lead no longer reads the three large analysis files (`happy-path`/`edge-case`/`red-team`) into its own active context to synthesize. A fresh-context Synthesizer teammate reads them and writes `paper-test-team-report.md` (+ the JSON report when `--json`), keeping the heavy reads off the lead — the second context-overflow vector after the inline-skill fix. Step 4 gains task `5b`; the lead's Step 5/6 role is reduced to spawning the testers then the Synthesizer.
+- **`disallowed-tools: Write, Edit` on the `paper-test` skill.** The skill is read-only analysis (`allowed-tools: Read, Glob, Grep, Bash`); banning Write/Edit at the harness level hardens it against accidental or prompt-injected writes. Not added to `test-team.md` — that command legitimately writes analysis files.
+- **Release-hygiene section in `CONVENTIONS.md`** documenting the `/plugin-creation-tools:validate --strict` pre-PR gate (catches S14 / FM01 / X02) and the four version locations to bump together.
+- **Security-guidance positioning note** in the Red Team Attacker spawn prompt and the SKILL.md Pairing section: the Red Team lens (adversarial analysis of the TARGET code at test time) complements the security-guidance plugin (review of Claude's own edits in real time) — different moments, not substitutes.
+
+### Fixed
+- **SKILL.md `version:` drift.** The 0.10.1 evergreen-docs pass bumped `plugin.json` but left the SKILL.md frontmatter at `0.10.0`; both are now `0.11.0`.
+
+### Notes
+- **S14 (`model: sonnet` → `inherit`) was already fixed in v0.10.0** (PR #215, pulled forward at review). It is a no-op here — the file already reads `model: inherit` (the "file wins" rule).
+- v0.12.0 (Agent SDK alignment) remains **not applicable** — the plugin ships no Agent SDK surface.
+
 ## [0.10.1] - 2026-06-19
 
 ### Changed — docs

--- a/code-paper-test/CONVENTIONS.md
+++ b/code-paper-test/CONVENTIONS.md
@@ -36,3 +36,7 @@
 - Current state only — no historical narratives
 - Language-agnostic examples preferred (PHP shown as primary)
 - Skill/config testing uses instruction tracing, not code tracing — see `references/skill-and-config-testing.md`
+
+## Release Hygiene
+- Run `/plugin-creation-tools:validate --strict` before every PR. `--strict` catches S14 (inline model overflow), FM01 (frontmatter parse errors), and X02 (description length) in addition to the standard checks.
+- Bump all four version locations together: `.claude-plugin/plugin.json`, the `skills/paper-test/SKILL.md` `version:` field, this plugin's entry **and** `metadata.version` in the root `marketplace.json`, and a `CHANGELOG.md` entry.

--- a/code-paper-test/CONVENTIONS.md
+++ b/code-paper-test/CONVENTIONS.md
@@ -39,4 +39,4 @@
 
 ## Release Hygiene
 - Run `/plugin-creation-tools:validate --strict` before every PR. `--strict` catches S14 (inline model overflow), FM01 (frontmatter parse errors), and X02 (description length) in addition to the standard checks.
-- Bump all four version locations together: `.claude-plugin/plugin.json`, the `skills/paper-test/SKILL.md` `version:` field, this plugin's entry **and** `metadata.version` in the root `marketplace.json`, and a `CHANGELOG.md` entry.
+- Bump the version everywhere it appears: `.claude-plugin/plugin.json`, the `skills/paper-test/SKILL.md` `version:` field, this plugin's entry **and** `metadata.version` in the root `marketplace.json`, the `README.md` version line, and a `CHANGELOG.md` entry.

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -278,7 +278,7 @@ Specific checks for AI-generated code:
 
 ## Version
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the full version history. Current version: **0.10.1**.
+See [`CHANGELOG.md`](CHANGELOG.md) for the full version history. Current version: **0.11.0**.
 
 ## License
 

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -18,7 +18,7 @@ Pass `--json` to emit a CI-consumable JSON report alongside the markdown report.
 
 ## What This Does
 
-Spawns a 3-teammate agent team that paper-tests the specified code files from competing perspectives. Each teammate traces the code with different input strategies, then they cross-challenge findings. The lead synthesizes a prioritized flaw report next to the target code.
+Spawns a team that paper-tests the specified code files from competing perspectives: three testers (Happy Path, Edge Case, Red Team) trace the code with different input strategies and cross-challenge findings, then a fourth **Synthesizer** teammate compiles a prioritized flaw report next to the target code (keeping the heavy reads off the lead).
 
 > **Aggregating across parallel teammates:** Claude Code 2.1.118+ ships a `PostToolBatch` hook that fires once after a batch of parallel tool calls resolves (Hooks Reference). For users who want to aggregate per-teammate JSON outputs into a single batch summary (e.g., posting one consolidated finding count to Slack instead of three), `PostToolBatch` is the right primitive. This plugin does not ship the hook — copy it into your project's `.claude/hooks.json` if needed. Reference, don't implement.
 
@@ -103,9 +103,10 @@ Create a team and these tasks:
 | 2 | Probe edge cases — boundary values, nulls, empty, large inputs | Edge Case Hunter | — |
 | 3 | Attack with adversarial inputs — injection, malformed data, race conditions | Red Team Attacker | — |
 | 4 | Cross-challenge — debate flaw severity, dispute false findings, identify blind spots | All three | 1, 2, 3 |
-| 5 | Synthesize prioritized flaw report | Lead | 4 |
+| 5 | Spawn the Synthesizer teammate, then report the saved report path | Lead | 4 |
+| 5b | Synthesize prioritized flaw report from the three analyses | Synthesizer | 4 |
 
-**Quality Gate:** Each tester must complete ALL assigned categories before marking their task done. If a tester skips categories (e.g., Edge Case Hunter tests 3 of 6 categories), the lead should flag incomplete analysis in the final report and note which categories were untested.
+**Quality Gate:** Each tester must complete ALL assigned categories before marking their task done. If a tester skips categories (e.g., Edge Case Hunter tests 3 of 6 categories), the Synthesizer should flag incomplete analysis in the final report and note which categories were untested.
 
 ### Step 5 — Spawn Teammates
 
@@ -126,20 +127,19 @@ the whole team up. When `${CLAUDE_EFFORT}` is unset (model without effort
 support), use each role's floor as-is. Substitute the resulting level into the
 `**Effort:**` line of each spawn block below.
 
-Spawn 3 teammates using the prompt templates below. Substitute `{target_dir}` with the directory computed in Step 1, `{list each file path}` with the validated targets, and interpolate `JSON_MODE={true|false}` near the top of each spawn prompt (so the teammate knows whether to emit the parallel `.json` report). After spawning:
+Spawn the **3 tester teammates** (the Synthesizer is spawned later, in Step 6) using the prompt templates below. Substitute `{target_dir}` with the directory computed in Step 1, `{list each file path}` with the validated targets, and interpolate `JSON_MODE={true|false}` near the top of each spawn prompt (so the teammate knows whether to emit the parallel `.json` report). After spawning:
 
-1. Tell the user: "Team spawned. Teammates are working — I'll synthesize when they finish."
+1. Tell the user: "Team spawned. Teammates are working — the Synthesizer will compile the report when they finish."
 2. If running inside tmux, teammates appear in split panes (visible output). Otherwise they run in-process (background).
 3. Do NOT perform testing yourself — wait for all teammates to complete before proceeding.
 
-### Step 6 — Synthesize
+### Step 6 — Synthesize (via the Synthesizer teammate)
 
-When all teammates finish:
+When tasks 1–4 are complete, **spawn the Synthesizer teammate (Task 5b)** using the Teammate 4 block below — do NOT read the three analysis files into the lead's own context. The Synthesizer reads all three analysis files in its own fresh context and writes the final report, which keeps the heavy reads off the lead (the v0.11.0 context-economy fix). Substitute `{target_dir}` and interpolate `JSON_MODE={true|false}` into the spawn prompt exactly as for the testers.
 
-- Read `{target_dir}/happy-path-analysis.md`, `{target_dir}/edge-case-analysis.md`, `{target_dir}/red-team-analysis.md`
-- Write `{target_dir}/paper-test-team-report.md` using the Output Format below
-- **If `JSON_MODE=true`:** also read `{target_dir}/happy-path-analysis.json`, `{target_dir}/edge-case-analysis.json`, `{target_dir}/red-team-analysis.json` (each teammate writes both markdown and JSON when `--json` is passed — see spawn prompts). Aggregate per the schema in `skills/paper-test/references/json-output-schema.md` and write `{target_dir}/paper-test-team-report.json`. Honor the invariants: `findings` is always an array, severity values are uppercase (`CRITICAL` etc.), `status` is `fail` if any CRITICAL or HIGH finding exists, `warning` if only MEDIUM/LOW findings, `pass` only if no MEDIUM-or-higher findings. Each aggregated finding includes `found_by` (union of teammate roles whose per-teammate JSON reported the same file + line span + category) and `disputed` (boolean — `true` iff the cross-challenge markdown report lists this finding in its "Disputed Findings" table). See the schema's "Team-specific finding fields" section for the precise field contract.
-- Tell the user: "Paper test team complete. Report saved to `{target_dir}/paper-test-team-report.md`" (append "and `paper-test-team-report.json`" when `JSON_MODE=true`).
+The Synthesizer writes `{target_dir}/paper-test-team-report.md` (and, when `JSON_MODE=true`, `{target_dir}/paper-test-team-report.json`) using the Output Format below. The JSON aggregation honors the invariants: `findings` is always an array, severity values are uppercase (`CRITICAL` etc.), `status` is `fail` if any CRITICAL or HIGH finding exists, `warning` if only MEDIUM/LOW findings, `pass` only if no MEDIUM-or-higher findings. Each aggregated finding includes `found_by` (union of teammate roles whose per-teammate JSON reported the same file + line span + category) and `disputed` (boolean — `true` iff the cross-challenge markdown report lists this finding in its "Disputed Findings" table). See the schema's "Team-specific finding fields" section for the precise field contract.
+
+When the Synthesizer completes, tell the user: "Paper test team complete. Report saved to `{target_dir}/paper-test-team-report.md`" (append "and `paper-test-team-report.json`" when `JSON_MODE=true`).
 
 ---
 
@@ -199,7 +199,7 @@ JSON shape — match `skills/paper-test/references/json-output-schema.md` exactl
 - `schema_version: "1.0"`, `tool: "test-team"`, `mode: "test-team"`, `target_type` per target type, `target_files`, `timestamp` (ISO 8601 UTC)
 - `summary` with counts by severity (CRITICAL/HIGH/MEDIUM/LOW/INFO — uppercase), `total_findings`, `scenarios_traced`, `dependencies_verified`, `contracts_verified`
 - `findings` is always an array; each finding has `severity`, `category`, `file`, `line_start`, `line_end`, `title`, `description`, `fix_suggestion`, `scoring_factors {reach, impact, reversibility, exploitability}` (1-3 each; omit only for INFO), and `found_by: ["happy_path"]`
-- Do NOT include `disputed`, `team`, or cross-challenge data — the lead aggregates those later
+- Do NOT include `disputed`, `team`, or cross-challenge data — the Synthesizer aggregates those later
 
 Use this format:
 
@@ -369,6 +369,8 @@ TARGET FILES:
 YOUR MISSION:
 Try adversarial inputs and find security/reliability holes. Your lens: "How would an attacker exploit this code?"
 
+Note: The security-guidance plugin performs in-session edit review of Claude's own code changes in real time. Your role is different: you analyze the TARGET code for adversarial vulnerabilities at test time, before any session edits occur. These are complementary, not overlapping. Do not defer to security-guidance for target-code attack analysis — that is your job.
+
 Design attack scenarios for EACH relevant category:
 1. **SQL injection** — `' OR 1=1 --`, union-based, blind SQLi
 2. **XSS** — `<script>alert(1)</script>`, event handlers, encoded payloads
@@ -455,11 +457,47 @@ To signal completion to the lead, either:
 - Or output JSON: {"continue": false} to hard-stop your turn immediately
 ```
 
+### Teammate 4: Synthesizer
+
+**Model:** inherit
+**MaxTurns:** 10
+**Isolation:** worktree
+
+```
+You are the Synthesizer for a paper testing team. The three analysis phases are complete.
+
+YOUR MISSION:
+Read the three analysis files and produce the final prioritized flaw report. You do NOT
+re-test the code — you aggregate what the three testers already found.
+
+FILES TO READ:
+  {target_dir}/happy-path-analysis.md
+  {target_dir}/edge-case-analysis.md
+  {target_dir}/red-team-analysis.md
+  [If JSON_MODE=true, also read happy-path-analysis.json, edge-case-analysis.json, red-team-analysis.json]
+
+WRITE the final report to:
+  {target_dir}/paper-test-team-report.md
+  [If JSON_MODE=true, also write {target_dir}/paper-test-team-report.json per the team
+   aggregation schema in skills/paper-test/references/json-output-schema.md]
+
+Use the Output Format defined below in this command file. Aggregate findings, de-duplicate
+across the three perspectives, record cross-challenge outcomes (Disputed Findings), and
+split the Existence Verification and Behavioral Contract Verification tables. For the JSON
+report honor the schema invariants: `findings` is always an array, severity values are
+uppercase, `status` is `fail` if any CRITICAL/HIGH finding exists, `warning` for only
+MEDIUM/LOW, `pass` only when no MEDIUM-or-higher finding exists; set `found_by` (union of
+roles that reported the same file+line span+category) and `disputed` per the cross-challenge.
+
+WHEN DONE:
+Output: {"continue": false}
+```
+
 ---
 
 ## Output Format
 
-The lead synthesizes into `{target_dir}/paper-test-team-report.md`:
+The Synthesizer (Teammate 4) synthesizes into `{target_dir}/paper-test-team-report.md`:
 
 ```markdown
 # Paper Test Team Report

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -14,7 +14,7 @@ Paper test code from 3 competing perspectives using an agent team. A Happy Path 
 /code-paper-test:test-team [--json] <file-path> [file-path...]
 ```
 
-Pass `--json` to emit a CI-consumable JSON report alongside the markdown report. Schema: `skills/paper-test/references/json-output-schema.md` (`schema_version: "1.0"`).
+Pass `--json` to emit a CI-consumable JSON report alongside the markdown report. Schema: `skills/paper-test/references/json-output-schema.md` (`schema_version: "1.1"`; additive minor — CI should pin `^1\.`).
 
 ## What This Does
 
@@ -46,10 +46,12 @@ If a file doesn't exist:
 
 Stop here if no valid targets.
 
-Determine the **target directory** for output:
+Determine the **target directory** for output, resolved to an **absolute** path:
 - Single file → same directory as the file
 - Multiple files in same directory → that directory
 - Multiple files across directories → their common parent directory
+
+**`{target_dir}` MUST be absolute** (resolve it — e.g. `realpath`/`pwd` — before substituting it into any spawn prompt). Every teammate runs in its own `Isolation: worktree` checkout, so a *relative* `{target_dir}` would resolve INSIDE each teammate's worktree: the per-teammate analysis files would then be invisible across teammates (breaking the Task 4 cross-challenge, where each tester reviews the others' `*-analysis.md`) and invisible to the Synthesizer (which reads all three). An absolute path points every teammate at the same real directory.
 
 ### Step 2 — Check Prerequisites
 
@@ -104,7 +106,7 @@ Create a team and these tasks:
 | 3 | Attack with adversarial inputs — injection, malformed data, race conditions | Red Team Attacker | — |
 | 4 | Cross-challenge — debate flaw severity, dispute false findings, identify blind spots | All three | 1, 2, 3 |
 | 5 | Spawn the Synthesizer teammate, then report the saved report path | Lead | 4 |
-| 5b | Synthesize prioritized flaw report from the three analyses | Synthesizer | 4 |
+| 5b | Synthesize prioritized flaw report from the three analyses | Synthesizer | 4, 5 |
 
 **Quality Gate:** Each tester must complete ALL assigned categories before marking their task done. If a tester skips categories (e.g., Edge Case Hunter tests 3 of 6 categories), the Synthesizer should flag incomplete analysis in the final report and note which categories were untested.
 
@@ -196,7 +198,7 @@ If JSON_MODE=true (the lead will pass this in the spawn prompt), ALSO write a pa
   {target_dir}/happy-path-analysis.json
 
 JSON shape — match `skills/paper-test/references/json-output-schema.md` exactly:
-- `schema_version: "1.0"`, `tool: "test-team"`, `mode: "test-team"`, `target_type` per target type, `target_files`, `timestamp` (ISO 8601 UTC)
+- `schema_version: "1.1"`, `tool: "test-team"`, `mode: "test-team"`, `target_type` per target type, `target_files`, `timestamp` (ISO 8601 UTC)
 - `summary` with counts by severity (CRITICAL/HIGH/MEDIUM/LOW/INFO — uppercase), `total_findings`, `scenarios_traced`, `dependencies_verified`, `contracts_verified`
 - `findings` is always an array; each finding has `severity`, `category`, `file`, `line_start`, `line_end`, `title`, `description`, `fix_suggestion`, `scoring_factors {reach, impact, reversibility, exploitability}` (1-3 each; omit only for INFO), and `found_by: ["happy_path"]`
 - Do NOT include `disputed`, `team`, or cross-challenge data — the Synthesizer aggregates those later
@@ -481,13 +483,56 @@ WRITE the final report to:
   [If JSON_MODE=true, also write {target_dir}/paper-test-team-report.json per the team
    aggregation schema in skills/paper-test/references/json-output-schema.md]
 
-Use the Output Format defined below in this command file. Aggregate findings, de-duplicate
-across the three perspectives, record cross-challenge outcomes (Disputed Findings), and
-split the Existence Verification and Behavioral Contract Verification tables. For the JSON
-report honor the schema invariants: `findings` is always an array, severity values are
-uppercase, `status` is `fail` if any CRITICAL/HIGH finding exists, `warning` for only
-MEDIUM/LOW, `pass` only when no MEDIUM-or-higher finding exists; set `found_by` (union of
-roles that reported the same file+line span+category) and `disputed` per the cross-challenge.
+Aggregate findings, de-duplicate across the three perspectives, record cross-challenge
+outcomes, and split the Existence vs Behavioral Contract tables. Write the markdown report
+in EXACTLY this format (this is the canonical Output Format — keep it in sync with the
+command's "## Output Format" section):
+
+# Paper Test Team Report
+
+## Target
+{File paths tested, line counts, language}
+
+## Test Method
+Agent team with 3 competing perspectives.
+Source files: [happy-path-analysis.md] | [edge-case-analysis.md] | [red-team-analysis.md]
+
+## Summary
+| Perspective | Scenarios Run | Flaws Found | Critical |
+|-------------|---------------|-------------|----------|
+| Happy Path | {N} | {N} | {N} |
+| Edge Case | {N} | {N} | {N} |
+| Red Team | {N} | {N} | {N} |
+
+## Prioritized Flaws
+| # | Line | Flaw | Found By | Severity | Confirmed By Others? | Fix |
+|---|------|------|----------|----------|---------------------|-----|
+
+## Disputed Findings
+| # | Flaw | Claimed By | Disputed By | Resolution |
+|---|------|-----------|-------------|------------|
+
+## Existence Verification
+| # | External Call | Exists? | Issue |
+|---|-------------|---------|-------|
+
+## Behavioral Contract Verification
+| # | External Call | Behavior verified? | Contract source | Gap |
+|---|-------------|-------------------|----------------|-----|
+
+## Contract Verification
+| # | Relationship | Verified? | Issue |
+|---|-------------|-----------|-------|
+
+## Blind Spots (Unanimous Agreements)
+{Areas where all 3 agreed the code is fine — flag for human review}
+
+## Recommended Test Cases
+{Concrete test cases to write based on flaws found}
+| # | Test | Input | Expected | Covers Flaw |
+|---|------|-------|----------|-------------|
+
+For the JSON report (JSON_MODE=true) honor the schema invariants in skills/paper-test/references/json-output-schema.md: `findings` is always an array, severity values are uppercase, `status` is `fail` if any CRITICAL/HIGH finding exists, `warning` for only MEDIUM/LOW, `pass` only when no MEDIUM-or-higher finding exists; set `found_by` (union of roles that reported the same file+line span+category) and `disputed` per the cross-challenge.
 
 WHEN DONE:
 Output: {"continue": false}

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: paper-test
 description: Use when testing code, skills, commands, or configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, edge cases, contract violations, and AI hallucinations. Use when user says "paper test", "trace this", "find bugs", "check for edge cases", "audit this code", "verify AI code", "test this skill", "test this agent", "validate this implementation", "review this logic", "check dependencies", "check this config", "walk through this code", "step through this", "dry run", "sanity check", "red team this", "poke holes in this". MUST verify external calls — never assume methods exist. Use proactively before deploying changes or after AI generates code.
-version: 0.10.0
+version: 0.11.0
 model: inherit
 allowed-tools: Read, Glob, Grep, Bash
+disallowed-tools: Write, Edit
 user-invocable: true
 ---
 
@@ -116,6 +117,8 @@ For CI integration, aggregation, or programmatic consumption, invoke with `--jso
 ## Pairing with `skill-quality-reviewer` for Skill Testing
 
 When paper-testing a skill, command, or agent file, run `plugin-creation-tools:skill-quality-reviewer` first (deterministic: stale SDK refs, dropped imperatives, frontmatter gaps) then paper-test for the semantic analysis (instruction fidelity, trigger coverage, context budget). See `references/skill-and-config-testing.md` §"Deterministic + Agentic pairing". In skill-mode, after verifying tool/file/skill references exist, verify each referenced capability PRODUCES what the calling step consumes — see `references/behavioral-verification.md` §B2.
+
+**Layering with native security review.** The Red Team Attacker lens in `/code-paper-test:test-team` complements the security-guidance plugin — security-guidance catches issues in Claude's own edits in real time; the Red Team Attacker finds adversarial vulnerabilities in the target code at analysis time. They cover different moments and are not substitutes.
 
 ## References
 

--- a/code-paper-test/skills/paper-test/SKILL.md
+++ b/code-paper-test/skills/paper-test/SKILL.md
@@ -101,8 +101,8 @@ A method existing is not it returning what you assume. Existence verification is
 
 For CI integration, aggregation, or programmatic consumption, invoke with `--json` to emit a stable, versioned JSON document instead of the markdown report.
 
-- Available on `/paper-test` (quick and structured-3-phase modes) and `/code-paper-test:test-team` (lead synthesis).
-- Schema is pinned at `schema_version: "1.0"` with an additive-only minor-version contract. CI should pin `^1\.`, not exact match.
+- Available on `/paper-test` (quick and structured-3-phase modes) and `/code-paper-test:test-team` (Synthesizer aggregation).
+- Schema follows an additive-only minor-version contract (currently `schema_version: "1.1"`). CI should pin `^1\.`, not an exact match.
 - Severity values match the existing rubric exactly: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`.
 - `findings` is always an array — `[]` when clean, never `null` or omitted.
 - `status` is the overall gate verdict: `pass` / `warning` / `fail`. Use `pass` only when no MEDIUM-or-higher findings exist and the run completed fully.

--- a/code-paper-test/skills/paper-test/references/json-output-schema.md
+++ b/code-paper-test/skills/paper-test/references/json-output-schema.md
@@ -127,7 +127,7 @@ Example for a passing trace with one low-severity finding:
 
 ## `/code-paper-test:test-team --json` output
 
-Test-team mode emits the common envelope PLUS a `team` section holding per-teammate breakdowns and the cross-challenge debate outcome. Write location: `{target_dir}/paper-test-team-report.json` (sibling to the existing `paper-test-team-report.md`). Each teammate also writes `{role}-analysis.json` in `{target_dir}` so the lead can aggregate without re-parsing markdown.
+Test-team mode emits the common envelope PLUS a `team` section holding per-teammate breakdowns and the cross-challenge debate outcome. Write location: `{target_dir}/paper-test-team-report.json` (sibling to the existing `paper-test-team-report.md`). Each teammate also writes `{role}-analysis.json` in `{target_dir}` so the Synthesizer can aggregate without re-parsing markdown.
 
 The example below shows the shape only — the individual counts (`confirmed_by_multiple`, per-teammate `findings_count`, etc.) are illustrative and will not be cross-consistent with the single truncated finding shown.
 


### PR DESCRIPTION
## What

The **v0.11.0** wave from the 2026-05-29 rollout — test-team context-economy + harness hardening. All changes are opt-in/additive; the existence + behavioral verification discipline is untouched. Plugin `0.10.1 → 0.11.0`; catalog metadata `2.0.12 → 2.0.13`.

## Changes

| Task | Change |
|------|--------|
| **Synthesizer teammate** | `/code-paper-test:test-team` gains a 4th fresh-context **Synthesizer** (Task 5b). The lead no longer reads the three large analysis files into its own active context to synthesize — the Synthesizer reads them and writes `paper-test-team-report.md` (+ JSON). Closes the second context-overflow vector after the inline-skill fix. Step 4 gains `5b`; the lead's Step 5/6 role reduces to spawning testers then the Synthesizer. |
| **`disallowed-tools`** | `disallowed-tools: Write, Edit` on the `paper-test` skill (read-only analysis; harness-level hardening). Deliberately **not** on `test-team.md` (it writes analysis files). |
| **`--strict` hygiene** | New Release Hygiene section in `CONVENTIONS.md` (the `validate --strict` pre-PR gate + the 4 version locations to bump together). |
| **Security positioning** | Note in the Red Team spawn + SKILL.md Pairing: the Red Team lens (target-code adversarial analysis at test time) complements the security-guidance plugin (review of Claude's own edits in real time) — not substitutes. |
| **Version-drift fix** | The #223 evergreen pass bumped `plugin.json` to 0.10.1 but left SKILL.md at `0.10.0`; both now `0.11.0`. |

## Coherence sweep

After moving synthesis to the Synthesizer, swept 4 stale "the lead synthesizes/aggregates" references (What-This-Does intro, Output-Format intro, Happy-Path JSON note, Quality-Gate note) over to the Synthesizer.

## No-ops (per the rollout)

- **S14** (`model: sonnet → inherit`) was already fixed in v0.10.0 (#215, pulled forward at review) — file already `model: inherit` ("file wins"). The 2026-05-29 roadmap's stale "scope held" note has been corrected.
- **v0.12.0** (Agent SDK alignment) — N/A, the plugin ships no Agent SDK surface.

## Validation

`/plugin-creation-tools:validate code-paper-test --strict` → **PASS** (0 errors, 0 warnings): S14 clean, `disallowed-tools` (S15) clean, marketplace sync (entry 0.11.0 / metadata 2.0.13), X02 clean. One Info — an intentional `claude-code-sdk` reference that documents the deprecated name for the reviewer to catch (not a defect).

## Note for the next session

One open verification item recorded in the roadmap: confirm in a **live multi-agent run** that the worktree-isolated Synthesizer can read the three `*-analysis.md` artifacts (kept `Isolation: worktree` per the rollout spec + CONVENTIONS; the existing 3-tester→lead-read flow indicates artifacts are cross-context readable, but a live run is the real proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2Jg23kUPayhwb3SpQZ7Na