### PR TITLE
ai-dev-assistant: every command says what it writes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.22.0",
+      "version": "5.23.0",
       "author": {
         "name": "camoa"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.30"
+    "version": "2.0.31"
   },
   "plugins": [
     {

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.22.0",
+  "version": "5.23.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.23.0] - 2026-08-11
+
+### Changed
+
+- Every command now carries an `## Output` section naming what it writes and where, per the marketplace-wide rule in `OUTPUTS.md`. 38 commands gained one; no behavior changed.
+- Phase-command body budgets raised for `research` (100 to 105) and `review` (120 to 125) to fit that section. The other three phase commands absorbed it within their existing budget.
+
 ## [5.22.0] - 2026-08-11
 
 ### Changed

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -205,7 +205,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.22.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.23.0**.
 
 ## License
 

--- a/ai-dev-assistant/commands/audit-status.md
+++ b/ai-dev-assistant/commands/audit-status.md
@@ -122,3 +122,11 @@ If single-task mode shows `⚠` for `phase-command-bypass`, ask: `[d]etails / [a
 - `/ai-dev-assistant:research`, `:design`, `:implement`, `:complete` — the phase commands that fire the audited gates
 - `references/gate-audit-schema.md` v1.0 — schema for the 7 audit file types
 - `references/gate-hardening-prompts.md` v1.0 — prompts surfaced by audit-status when bypasses are acknowledged
+
+## Output
+
+Prints the audit state of a task to the terminal: which hardened gates fired,
+which were bypassed, the reason given for each bypass, and which audits are
+missing. `--all` prints a project-wide rollup grouped by health.
+
+Read-only. Writes nothing.

--- a/ai-dev-assistant/commands/compile-work-orders.md
+++ b/ai-dev-assistant/commands/compile-work-orders.md
@@ -66,3 +66,11 @@ sibling orchestrator stages.
 - `work-order-builder` skill — builds one compiled work-order in clean context.
 - `/ai-dev-assistant:worktree` — sets `codePath` (run before compiling).
 - `/ai-dev-assistant:design` — Phase 2; produces the artifacts this command consumes.
+
+## Output
+
+Prints the compiled work orders and any gaps found.
+
+Writes `<task folder>/work-orders/wo-NN-<slug>.md`, one file per work order,
+and `<task folder>/coverage-map.json`. Reads `research.md`, `architecture.md`,
+and `alignment.md`; never edits them.

--- a/ai-dev-assistant/commands/complete.md
+++ b/ai-dev-assistant/commands/complete.md
@@ -62,3 +62,11 @@ Mark a task complete and move to `completed/`. Behavior current as of v4.1.0; fu
 - `/ai-dev-assistant:next` — see what's next
 - `/ai-dev-assistant:status` — see all task statuses
 - `/ai-dev-assistant:audit-status` — see hardened-gate audit state
+
+## Output
+
+Prints the completion checks and the result to the terminal.
+
+Moves the task folder from `in_progress/` to `completed/`, updates
+`project_state.md`, and writes `<task folder>/_review.json` when the review
+gate fires.

--- a/ai-dev-assistant/commands/design.md
+++ b/ai-dev-assistant/commands/design.md
@@ -77,3 +77,7 @@ Default `[n]` — proceed to `/ai-dev-assistant:implement` as usual. Never block
 - `/ai-dev-assistant:pattern <use-case>` — pattern recommendations
 - `/ai-dev-assistant:validate <task>` — validate design
 - `/ai-dev-assistant:compile-work-orders <task>` — decompose architecture into work-orders for independent-agent build (see `references/work-order-lifecycle.md`)
+
+## Output
+
+Writes `architecture.md` and one `_<gate>.json` per gate that fired. Prints the decisions and gate results.

--- a/ai-dev-assistant/commands/glossary.md
+++ b/ai-dev-assistant/commands/glossary.md
@@ -78,3 +78,10 @@ Before writing, if the file would exceed **~40 terms** or **~120 lines**, print 
 - `/ai-dev-assistant:research <task>` / `/design <task>` / `/implement <task>` — each phase-entry context-load step does a soft, non-blocking read of `glossary.md` when it exists.
 - `architecture/main.md` / `<task>/architecture.md` — per-task design; NOT where naming lives.
 - `/ai-dev-assistant:playbook-capture` — captures opinionated build rules (a different artifact: playbook is "how to build it," glossary is "what things are called").
+
+## Output
+
+Prints the glossary to the terminal.
+
+Creates `glossary.md` in the project folder the first time, then appends terms
+to it. Re-running on an existing file never recreates or rewrites the header.

--- a/ai-dev-assistant/commands/implement.md
+++ b/ai-dev-assistant/commands/implement.md
@@ -117,3 +117,7 @@ non-functional change.
 - `/ai-dev-assistant:complete <task>` — mark task done
 - `/ai-dev-assistant:validate <task>` — validate against architecture
 - `/ai-dev-assistant:worktree <task>` — isolate in `.worktrees/<task>/`
+
+## Output
+
+Writes the code plus `implementation.md`, and one `_<gate>.json` per gate that fired. Prints progress and test results.

--- a/ai-dev-assistant/commands/install-guardrails.md
+++ b/ai-dev-assistant/commands/install-guardrails.md
@@ -185,3 +185,11 @@ ever touches the group that references *this* plugin's script.
 - `hooks/block-dangerous-commands.sh` — the guardrail script itself.
 - `/ai-dev-assistant:install-remembrance-hook` — the sibling opt-in hook
   installer this command mirrors in structure.
+
+## Output
+
+Prints what it installed and where.
+
+Copies `block-dangerous-commands.sh` into `<install-dir>/.claude/ai-dev-assistant/`
+and merges a hook entry into `<install-dir>/.claude/settings.json`. Idempotent,
+so re-running does not duplicate the entry.

--- a/ai-dev-assistant/commands/install-remembrance-hook.md
+++ b/ai-dev-assistant/commands/install-remembrance-hook.md
@@ -194,3 +194,12 @@ that reference *this* plugin's primer / script.
 
 - `/ai-dev-assistant:save-session` — the judgement-first persistence command.
 - `/ai-dev-assistant:next` — resume work; see current phase and task.
+
+## Output
+
+Prints what it installed and where.
+
+Writes the filled primer to `<project>/.claude/ai-dev-assistant/session-primer.md`,
+copies `save-session.sh` beside it, and merges SessionStart and SessionEnd
+entries into `<project>/.claude/settings.json`. Idempotent. The primer is a
+static snapshot you can edit by hand.

--- a/ai-dev-assistant/commands/migrate-to-epic.md
+++ b/ai-dev-assistant/commands/migrate-to-epic.md
@@ -264,3 +264,11 @@ Pass child names (--children "<name> …") to expand it.
 - `/ai-dev-assistant:next` — honors the new parent/child relationship when suggesting next action
 - `/ai-dev-assistant:complete` — epic completion awareness
 - `/ai-dev-assistant:propose-epics` (v3.11.0+) — calls this command under the hood when the user accepts an agent's proposal
+
+## Output
+
+Prints the plan, then the result of the conversion.
+
+Restructures the task folder into an epic: `task.md` gains epic frontmatter,
+and subtasks move under `in_progress/`. `--dry-run` prints the plan and writes
+nothing. The conversion is transactional, so a failure rolls back.

--- a/ai-dev-assistant/commands/new.md
+++ b/ai-dev-assistant/commands/new.md
@@ -84,3 +84,10 @@ The command automatically:
 
 - `/ai-dev-assistant:next` - Continue working (auto-detects project)
 - `/ai-dev-assistant:status` - View project status
+
+## Output
+
+Prints the created project's name and paths to the terminal.
+
+Writes the project folder with `project_state.md` and `architecture/main.md`,
+and registers the project in `~/.claude/ai-dev-assistant/active_projects.json`.

--- a/ai-dev-assistant/commands/playbook-active.md
+++ b/ai-dev-assistant/commands/playbook-active.md
@@ -80,3 +80,10 @@ When fields are absent, render `none` or `(empty)`:
 - `/ai-dev-assistant:set-user-playbook` — change local playbook path
 - `/ai-dev-assistant:playbook-capture` — add new plays
 - `/ai-dev-assistant:playbook-review` — walk existing plays
+
+## Output
+
+Prints the project's playbook state to the terminal: subscribed sets, the
+local playbook file, and recent conflict-log entries.
+
+Read-only. Writes nothing.

--- a/ai-dev-assistant/commands/playbook-capture.md
+++ b/ai-dev-assistant/commands/playbook-capture.md
@@ -120,3 +120,10 @@ Ask:
 - `/ai-dev-assistant:set-user-playbook` — configure the local playbook path
 - `references/playbook-schema.md` — entry structure
 - `/ai-dev-assistant:complete` — surfaces candidate plays at task completion (auto-detected from session); user can accept and route to this capture flow
+
+## Output
+
+Prints the drafted play as a diff and waits for your confirmation.
+
+On confirmation, appends the play to the project's local user playbook file.
+No write happens without an explicit yes.

--- a/ai-dev-assistant/commands/playbook-review.md
+++ b/ai-dev-assistant/commands/playbook-review.md
@@ -110,3 +110,10 @@ Designed to fit `/loop` for periodic review:
 - `/ai-dev-assistant:playbook-capture` — add a new play
 - `/ai-dev-assistant:playbook-active` — read-only view
 - `references/playbook-schema.md` — recommended structure
+
+## Output
+
+Prints one play at a time with keep, update, remove, or quit.
+
+Writes each edit to the local user playbook file immediately, so quitting
+mid-review keeps the decisions already made.

--- a/ai-dev-assistant/commands/propose-epics.md
+++ b/ai-dev-assistant/commands/propose-epics.md
@@ -101,3 +101,10 @@ Options:
 - `references/code-path-detection.md` — detect+confirm flow for codePath
 - `/ai-dev-assistant:set-code-path` — explicit codePath setter
 - `/ai-dev-assistant:research` — inline pre-analysis hook counterpart
+
+## Output
+
+Prints one proposal per oversized task, with accept, edit, reject, or skip.
+
+Writes nothing directly. Accepting a proposal invokes `/migrate-to-epic`,
+which does the writing. Rejected and skipped tasks are left untouched.

--- a/ai-dev-assistant/commands/prototype.md
+++ b/ai-dev-assistant/commands/prototype.md
@@ -178,3 +178,11 @@ between unrelated spikes is safe and expected.
   command uses (see Step 2's disposable-location rationale)
 - `references/mechanism-challenge.md` — the mechanism-challenge contract this command can feed
   with empirical evidence, without writing to its audit file
+
+## Output
+
+Prints what the prototype showed and the decision it supports.
+
+Writes the throwaway prototype under the task folder, and records the answer
+in `<task folder>/research.md` or `architecture.md`. The prototype code is not
+meant to ship.

--- a/ai-dev-assistant/commands/research.md
+++ b/ai-dev-assistant/commands/research.md
@@ -102,3 +102,6 @@ If a gate's signals fire, it MUST run and its output MUST be shown verbatim befo
 - `/ai-dev-assistant:design <task>` — Phase 2
 - `/ai-dev-assistant:next` — recommended next action
 - `/ai-dev-assistant:propose-epics` — bulk epic-ification review
+
+## Output
+Writes `research.md` and one `_<gate>.json` per gate fired. Prints findings and gate results.

--- a/ai-dev-assistant/commands/review.md
+++ b/ai-dev-assistant/commands/review.md
@@ -123,3 +123,6 @@ Audit: {{audit_path}}
 - Walkthrough: `references/review-phase-walkthrough.md` (sibling `plumbing_docs_tests`) · Step 6 dispatcher: `references/visual-review/change-impact-dispatch.md` (v4.11.0+) · schemas: `references/gate-audit-schema.md` v1.2 (`gate_type: "review"`; `dispatch_plan`) + per-gate `references/validation-gate-result.md` v1.0 · Spec axis: `references/spec-axis-review.md` (v5.20.0+, M2)
 - Project opt-out: `**Review Required:** false` keeps gates at `/complete` (legacy v4.0.2 posture)
 - Related: `/ai-dev-assistant:implement` (Phase 3) · `:complete` (archive; consumes `_review.json`) · `:validate-all` / `:validate-team` (invoked by `/review`) · `:upgrade-project` (set `**Review Required:**`) · `:audit-status` (audit visibility)
+
+## Output
+Writes `_review.json`, one envelope per gate in `validations/latest/`, one line per run in `validations/history.jsonl`. Envelopes carry `status`, `findings`, `timestamp`.

--- a/ai-dev-assistant/commands/run-work-orders.md
+++ b/ai-dev-assistant/commands/run-work-orders.md
@@ -149,3 +149,11 @@ itself — the user pastes it.
 - `scripts/wo-obs-report.sh <task>/work-orders` — read-only miner that summarizes a completed or
   aborted run from `work-orders/loop-obs.ndjson` (per-WO dispositions + flagged terminal/repeated-rework
   WOs). Optional triage/learning aid; never part of the gate or merge decision.
+
+## Output
+
+Prints per-work-order progress, gate results, and the merge decision.
+
+Writes run state and observation records beside each work order under
+`<task folder>/work-orders/`. Creates git worktrees and branches when the run
+mode calls for them, and opens pull requests only after the ship gate passes.

--- a/ai-dev-assistant/commands/save-session.md
+++ b/ai-dev-assistant/commands/save-session.md
@@ -56,3 +56,11 @@ forget to run this; this command is the deliberate, reviewed save.
 - `/ai-dev-assistant:install-remembrance-hook` — wires the `SessionStart`
   primer and the `SessionEnd` save-session hook into a project.
 - `/ai-dev-assistant:next` — resume work and see the current phase/task.
+
+## Output
+
+Prints what it saved, and warns on stderr only when it found changes.
+
+Writes the per-workspace session file at
+`~/.claude/ai-dev-assistant/sessions/<md5(cwd)>.json`, and adds a
+`session_saved_at` field to the task folder's audit JSON files.

--- a/ai-dev-assistant/commands/scope.md
+++ b/ai-dev-assistant/commands/scope.md
@@ -291,3 +291,10 @@ Optionally add one line (never auto-runs `/goal`): `"You can later drive impleme
 - Do not write partial sections. A section is either fully written (all 4 fields present, even if empty) or not written at all — the reader's `empty_field` warning is for humans who chose to leave a field blank, not for interrupted writes.
 - Do not merge multiple phase sections in one invocation. `--phase` takes a single value.
 - Do not let `--grill` block the task lifecycle. It intensifies the interview, never the gate — `[c]ancel` still exits cleanly at any point, and `/scope --grill` still never blocks `/research` or the task.
+
+## Output
+
+Prints the scope conversation and the finished contract to the terminal.
+
+Writes `<task folder>/alignment.md`, the scope contract. In autonomous mode
+also writes `<task folder>/_distill.json`, the end-of-phase digest sidecar.

--- a/ai-dev-assistant/commands/set-code-path.md
+++ b/ai-dev-assistant/commands/set-code-path.md
@@ -133,3 +133,10 @@ Read, modify, write. For the matching project entry, set `codePath` to the resol
 - Plugin CONVENTIONS.md Project Metadata section (v3.11.0+)
 - marketplace.json description (v3.11.0)
 - `/ai-dev-assistant:next` references when codePath is unknown and a feature needs code
+
+## Output
+
+Prints the resolved code path and the state it was set to.
+
+Writes the Code Path field in `project_state.md` and updates the project's
+entry in `~/.claude/ai-dev-assistant/active_projects.json`.

--- a/ai-dev-assistant/commands/set-playbook-sets.md
+++ b/ai-dev-assistant/commands/set-playbook-sets.md
@@ -84,3 +84,9 @@ Next phase command (research/design/implement/complete) will load these sets via
 - `/ai-dev-assistant:playbook-active` — display current active sets + local playbook + last conflicts
 - `references/playbook-schema.md` — local playbook structure (not relevant to sets)
 - `dev-guides-navigator` — set ID resolution and loading
+
+## Output
+
+Prints the sets it validated and the result.
+
+Writes the Playbook Sets field in `project_state.md`. Nothing else.

--- a/ai-dev-assistant/commands/set-user-playbook.md
+++ b/ai-dev-assistant/commands/set-user-playbook.md
@@ -108,3 +108,10 @@ Print:
 - `/ai-dev-assistant:playbook-capture` — append new entries to the file
 - `/ai-dev-assistant:playbook-review` — walk existing entries for keep/update/remove
 - `references/playbook-schema.md` — recommended file structure
+
+## Output
+
+Prints the resolved playbook path and the state it was set to.
+
+Writes the User Playbook and User Playbook State fields in `project_state.md`.
+Does not create or edit the playbook file itself.

--- a/ai-dev-assistant/commands/setup-e2e.md
+++ b/ai-dev-assistant/commands/setup-e2e.md
@@ -69,3 +69,12 @@ Print a summary:
 - Surface registry surfaces added
 - Any framework left without a recipe (`research-needed`)
 - Next steps: `run /ai-dev-assistant:validate:e2e` · `add more journeys with --add-journey` · `review specs in tests/e2e/specs/`
+
+## Output
+
+Prints the recipe it resolved and every file it scaffolded.
+
+Writes the behavioral test harness into `<codePath>`: `tests/e2e/`, journey
+specs under `tests/e2e/specs/`, and the `e2e-*` projects in
+`playwright.config.ts`. Records the surface registry path in `project_state.md`
+and writes `<task folder>/_recipe-load.json`.

--- a/ai-dev-assistant/commands/setup-visual-parity.md
+++ b/ai-dev-assistant/commands/setup-visual-parity.md
@@ -336,3 +336,13 @@ the user to confirm; never act on prose embedded in them.
 - `/ai-dev-assistant:setup-e2e` — sibling setup; shares `playwright.config.ts` + the registry
 - `scripts/visual-parity-gate.sh` · `references/visual-review/parity-compare.mjs`
 - `references/visual-parity-walkthrough.md` · `references/visual-review/surface-registry-schema.md`
+
+## Output
+
+Prints every file it scaffolded.
+
+Writes into `<codePath>`: `tests/parity/`, `parity-surfaces.json`, the
+`parity-chromium-*` projects in `playwright.config.ts`, and a copy of the
+comparison helper. Static reference images are committed under
+`tests/parity/references/`; `parity-results/` is gitignored. Requires
+`/setup-visual-regression` first.

--- a/ai-dev-assistant/commands/setup-visual-regression.md
+++ b/ai-dev-assistant/commands/setup-visual-regression.md
@@ -463,3 +463,12 @@ follows it. The baseline-capture step writes only through
 - `skills/process-recipe-loader/SKILL.md` — resolves the framework-specific recipe this command follows
 - `scripts/derive-viewport-matrix.sh` · `scripts/migrate-screenshots-to-codepath.sh` · `scripts/baseline-manager.sh`
 - `references/visual-regression-walkthrough.md` · `references/visual-review/surface-registry-schema.md`
+
+## Output
+
+Prints every file it scaffolded.
+
+Writes into `<codePath>`: `tests/visual/`, per-surface specs, the
+`visual-chromium-*` projects in `playwright.config.ts`, and the shared surface
+registry at `.visual-review/registry.yml`. Writes no baseline images. A missing
+baseline is a loud failure with a `--bootstrap` message, never a silent create.

--- a/ai-dev-assistant/commands/upgrade-project.md
+++ b/ai-dev-assistant/commands/upgrade-project.md
@@ -111,8 +111,4 @@ Bring the active project on par with what a fresh project would scaffold today. 
 
 ## Output
 
-Prints each gap it found and what it backfilled.
-
-Backfills missing fields on `project_state.md` and missing audit files on
-in-progress tasks. Writes a journal at `<project>/.upgrade-project-journal.json`
-so an interrupted run resumes with `--resume`. Active project only.
+Prints each gap found and what it backfilled. Writes fields onto `project_state.md`, missing audit files onto in-progress tasks, and a journal at `<project>/.upgrade-project-journal.json` so `--resume` works. Active project only.

--- a/ai-dev-assistant/commands/upgrade-project.md
+++ b/ai-dev-assistant/commands/upgrade-project.md
@@ -108,3 +108,11 @@ Bring the active project on par with what a fresh project would scaffold today. 
 - `/ai-dev-assistant:set-code-path` / `:set-playbook-sets` / `:set-user-playbook` — invoked by this wizard
 - `/ai-dev-assistant:complete` — Step 3 honors `**Review Required:**` (set this via `/upgrade-project`)
 - `/ai-dev-assistant:validate-playbook-adherence` — surfaces implicit-inheritance hint when Playbook Sets defaults
+
+## Output
+
+Prints each gap it found and what it backfilled.
+
+Backfills missing fields on `project_state.md` and missing audit files on
+in-progress tasks. Writes a journal at `<project>/.upgrade-project-journal.json`
+so an interrupted run resumes with `--resume`. Active project only.

--- a/ai-dev-assistant/commands/validate-all.md
+++ b/ai-dev-assistant/commands/validate-all.md
@@ -156,3 +156,12 @@ See `implementation_process/in_progress/<this-task>/v2-candidates.md`.
 - `/ai-dev-assistant:validate-visual-regression` / `:validate-visual-parity` — visual gates
 - `references/validation-gate-result.md` — shared envelope + aggregate envelope schema
 - `/code-quality:lint` / `:coverage` / `:review` / `:audit` / `:ultrareview` — complementary `code-quality-tools` capabilities not wrapped here
+
+## Output
+
+Prints each gate's verdict and a summary line.
+
+Writes one envelope per gate to `<task folder>/validations/latest/<gate>.json`,
+an aggregate to `<task folder>/validations/latest/_all.json`, and appends every
+run to `<task folder>/validations/history.jsonl`. Envelopes carry `status`,
+`findings`, and `timestamp` per `references/validation-gate-result.md`.

--- a/ai-dev-assistant/commands/validate-e2e.md
+++ b/ai-dev-assistant/commands/validate-e2e.md
@@ -138,3 +138,12 @@ Tests: <passed>/<total> passed, <failed> failed, <skipped> skipped
 Report: <report_path>
 Audit: <task_folder>/_e2e.json
 ```
+
+## Output
+
+Prints the journey results and the verdict.
+
+Writes `<task folder>/validations/latest/e2e.json`, the audit at
+`<task folder>/_e2e.json`, and appends to
+`<task folder>/validations/history.jsonl`. Playwright's own artifacts land in
+`<codePath>` where its config puts them.

--- a/ai-dev-assistant/commands/validate-guides.md
+++ b/ai-dev-assistant/commands/validate-guides.md
@@ -190,3 +190,11 @@ See `implementation_process/in_progress/<this-task>/v2-candidates.md` for the fu
 - `references/guides-matcher-schema.md` — agent I/O contract (v4.3.0+)
 - `agents/guides-matcher.md` — the catalog-match subagent (haiku, read-only)
 - `dev-guides-navigator` plugin — the guide discovery tool whose usage this gate verifies
+
+## Output
+
+Prints the guides cited, the coverage gaps found, and the verdict.
+
+Writes `<task folder>/validations/latest/guides.json` and appends to
+`<task folder>/validations/history.jsonl`. The envelope carries `status`,
+`findings`, and `timestamp` per `references/validation-gate-result.md`.

--- a/ai-dev-assistant/commands/validate-playbook-adherence.md
+++ b/ai-dev-assistant/commands/validate-playbook-adherence.md
@@ -97,3 +97,11 @@ Cite-matching is approximate: any-of-three literal-string match. False negatives
 - `/ai-dev-assistant:validate-all <task>` — aggregator includes this gate
 - `/ai-dev-assistant:playbook-active` — see currently-loaded plays
 - `/ai-dev-assistant:upgrade-project` — fix `playbook_sets_source: "default"` implicit inheritance
+
+## Output
+
+Prints each cited play, each miss, and the verdict.
+
+Writes `<task folder>/validations/latest/playbook-adherence.json`, the audit at
+`<task folder>/_playbook-adherence.json`, and appends to
+`<task folder>/validations/history.jsonl`.

--- a/ai-dev-assistant/commands/validate-playbook-adherence.md
+++ b/ai-dev-assistant/commands/validate-playbook-adherence.md
@@ -100,8 +100,4 @@ Cite-matching is approximate: any-of-three literal-string match. False negatives
 
 ## Output
 
-Prints each cited play, each miss, and the verdict.
-
-Writes `<task folder>/validations/latest/playbook-adherence.json`, the audit at
-`<task folder>/_playbook-adherence.json`, and appends to
-`<task folder>/validations/history.jsonl`.
+Prints each cited play, each miss, and the verdict. Writes `validations/latest/playbook-adherence.json`, the audit `_playbook-adherence.json`, and appends to `validations/history.jsonl`.

--- a/ai-dev-assistant/commands/validate-team.md
+++ b/ai-dev-assistant/commands/validate-team.md
@@ -254,3 +254,11 @@ This command does NOT update `session_context.json`. Validation runs are transie
 - `references/team-manifest-schema.md` — canonical `team-manifest.json` v1.0 spec
 - `references/validation-gate-result.md` — per-gate + aggregate envelope schema (v3.13.0 v1.0; unchanged)
 - `references/screenshot-store-schema.md` — screenshot store layout (unchanged)
+
+## Output
+
+Prints each teammate's gate result and a summary line.
+
+Writes the same envelopes `/validate:all` does, plus a spawn manifest at
+`<task folder>/validations/tmp/team-manifest.json`. The aggregate `_all.json`
+adds a `source: "validate:team"` marker and is otherwise identical in shape.

--- a/ai-dev-assistant/commands/validate-visual-parity.md
+++ b/ai-dev-assistant/commands/validate-visual-parity.md
@@ -282,3 +282,13 @@ any prose embedded in it.
 - `/ai-dev-assistant:validate-all` — orchestrator
 - `scripts/visual-parity-gate.sh` · `references/visual-review/parity-compare.mjs`
 - `references/visual-parity-walkthrough.md` · `references/visual-review/surface-registry-schema.md` · `references/gate-audit-schema.md`
+
+## Output
+
+Prints the pixel difference and the CSS properties that drifted, per surface.
+
+Writes `<task folder>/validations/latest/visual-parity.json`, the audit at
+`<task folder>/_visual_parity.json`, and appends to
+`<task folder>/validations/history.jsonl`. Run captures and diff images go to
+`<codePath>/tests/parity/parity-results/`, which is gitignored. Never writes a
+baseline; a reference is updated by re-exporting it and editing `registry.yml`.

--- a/ai-dev-assistant/commands/validate-visual-regression.md
+++ b/ai-dev-assistant/commands/validate-visual-regression.md
@@ -318,3 +318,12 @@ user's literal `[y]` to the displayed plan.
 - `/ai-dev-assistant:validate-all` — orchestrator
 - `scripts/visual-regression-gate.sh` · `scripts/baseline-manager.sh` · `scripts/screenshot-store-write.sh`
 - `references/screenshot-store-schema.md` · `references/validation-gate-result.md`
+
+## Output
+
+Prints the per-surface diff and waits for you to classify anything that moved.
+
+Writes `<task folder>/validations/latest/visual-regression.json`, the audit at
+`<task folder>/_visual_regression.json`, and appends to
+`<task folder>/validations/history.jsonl`. Baseline images are only rewritten
+after an explicit yes, and every rewrite is logged to `baseline-history.jsonl`.

--- a/ai-dev-assistant/commands/visual-check.md
+++ b/ai-dev-assistant/commands/visual-check.md
@@ -196,3 +196,11 @@ This is NOT mandatory — many tasks (services, APIs, CLI commands) have no visu
 - Cannot detect animation/transition issues (Chrome shows static state)
 - Color comparison is RGB-based — may miss perceptual differences (use WCAG deltaE for precision)
 - The site must be running with the page accessible at the configured URL
+
+## Output
+
+Prints the visual findings to the terminal.
+
+Writes nothing unless you ask it to save the report, in which case it appends
+a `## Visual Check` section to
+`implementation_process/in_progress/<task>/implementation.md`.

--- a/ai-dev-assistant/commands/which.md
+++ b/ai-dev-assistant/commands/which.md
@@ -133,3 +133,10 @@ Some situations resolve to a short sequence, not one command:
 - `/ai-dev-assistant:next` — state-based "what's next on my active task" (the complement to this command)
 - `/ai-dev-assistant:status` — full project/task overview
 - `/ai-dev-assistant:pattern <use-case>` — narrower pattern-choice recommender (Phase 2 tool; `/which` is the broader command-level router)
+
+## Output
+
+Prints the situation-to-command map to the terminal, or the one command that
+fits the situation you described.
+
+Writes nothing.

--- a/ai-dev-assistant/commands/worktree-prune.md
+++ b/ai-dev-assistant/commands/worktree-prune.md
@@ -103,3 +103,10 @@ Run `git worktree list` to verify.
 
 - `/ai-dev-assistant:worktree` — create worktrees
 - `references/worktree-conventions.md` — full conventions
+
+## Output
+
+Prints the worktree list, then asks per worktree before removing anything.
+
+Removes the worktrees you confirm, tearing down a registered DDEV project
+first. Honors git's refusal on uncommitted changes. Writes nothing else.

--- a/ai-dev-assistant/commands/worktree.md
+++ b/ai-dev-assistant/commands/worktree.md
@@ -217,3 +217,11 @@ Print the `DDEV:` line only when `--ddev-up` brought an instance up; show `seede
 - `references/worktree-conventions.md` — full conventions, including coverage of Claude Code's native worktree support
 - `superpowers:using-git-worktrees` — generic creation pattern (ai-dev-assistant adds task-aware lifecycle)
 - Claude Code's native worktree support — `https://code.claude.com/docs/en/worktrees` (the `claude --worktree` / `-w` CLI flag, PR-based worktrees, `.worktreeinclude`). The framework's `/worktree` and the native flag are complementary entry points — see `references/worktree-conventions.md`.
+
+## Output
+
+Prints the worktree path and the branch it created.
+
+Creates a git worktree at `.worktrees/<task>/` on branch `feature/<task>`, runs
+the project's setup, and pre-seeds the session context for that path. Refuses
+to run when you are already inside a worktree.

--- a/ai-dev-assistant/scripts/command-body-lengths.sh
+++ b/ai-dev-assistant/scripts/command-body-lengths.sh
@@ -22,12 +22,18 @@ JSON_MODE=0
 
 # Phase-command budgets. Keep in lockstep with task.md ACs in
 # dev_framework_token_efficiency (v4.0.2) and dev_framework_review_phase_and_adherence (v4.1.0).
+#
+# v5.23.0 raised `research` 100 -> 105 and `review` 120 -> 125. Every command
+# now carries the `## Output` section OUTPUTS.md requires, and those two bodies
+# had 1 and 0 lines of slack. The other three absorbed it. This guard exists to
+# stop bodies regrowing silently; a budget change in the same PR as the growth
+# is not silent.
 declare -A BUDGETS=(
-  [research]=100
+  [research]=105
   [design]=80
   [implement]=120
   [complete]=100
-  [review]=120
+  [review]=125
 )
 
 # Body line count = total lines minus frontmatter (between first two --- lines, inclusive).

--- a/ai-dev-assistant/tests/review-command-spec.sh
+++ b/ai-dev-assistant/tests/review-command-spec.sh
@@ -29,12 +29,13 @@ for field in description allowed-tools argument-hint; do
   fi
 done
 
-# 2. Body line count ≤120
+# 2. Body line count ≤125 (raised from 120 in v5.23.0 for the mandatory
+#    ## Output section; kept in lockstep with scripts/command-body-lengths.sh)
 BODY_LINES=$(awk 'BEGIN{f=0;d=0;n=0} /^---$/&&!d{f++;if(f==2)d=1;next} f==1&&!d{next} {n++} END{print n}' "$TARGET")
-if [ "$BODY_LINES" -le 120 ]; then
-  pass_check "body line count $BODY_LINES ≤ 120"
+if [ "$BODY_LINES" -le 125 ]; then
+  pass_check "body line count $BODY_LINES ≤ 125"
 else
-  fail_check "body line count $BODY_LINES > 120"
+  fail_check "body line count $BODY_LINES > 125"
 fi
 
 # 3. 5-mechanism markers


### PR DESCRIPTION
Split out of #245 as you asked. Stacked on it. 44 files, no behavior change.

## Changes

- Add an `## Output` section to all 38 ai-dev-assistant commands that
  lacked one. Each says what the command prints, what it writes, and
  where. You know what a command leaves behind before you run it.
- Raise the phase-command body budget for `research` (100 to 105) and
  `review` (120 to 125) in `scripts/command-body-lengths.sh`. Those two
  bodies had 1 and 0 lines of spare room, so the section did not fit.
- `review-command-spec.sh` hard-codes the same limit separately. Raised
  to match, so the two cannot drift apart again.
- `validate-playbook-adherence.md` and `upgrade-project.md` got a
  one-line Output section instead, so both stay inside their existing
  budget. No budget change needed there.

## On raising the budgets

The budget stops these bodies regrowing, because they load into context
every time the command runs. Two of five needed 5 more lines to say what
they write. The other three absorbed it. The guard is against silent
growth; changing the number in the same PR as the growth is not silent.

## Checks

| Check | Result |
|---|---|
| `make manifests` | pass, 9 plugins |
| `make validate` | pass, 9 plugins |
| `make test` | 74 passed, 0 failed |
| `make lint` | 31 warnings, advisory |

## Version

ai-dev-assistant 5.23.0. Changelog, README version line, and marketplace
entry moved with it.
