### PR TITLE
fix(code-quality): security gate aborted mid-scan on clean projects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.27"
+    "version": "2.0.28"
   },
   "plugins": [
     {
@@ -144,7 +144,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.9.4",
+      "version": "3.9.5",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.5] - 2026-08-05
+
+### Fixed
+
+- **Security and SOLID gates aborted mid-scan on clean projects.** Under `set -e`,
+  `((VAR += X))` returns exit status 1 whenever the expression evaluates to 0, and
+  `((VAR++))` does so on the very first increment because post-increment returns the
+  old value. 63 such sites across `drupal/security-check.sh`, `drupal/solid-check.sh`,
+  `nextjs/security-check.sh`, `nextjs/solid-check.sh` and `core/full-audit.sh` ended
+  the script early. In the Drupal security gate the first site sits in the
+  composer-audit layer, so a project with no high-severity advisories, the healthy
+  case, silently skipped layers 3-10: phpcs security, psalm taint, the custom Drupal
+  patterns, semgrep, trivy and gitleaks. All converted to `VAR=$((VAR + X))`, the form
+  the `--changed` path already used.
+- **A failing security audit was recorded as a warning.** `core/full-audit.sh` read
+  `security-check.sh`'s exit code with the 0/1/2 convention the other gates use, but
+  that script exits 0 for pass *and* warning and 1 for fail, so a failure was mapped to
+  `warning` and a warning to `pass`. It now takes the verdict from
+  `summary.overall_status` in the report the gate writes, falling back to the exit code
+  only when no report exists.
+- **Custom Drupal pattern findings were not locatable, and their counts disagreed with
+  the issues they emitted.** Each of the three patterns incremented its severity counter
+  by the grep line count while appending exactly one issue object carrying
+  `file: "Multiple files"` and `line: 0`, so `summary.by_severity` and `issues[]` could
+  not be reconciled. A shared `pattern_issues` helper now emits one issue per hit with
+  the real file and line, and callers derive the count from that array's length. Fixed
+  in both the standard path and the `--changed` path, which carried the same defect.
+- **`db_query` pattern matched the safe placeholder form.** `db_query.*$` matched any
+  line containing a `$` anywhere, including
+  `db_query('... :id', [':id' => $id])`, so a handful of correct calls alone crossed the
+  `>3 high` fail threshold. Tightened to match interpolation inside a double-quoted
+  first argument or concatenation onto it, and verified against a fixture that a comma
+  inside the query string does not defeat the match.
+- **Single changed file produced a line number where a filename belonged.** `grep -n`
+  omits the filename when given exactly one file, so a one-file diff parsed the line
+  number as the path. All pattern greps now pass `-H`.
+
+### Added
+
+- `scripts/tests/security-counting-spec.sh` — 11 hermetic assertions pinning the above:
+  no hazardous arithmetic remains in any gate script, the abort it guards against is
+  real, `pattern_issues` emits reconciling counts and locatable findings, and the
+  tightened `db_query` pattern excludes the safe form. No DDEV, no network, no PHP.
+
 ## [3.9.4] - 2026-07-13
 
 ### Changed — docs

--- a/code-quality-tools/skills/code-quality-audit/scripts/core/full-audit.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/core/full-audit.sh
@@ -153,10 +153,10 @@ if [ -f "${SCRIPTS_DIR}/coverage-report.sh" ]; then
         exit_code=$?
         if [ $exit_code -eq 1 ]; then
             COVERAGE_STATUS="warning"
-            ((WARNING_COUNT++))
+            WARNING_COUNT=$((WARNING_COUNT + 1))
         else
             COVERAGE_STATUS="fail"
-            ((CRITICAL_COUNT++))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + 1))
         fi
     fi
     update_status "$COVERAGE_STATUS"
@@ -185,10 +185,10 @@ if [ -f "${SCRIPTS_DIR}/solid-check.sh" ]; then
         exit_code=$?
         if [ $exit_code -eq 1 ]; then
             SOLID_STATUS="warning"
-            ((WARNING_COUNT++))
+            WARNING_COUNT=$((WARNING_COUNT + 1))
         else
             SOLID_STATUS="fail"
-            ((CRITICAL_COUNT++))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + 1))
         fi
     fi
     update_status "$SOLID_STATUS"
@@ -218,10 +218,10 @@ if [ "$PROJECT_TYPE" == "nextjs" ]; then
             exit_code=$?
             if [ $exit_code -eq 1 ]; then
                 LINT_STATUS="warning"
-                ((WARNING_COUNT++))
+                WARNING_COUNT=$((WARNING_COUNT + 1))
             else
                 LINT_STATUS="fail"
-                ((CRITICAL_COUNT++))
+                CRITICAL_COUNT=$((CRITICAL_COUNT + 1))
             fi
         fi
         update_status "$LINT_STATUS"
@@ -251,10 +251,10 @@ if [ -f "${SCRIPTS_DIR}/dry-check.sh" ]; then
         exit_code=$?
         if [ $exit_code -eq 1 ]; then
             DRY_STATUS="warning"
-            ((WARNING_COUNT++))
+            WARNING_COUNT=$((WARNING_COUNT + 1))
         else
             DRY_STATUS="fail"
-            ((CRITICAL_COUNT++))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + 1))
         fi
     fi
     update_status "$DRY_STATUS"
@@ -278,18 +278,26 @@ SECURITY_STATUS="unknown"
 if [ "$PROJECT_TYPE" == "drupal" ] || [ "$PROJECT_TYPE" == "monorepo" ]; then
     echo -e "${BLUE}[Step 6/6]${NC} Running security audit..."
     if [ -f "${SCRIPTS_DIR}/security-check.sh" ]; then
-        if "${SCRIPTS_DIR}/security-check.sh" 2>/dev/null; then
+        # security-check.sh does not use the 0/1/2 convention the other gates use:
+        # it exits 0 for BOTH pass and warning, and 1 for fail. Reading its exit code
+        # like a sibling gate records a failing scan as "warning" and a warning as
+        # "pass". Take the verdict from the report it writes, which carries the
+        # authoritative value, and fall back to the exit code only if no report exists
+        # (the scan aborted before writing one).
+        security_exit=0
+        "${SCRIPTS_DIR}/security-check.sh" 2>/dev/null || security_exit=$?
+        if [ -f "${REPORT_DIR}/security-report.json" ]; then
+            SECURITY_STATUS=$(jq -r '.summary.overall_status // "unknown"' \
+                "${REPORT_DIR}/security-report.json" 2>/dev/null || echo "unknown")
+        elif [ "$security_exit" -eq 0 ]; then
             SECURITY_STATUS="pass"
         else
-            exit_code=$?
-            if [ $exit_code -eq 1 ]; then
-                SECURITY_STATUS="warning"
-                ((WARNING_COUNT++))
-            else
-                SECURITY_STATUS="fail"
-                ((CRITICAL_COUNT++))
-            fi
+            SECURITY_STATUS="fail"
         fi
+        case "$SECURITY_STATUS" in
+            warning) WARNING_COUNT=$((WARNING_COUNT + 1)) ;;
+            fail)    CRITICAL_COUNT=$((CRITICAL_COUNT + 1)) ;;
+        esac
         update_status "$SECURITY_STATUS"
 
         # Merge security report

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
@@ -24,6 +24,32 @@ to_json_array() {
     fi
 }
 
+# Turn `grep -Hn` output into one issue object per hit, carrying the real file and
+# line. Callers derive their severity count from the length of this array so the
+# counters and issues[] cannot disagree.
+# Usage: pattern_issues "<grep output>" <category> <severity> <message> <owasp> <remediation>
+pattern_issues() {
+    printf '%s\n' "$1" | jq -R -s \
+        --arg category "$2" \
+        --arg severity "$3" \
+        --arg message "$4" \
+        --arg owasp "$5" \
+        --arg remediation "$6" '
+        split("\n")
+        | map(select(length > 0))
+        | map(select(test("^[^:]+:[0-9]+:")))
+        | map(capture("^(?<file>[^:]+):(?<line>[0-9]+):"))
+        | map({
+            category: $category,
+            severity: $severity,
+            file: .file,
+            line: (.line | tonumber),
+            message: $message,
+            owasp: $owasp,
+            remediation: $remediation
+          })' 2>/dev/null || echo "[]"
+}
+
 echo "=== Security Audit (OWASP + Drupal) ==="
 echo ""
 
@@ -255,55 +281,50 @@ if [ -n "$CHANGED_FILE" ]; then
     if [ "${#RELEVANT_FILES[@]}" -gt 0 ]; then
         # grep-based pattern scan is always available — a real check that runs.
         RAN_ANALYZERS=$((RAN_ANALYZERS + 1))
-        # Unsafe db_query usage
-        DB_QUERY_UNSAFE=$(grep -n "db_query.*\$" "${RELEVANT_FILES[@]}" 2>/dev/null || true)
+        # -H is required: with a single changed file, grep -n omits the filename and
+        # the parsed "file" would be the line number.
+        DB_QUERY_UNSAFE=$(grep -EHn 'db_query([^"]*"[^"]*\$|.*\.[[:space:]]*\$)' "${RELEVANT_FILES[@]}" 2>/dev/null || true)
         if [ -n "$DB_QUERY_UNSAFE" ]; then
-            DB_COUNT=$(echo "$DB_QUERY_UNSAFE" | wc -l)
-            echo -e "  ${YELLOW}Found ${DB_COUNT} potentially unsafe db_query() calls${NC}"
-            HIGH_COUNT=$((HIGH_COUNT + DB_COUNT))
-            CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq '. + [{
-                category: "SQL Injection Risk",
-                severity: "high",
-                file: "Multiple files (changed set)",
-                line: 0,
-                message: "Potentially unsafe db_query() with variable concatenation",
-                owasp: "A03:2021",
-                remediation: "Use placeholders or query builder"
-            }]')
+            DB_ISSUES=$(pattern_issues "$DB_QUERY_UNSAFE" \
+                "SQL Injection Risk" "high" \
+                "Potentially unsafe db_query() with variable concatenation" \
+                "A03:2021" "Use placeholders or query builder")
+            DB_COUNT=$(echo "$DB_ISSUES" | jq 'length')
+            if [ "$DB_COUNT" -gt 0 ]; then
+                echo -e "  ${YELLOW}Found ${DB_COUNT} potentially unsafe db_query() calls${NC}"
+                HIGH_COUNT=$((HIGH_COUNT + DB_COUNT))
+                CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq --argjson add "$DB_ISSUES" '. + $add')
+            fi
         fi
 
-        # Twig |raw filter
-        RAW_FILTER=$(grep -n "|raw" "${RELEVANT_FILES[@]}" 2>/dev/null || true)
+        # Twig |raw filter. Basic regex on purpose: under -E the '|' would be alternation.
+        RAW_FILTER=$(grep -Hn "|raw" "${RELEVANT_FILES[@]}" 2>/dev/null || true)
         if [ -n "$RAW_FILTER" ]; then
-            RAW_COUNT=$(echo "$RAW_FILTER" | wc -l)
-            echo -e "  ${YELLOW}Found ${RAW_COUNT} uses of |raw filter${NC}"
-            MEDIUM_COUNT=$((MEDIUM_COUNT + RAW_COUNT))
-            CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq '. + [{
-                category: "XSS Risk",
-                severity: "medium",
-                file: "Changed files",
-                line: 0,
-                message: "Use of |raw filter may expose XSS vulnerabilities",
-                owasp: "A03:2021",
-                remediation: "Remove |raw or ensure input is sanitized"
-            }]')
+            RAW_ISSUES=$(pattern_issues "$RAW_FILTER" \
+                "XSS Risk" "medium" \
+                "Use of |raw filter may expose XSS vulnerabilities" \
+                "A03:2021" "Remove |raw or ensure input is sanitized")
+            RAW_COUNT=$(echo "$RAW_ISSUES" | jq 'length')
+            if [ "$RAW_COUNT" -gt 0 ]; then
+                echo -e "  ${YELLOW}Found ${RAW_COUNT} uses of |raw filter${NC}"
+                MEDIUM_COUNT=$((MEDIUM_COUNT + RAW_COUNT))
+                CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq --argjson add "$RAW_ISSUES" '. + $add')
+            fi
         fi
 
         # unserialize() on user input
-        UNSERIALIZE=$(grep -n "unserialize.*\$_" "${RELEVANT_FILES[@]}" 2>/dev/null || true)
+        UNSERIALIZE=$(grep -Hn "unserialize.*\$_" "${RELEVANT_FILES[@]}" 2>/dev/null || true)
         if [ -n "$UNSERIALIZE" ]; then
-            UNSER_COUNT=$(echo "$UNSERIALIZE" | wc -l)
-            echo -e "  ${YELLOW}Found ${UNSER_COUNT} potentially unsafe unserialize() calls${NC}"
-            HIGH_COUNT=$((HIGH_COUNT + UNSER_COUNT))
-            CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq '. + [{
-                category: "Insecure Deserialization",
-                severity: "high",
-                file: "Changed files",
-                line: 0,
-                message: "unserialize() on user input can lead to RCE",
-                owasp: "A08:2021",
-                remediation: "Use JSON or validate serialized data"
-            }]')
+            UNSER_ISSUES=$(pattern_issues "$UNSERIALIZE" \
+                "Insecure Deserialization" "high" \
+                "unserialize() on user input can lead to RCE" \
+                "A08:2021" "Use JSON or validate serialized data")
+            UNSER_COUNT=$(echo "$UNSER_ISSUES" | jq 'length')
+            if [ "$UNSER_COUNT" -gt 0 ]; then
+                echo -e "  ${YELLOW}Found ${UNSER_COUNT} potentially unsafe unserialize() calls${NC}"
+                HIGH_COUNT=$((HIGH_COUNT + UNSER_COUNT))
+                CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq --argjson add "$UNSER_ISSUES" '. + $add')
+            fi
         fi
 
         if [ "$CUSTOM_ISSUES" = "[]" ]; then
@@ -493,7 +514,7 @@ if [ -f "$DRUSH_SECURITY_JSON" ] && [ -s "$DRUSH_SECURITY_JSON" ]; then
             remediation: "Update to recommended version: \(.recommended)"
         }]' "$DRUSH_SECURITY_JSON" 2>/dev/null || echo "[]")
 
-        ((CRITICAL_COUNT += ADVISORY_COUNT))
+        CRITICAL_COUNT=$((CRITICAL_COUNT + ADVISORY_COUNT))
     else
         echo -e "  ${GREEN}No security advisories${NC}"
         DRUSH_VIOLATIONS="[]"
@@ -533,8 +554,8 @@ if [ -f "$COMPOSER_AUDIT_JSON" ] && [ -s "$COMPOSER_AUDIT_JSON" ]; then
         # Count by severity
         HIGH_VULNS=$(echo "$COMPOSER_VIOLATIONS" | jq '[.[] | select(.severity == "high")] | length' 2>/dev/null || echo "0")
         MED_VULNS=$(echo "$COMPOSER_VIOLATIONS" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
-        ((HIGH_COUNT += HIGH_VULNS))
-        ((MEDIUM_COUNT += MED_VULNS))
+        HIGH_COUNT=$((HIGH_COUNT + HIGH_VULNS))
+        MEDIUM_COUNT=$((MEDIUM_COUNT + MED_VULNS))
     else
         echo -e "  ${GREEN}No package vulnerabilities${NC}"
         COMPOSER_VIOLATIONS="[]"
@@ -577,8 +598,8 @@ if ddev exec test -f vendor/bin/php-security-linter &> /dev/null; then
 
             PHPCS_HIGH=$(echo "$PHPCS_ISSUES" | jq '[.[] | select(.severity == "high")] | length' 2>/dev/null || echo "0")
             PHPCS_MED=$(echo "$PHPCS_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
-            ((HIGH_COUNT += PHPCS_HIGH))
-            ((MEDIUM_COUNT += PHPCS_MED))
+            HIGH_COUNT=$((HIGH_COUNT + PHPCS_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + PHPCS_MED))
         else
             echo -e "  ${GREEN}No PHPCS security issues${NC}"
         fi
@@ -650,9 +671,9 @@ EOF
             PSALM_HIGH=$(echo "$PSALM_ISSUES" | jq '[.[] | select(.severity == "high")] | length' 2>/dev/null || echo "0")
             PSALM_MED=$(echo "$PSALM_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
             PSALM_LOW=$(echo "$PSALM_ISSUES" | jq '[.[] | select(.severity == "low")] | length' 2>/dev/null || echo "0")
-            ((HIGH_COUNT += PSALM_HIGH))
-            ((MEDIUM_COUNT += PSALM_MED))
-            ((LOW_COUNT += PSALM_LOW))
+            HIGH_COUNT=$((HIGH_COUNT + PSALM_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + PSALM_MED))
+            LOW_COUNT=$((LOW_COUNT + PSALM_LOW))
         else
             echo -e "  ${GREEN}No taint analysis issues${NC}"
         fi
@@ -675,59 +696,51 @@ CUSTOM_ISSUES="[]"
 
 # SQL Injection patterns
 if [ -d "${DRUPAL_MODULES_PATH}" ]; then
-    # Unsafe db_query usage
-    DB_QUERY_UNSAFE=$(grep -rn "db_query.*\$" "${DRUPAL_MODULES_PATH}" --include="*.php" --include="*.module" --include="*.inc" 2>/dev/null || true)
+    # Unsafe db_query usage. The pattern matches interpolation inside a double-quoted
+    # first argument, or concatenation onto it, so the safe placeholder-array form
+    # (db_query('... :id', [':id' => $id])) no longer counts as a finding.
+    DB_QUERY_UNSAFE=$(grep -rEHn 'db_query([^"]*"[^"]*\$|.*\.[[:space:]]*\$)' "${DRUPAL_MODULES_PATH}" --include="*.php" --include="*.module" --include="*.inc" 2>/dev/null || true)
     if [ -n "$DB_QUERY_UNSAFE" ]; then
-        DB_COUNT=$(echo "$DB_QUERY_UNSAFE" | wc -l)
-        echo -e "  ${YELLOW}Found ${DB_COUNT} potentially unsafe db_query() calls${NC}"
-        ((HIGH_COUNT += DB_COUNT))
-
-        # Add to issues (simplified)
-        CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq '. + [{
-            category: "SQL Injection Risk",
-            severity: "high",
-            file: "Multiple files",
-            line: 0,
-            message: "Potentially unsafe db_query() with variable concatenation",
-            owasp: "A03:2021",
-            remediation: "Use placeholders or query builder"
-        }]')
+        DB_ISSUES=$(pattern_issues "$DB_QUERY_UNSAFE" \
+            "SQL Injection Risk" "high" \
+            "Potentially unsafe db_query() with variable concatenation" \
+            "A03:2021" "Use placeholders or query builder")
+        DB_COUNT=$(echo "$DB_ISSUES" | jq 'length')
+        if [ "$DB_COUNT" -gt 0 ]; then
+            echo -e "  ${YELLOW}Found ${DB_COUNT} potentially unsafe db_query() calls${NC}"
+            HIGH_COUNT=$((HIGH_COUNT + DB_COUNT))
+            CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq --argjson add "$DB_ISSUES" '. + $add')
+        fi
     fi
 
-    # Twig |raw filter
-    RAW_FILTER=$(grep -rn "|raw" "${DRUPAL_MODULES_PATH}" "${DRUPAL_THEMES_PATH}" --include="*.twig" 2>/dev/null || true)
+    # Twig |raw filter. Kept as a basic-regex grep: under -E the '|' would be alternation.
+    RAW_FILTER=$(grep -rHn "|raw" "${DRUPAL_MODULES_PATH}" "${DRUPAL_THEMES_PATH}" --include="*.twig" 2>/dev/null || true)
     if [ -n "$RAW_FILTER" ]; then
-        RAW_COUNT=$(echo "$RAW_FILTER" | wc -l)
-        echo -e "  ${YELLOW}Found ${RAW_COUNT} uses of |raw filter in Twig${NC}"
-        ((MEDIUM_COUNT += RAW_COUNT))
-
-        CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq '. + [{
-            category: "XSS Risk",
-            severity: "medium",
-            file: "Twig templates",
-            line: 0,
-            message: "Use of |raw filter may expose XSS vulnerabilities",
-            owasp: "A03:2021",
-            remediation: "Remove |raw or ensure input is sanitized"
-        }]')
+        RAW_ISSUES=$(pattern_issues "$RAW_FILTER" \
+            "XSS Risk" "medium" \
+            "Use of |raw filter may expose XSS vulnerabilities" \
+            "A03:2021" "Remove |raw or ensure input is sanitized")
+        RAW_COUNT=$(echo "$RAW_ISSUES" | jq 'length')
+        if [ "$RAW_COUNT" -gt 0 ]; then
+            echo -e "  ${YELLOW}Found ${RAW_COUNT} uses of |raw filter in Twig${NC}"
+            MEDIUM_COUNT=$((MEDIUM_COUNT + RAW_COUNT))
+            CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq --argjson add "$RAW_ISSUES" '. + $add')
+        fi
     fi
 
     # unserialize() on user input
-    UNSERIALIZE=$(grep -rn "unserialize.*\$_" "${DRUPAL_MODULES_PATH}" --include="*.php" --include="*.module" 2>/dev/null || true)
+    UNSERIALIZE=$(grep -rHn "unserialize.*\$_" "${DRUPAL_MODULES_PATH}" --include="*.php" --include="*.module" 2>/dev/null || true)
     if [ -n "$UNSERIALIZE" ]; then
-        UNSER_COUNT=$(echo "$UNSERIALIZE" | wc -l)
-        echo -e "  ${YELLOW}Found ${UNSER_COUNT} potentially unsafe unserialize() calls${NC}"
-        ((HIGH_COUNT += UNSER_COUNT))
-
-        CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq '. + [{
-            category: "Insecure Deserialization",
-            severity: "high",
-            file: "Multiple files",
-            line: 0,
-            message: "unserialize() on user input can lead to RCE",
-            owasp: "A08:2021",
-            remediation: "Use JSON or validate serialized data"
-        }]')
+        UNSER_ISSUES=$(pattern_issues "$UNSERIALIZE" \
+            "Insecure Deserialization" "high" \
+            "unserialize() on user input can lead to RCE" \
+            "A08:2021" "Use JSON or validate serialized data")
+        UNSER_COUNT=$(echo "$UNSER_ISSUES" | jq 'length')
+        if [ "$UNSER_COUNT" -gt 0 ]; then
+            echo -e "  ${YELLOW}Found ${UNSER_COUNT} potentially unsafe unserialize() calls${NC}"
+            HIGH_COUNT=$((HIGH_COUNT + UNSER_COUNT))
+            CUSTOM_ISSUES=$(echo "$CUSTOM_ISSUES" | jq --argjson add "$UNSER_ISSUES" '. + $add')
+        fi
     fi
 fi
 
@@ -763,7 +776,7 @@ if ddev drush pm:list --filter=security_review --format=json 2>/dev/null | jq -e
                 remediation: "Check Drupal security review report"
             }]' "$SECREVIEW_JSON" 2>/dev/null || echo "[]")
 
-            ((MEDIUM_COUNT += FAILED_CHECKS))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + FAILED_CHECKS))
         else
             echo -e "  ${GREEN}All security review checks passed${NC}"
             SECREVIEW_ISSUES="[]"
@@ -819,9 +832,9 @@ if ddev exec semgrep --version &> /dev/null || command -v semgrep &> /dev/null; 
             SEMGREP_MEDIUM=$(echo "$SEMGREP_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
             SEMGREP_LOW=$(echo "$SEMGREP_ISSUES" | jq '[.[] | select(.severity == "low")] | length' 2>/dev/null || echo "0")
 
-            ((HIGH_COUNT += SEMGREP_HIGH))
-            ((MEDIUM_COUNT += SEMGREP_MEDIUM))
-            ((LOW_COUNT += SEMGREP_LOW))
+            HIGH_COUNT=$((HIGH_COUNT + SEMGREP_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + SEMGREP_MEDIUM))
+            LOW_COUNT=$((LOW_COUNT + SEMGREP_LOW))
         else
             echo -e "  ${GREEN}No Semgrep issues${NC}"
         fi
@@ -881,10 +894,10 @@ if command -v trivy &> /dev/null; then
             TRIVY_MEDIUM=$(echo "$TRIVY_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
             TRIVY_LOW=$(echo "$TRIVY_ISSUES" | jq '[.[] | select(.severity == "low")] | length' 2>/dev/null || echo "0")
 
-            ((CRITICAL_COUNT += TRIVY_CRITICAL))
-            ((HIGH_COUNT += TRIVY_HIGH))
-            ((MEDIUM_COUNT += TRIVY_MEDIUM))
-            ((LOW_COUNT += TRIVY_LOW))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + TRIVY_CRITICAL))
+            HIGH_COUNT=$((HIGH_COUNT + TRIVY_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + TRIVY_MEDIUM))
+            LOW_COUNT=$((LOW_COUNT + TRIVY_LOW))
         else
             echo -e "  ${GREEN}No Trivy issues${NC}"
         fi
@@ -925,7 +938,7 @@ if command -v gitleaks &> /dev/null; then
                 remediation: "Remove secret from code, rotate credentials, and use secret management"
             }]' "$GITLEAKS_JSON" 2>/dev/null || echo "[]")
 
-            ((CRITICAL_COUNT += SECRET_COUNT))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + SECRET_COUNT))
         else
             echo -e "  ${GREEN}No secrets detected${NC}"
         fi
@@ -961,7 +974,7 @@ else
         remediation: "Run: ddev composer require --dev roave/security-advisories:dev-master"
     }]')
 
-    ((LOW_COUNT += 1))
+    LOW_COUNT=$((LOW_COUNT + 1))
 fi
 
 # =====================

--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/solid-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/solid-check.sh
@@ -384,7 +384,7 @@ if tool_present phpstan; then
             }]' "$PHPSTAN_JSON" 2>/dev/null || echo "[]")
 
             # Count by severity
-            ((WARNING_COUNT += PHPSTAN_ERRORS))
+            WARNING_COUNT=$((WARNING_COUNT + PHPSTAN_ERRORS))
         else
             PHPSTAN_VIOLATIONS="[]"
         fi
@@ -437,9 +437,9 @@ if tool_present phpmd; then
             PHPMD_WARNINGS=$(jq '[.files[].violations[] | select(.priority == 3)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
             PHPMD_SUGGESTIONS=$(jq '[.files[].violations[] | select(.priority > 3)] | length' "$PHPMD_JSON" 2>/dev/null || echo "0")
 
-            ((CRITICAL_COUNT += PHPMD_CRITICAL)) || true
-            ((WARNING_COUNT += PHPMD_WARNINGS)) || true
-            ((SUGGESTION_COUNT += PHPMD_SUGGESTIONS)) || true
+            CRITICAL_COUNT=$((CRITICAL_COUNT + PHPMD_CRITICAL)) || true
+            WARNING_COUNT=$((WARNING_COUNT + PHPMD_WARNINGS)) || true
+            SUGGESTION_COUNT=$((SUGGESTION_COUNT + PHPMD_SUGGESTIONS)) || true
         else
             PHPMD_VIOLATIONS="[]"
         fi
@@ -475,7 +475,7 @@ STATIC_CALLS=$(ddev exec grep -r "\\\\Drupal::" "${DRUPAL_MODULES_PATH}" \
 
 if [ "$STATIC_CALLS" -gt 0 ]; then
     echo -e "  ${YELLOW}[WARN]${NC} Found ${STATIC_CALLS} files with static \\Drupal:: calls"
-    ((WARNING_COUNT += STATIC_CALLS)) || true
+    WARNING_COUNT=$((WARNING_COUNT + STATIC_CALLS)) || true
 
     # Create DIP violations for static calls
     STATIC_VIOLATIONS=$(ddev exec grep -rn "\\\\Drupal::" "${DRUPAL_MODULES_PATH}" \

--- a/code-quality-tools/skills/code-quality-audit/scripts/nextjs/security-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/nextjs/security-check.sh
@@ -72,10 +72,10 @@ if [ -f "$NPM_AUDIT_JSON" ] && [ -s "$NPM_AUDIT_JSON" ]; then
         NPM_MEDIUM=$(echo "$NPM_VIOLATIONS" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
         NPM_LOW=$(echo "$NPM_VIOLATIONS" | jq '[.[] | select(.severity == "low")] | length' 2>/dev/null || echo "0")
 
-        ((CRITICAL_COUNT += NPM_CRITICAL))
-        ((HIGH_COUNT += NPM_HIGH))
-        ((MEDIUM_COUNT += NPM_MEDIUM))
-        ((LOW_COUNT += NPM_LOW))
+        CRITICAL_COUNT=$((CRITICAL_COUNT + NPM_CRITICAL))
+        HIGH_COUNT=$((HIGH_COUNT + NPM_HIGH))
+        MEDIUM_COUNT=$((MEDIUM_COUNT + NPM_MEDIUM))
+        LOW_COUNT=$((LOW_COUNT + NPM_LOW))
     else
         echo -e "  ${GREEN}No package vulnerabilities${NC}"
     fi
@@ -118,8 +118,8 @@ if npm list eslint-plugin-security &> /dev/null; then
             ESLINT_HIGH=$(echo "$ESLINT_ISSUES" | jq '[.[] | select(.severity == "high")] | length' 2>/dev/null || echo "0")
             ESLINT_MEDIUM=$(echo "$ESLINT_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
 
-            ((HIGH_COUNT += ESLINT_HIGH))
-            ((MEDIUM_COUNT += ESLINT_MEDIUM))
+            HIGH_COUNT=$((HIGH_COUNT + ESLINT_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + ESLINT_MEDIUM))
         else
             echo -e "  ${GREEN}No ESLint security issues${NC}"
         fi
@@ -164,9 +164,9 @@ if command -v semgrep &> /dev/null; then
             SEMGREP_MEDIUM=$(echo "$SEMGREP_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
             SEMGREP_LOW=$(echo "$SEMGREP_ISSUES" | jq '[.[] | select(.severity == "low")] | length' 2>/dev/null || echo "0")
 
-            ((HIGH_COUNT += SEMGREP_HIGH))
-            ((MEDIUM_COUNT += SEMGREP_MEDIUM))
-            ((LOW_COUNT += SEMGREP_LOW))
+            HIGH_COUNT=$((HIGH_COUNT + SEMGREP_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + SEMGREP_MEDIUM))
+            LOW_COUNT=$((LOW_COUNT + SEMGREP_LOW))
         else
             echo -e "  ${GREEN}No Semgrep issues${NC}"
         fi
@@ -225,10 +225,10 @@ if command -v trivy &> /dev/null; then
             TRIVY_MEDIUM=$(echo "$TRIVY_ISSUES" | jq '[.[] | select(.severity == "medium")] | length' 2>/dev/null || echo "0")
             TRIVY_LOW=$(echo "$TRIVY_ISSUES" | jq '[.[] | select(.severity == "low")] | length' 2>/dev/null || echo "0")
 
-            ((CRITICAL_COUNT += TRIVY_CRITICAL))
-            ((HIGH_COUNT += TRIVY_HIGH))
-            ((MEDIUM_COUNT += TRIVY_MEDIUM))
-            ((LOW_COUNT += TRIVY_LOW))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + TRIVY_CRITICAL))
+            HIGH_COUNT=$((HIGH_COUNT + TRIVY_HIGH))
+            MEDIUM_COUNT=$((MEDIUM_COUNT + TRIVY_MEDIUM))
+            LOW_COUNT=$((LOW_COUNT + TRIVY_LOW))
         else
             echo -e "  ${GREEN}No Trivy issues${NC}"
         fi
@@ -268,7 +268,7 @@ if command -v gitleaks &> /dev/null; then
                 remediation: "Remove secret from code, rotate credentials, and use secret management"
             }]' "$GITLEAKS_JSON" 2>/dev/null || echo "[]")
 
-            ((CRITICAL_COUNT += SECRET_COUNT))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + SECRET_COUNT))
         else
             echo -e "  ${GREEN}No secrets detected${NC}"
         fi
@@ -290,7 +290,7 @@ if [ -d "$SRC_PATH" ]; then
     if [ -n "$DANGEROUS_HTML" ]; then
         echo -e "  ${YELLOW}Found dangerouslySetInnerHTML usage${NC}"
         CUSTOM_COUNT=$(echo "$DANGEROUS_HTML" | wc -l)
-        ((MEDIUM_COUNT += CUSTOM_COUNT))
+        MEDIUM_COUNT=$((MEDIUM_COUNT + CUSTOM_COUNT))
     fi
 
     # Check for eval() usage
@@ -298,7 +298,7 @@ if [ -d "$SRC_PATH" ]; then
     if [ -n "$EVAL_USAGE" ]; then
         echo -e "  ${YELLOW}Found eval() usage${NC}"
         EVAL_COUNT=$(echo "$EVAL_USAGE" | wc -l)
-        ((HIGH_COUNT += EVAL_COUNT))
+        HIGH_COUNT=$((HIGH_COUNT + EVAL_COUNT))
     fi
 
     # Check for window.location href XSS
@@ -306,7 +306,7 @@ if [ -d "$SRC_PATH" ]; then
     if [ -n "$HREF_XSS" ]; then
         echo -e "  ${YELLOW}Found window.location.href assignments (potential XSS)${NC}"
         HREF_COUNT=$(echo "$HREF_XSS" | wc -l)
-        ((MEDIUM_COUNT += HREF_COUNT))
+        MEDIUM_COUNT=$((MEDIUM_COUNT + HREF_COUNT))
     fi
 
     if [ -z "$DANGEROUS_HTML" ] && [ -z "$EVAL_USAGE" ] && [ -z "$HREF_XSS" ]; then
@@ -343,7 +343,7 @@ if npx socket-npm --version &> /dev/null 2>&1; then
             owasp: "A08:2021",
             remediation: "Review Socket CLI output: npx socket-npm audit"
         }]')
-        ((MEDIUM_COUNT += 1))
+        MEDIUM_COUNT=$((MEDIUM_COUNT + 1))
     else
         echo -e "  ${GREEN}No supply chain issues detected${NC}"
     fi
@@ -362,7 +362,7 @@ else
         remediation: "Run: npm install -D @socketsecurity/cli"
     }]')
 
-    ((LOW_COUNT += 1))
+    LOW_COUNT=$((LOW_COUNT + 1))
 fi
 
 # =====================

--- a/code-quality-tools/skills/code-quality-audit/scripts/nextjs/solid-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/nextjs/solid-check.sh
@@ -92,7 +92,7 @@ if npx madge --version &> /dev/null 2>&1; then
             echo ""
             # Show first 3 chains
             jq -r '.[0:3][] | "  Chain: " + (. | join(" -> "))' "${CIRCULAR_REPORT}" 2>/dev/null || true
-            ((CRITICAL_COUNT += CIRCULAR_DEPS))
+            CRITICAL_COUNT=$((CRITICAL_COUNT + CIRCULAR_DEPS))
         else
             echo -e "${GREEN}[PASS]${NC} No circular dependencies found"
         fi
@@ -135,7 +135,7 @@ if npx eslint --version &> /dev/null 2>&1; then
             echo ""
             # Show first 5 violations
             jq -r '[.[].messages[] | select(.ruleId == "complexity" or .ruleId == "max-lines-per-function")][0:5] | .[] | "  \(.ruleId) in \(.message)"' "${COMPLEXITY_REPORT}" 2>/dev/null || true
-            ((WARNING_COUNT += COMPLEXITY_VIOLATIONS))
+            WARNING_COUNT=$((WARNING_COUNT + COMPLEXITY_VIOLATIONS))
         else
             echo -e "${GREEN}[PASS]${NC} Complexity within limits"
         fi
@@ -170,7 +170,7 @@ while IFS= read -r -d '' file; do
             echo "," >> "${LARGE_FILES_REPORT}"
         fi
         echo "  {\"file\": \"${file}\", \"lines\": ${lines}, \"max\": ${MAX_FILE_LINES}}" >> "${LARGE_FILES_REPORT}"
-        ((LARGE_FILES++))
+        LARGE_FILES=$((LARGE_FILES + 1))
     fi
 done < <(find "${SOURCE_DIR}" -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \) ! -path "*/node_modules/*" ! -path "*/.next/*" ! -name "*.test.*" ! -name "*.spec.*" -print0 2>/dev/null)
 
@@ -184,7 +184,7 @@ if [ "$LARGE_FILES" -gt 0 ]; then
     echo "  - Consider splitting into smaller, focused modules"
     echo ""
     jq -r '.[] | "  \(.file): \(.lines) lines"' "${LARGE_FILES_REPORT}" 2>/dev/null | head -5
-    ((WARNING_COUNT += LARGE_FILES))
+    WARNING_COUNT=$((WARNING_COUNT + LARGE_FILES))
 else
     echo -e "${GREEN}[PASS]${NC} All files within size limits"
 fi
@@ -219,16 +219,16 @@ EOF
         echo "  Strict mode helps enforce:"
         echo "  - Liskov Substitution (proper type contracts)"
         echo "  - Dependency Inversion (interface-based programming)"
-        ((TS_ISSUES++))
-        ((WARNING_COUNT++))
+        TS_ISSUES=$((TS_ISSUES + 1))
+        WARNING_COUNT=$((WARNING_COUNT + 1))
     else
         echo -e "${GREEN}[PASS]${NC} TypeScript strict mode enabled"
     fi
 
     if [ "$STRICT" != "true" ] && [ "$NO_IMPLICIT_ANY" != "true" ]; then
         echo -e "${YELLOW}[WARN]${NC} noImplicitAny not enabled"
-        ((TS_ISSUES++))
-        ((WARNING_COUNT++))
+        TS_ISSUES=$((TS_ISSUES + 1))
+        WARNING_COUNT=$((WARNING_COUNT + 1))
     fi
 else
     echo -e "${YELLOW}[SKIP]${NC} No tsconfig.json found"

--- a/code-quality-tools/skills/code-quality-audit/scripts/tests/security-counting-spec.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/tests/security-counting-spec.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# security-counting-spec.sh — Hermetic unit tests for the security gate's counting
+# and reporting defects. No DDEV, no network, no PHP. Fixtures in a tmp dir only.
+#
+# Run: bash scripts/tests/security-counting-spec.sh
+# Exit 0 = all pass; exit 1 = failures (details printed).
+#
+# Covers:
+#   A1  No `((VAR += X))` / `((VAR++))` remains in any gate script. Under `set -e`
+#       those abort the script whenever the expression evaluates to 0 — which for
+#       `((C++))` is the very first increment, and for `+=` is any clean counter.
+#   A2  The abort is real, so the guard in A1 is not academic.
+#   B1  pattern_issues emits one issue per grep hit carrying the real file and line.
+#   B2  The severity count equals the issues[] length (they cannot disagree).
+#   B3  A single changed file still yields a filename, not a line number (grep -H).
+#   C1  The tightened db_query pattern ignores the safe placeholder-array form.
+#   C2  It still catches interpolation and concatenation, including a query string
+#       containing a comma.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_ROOT="${SCRIPT_DIR}/.."
+SEC="${SCRIPTS_ROOT}/drupal/security-check.sh"
+
+if [[ ! -f "$SEC" ]]; then
+  echo "FATAL: security-check.sh not found at $SEC" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+declare -a ERRORS=()
+
+ok()   { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+bad()  { FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $1"); echo "  FAIL: $1"; }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then ok "$desc"; else bad "$desc | expected '$expected', got '$actual'"; fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── A. The set -e arithmetic hazard ──────────────────────────────────────────
+echo ""
+echo "A: no set -e arithmetic aborts remain"
+
+# Scope to the gate scripts: this spec deliberately contains the hazardous form
+# below to prove it aborts, and must not match itself.
+RISKY=$(find "$SCRIPTS_ROOT" -name '*.sh' -not -path '*/tests/*' \
+  -exec grep -nE '\(\(\s*[A-Za-z_][A-Za-z0-9_]*\s*(\+\+|\+=)' {} + 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "no ((VAR += X)) or ((VAR++)) in any gate script" "0" "$RISKY"
+
+# A2: prove the construct really does abort, so A1 guards something real.
+abort_status=0
+bash -c 'set -e; C=0; ((C++)); exit 0' 2>/dev/null || abort_status=$?
+assert_eq "((C++)) under set -e aborts when C starts at 0" "1" "$abort_status"
+
+safe_status=0
+bash -c 'set -e; C=0; C=$((C + 1)); exit 0' 2>/dev/null || safe_status=$?
+assert_eq "the assignment form does not abort" "0" "$safe_status"
+
+# ── B. pattern_issues emits locatable findings ───────────────────────────────
+echo ""
+echo "B: pattern_issues emits real file:line and reconciling counts"
+
+# Extract the helper from the gate script rather than re-implementing it here,
+# so this spec fails if the real function changes shape.
+sed -n '/^pattern_issues()/,/^}/p' "$SEC" > "$TMP/helper.sh"
+if [[ ! -s "$TMP/helper.sh" ]]; then
+  bad "pattern_issues() not found in security-check.sh"
+else
+  # shellcheck source=/dev/null
+  source "$TMP/helper.sh"
+
+  cat > "$TMP/alpha.module" <<'PHPEOF'
+$safe   = db_query('SELECT a, b FROM {n} WHERE id = :id', [':id' => $id]);
+$unsafe = db_query("SELECT a, b FROM {n} WHERE id = $id");
+$concat = db_query('SELECT a FROM {n} WHERE id = ' . $id);
+PHPEOF
+  cat > "$TMP/beta.module" <<'PHPEOF'
+$also = db_query("SELECT x FROM {t} WHERE y = $y");
+PHPEOF
+
+  RAW=$(grep -EHn 'db_query([^"]*"[^"]*\$|.*\.[[:space:]]*\$)' "$TMP/alpha.module" "$TMP/beta.module" 2>/dev/null || true)
+  OUT=$(pattern_issues "$RAW" "SQL Injection Risk" "high" "msg" "A03:2021" "fix")
+
+  COUNT=$(echo "$OUT" | jq 'length')
+  assert_eq "one issue per hit across two files (3 hits)" "3" "$COUNT"
+
+  ZERO_LINES=$(echo "$OUT" | jq '[.[] | select(.line == 0)] | length')
+  assert_eq "no issue carries the line 0 placeholder" "0" "$ZERO_LINES"
+
+  PLACEHOLDER=$(echo "$OUT" | jq '[.[] | select(.file | test("Multiple files|Changed files|Twig templates"))] | length')
+  assert_eq "no issue carries a placeholder filename" "0" "$PLACEHOLDER"
+
+  FIRST_LINE=$(echo "$OUT" | jq -r '.[0].line')
+  assert_eq "first hit records its real line number" "2" "$FIRST_LINE"
+
+  # B2: the counter a caller derives is the array length, so they cannot diverge.
+  assert_eq "severity count equals issues[] length" "$COUNT" "$(echo "$OUT" | jq 'length')"
+
+  # B3: single-file grep still yields a filename, not a line number.
+  SINGLE=$(grep -EHn 'db_query([^"]*"[^"]*\$|.*\.[[:space:]]*\$)' "$TMP/beta.module" 2>/dev/null || true)
+  SINGLE_FILE=$(pattern_issues "$SINGLE" c s m o r | jq -r '.[0].file' | xargs basename)
+  assert_eq "single file yields a filename, not a line number" "beta.module" "$SINGLE_FILE"
+fi
+
+# ── C. The tightened db_query pattern ────────────────────────────────────────
+echo ""
+echo "C: db_query pattern excludes the safe placeholder form"
+
+PAT='db_query([^"]*"[^"]*\$|.*\.[[:space:]]*\$)'
+
+cat > "$TMP/patterns.module" <<'PHPEOF'
+$a = db_query('SELECT a, b FROM {n} WHERE id = :id', [':id' => $id]);
+$b = db_query("SELECT a, b FROM {n} WHERE id = $id");
+$c = db_query('SELECT a FROM {n} WHERE id = ' . $id);
+$d = db_query("SELECT a, b FROM {n} WHERE x = :x", [':x' => $x]);
+PHPEOF
+
+MATCHED=$(grep -EHn "$PAT" "$TMP/patterns.module" 2>/dev/null | cut -d: -f2 | tr '\n' ',' | sed 's/,$//')
+assert_eq "matches only the interpolated and concatenated forms" "2,3" "$MATCHED"
+
+# The comma inside the query string must not end the match early.
+COMMA_HIT=$(grep -EHn "$PAT" "$TMP/patterns.module" 2>/dev/null | grep -c 'SELECT a, b FROM {n} WHERE id = \$id' | tr -d ' ')
+assert_eq "a comma inside the query string does not defeat the match" "1" "$COMMA_HIT"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────────────────────────────"
+echo "Results: $PASS passed, $FAIL failed"
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  printf '%s\n' "${ERRORS[@]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Five defects in the Drupal and Next.js quality gates. Found while comparing the plugin against an external deterministic Drupal scanner; every one verified by execution, not inspection.

## The severe one

`security-check.sh` runs under `set -e`. In bash, `((VAR += X))` returns exit status **1** whenever the expression evaluates to 0, and `((VAR++))` does so on the *first* increment because post-increment returns the old value:

```bash
$ bash -c 'set -e; C=0; ((C++)); echo reached'
$ echo $?
1        # never printed "reached"
```

The first such site sits in the composer-audit layer, at top level with `set -e` active. So on a project with **no high-severity composer advisories** — the healthy case — the scan died there and layers 3-10 never ran: phpcs security, psalm taint, the custom Drupal patterns, semgrep, trivy, gitleaks.

63 sites across `drupal/security-check.sh`, `drupal/solid-check.sh`, `nextjs/security-check.sh`, `nextjs/solid-check.sh`, `core/full-audit.sh`. All converted to `VAR=$((VAR + X))` — the form the `--changed` path already used, so the fix was already proven in-file.

## The other four

- **A failing security audit recorded as a warning.** `full-audit.sh` read the exit code using the 0/1/2 convention the sibling gates use, but `security-check.sh` exits 0 for pass *and* warning, 1 for fail. So fail → `warning`, warning → `pass`. Now reads `summary.overall_status` from the report, falling back to the exit code only when no report exists (the scan aborted before writing one). The published exit contract is unchanged — this fixes the reader, not the interface.
- **Pattern findings were unlocatable and their counts unreconcilable.** Each of the three custom Drupal patterns incremented its severity counter by the grep *line count* while appending exactly **one** issue object carrying `file: "Multiple files"`, `line: 0`. A shared `pattern_issues` helper now emits one issue per hit with the real file and line, and the count is the array length, so `summary.by_severity` and `issues[]` cannot disagree by construction. Fixed in **both** the standard path and the `--changed` path, which carried the identical defect.
- **`db_query` pattern matched the safe form.** `db_query.*$` matched any line with a `$` anywhere, including `db_query('... :id', [':id' => $id])`. On a fixture of 4 calls it flagged all 4; the tightened pattern flags exactly the 2 genuinely unsafe ones, and still matches when the query string contains a comma.
- **Single changed file lost its filename.** `grep -n` omits the filename when given exactly one file, so a one-file diff would parse the line number as the path. All pattern greps now pass `-H`.

## Verification

New `scripts/tests/security-counting-spec.sh` — 11 hermetic assertions, no DDEV, no network, no PHP. It pins that no hazardous arithmetic remains, that the abort it guards against is real, that `pattern_issues` produces reconciling counts and locatable findings, and that the tightened pattern excludes the safe form.

| Suite | Result |
|---|---|
| `security-counting-spec.sh` (new) | 11 passed, 0 failed |
| `changed-mode-spec.sh` | 22 passed, 0 failed |
| `tests/changed-mode.sh` | 34 passed, 0 failed |

All scripts pass `bash -n`. Metadata updated: plugin.json 3.9.5, marketplace entry 3.9.5, marketplace metadata 2.0.28, CHANGELOG.

## Not included

The `/review` extension-floor gap reported alongside these turned out not to be a bug — the Drupal review recipe already declares `.module`, `.theme`, `.install` and `/review` unions them onto the neutral floor. See the PR discussion for the residual question, which is a design decision rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)