### PR TITLE
docs: community-health profile + per-plugin usage examples & badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Report something that isn't working as expected in one of the camoa-skills plugins.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out as much detail as you can — it makes triage much faster.
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Plugin
+      description: Which plugin is affected?
+      options:
+        - dev-guides-navigator
+        - plugin-creation-tools
+        - ai-dev-assistant
+        - code-quality-tools
+        - brand-content-design
+        - drupal-htmx
+        - drupal-ai-contrib
+        - code-paper-test
+        - drupal-dev-framework
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Tell us what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The exact command(s) or actions that trigger the bug.
+      placeholder: |
+        1. Run `/plugin-name:command ...`
+        2. ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / version
+      description: Plugin version (see `<plugin>/plugin.json` or the marketplace listing), Claude Code version, OS.
+      placeholder: |
+        Plugin version:
+        Claude Code version:
+        OS:
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, or anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and general discussion
+    url: https://github.com/camoa/claude-skills/discussions
+    about: Have a question or want to discuss an idea before filing an issue? Use Discussions instead.
+  - name: Plugin documentation
+    url: https://github.com/camoa/claude-skills#readme
+    about: Check the repo README for plugin descriptions, installation, and links to each plugin's own README before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Suggest a new capability or improvement for one of the camoa-skills plugins.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the problem before the solution — it helps us evaluate the right fix.
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Plugin
+      description: Which plugin is this request for?
+      options:
+        - dev-guides-navigator
+        - plugin-creation-tools
+        - ai-dev-assistant
+        - code-quality-tools
+        - brand-content-design
+        - drupal-htmx
+        - drupal-ai-contrib
+        - code-paper-test
+        - drupal-dev-framework
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What's missing or awkward today?
+      placeholder: Tell us what's frustrating or missing.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? Sketch the command/skill/behavior if you can.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches or workarounds you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that would help us understand the request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Checklist
+
+- [ ] Branched off `main` (kebab-case `<type>/<slug>` name, e.g. `fix/my-change`)
+- [ ] This PR touches **one plugin** (or is a repo-wide doc/config change with no plugin-specific behavior)
+- [ ] If this is a **plugin release**: the 4-file version bump is done in lockstep —
+      `<plugin>/plugin.json`, `<plugin>/CHANGELOG.md`, `<plugin>/README.md`, and the
+      root `.claude-plugin/marketplace.json` entry — and `metadata.version` in
+      `marketplace.json` was bumped per the patch/minor/major rule
+- [ ] `CHANGELOG.md` entry added for this change (if user-visible)
+- [ ] `/plugin-creation-tools:validate <plugin-path>` run for any plugin-structure change (commands/skills/agents/hooks/frontmatter) and passing
+- [ ] No secrets, credentials, or machine-specific absolute paths introduced
+
+## Notes for the maintainer
+
+<!-- Anything the maintainer should know before merging (e.g. version-line conflicts with another open PR). -->
+
+This repo's `main` branch is protected — the maintainer will review and merge; contributors do not merge their own PRs.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,142 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political
+  attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported through this repository on GitHub, using one of the following
+channels:
+
+* Open a [GitHub private security advisory](../../security/advisories/new)
+  for this repository, which is visible only to the maintainer.
+* Contact the maintainer directly through their GitHub profile
+  ([@camoa](https://github.com/camoa)) — for example, by mentioning them on
+  an issue or opening a private conversation via GitHub.
+
+Do not report Code of Conduct concerns in public issues or pull requests. All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to camoa-skills
+
+Thanks for your interest in contributing to this marketplace of Claude Code plugins. This document describes the real workflow used in this repo — please follow it as written.
+
+## Workflow
+
+`main` is protected — there are no direct pushes to it. All changes land through a pull request:
+
+1. Branch off `main`.
+2. Commit your changes.
+3. Push your branch.
+4. Open a pull request.
+5. The maintainer reviews and merges.
+
+You will not be able to merge your own PR; that's expected. If your branch conflicts with something already merged (see the version-line conflict note below), rebase or merge `main` in and push again.
+
+## Branch naming
+
+Branches are kebab-case, named `<type>/<slug>`:
+
+- `feature/<slug>` — new capability
+- `fix/<slug>` — bug fix
+- `docs/<slug>` — documentation-only change
+- `chore/<slug>` — maintenance, tooling, non-functional cleanup
+
+Examples from this repo's history: `feature/aida-gap-g-mechanism-challenge`, `fix/aida-migrate-to-epic-preserves-references`, `docs/root-readme-rename-banner`.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/), with the **plugin name as the scope**:
+
+```
+fix(ai-dev-assistant): correct worktree path resolution
+docs(code-quality-tools): clarify security gate usage
+```
+
+When a commit is part of a **plugin release**, include the new version in the subject:
+
+```
+feat(ai-dev-assistant 5.19.0): mechanism-challenge gate
+chore(drupal-htmx 1.6.1): bump dependency pin
+```
+
+**One plugin per PR is the norm.** If your change touches more than one plugin, consider splitting it into separate PRs unless the changes are genuinely coupled (e.g. a repo-wide doc pass).
+
+## Plugin releases: the 4-file version-bump rule
+
+When a PR changes a plugin's version, the following files move together, in lockstep, in the same commit:
+
+1. `<plugin>/plugin.json` — bump the `version` field.
+2. `<plugin>/CHANGELOG.md` — add an entry for the new version.
+3. `<plugin>/README.md` — update any version references.
+4. Root `.claude-plugin/marketplace.json` — update that plugin's entry (including its version).
+
+In addition, the marketplace's own `metadata.version` in `.claude-plugin/marketplace.json` gets bumped:
+
+- **patch** — pointer/doc-only updates to the catalog entry
+- **minor** — a new plugin added to the marketplace
+- **major** — a breaking change to the catalog schema itself
+
+If you're not releasing a new plugin version (docs-only, internal refactor with no version bump), none of the above applies — just make your change and open the PR.
+
+**Parallel-PR conflict note:** because `marketplace.json` and each plugin's `CHANGELOG.md` are shared files, two PRs bumping versions at the same time will conflict on those lines. This is expected — rebase and deconflict the version lines before merge; the maintainer will help resolve if needed.
+
+## Plugin folder anatomy
+
+The marketplace catalog is `.claude-plugin/marketplace.json` — it is the **only** valid marketplace manifest in this repo. Each plugin is a top-level folder containing:
+
+- `plugin.json` — plugin manifest (name, version, description)
+- `README.md` — user-facing documentation
+- `CHANGELOG.md` — version history
+- `CONVENTIONS.md` — plugin-root conventions (note: **not** `CLAUDE.md` — a plugin-root `CLAUDE.md` is not loaded as context by Claude Code)
+- optional `commands/`, `skills/`, `agents/`, `hooks/`, `.claude/rules/` (path-scoped rule files)
+
+## Validating plugin changes
+
+Before opening a PR that touches a plugin's structure (commands, skills, agents, hooks, frontmatter), run:
+
+```
+/plugin-creation-tools:validate <plugin-path>
+```
+
+This checks frontmatter, structure, and best practices, and should pass before you push.
+
+## Non-Claude-Code tools
+
+If you're contributing from or targeting a tool other than Claude Code (Cursor, Codex, Copilot, Gemini, Cline, OpenCode, Windsurf), see `PORTABILITY.md` at the repo root for how these skills port across tools.
+
+## A note on AI assistance
+
+Many contributions to this repo are made with AI assistance, and commit trailers noting AI co-authorship are common in this repo's history. That's optional — it's not required of contributors and is out of scope for this document.

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -1,5 +1,7 @@
 # AI Dev Assistant
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-ai-dev-assistant-ai-dev-assistant)](https://www.claudepluginhub.com/plugins/camoa-ai-dev-assistant-ai-dev-assistant?ref=badge)
+
 **An AI assistant for developers that focuses on getting the process right**, not just getting code out fast. It runs each task through a disciplined **Research → Architecture → Implementation → Review** flow before code gets written: understand the problem first, reuse what already exists, follow your standards, and verify. That heads off the usual AI pitfalls, like jumping to code without understanding requirements, missing a library that already solves the problem, building inconsistent architecture, or skipping tests. The orchestration engine is **stack-agnostic**.
 
 > **New here?** Read [GETTING_STARTED.md](GETTING_STARTED.md): a 5-minute walkthrough that takes you from install to your first task. This README is the reference.
@@ -77,6 +79,15 @@ Both enforced via `plugin.json` `dependencies`. Missing-dependency failures surf
 ```
 
 `/next` is your main command. It selects your project, shows tasks with their current phase, and tells you exactly what to run next. Use it at the start of every session.
+
+### Examples
+
+```bash
+/ai-dev-assistant:new my_module
+/ai-dev-assistant:next
+/ai-dev-assistant:research my_task    # → /design → /implement → /review → /complete
+/ai-dev-assistant:research-team my_task
+```
 
 ### Adding More Tasks
 

--- a/brand-content-design/README.md
+++ b/brand-content-design/README.md
@@ -1,5 +1,7 @@
 # Brand Content Design Plugin
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-brand-content-design-brand-content-design)](https://www.claudepluginhub.com/plugins/camoa-brand-content-design-brand-content-design?ref=badge)
+
 > **Current version: v3.5.0**
 
 Create branded presentations, LinkedIn carousels, infographics, and HTML pages with consistent visual identity.
@@ -26,6 +28,14 @@ claude plugins:add brand-content-design@camoa-skills
 
 ```
 /brand                    # Start here - status, switch projects, or create new
+```
+
+**Examples:**
+```bash
+/brand-content-design:brand-init
+/brand-content-design:brand-extract
+/brand-content-design:presentation-quick
+/brand-content-design:carousel
 ```
 
 ### First Time Setup (do once per brand)

--- a/code-paper-test/README.md
+++ b/code-paper-test/README.md
@@ -1,5 +1,7 @@
 # Paper Test
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-code-paper-test-code-paper-test)](https://www.claudepluginhub.com/plugins/camoa-code-paper-test-code-paper-test?ref=badge)
+
 Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, logic errors, missing code, edge cases, AI hallucinations, and contract violations before deployment.
 
 > **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
@@ -256,6 +258,13 @@ FLAW FOUND:
   Severity: HIGH (Reach: 2, Impact: 2, Reversibility: 1, Exploitability: 2 = 7)
   FIX: Initialize $discount = 0 at start of function
 ```
+
+**Run it with the competing-team command:**
+```bash
+/code-paper-test:test-team scripts/deploy.sh
+/code-paper-test:test-team src/Service/Foo.php src/Service/Bar.php
+```
+Or invoke the single-agent skill directly: "paper test this function for edge cases".
 
 ## AI Code Auditing
 

--- a/dev-guides-navigator/README.md
+++ b/dev-guides-navigator/README.md
@@ -1,5 +1,7 @@
 # Dev Guides Navigator
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-dev-guides-navigator-dev-guides-navigator)](https://www.claudepluginhub.com/plugins/camoa-dev-guides-navigator-dev-guides-navigator?ref=badge)
+
 Smart guide discovery and routing for the [dev-guides](https://camoa.github.io/dev-guides/) site. Routes AI to the correct guide using hash-based caching and KG metadata for disambiguation.
 
 **Two modes:** the navigator routes over two separate published catalogs —
@@ -34,6 +36,13 @@ The skill triggers automatically when any development task might benefit from a 
 /dev-guides-navigator forms
 /dev-guides-navigator SOLID drupal
 /dev-guides-navigator design system bootstrap
+```
+
+**More examples:**
+```
+/dev-guides-navigator drupal form validation
+/dev-guides-navigator SDC component
+/dev-guides-navigator style guide
 ```
 
 ### What It Covers

--- a/drupal-ai-contrib/README.md
+++ b/drupal-ai-contrib/README.md
@@ -1,5 +1,7 @@
 # drupal-ai-contrib
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-drupal-ai-contrib-drupal-ai-contrib)](https://www.claudepluginhub.com/plugins/camoa-drupal-ai-contrib-drupal-ai-contrib?ref=badge)
+
 AI-assisted Drupal contribution **quality** — *evidence over assertion*.
 
 > **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
@@ -74,6 +76,15 @@ operations — the executable is `drupalorg`; install the PHAR per
 `skills/drupal-ai-contrib/references/drupalorg-cli.md`), DDEV (the local environment),
 and a drupal.org account with GitLab access. `setup` detects what is missing and points
 you at it; nothing is a hard prerequisite.
+
+## Usage
+
+```bash
+/drupal-ai-contrib:setup
+/drupal-ai-contrib:issue 3456789
+/drupal-ai-contrib:verify
+/drupal-ai-contrib:submit
+```
 
 ## The contribution arc
 

--- a/drupal-dev-framework/README.md
+++ b/drupal-dev-framework/README.md
@@ -1,6 +1,10 @@
 # drupal-dev-framework: DEPRECATED
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-drupal-dev-framework-drupal-dev-framework)](https://www.claudepluginhub.com/plugins/camoa-drupal-dev-framework-drupal-dev-framework?ref=badge)
+
 This plugin has been renamed to **ai-dev-assistant**. Install that going forward.
+
+**Usage:** `/drupal-dev-framework:upgrade` (one-time migration to ai-dev-assistant, then uninstall this plugin).
 
 `drupal-dev-framework` remains installable only as a thin **deprecation shell** whose
 sole job is to run a **one-time upgrade** that migrates your local wiring to the new

--- a/drupal-htmx/README.md
+++ b/drupal-htmx/README.md
@@ -1,5 +1,7 @@
 # Drupal HTMX Plugin
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-drupal-htmx-drupal-htmx)](https://www.claudepluginhub.com/plugins/camoa-drupal-htmx-drupal-htmx?ref=badge)
+
 HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+.
 
 > **Not using Claude Code?** See the marketplace [PORTABILITY.md](../PORTABILITY.md) — skills work in Cursor, Codex CLI, Copilot, Gemini CLI, Cline, and more.
@@ -56,6 +58,15 @@ The `htmx-development` skill auto-activates when discussing:
 
 ```bash
 /htmx-pattern dependent dropdown
+```
+
+### More Examples
+
+```bash
+/drupal-htmx:htmx-analyze web/modules/custom/my_module
+/drupal-htmx:htmx-migrate web/modules/custom/my_module/src/Form/MyForm.php
+/drupal-htmx:htmx-pattern dependent dropdown
+/drupal-htmx:htmx-validate web/modules/custom/my_module
 ```
 
 ### Migrate Specific Pattern

--- a/plugin-creation-tools/README.md
+++ b/plugin-creation-tools/README.md
@@ -1,5 +1,7 @@
 # Plugin Creation Tools
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/camoa-plugin-creation-tools-plugin-creation-tools)](https://www.claudepluginhub.com/plugins/camoa-plugin-creation-tools-plugin-creation-tools?ref=badge)
+
 Complete authoring guide for Claude Code plugins — skills, commands, agents, hooks, MCP servers, themes, `userConfig`, plugin dependencies, the Agent SDK, and distribution.
 
 The plugin contains one large skill (`plugin-creation`) that progressively discloses references for every component type, plus three commands and two structural-audit agents. Aimed at plugin authors building or maintaining plugins for the public marketplace.
@@ -10,6 +12,14 @@ The plugin contains one large skill (`plugin-creation`) that progressively discl
 
 ```bash
 /plugin install plugin-creation-tools@camoa-skills
+```
+
+## Usage
+
+```bash
+/plugin-creation-tools:create my-tools --skill --agent
+/plugin-creation-tools:add-component command deploy
+/plugin-creation-tools:validate ./my-tools --strict
 ```
 
 ## Components


### PR DESCRIPTION
## Community-health profile + per-plugin usage examples & badges

Raises the camoa-skills marketplace's GitHub community-health score (28% per the ClaudePluginHub owner dashboard) and listing quality. **Docs-only: no plugin behavior, no catalog change, no version bumps.** Shipped as one PR per maintainer request.

### Community docs (repo root + .github/)
- **CONTRIBUTING.md** — the real workflow (branch off `main` → PR → **maintainer merges**; main protected), Conventional Commits with plugin-as-scope, one-plugin-per-PR, the 4-file plugin-release version-bump rule, plugin folder anatomy, pointers to `/plugin-creation-tools:validate` + `PORTABILITY.md`.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, **GitHub-only** enforcement (no email published).
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml` + `feature_request.yml` issue **forms** with a required **plugin dropdown** (9 plugins); `config.yml` disables blank issues.
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist matching the real flow.
- **LICENSE** (MIT) already present — untouched.

### Per-plugin README usage examples + ClaudePluginHub badges (8 plugins)
Each gets a badge (its own `camoa-<plugin>-<plugin>` slug, all page-verified live) + a usage-example section using the plugin's **real** commands (every example cross-checked against `<plugin>/commands/*.md`). Additive-only — existing prose untouched.

Plugins: ai-dev-assistant, brand-content-design, code-paper-test, dev-guides-navigator, drupal-ai-contrib, drupal-dev-framework, drupal-htmx, plugin-creation-tools.

### Deferred (follow-on, not this PR)
**code-quality-tools** — surfaced a real pre-existing bug: its `plugin.json` name is `code-quality-tools` (so commands run as `/code-quality-tools:…`) but its README + command docs use `/code-quality:…` 100+ times (stale from the `code-quality` → `code-quality-tools` rename). Fixing the namespace properly + adding its examples is a dedicated follow-on so this docs PR doesn't paper over it.

### Review
Both slices reviewed by fresh-context agents: community docs accurate to the real flow + forms render; every README example is a real command + every badge slug correct + additive-only. Containment scan: my files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
