### PR TITLE
fix(ai-dev-assistant 5.19.2): run_mode wiring loose ends (task-override + initializer seed)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.21"
+    "version": "2.0.22"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.19.1",
+      "version": "5.19.2",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.19.1",
+  "version": "5.19.2",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.19.2] - 2026-07-04
+
+### Fixed — run_mode wiring loose ends (from the orchestrator_context_hygiene gap-audit)
+
+- `/run-work-orders` now resolves `run_mode` **monotonic-toward-strict from BOTH the project `.runMode`
+  AND the task-level `.run_mode`** (via `fm-read.sh`), exactly as `wo-mode-gate.sh` does — so the loop's
+  reported Exit posture matches the kernel's enforced mode. Previously it threaded only the project dial,
+  so a task tightening to `autonomous` under an `interactive` project printed the wrong Exit posture
+  (the kernel still correctly withheld the PR — cosmetic, but now consistent).
+- `project-initializer` seeds `**Run Mode:** interactive` into `project_state.md` at project creation, so
+  new projects carry the spine explicitly instead of relying on the `/upgrade-project` backfill (readers
+  already fail-closed to `interactive`, so this is non-breaking).
+- Specs: `run-work-orders-contract-spec.sh` asserts the task-override threading; `run-mode-dial-spec.sh`
+  asserts the initializer seed.
+
 ## [5.19.1] - 2026-07-04
 
 ### Fixed — `migrate-to-epic` no longer drops a task's `references/` (and other sibling dirs)

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -338,7 +338,7 @@ v3.x uses folder-based task structure. Run `/next` after upgrading: it auto-dete
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **5.19.1**.
+See [CHANGELOG.md](./CHANGELOG.md) for full version history. Current version: **5.19.2**.
 
 ## License
 

--- a/ai-dev-assistant/commands/run-work-orders.md
+++ b/ai-dev-assistant/commands/run-work-orders.md
@@ -91,11 +91,17 @@ batch size. The **default (no `--parallel`) is unchanged** — the sequential `w
    depth-2 (unsupported). Do NOT re-implement either loop here. The parallel and in-place paths are
    **additive** — they do not change the default sequential worktree behavior.
 
-   **Thread `<run_mode>` into the loop invocation on ALL THREE paths.** Set `<run_mode>` = the `.runMode`
-   value **already parsed from the Step-1 `project-state-read.sh` JSON** (zero new reads; there is **no**
-   dedicated mode CLI flag — mode is disk-scoped, never a dispatch boolean). Absent or unrecognized →
-   `interactive` (fail-closed,
-   mirroring `wo-mode-gate.sh` and the distill seam). **`run_mode` is orthogonal to the flags** — it does
+   **Thread `<run_mode>` into the loop invocation on ALL THREE paths.** Set `<run_mode>` = the **effective
+   mode, resolved monotonic-toward-strict EXACTLY as `wo-mode-gate.sh` does**, so the loop's reported posture
+   equals the kernel's enforced mode: it is `autonomous` if **either** the project `.runMode` (already parsed
+   from the Step-1 `project-state-read.sh` JSON) **or** the task-level `.run_mode`
+   (`${CLAUDE_PLUGIN_ROOT}/scripts/fm-read.sh "<task_folder>" | jq -r '.run_mode // empty'`; `null`/absent =
+   inherit) is `autonomous`; otherwise `interactive`. A task can **tighten** to `autonomous` but cannot
+   **loosen** a project's `autonomous`. There is **no** dedicated mode CLI flag — mode is disk-scoped, never a
+   dispatch boolean. Absent/unrecognized on both → `interactive` (fail-closed, mirroring `wo-mode-gate.sh` and
+   the distill seam). This is one task-frontmatter read (the earlier project-only threading missed the
+   task override, so a task tightening to `autonomous` under an `interactive` project printed the wrong Exit
+   posture while the kernel still correctly withheld the PR — gap-audit fix). **`run_mode` is orthogonal to the flags** — it does
    **not** select a loop or force a specific path; it overlays only the loop's Exit **reporting** posture on
    whichever loop the flags picked. **When `.runMode ∈ {interactive, absent}` this command executes
    byte-identically to today** — the attended / `--parallel` / `--in-place` behavior is UNCHANGED.

--- a/ai-dev-assistant/skills/project-initializer/SKILL.md
+++ b/ai-dev-assistant/skills/project-initializer/SKILL.md
@@ -89,6 +89,7 @@ Use `Write` tool to create `{path}/{project_name}/project_state.md`:
 **Path:** {full_path_to_project_folder}
 **Code path:** {absolute_code_path OR (docs-only) OR omit-entirely-if-caller-did-not-provide}
 **Frameworks:** {when code path is known: run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/detect-frameworks.sh" "<code_path>"` and write the `jq -r 'join(", ")'` result (e.g. `drupal, nextjs, claude-code-plugins`); omit this line entirely when code path is unknown or the returned array is empty}
+**Run Mode:** interactive
 
 ## Overview
 {To be filled during requirements gathering}

--- a/ai-dev-assistant/tests/run-mode-dial-spec.sh
+++ b/ai-dev-assistant/tests/run-mode-dial-spec.sh
@@ -208,6 +208,15 @@ else
   fail_check "reminder no-session fast-gate — rc=$RC out='$OUT3'"
 fi
 
+# 4. project-initializer scaffold seeds the **Run Mode:** dial at creation (gap-audit fix:
+#    /new no longer relies solely on /upgrade-project backfill).
+INIT="$(cd "$(dirname "$0")" && pwd)/../skills/project-initializer/SKILL.md"
+if grep -q '\*\*Run Mode:\*\* interactive' "$INIT"; then
+  pass_check "project-initializer scaffold seeds **Run Mode:** interactive at creation"
+else
+  fail_check "project-initializer scaffold missing **Run Mode:** seed"
+fi
+
 if [ "$FAIL" -ne 0 ]; then
   printf '\nrun_mode spine invariants violated.\n' >&2
   exit 1

--- a/ai-dev-assistant/tests/run-work-orders-contract-spec.sh
+++ b/ai-dev-assistant/tests/run-work-orders-contract-spec.sh
@@ -53,6 +53,10 @@ check "Do NOT run /goal itself"                          'Do NOT run.*goal|do no
 # --- Session context persistence ---
 check "session-context-write.sh persists context"       'session-context-write\.sh'
 
+# --- run_mode threading (gap-audit fix: task-level override, not project-only) ---
+check "run_mode threads task-level .run_mode via fm-read" 'fm-read\.sh.*run_mode|run_mode.*fm-read\.sh'
+check "run_mode resolved monotonic-toward-strict (matches wo-mode-gate)" 'monotonic-toward-strict|tighten.*autonomous|cannot.*loosen'
+
 if [ "$fail" -eq 0 ]; then
   echo "ALL PASS — run-work-orders contract present in run-work-orders.md"
   exit 0


### PR DESCRIPTION
## run_mode wiring loose ends (from the orchestrator_context_hygiene gap-audit)

Two low-severity gaps the epic's own integration gap-audit flagged, now closed:

1. **`/run-work-orders` threaded only the project `.runMode`** — now resolves `run_mode` **monotonic-toward-strict from both the project `.runMode` and the task-level `.run_mode`** (`fm-read.sh`), exactly as `wo-mode-gate.sh` does. So the loop's reported Exit posture matches the kernel's enforced mode. (Before: a task tightening to `autonomous` under an `interactive` project printed the wrong Exit posture — the kernel still correctly withheld the PR, so it was cosmetic, but now consistent.)
2. **`project-initializer` didn't seed the dial** — new projects now get `**Run Mode:** interactive` written into `project_state.md` at creation, instead of relying on the `/upgrade-project` backfill. Readers already fail-closed to `interactive`, so non-breaking.

**Specs:** `run-work-orders-contract-spec.sh` asserts the task-override threading; `run-mode-dial-spec.sh` asserts the initializer seed — both verified to fail if the fix is reverted (real regression guards, not tautologies).

No kernel/logic change; `wo-mode-gate.sh` untouched. PATCH bump 5.19.1 → 5.19.2 / metadata 2.0.22. Fresh-context review: PASS; suite 56/57 (the 1 = pre-existing `upgrade-project` body-length lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)