### PR TITLE
Make tool output consistent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.29"
+    "version": "2.0.30"
   },
   "plugins": [
     {
@@ -39,7 +39,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Authoring toolkit and quality gate for Claude Code plugins. Scaffolds and audits every component — skills, commands, agents, hooks, MCP servers, themes, dependencies, userConfig, and Routines — with a deterministic `validate` command (opt-in auto-fix), a pre-publish containment scan that catches leaked home paths and secrets, and the `plugin-creation` authoring skill. Tracks the current plugin spec: hook handler types and pre-spawn filters, exec-form args, JSON output controls, subfolder agent scoping, single-skill auto-discovery, and cross-marketplace dependencies.",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "author": {
         "name": "camoa"
       },
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.21.0",
+      "version": "5.22.0",
       "author": {
         "name": "camoa"
       },
@@ -101,7 +101,7 @@
       "name": "drupal-htmx",
       "source": "./drupal-htmx",
       "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "author": {
         "name": "camoa"
       },
@@ -120,7 +120,7 @@
       "name": "drupal-ai-contrib",
       "source": "./drupal-ai-contrib",
       "description": "AI-assisted Drupal contribution quality — evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline) with a local drupalci-parity gate set plus AI-policy and eval gates, and 3 read-only fresh-context review agents. Authenticated GitLab writes delegate to the drupal-gitlab skill (glab); drupalorg-cli covers no-auth reads and the legacy queue. A quality layer outside ai-dev-assistant, built on the camoa/dev-guides contribution guides.",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "author": {
         "name": "camoa"
       },
@@ -144,7 +144,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.9.6",
+      "version": "3.9.7",
       "author": {
         "name": "camoa"
       },
@@ -201,7 +201,7 @@
       "name": "brand-content-design",
       "source": "./brand-content-design",
       "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, a style-recommendation engine, 26 visual styles, 114 infographic templates, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF, PPTX, and Google Slides output (canonical PPTX→Slides import via Drive for design fidelity), HTML composition, and infographic rendering.",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "author": {
         "name": "camoa"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,19 @@ picks it up.
 None of these dependencies fail loudly on their own. A green `make test`
 on a machine missing gitleaks is a smaller green than it looks.
 
+## Writing output
+
+Read `OUTPUTS.md` before adding anything that writes a file.
+
+- Tied to a task: the task folder.
+- The result of a check: `.reports/` at the root of the code being checked.
+- Something the person asked to be made: `outputs/<type>/<date>-<name>/`.
+- Otherwise print and exit. Do not leave a file nobody asked for.
+
+Anything a machine reads is JSON carrying `status`, `findings`, and
+`timestamp`. Every command that produces something has an `## Output`
+section saying what and where.
+
 ## Where things live
 
 - Plugin folders are top level. Each has `.claude-plugin/plugin.json`.

--- a/OUTPUTS.md
+++ b/OUTPUTS.md
@@ -1,0 +1,50 @@
+# Where output goes
+
+Every command in this marketplace writes somewhere. Before this page there
+was no rule, so four plugins picked four different places. This is the rule
+for new work, and a record of where each plugin writes today.
+
+## The rule
+
+1. **Tied to a task** goes in the task folder, under
+   `implementation_process/in_progress/<task>/`. Phase artifacts, gate
+   results, audit files.
+2. **The result of a check** goes in `.reports/` at the root of the code
+   being checked. One file per tool, named after the tool.
+3. **Something the person asked to be made** goes in
+   `outputs/<type>/<YYYY-MM-DD>-<name>/`. Decks, images, pages.
+4. **Nothing else is written to disk.** If a command only reports, it
+   prints and exits. Do not leave a file behind that nobody asked for.
+5. **Never write outside the project** without saying so in the command's
+   Output section first.
+
+## What each plugin writes today
+
+| Plugin | Writes | Where |
+|---|---|---|
+| ai-dev-assistant | phase artifacts, gate results | `implementation_process/in_progress/<task>/`, gate JSON under `<task>/validations/latest/` and `<task>/validations/history.jsonl` |
+| code-quality-tools | tool reports, review write-up | `.reports/*.json`, `.reports/*.md`, `REVIEW.md` |
+| code-paper-test | trace report | `<target_dir>/paper-test-team-report.md` and `.json` |
+| brand-content-design | finished content | `outputs/<type>/<YYYY-MM-DD>-<name>/` |
+| plugin-creation-tools | nothing, prints only | terminal |
+| drupal-ai-contrib | evidence artifacts | the contribution working folder |
+| drupal-htmx | nothing, prints only | terminal |
+| dev-guides-navigator | cached guide bodies | the shared content store, outside the project |
+
+Rule 3 and rule 2 are already what `brand-content-design` and
+`code-quality-tools` do. `code-paper-test` writes beside the file it
+traced, which predates this page.
+
+## Saying so in the command
+
+Every command that produces anything carries an `## Output` section naming
+what it writes and where. If a command writes nothing, the section says
+so. A person should not have to run a command to find out what it leaves
+behind.
+
+## Result format
+
+Anything a machine reads is JSON and carries `status`, `findings`, and
+`timestamp`. See
+`ai-dev-assistant/references/validation-gate-result.md` and
+`code-paper-test/skills/paper-test/references/json-output-schema.md`.

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.21.0",
+  "version": "5.22.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.22.0] - 2026-08-11
+
+### Changed
+
+- Validation gate envelope v1.1: every `/validate:*` result now also carries `status`, `timestamp`, and `findings`, the names `code-quality-tools` and `code-paper-test` already use. `verdict`, `run_at`, and `messages` are unchanged and not deprecated, so existing consumers keep working.
+- Versioning policy for the envelope now matches `code-paper-test`: additive changes bump the minor, consumers pin `^1.`.
+
 ## [5.21.0] - 2026-07-13
 
 ### Added

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -205,7 +205,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.21.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.22.0**.
 
 ## License
 

--- a/ai-dev-assistant/commands/validate-all.md
+++ b/ai-dev-assistant/commands/validate-all.md
@@ -51,22 +51,33 @@ Run every validation gate sequentially against the current task. Aggregate the p
 
    ```json
    {
-     "schema_version": "1.0",
+     "schema_version": "1.1",
      "run_at": "<ISO-8601 UTC>",
+     "timestamp": "<ISO-8601 UTC>",
      "task": "<task_name>",
+     "status": "fail",
      "gates": [
-       {"gate": "tdd", "verdict": "pass"},
-       {"gate": "solid", "verdict": "warning", "messages": ["..."]},
-       {"gate": "dry", "verdict": "pass"},
-       {"gate": "security", "verdict": "pass"},
-       {"gate": "guides", "verdict": "fail", "messages": ["..."]},
-       {"gate": "visual-regression", "verdict": "skipped", "messages": ["No baselines in store"]},
-       {"gate": "visual-parity", "verdict": "skipped", "messages": ["design-implementation-scoped — run /validate:visual-parity or let /review auto-run it"]}
+       {"gate": "tdd", "verdict": "pass", "status": "pass"},
+       {"gate": "solid", "verdict": "warning", "status": "warning", "messages": ["..."]},
+       {"gate": "dry", "verdict": "pass", "status": "pass"},
+       {"gate": "security", "verdict": "pass", "status": "pass"},
+       {"gate": "guides", "verdict": "fail", "status": "fail", "messages": ["..."]},
+       {"gate": "visual-regression", "verdict": "skipped", "status": "skipped", "messages": ["No baselines in store"]},
+       {"gate": "visual-parity", "verdict": "skipped", "status": "skipped", "messages": ["design-implementation-scoped — run /validate:visual-parity or let /review auto-run it"]}
      ],
      "summary": {"pass": 3, "warning": 1, "fail": 1, "skipped": 2, "total": 7},
+     "findings": [
+       {"severity": "MEDIUM", "title": "solid: ..."},
+       {"severity": "HIGH", "title": "guides: ..."}
+     ],
      "discoverability_hint": "For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
    }
    ```
+
+   The aggregate's own `status` is the worst gate status present: `fail` if any
+   gate failed, else `warning` if any warned, else `pass`. `findings[]` collects
+   every gate's findings with the gate name prefixed onto each `title`. Both are
+   always present, `findings` always an array.
 
 6. **Persist** — write aggregate to:
    - `<task_folder>/validations/latest/_all.json` (overwrite)

--- a/ai-dev-assistant/commands/validate-dry.md
+++ b/ai-dev-assistant/commands/validate-dry.md
@@ -57,17 +57,20 @@ If `/code-quality:dry` emits JSON via a `--json` flag (future enhancement), pref
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "dry",
   "task": "<task_name>",
   "run_at": "<ISO-8601 UTC>",
+  "timestamp": "<ISO-8601 UTC>",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "code-quality-tools:dry",
     "raw_output_path": "<path to .reports/dry.json if produced, else null>",
     "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
   },
-  "messages": ["<top findings>"]
+  "messages": ["<top findings>"],
+  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
 }
 ```
 

--- a/ai-dev-assistant/commands/validate-e2e.md
+++ b/ai-dev-assistant/commands/validate-e2e.md
@@ -46,6 +46,7 @@ If `--skip <reason>` is present:
     "bypass_reason": "<reason>",
     "gate_specific": {
       "verdict": "skipped",
+      "status": "skipped",
       "total_tests": 0,
       "passed": 0,
       "failed": 0,
@@ -80,13 +81,16 @@ Before proceeding: verify the script's stdout is valid JSON by running `jq empty
 Write the result to `<task_folder>/validations/latest/e2e.json` per `references/validation-gate-result.md` v1.0:
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "e2e",
   "task": "<task>",
   "run_at": "<ISO timestamp>",
+  "timestamp": "<ISO timestamp>",
   "verdict": "<pass|fail|warning>",
+  "status": "<pass|fail|warning>",
   "details": "<script result JSON>",
-  "messages": []
+  "messages": [],
+  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
 }
 ```
 
@@ -102,6 +106,7 @@ Build the `_e2e.json` payload from the script's result JSON. Use `jq -n --arg`/`
   "task_folder": "<abs task folder>",
   "gate_specific": {
     "verdict": "<pass|fail|warning>",
+    "status": "<pass|fail|warning>",
     "total_tests": <n>,
     "passed": <n>,
     "failed": <n>,

--- a/ai-dev-assistant/commands/validate-playbook-adherence.md
+++ b/ai-dev-assistant/commands/validate-playbook-adherence.md
@@ -52,8 +52,9 @@ Task name must match `^[a-z0-9_-]+$` (path-traversal mitigation). When `--skip-p
 
    ```json
    {
-     "schema_version": "1.0", "gate": "playbook-adherence", "task": "<name>",
+     "schema_version": "1.1", "gate": "playbook-adherence", "task": "<name>",
      "run_at": "<ISO-8601 UTC>", "verdict": "<...>",
+     "timestamp": "<ISO-8601 UTC>", "verdict": "<...>",
      "details": {
        "source": "framework:playbook-adherence",
        "invoked_by": "review | cli | validate-all | validate-team",
@@ -63,7 +64,8 @@ Task name must match `^[a-z0-9_-]+$` (path-traversal mitigation). When `--skip-p
        "cite_locations": {"<play_id>": [{"file","line","match_type"}, ...]},
        "skipped_sections": [{"file","heading","line_range"}, ...]
      },
-     "messages": [...]
+     "messages": [...],
+     "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
    }
    ```
 

--- a/ai-dev-assistant/commands/validate-security.md
+++ b/ai-dev-assistant/commands/validate-security.md
@@ -57,17 +57,20 @@ If `/code-quality:security` emits JSON via a `--json` flag (future enhancement),
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "security",
   "task": "<task_name>",
   "run_at": "<ISO-8601 UTC>",
+  "timestamp": "<ISO-8601 UTC>",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "code-quality-tools:security",
     "raw_output_path": "<path to .reports/security.json if produced, else null>",
     "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
   },
-  "messages": ["<top findings>"]
+  "messages": ["<top findings>"],
+  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
 }
 ```
 

--- a/ai-dev-assistant/commands/validate-solid.md
+++ b/ai-dev-assistant/commands/validate-solid.md
@@ -57,17 +57,20 @@ If `/code-quality:solid` emits JSON via a `--json` flag (future enhancement), pr
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "solid",
   "task": "<task_name>",
   "run_at": "<ISO-8601 UTC>",
+  "timestamp": "<ISO-8601 UTC>",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "code-quality-tools:solid",
     "raw_output_path": "<path to .reports/solid.json if produced, else null>",
     "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
   },
-  "messages": ["<top findings>"]
+  "messages": ["<top findings>"],
+  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
 }
 ```
 

--- a/ai-dev-assistant/commands/validate-tdd.md
+++ b/ai-dev-assistant/commands/validate-tdd.md
@@ -57,17 +57,20 @@ If `/code-quality:tdd` emits JSON via a `--json` flag (future enhancement), pref
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "tdd",
   "task": "<task_name>",
   "run_at": "<ISO-8601 UTC>",
+  "timestamp": "<ISO-8601 UTC>",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "code-quality-tools:tdd",
     "raw_output_path": "<path to .reports/tdd.json if produced, else null>",
     "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
   },
-  "messages": ["<top findings>"]
+  "messages": ["<top findings>"],
+  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
 }
 ```
 

--- a/ai-dev-assistant/commands/validate-visual-parity.md
+++ b/ai-dev-assistant/commands/validate-visual-parity.md
@@ -174,6 +174,7 @@ Aggregate to the worst verdict across all surfaces (`fail` > `warning` > `pass`;
   "surfaces": [
     {"id": "marketing-landing", "viewport": "desktop", "reference_type": "html-template",
      "verdict": "fail", "classification": "build-gap", "reference_updated": false,
+     "status": "fail", "classification": "build-gap", "reference_updated": false,
      "pixel_diff_ratio": 0.042, "css_diff_mode": "full", "css_diff_count": 3,
      "css_diff": [
        {"selector": ".hero-title", "property": "font-weight", "build": "400", "reference": "500"}
@@ -205,6 +206,7 @@ interpolation) and write it via
   "bypass_reason": null,
   "gate_specific": {
     "verdict": "pass | warning | fail | skipped",
+    "status": "pass | warning | fail | skipped",
     "envelope_path": "<task>/validations/latest/visual-parity.json",
     "surfaces_run": 3,
     "surfaces_passed": 2,

--- a/ai-dev-assistant/commands/validate-visual-regression.md
+++ b/ai-dev-assistant/commands/validate-visual-regression.md
@@ -222,6 +222,7 @@ Aggregate to the worst verdict across all surfaces (`fail` > `warning` >
   "surfaces": [
     {"id": "home-hero", "url": "/", "viewports": ["desktop","tablet","phone"],
      "verdict": "pass", "classification": null, "baseline_updated": false,
+     "status": "pass", "classification": null, "baseline_updated": false,
      "a11y_diff_path": null}
   ],
   "diff_tolerance": 0.005,
@@ -247,6 +248,7 @@ string interpolation) and write it via
   "bypass_reason": null,
   "gate_specific": {
     "verdict": "pass | warning | fail | skipped",
+    "status": "pass | warning | fail | skipped",
     "envelope_path": "<task>/validations/latest/visual-regression.json",
     "surfaces_run": 3,
     "surfaces_passed": 2,

--- a/ai-dev-assistant/references/validation-gate-result.md
+++ b/ai-dev-assistant/references/validation-gate-result.md
@@ -1,4 +1,4 @@
-# Validation Gate Result Envelope v1.0
+# Validation Gate Result Envelope v1.1
 
 **Introduced:** ai-dev-assistant v3.13.0
 **Owner:** `commands/validate-*.md`
@@ -6,15 +6,35 @@
 
 Every `/validate:*` command emits and persists a JSON result object with this shape, regardless of whether it wraps a `code-quality-tools` skill or implements its own check (guides, visual-parity, visual-regression). A shared envelope keeps consumers (`/validate:all`, future reports, `/complete` hooks) simple.
 
+## 0. Cross-plugin field names (v1.1)
+
+`code-quality-tools` and `code-paper-test` report results as `status`, `findings`, and `timestamp`. This envelope used `verdict`, `messages`, and `run_at` for the same three ideas, so a tool reading both plugins needed two code paths.
+
+As of v1.1 every envelope carries **both** sets. The pairs hold the same information:
+
+| Shared name | ai-dev-assistant name | Relationship |
+|---|---|---|
+| `status` | `verdict` | Same string, always equal |
+| `timestamp` | `run_at` | Same ISO-8601 UTC string, always equal |
+| `findings` | `messages` | `findings` is the structured form. See below |
+
+`messages[]` holds human-readable strings. `findings[]` holds one object per message: `{"severity": <string>, "title": <the message string>}`. Severity comes from the verdict: `fail` → `HIGH`, `warning` → `MEDIUM`, `pass` and `skipped` → `INFO`. `findings` is always an array, never `null` and never absent, so `jq '.findings[]'` is safe on a clean run.
+
+The ai-dev-assistant names are **not** deprecated in v1.1. Anything reading `verdict`, `messages`, or `run_at` keeps working unchanged. Prefer the shared names in new code.
+
+One difference remains: this envelope's `status` can be `skipped`, which the other two plugins do not emit. Treat an unknown status as non-blocking.
+
 ## 1. Shape
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "tdd",
   "task": "dev_framework_granular_validation",
   "run_at": "2026-04-24T15:00:00Z",
+  "timestamp": "2026-04-24T15:00:00Z",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "code-quality-tools:tdd",
     "raw_output_path": "/abs/path/.reports/tdd.json"
@@ -22,6 +42,10 @@ Every `/validate:*` command emits and persists a JSON result object with this sh
   "messages": [
     "Red-Green-Refactor cycle observed across 3 commits",
     "All new logic has tests"
+  ],
+  "findings": [
+    {"severity": "INFO", "title": "Red-Green-Refactor cycle observed across 3 commits"},
+    {"severity": "INFO", "title": "All new logic has tests"}
   ]
 }
 ```
@@ -30,13 +54,16 @@ Every `/validate:*` command emits and persists a JSON result object with this sh
 
 | Field | Type | Values / constraints |
 |---|---|---|
-| `schema_version` | string | `"1.0"` at v3.13.0. JSON string. Consumers match on major |
+| `schema_version` | string | `"1.1"` at v5.22.0. JSON string. Consumers match on major (`^1\.`) |
 | `gate` | string | Gate identifier: `tdd` \| `solid` \| `dry` \| `security` \| `guides` \| `visual-parity` \| `visual-regression`. Matches the `/validate:<gate>` command name |
 | `task` | string | Task folder name the run was scoped to |
 | `run_at` | string | ISO-8601 UTC with `Z` suffix |
+| `timestamp` | string | Same value as `run_at`. The cross-plugin name |
 | `verdict` | enum | `"pass"` \| `"warning"` \| `"fail"` \| `"skipped"` |
+| `status` | enum | Same value as `verdict`. The cross-plugin name |
 | `details` | object | Gate-specific detail structure. See the gate details section |
 | `messages` | array of string | Human-readable findings. Shown in CLI output. Non-empty for warning/fail; usually present for pass too (e.g., "3 checks passed") |
+| `findings` | array of object | One `{severity, title}` per entry in `messages`. Always an array, never `null`, never absent. The cross-plugin name |
 
 ## 3. Verdict semantics
 
@@ -149,13 +176,15 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "run_at": "2026-04-24T15:30:00Z",
+  "timestamp": "2026-04-24T15:30:00Z",
   "task": "dev_framework_granular_validation",
+  "status": "warning",
   "gates": [
-    {"gate": "tdd", "verdict": "pass"},
-    {"gate": "solid", "verdict": "warning", "messages": ["1 class exceeds 200 lines"]},
-    {"gate": "visual-regression", "verdict": "pass"}
+    {"gate": "tdd", "verdict": "pass", "status": "pass"},
+    {"gate": "solid", "verdict": "warning", "status": "warning", "messages": ["1 class exceeds 200 lines"]},
+    {"gate": "visual-regression", "verdict": "pass", "status": "pass"}
   ],
   "summary": {
     "pass": 5,
@@ -164,25 +193,40 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
     "skipped": 1,
     "total": 7
   },
+  "findings": [
+    {"severity": "MEDIUM", "title": "solid: 1 class exceeds 200 lines"}
+  ],
   "discoverability_hint": "See also: /code-quality:lint, :coverage, :review, :audit, :ultrareview"
 }
 ```
 
+The aggregate's own `status` is the worst gate status present: `fail` if any gate failed, else `warning` if any warned, else `pass`. Its `findings[]` collects every gate's findings, each `title` prefixed with the gate name.
+
 ## 7. Invariants
 
-1. `schema_version` is always present and always `"1.0"` at v3.13.0
+1. `schema_version` is always present and matches `^1\.`
 2. `gate` matches one of the 7 known IDs OR `_all` for aggregate
 3. `verdict` is one of the 4 enum values
 4. `details.source` prefix identifies provenance: `code-quality-tools:*` for wrappers, `framework:*` for owned gates
 5. `messages[]` is always an array (possibly empty); never absent
+6. `findings[]` is always an array (possibly empty); never absent, never `null`
+7. `status == verdict` and `timestamp == run_at` in every envelope
 
 ## 8. Versioning policy
 
-- Adding fields at v1.x — consumers ignore unknowns. No bump
+Matches `code-paper-test`'s policy so both plugins version the same way.
+
+- Adding fields — bump the minor (`1.0` → `1.1`). Back-compatible
 - Adding new `gate` values — additive within v1.x
-- Adding new `verdict` values — requires major bump
+- Adding new `verdict` / `status` values — additive within v1.x; treat unknown values as non-blocking
 - Adding new `details.source` values — additive
-- Removing any field or changing semantics — major bump
+- Removing any field, or changing what one means — major bump
+
+Pin with `^1\.`, not `== "1.1"`:
+
+```bash
+jq -e '.schema_version | test("^1\\.")' <envelope> >/dev/null || exit 1
+```
 
 ## 9. Examples by gate
 
@@ -190,17 +234,22 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "tdd",
   "task": "fix_login_redirect",
   "run_at": "2026-04-24T15:00:00Z",
+  "timestamp": "2026-04-24T15:00:00Z",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "code-quality-tools:tdd",
     "raw_output_path": "/abs/path/.reports/tdd.json",
     "code_quality_tools_version": "3.0.0"
   },
-  "messages": ["Red-Green-Refactor cycle observed across 3 commits"]
+  "messages": ["Red-Green-Refactor cycle observed across 3 commits"],
+  "findings": [
+    {"severity": "INFO", "title": "Red-Green-Refactor cycle observed across 3 commits"}
+  ]
 }
 ```
 
@@ -208,11 +257,13 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "solid",
   "task": "settings_form_refactor",
   "run_at": "2026-04-24T15:01:00Z",
+  "timestamp": "2026-04-24T15:01:00Z",
   "verdict": "warning",
+  "status": "warning",
   "details": {
     "source": "code-quality-tools:solid",
     "raw_output_path": "/abs/path/.reports/solid.json",
@@ -221,6 +272,10 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
   "messages": [
     "SettingsForm::submit violates SRP (mixes validation + persistence + notification)",
     "Consider splitting into SettingsFormValidator + SettingsFormPersister"
+  ],
+  "findings": [
+    {"severity": "MEDIUM", "title": "SettingsForm::submit violates SRP (mixes validation + persistence + notification)"},
+    {"severity": "MEDIUM", "title": "Consider splitting into SettingsFormValidator + SettingsFormPersister"}
   ]
 }
 ```
@@ -229,11 +284,13 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "guides",
   "task": "data_model_refactor",
   "run_at": "2026-04-24T15:02:00Z",
+  "timestamp": "2026-04-24T15:02:00Z",
   "verdict": "fail",
+  "status": "fail",
   "details": {
     "source": "framework:guides",
     "checked_artifacts": ["/abs/path/research.md", "/abs/path/architecture.md"],
@@ -243,6 +300,10 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
   "messages": [
     "No dev-guides citations found in research.md or architecture.md",
     "Data-model work typically loads <framework>/entities/* guides; consider /dev-guides-navigator"
+  ],
+  "findings": [
+    {"severity": "HIGH", "title": "No dev-guides citations found in research.md or architecture.md"},
+    {"severity": "HIGH", "title": "Data-model work typically loads <framework>/entities/* guides; consider /dev-guides-navigator"}
   ]
 }
 ```
@@ -251,11 +312,13 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "gate": "visual-regression",
   "task": "hero_cta_update",
   "run_at": "2026-04-24T15:03:00Z",
+  "timestamp": "2026-04-24T15:03:00Z",
   "verdict": "pass",
+  "status": "pass",
   "details": {
     "source": "framework:visual-regression",
     "component": "home-hero",
@@ -271,6 +334,10 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
   "messages": [
     "Diff detected (4.2%). User classified as intentional; baseline rotated",
     "Previous baseline archived as .previous.png (prior_hash: 42936883...)"
+  ],
+  "findings": [
+    {"severity": "INFO", "title": "Diff detected (4.2%). User classified as intentional; baseline rotated"},
+    {"severity": "INFO", "title": "Previous baseline archived as .previous.png (prior_hash: 42936883...)"}
   ]
 }
 ```

--- a/brand-content-design/.claude-plugin/plugin.json
+++ b/brand-content-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "brand-content-design",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, style recommendation engine, visual components, 26 visual styles, design systems, and Presentation Zen principles",
   "author": {
     "name": "camoa"

--- a/brand-content-design/CHANGELOG.md
+++ b/brand-content-design/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the brand-content-design plugin.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.2] - 2026-08-11
+
+### Changed
+
+- `/template-infographic` now documents what it writes and where.
+
 ## [Unreleased]
 
 ## [3.5.1] - 2026-07-13

--- a/brand-content-design/commands/template-infographic.md
+++ b/brand-content-design/commands/template-infographic.md
@@ -825,3 +825,11 @@ Create a new infographic template or edit an existing one.
   ]
 }
 ```
+
+## Output
+
+Prints the wizard's choices back to you as you make them, then the path of
+the finished template.
+
+Writes the template into the project's infographic template folder. Editing
+an existing template overwrites that template in place.

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,11 +2,31 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["code-quality", "security", "tdd", "solid", "dry", "owasp", "drupal", "nextjs", "testing", "phpstan", "psalm", "semgrep", "trivy", "gitleaks", "roave", "socket", "dast", "zap", "nuclei"]
+  "keywords": [
+    "code-quality",
+    "security",
+    "tdd",
+    "solid",
+    "dry",
+    "owasp",
+    "drupal",
+    "nextjs",
+    "testing",
+    "phpstan",
+    "psalm",
+    "semgrep",
+    "trivy",
+    "gitleaks",
+    "roave",
+    "socket",
+    "dast",
+    "zap",
+    "nuclei"
+  ]
 }

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.7] - 2026-08-11
+
+### Changed
+
+- `/review` and `/ultrareview` now document what they write and where.
+
 ## [3.9.6] - 2026-08-10
 
 A sweep of the defects found by running this suite against a live client Drupal 11

--- a/code-quality-tools/commands/review.md
+++ b/code-quality-tools/commands/review.md
@@ -204,3 +204,14 @@ To gate merges on Code Review findings, parse the **Claude Code Review** check r
 - `/code-quality-tools:ultrareview` — cloud multi-agent deep review for pre-merge (slower, more rigorous, paid after free quota)
 - `@claude review once` — GitHub PR comment that triggers one managed Code Review without subscribing the PR to future push-triggered reviews. Requires the managed Code Review service enabled on the repository. Useful for long-running PRs with frequent rebases.
 - `claude --from-pr <number>` — resumes the Claude Code session linked to a PR (linked automatically when Claude opened it). Use it to act on review findings in the original session's context.
+
+## Output
+
+Prints the graded assessment to the terminal: per-category scores, the total
+out of 50, the quality gate verdict, and prioritized action items.
+
+Writes `REVIEW.md` next to the reviewed target when you ask for the write-up.
+
+With `--json`, prints one JSON object instead, carrying `status`, `findings`,
+and `timestamp` per `references/json-schemas.md`. `findings` is always an
+array, so `jq '.findings[]'` is safe on a clean review.

--- a/code-quality-tools/commands/ultrareview.md
+++ b/code-quality-tools/commands/ultrareview.md
@@ -177,3 +177,11 @@ A run that fails or is stopped **still consumes** one of the three free Pro/Max 
 - `/code-quality-tools:generate-review-md` — tune managed Code Review (separate from ultrareview)
 - `skills/code-quality-audit/references/scheduled-sweeps.md` — scheduling reviews across local and cloud surfaces
 - `claude --from-pr <number>` — resumes the Claude Code session linked to a PR (linked automatically when Claude opened it). Use it to pick up review or fix work on a PR; distinct from `/code-review ultra <PR>`, which clones a PR fresh to review it.
+
+## Output
+
+Prints the pre-flight check result and the cost note, then hands off to the
+built-in `/code-review ultra`. Findings arrive later through `/tasks`, not
+from this command.
+
+Writes nothing to disk. The cloud review reports separately.

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-ai-contrib",
   "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "camoa"
   },

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.2] - 2026-08-11
+
+### Changed
+
+- All six commands now document what they write and where. None of them write into the contribution tree.
+
 ## [0.4.1] - 2026-07-13
 
 ### Changed

--- a/drupal-ai-contrib/commands/issue.md
+++ b/drupal-ai-contrib/commands/issue.md
@@ -35,3 +35,10 @@ duplicate.
 The worker skill reviews existing comments, status, and MRs **before** acting, and
 handles the issue-fork three ways — your fork (checkout), someone else's (surface,
 coordinate, never clobber), or none (create the branch).
+
+## Output
+
+Prints the issue's current state to the terminal: summary, status, target
+branch, and the issue-fork branch to work on.
+
+Writes nothing to disk.

--- a/drupal-ai-contrib/commands/pipeline.md
+++ b/drupal-ai-contrib/commands/pipeline.md
@@ -36,3 +36,11 @@ real pipeline is green.
 The worker skill reads the pipeline honestly — a green pipeline can hide a red
 `allow_failure` job or un-run manual opt-in variants; those are surfaced, never implied
 as coverage.
+
+## Output
+
+Prints the real drupalci pipeline result to the terminal: per-job status, the
+failing job's log excerpt when there is one, and whether the pipeline agrees
+with what `verify` reported locally.
+
+Writes nothing to disk.

--- a/drupal-ai-contrib/commands/review.md
+++ b/drupal-ai-contrib/commands/review.md
@@ -30,3 +30,12 @@ Thin entry point. A builder cannot objectively review its own work.
 
 The worker skill dispatches the `fresh-context-reviewer` agent (no build narrative) and
 delegates the SOLID / DRY philosophy review to `code-quality-tools`.
+
+## Output
+
+Prints a findings report to the terminal: per finding a severity of blocker,
+should-fix or suggestion, a `file:line`, and a concrete fix. Ends with a
+plain verdict, either ready for `submit` or another development pass needed.
+
+Stamps a review-time marker in the plugin data directory so `submit` can spot
+files edited after the last review. Writes nothing to the contribution tree.

--- a/drupal-ai-contrib/commands/setup.md
+++ b/drupal-ai-contrib/commands/setup.md
@@ -33,3 +33,10 @@ Thin entry point. Onboarding is optional, idempotent, and never a gate.
 `contribution-setup` writes scaffolding files only with explicit confirmation and only
 within the target project. A contributor with a ready environment can skip straight to
 `/drupal-ai-contrib:issue`.
+
+## Output
+
+Prints a per-gap report to the terminal: which environment pieces were found,
+which were installed, and which still need a decision from you.
+
+Writes nothing to the contribution tree.

--- a/drupal-ai-contrib/commands/submit.md
+++ b/drupal-ai-contrib/commands/submit.md
@@ -31,3 +31,12 @@ Thin entry point. Prepares the policy-required AI disclosure with the MR.
 The worker skill surfaces — but does not silently block on — unmet preconditions
 (`verify` not green, `review` not run). It fetches the current AI-contribution policy
 live via the `ai-policy-checker` agent to decide the disclosure threshold.
+
+## Output
+
+Prints the result to the terminal: the merge request URL, the target branch,
+the AI-disclosure decision and where it was placed, the issue status set, and
+the next step.
+
+Pushes the issue-fork branch and creates or updates the merge request on
+drupal.org. Writes nothing else locally.

--- a/drupal-ai-contrib/commands/verify.md
+++ b/drupal-ai-contrib/commands/verify.md
@@ -32,3 +32,12 @@ The worker skill environment-matches first (installs the CI-target core), mirror
 enabled drupalci job locally at CI strictness, runs the AI-policy gate (every
 contribution) and the eval gate (best-effort), and re-fires any gate whose path was
 edited after it last passed.
+
+## Output
+
+Prints a per-gate report to the terminal: each gate's blocking status, PASS,
+FAIL or UNRUN, the captured artifact backing it, and the environment-match
+status. A gate passes on a produced artifact, never on an assertion.
+
+Clears the re-verify ledger in the plugin data directory. Writes nothing to
+the contribution tree.

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -2,11 +2,18 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": {
     "name": "camoa"
   },
   "license": "MIT",
   "repository": "https://github.com/camoa/claude-skills",
-  "keywords": ["drupal", "htmx", "ajax", "migration", "forms", "dynamic-content"]
+  "keywords": [
+    "drupal",
+    "htmx",
+    "ajax",
+    "migration",
+    "forms",
+    "dynamic-content"
+  ]
 }

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.2] - 2026-08-11
+
+### Changed
+
+- `/htmx-migrate` now documents that it edits files in place and writes no report.
+
 ## [1.6.1] - 2026-07-13
 
 ### Changed

--- a/drupal-htmx/commands/htmx-migrate.md
+++ b/drupal-htmx/commands/htmx-migrate.md
@@ -100,3 +100,11 @@ $form['category'] = ['#type' => 'select'];
 - Always backup before migrating
 - Test without JavaScript after migration
 - Run `/htmx-validate` to check result
+
+## Output
+
+Prints the before and after code for each pattern it migrates, and a summary
+of what changed.
+
+Edits the files you point it at, in place. Writes no report file. Run it on a
+clean working tree so `git diff` shows exactly what it changed.

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-creation-tools",
   "description": "Authoring toolkit and quality gate for Claude Code plugins. Scaffolds and audits every component — skills, commands, agents, hooks, MCP servers, themes, dependencies, userConfig, and Routines — with a deterministic `validate` command (opt-in auto-fix), a pre-publish containment scan that catches leaked home paths and secrets, and the `plugin-creation` authoring skill. Tracks the current plugin spec: hook handler types and pre-spawn filters, exec-form args, JSON output controls, subfolder agent scoping, single-skill auto-discovery, and cross-marketplace dependencies.",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2026-08-11
+
+### Changed
+
+- `/create` and `/add-component` now document what they write and where.
+
 ## [3.11.0] - 2026-07-07
 
 ### Changed — docs

--- a/plugin-creation-tools/commands/add-component.md
+++ b/plugin-creation-tools/commands/add-component.md
@@ -89,3 +89,12 @@ Scaffold the [session-remembrance pattern](../skills/plugin-creation/references/
 
 - `$component-type`: Component type (skill, command, agent, hook, mcp, theme, remembrance-hooks)
 - `$component-name`: Component name (hyphen-case) — ignored for `remembrance-hooks` (fixed component names)
+
+## Output
+
+Prints what it added to the terminal: the component type, its path, and the
+next step.
+
+Writes the new component inside the existing plugin folder, and updates
+`.claude-plugin/plugin.json` when the component needs registering. Writes
+nothing outside that plugin folder.

--- a/plugin-creation-tools/commands/create.md
+++ b/plugin-creation-tools/commands/create.md
@@ -47,3 +47,12 @@ After creating, guide the user to:
 
 - **Plugin name**: first non-`--` token in `$ARGUMENTS` (equivalently `$0` — `$N` is 0-based). Hyphen-case, e.g. `my-tools`.
 - **Component flags**: the `--skill` / `--command` / `--agent` / `--hook` / `--mcp` tokens in `$ARGUMENTS`.
+
+## Output
+
+Prints what it created to the terminal: the plugin root, every component
+scaffolded, and the next step.
+
+Writes a new plugin folder at the path you name, holding
+`.claude-plugin/plugin.json`, `README.md`, and one folder per component you
+selected. Writes nothing outside that folder.


### PR DESCRIPTION
Second of two pull requests. Stacked on #246, so the checks run green here.
Lands after #244 and #246.

## Changes

- Validation gate envelope v1.1. Every `/validate:*` result now also
  carries `status`, `timestamp`, and `findings`, the names
  `code-quality-tools` and `code-paper-test` already use. One set of
  field names to read across all three plugins.
- `verdict`, `run_at`, and `messages` are untouched and not deprecated.
  Anything reading them keeps working.
- The envelope's versioning rule now matches `code-paper-test`: additive
  changes bump the minor, consumers pin `^1.`. The two plugins had
  contradictory rules for the same kind of change.
- Add `OUTPUTS.md`: one rule for where output goes, plus a table of where
  each plugin writes today. Predictable file paths.
- `CLAUDE.md` points at it, so Claude follows the rule.
- Add an `## Output` section to the 12 commands missing one outside
  ai-dev-assistant. You know what a command produces before running it.

## Two corrections since the draft

**58 was wrong, 50 is right.** I was matching only headings named exactly
"Output". Four `drupal-htmx` commands already documented their output
under "Expected Output" and were counted as missing.

**The real split.** 95 non-deprecated commands, 50 with no output
section. 38 of those are ai-dev-assistant and follow in a separate PR, as
you asked. The 12 here are: drupal-ai-contrib 6, code-quality-tools 2,
plugin-creation-tools 2, drupal-htmx 1, brand-content-design 1.

## On `findings`

`messages` is a list of strings; `findings` in the other two plugins is a
list of objects. They do not mirror cleanly, so `findings` here holds one
`{severity, title}` per message, severity taken from the status: fail is
HIGH, warning is MEDIUM, pass and skipped are INFO. It is always an
array, so `jq '.findings[]'` is safe on a clean run.

## Checks

| Check | Result |
|---|---|
| `make manifests` | pass, 9 plugins |
| `make validate` | pass, 9 plugins |
| `make test` | 74 passed, 0 failed |
| `make lint` | 31 warnings, advisory |

## Versions

ai-dev-assistant 5.22.0, brand-content-design 3.5.2, code-quality-tools
3.9.6, drupal-ai-contrib 0.4.2, drupal-htmx 1.6.2, plugin-creation-tools
3.12.0. Changelogs, marketplace entries, and the one README version line
moved with them.
