### PR TITLE
Fix the failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: some tests compare a file against its version on main.
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch --no-tags origin main:main || true
 
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -18,6 +24,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,16 @@ Before opening a PR: `make ci`.
 New test: put it where that plugin already keeps its tests. `make test`
 picks it up.
 
-## macOS
+## Before `make test` works
 
-`make test` needs bash 4 or newer. macOS ships bash 3.2, and some tests
-fail on it for that reason alone. Install a current bash first:
-
-```
-brew install bash
-```
+- **bash 4 or newer.** macOS ships bash 3.2 and some tests fail on it for
+  that reason alone. `brew install bash`.
+- **PyYAML.** `ai-dev-assistant/scripts/fm-helpers.sh` reads task
+  frontmatter with it. Without it the reader returns nulls and the tests
+  that depend on it fail. `pip install pyyaml`.
+- **shellcheck**, for `make lint` only. `brew install shellcheck`.
+- **git history.** Some tests compare a file against its version on
+  `main`, so a shallow clone fails them.
 
 ## Where things live
 


### PR DESCRIPTION
Stacked on #244. Gets the test run to green before #244 merges.

All eight failures were the environment, not the code. No test and no
plugin script needed changing.

## Changes

- `.github/workflows/ci.yml`: check out full history and fetch `main`.
  `gate-prompts-literal.sh` compares a file against its version on
  `main`, which a shallow clone does not have.
- `.github/workflows/ci.yml`: `pip install pyyaml`.
  `ai-dev-assistant/scripts/fm-helpers.sh` parses task frontmatter with
  PyYAML and returns nulls without it, which broke every test that reads
  a task file.
- `CLAUDE.md`: list what a machine needs before `make test` works, so a
  person hits a clear message instead of eight confusing failures.

## Result

| Check | Before | After |
|---|---|---|
| `make test` | 66 passed, 8 failed | 74 passed, 0 failed |
| `make manifests` | pass | pass |
| `make validate` | pass | pass |
| `make lint` | 31 warnings, advisory | 31 warnings, advisory |

## Worth a separate look

`fm-helpers.sh` degrades silently when PyYAML is absent: it returns
nulls and a `malformed_yaml` warning rather than failing. Anyone running
`ai-dev-assistant` without PyYAML gets empty frontmatter and no clear
error. Out of scope here, but it is a real gap.
