### PR TITLE
Two rules that were written down are now checked

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.23.1",
+      "version": "5.24.0",
       "author": {
         "name": "camoa"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.31"
+    "version": "2.0.32"
   },
   "plugins": [
     {
@@ -39,7 +39,7 @@
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
       "description": "Authoring toolkit and quality gate for Claude Code plugins. Scaffolds and audits every component — skills, commands, agents, hooks, MCP servers, themes, dependencies, userConfig, and Routines — with a deterministic `validate` command (opt-in auto-fix), a pre-publish containment scan that catches leaked home paths and secrets, and the `plugin-creation` authoring skill. Tracks the current plugin spec: hook handler types and pre-spawn filters, exec-form args, JSON output controls, subfolder agent scoping, single-skill auto-discovery, and cross-marketplace dependencies.",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "author": {
         "name": "camoa"
       },
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.23.0",
+      "version": "5.23.1",
       "author": {
         "name": "camoa"
       },
@@ -85,7 +85,7 @@
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
       "description": "DEPRECATED — renamed to ai-dev-assistant. Installable only to run a one-time upgrade that repoints your project store at the new plugin and re-stamps per-project session-remembrance hooks, then is safe to uninstall. An opt-in --permissions flag also re-points stale Skill(drupal-dev-framework:*) grants. The shell exposes only /drupal-dev-framework:upgrade; install ai-dev-assistant going forward.",
-      "version": "4.24.1",
+      "version": "4.24.2",
       "author": {
         "name": "camoa"
       },
@@ -101,7 +101,7 @@
       "name": "drupal-htmx",
       "source": "./drupal-htmx",
       "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "author": {
         "name": "camoa"
       },
@@ -144,7 +144,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.9.7",
+      "version": "3.9.8",
       "author": {
         "name": "camoa"
       },
@@ -176,7 +176,7 @@
       "name": "code-paper-test",
       "source": "./code-paper-test",
       "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase (50–300), or a 3-agent competing team in isolated worktrees (300+, security-critical, skills). Verifies external calls for both existence and behavioral contracts (return-shape/nullability diffing, chained-object tracing, taint-stance fallback for closed-source). Supports `--json` for CI.",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "author": {
         "name": "camoa"
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,17 @@ jobs:
       - name: Install the claude CLI
         run: npm install -g @anthropic-ai/claude-code
 
-      # The four checks below each run even when an earlier one failed, so a
+      # The five checks below each run even when an earlier one failed, so a
       # single run reports every problem instead of stopping at the first.
       # `make ci` aggregates the same way, which is what keeps the promise in
       # CLAUDE.md that `make ci` is the same as the PR check.
       - name: Check plugin manifests
         if: ${{ !cancelled() }}
         run: make manifests
+
+      - name: Check command output sections
+        if: ${{ !cancelled() }}
+        run: make outputs
 
       - name: Check shell scripts
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,45 @@ jobs:
         with:
           python-version: '3.12'
 
+      # pyyaml is what ai-dev-assistant/scripts/fm-helpers.sh reads task
+      # frontmatter with. pytest is what runs
+      # brand-content-design/scripts/slides/tests; without it run-tests.sh
+      # counts that whole directory as one skip and still exits 0, so those
+      # tests had never run here. requirements.txt is needed too, not just
+      # pytest: the test modules import `slides.auth`, which imports
+      # googleapiclient at module level, so a pytest-only install collects
+      # zero tests.
+      #
+      # pytest is pinned to an exact version. shellcheck and gitleaks below
+      # are pinned by version AND sha256 because they are tarballs fetched
+      # from a release URL, where the sha is the only thing tying the bytes
+      # to the version. pip resolves from a signed index against a name and
+      # version, so the analogous pin here is the version. A full
+      # `--require-hashes` lock would need a hash-pinned file covering every
+      # transitive dependency, and this repo has no such file.
       - name: Install Python dependencies
-        run: pip install pyyaml
+        run: pip install pyyaml 'pytest==8.4.2' -r brand-content-design/scripts/slides/requirements.txt
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      # run-tests.sh skips infographic-generator/test.js when its node_modules
+      # is absent, and that skip does not fail the run, so this suite had
+      # never run here either. `npm ci` rather than `npm install`: the folder
+      # commits a package-lock.json, and npm ci installs exactly the locked
+      # tree and fails when the lockfile and package.json disagree. That
+      # lockfile is this dependency's version pin, the same role the sha256
+      # plays for the two tarballs.
+      #
+      # test.js calls svgToPng, which does `puppeteer.launch()`, so the suite
+      # needs a real browser and not only the package. npm ci runs
+      # puppeteer's install script, which downloads it. Verified from a cold
+      # PUPPETEER_CACHE_DIR: the install populated chrome/ and took 42s.
+      - name: Install Node dependencies
+        working-directory: brand-content-design/skills/infographic-generator
+        run: npm ci
 
       # `make validate` runs `claude plugin validate`, which reads manifests
       # off disk and needs no account and no API key (verified: it exits 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,11 @@ validator directly.
 | Rewrite the lint baseline | `make lint-baseline` |
 | Check plugin structure | `make validate` |
 | Check plugin manifests | `make manifests` |
+| Check every command says what it writes | `make outputs` |
 | Everything, same as the PR check | `make ci` |
 
-Before opening a PR: `make ci`. It runs all four checks even when one
-fails, so one run shows every problem. CI runs the same four the same way.
+Before opening a PR: `make ci`. It runs all five checks even when one
+fails, so one run shows every problem. CI runs the same five the same way.
 
 ## What each check can fail on
 
@@ -35,10 +36,19 @@ fails, so one run shows every problem. CI runs the same four the same way.
 - `make validate` does not catch a plugin folder missing from the catalog,
   and treats a version disagreement with the catalog as a warning only.
   `make manifests` is the check that fails on both.
+- `make outputs` fails on any tracked `*/commands/*.md` that does not carry
+  a line reading exactly `## Output`, outside a code fence, with at least
+  one non-blank line under it. The heading is matched exactly: `## Output
+  Format` is a different section, describing the shape of a printed report
+  rather than what the command leaves on disk, and it does not satisfy the
+  rule. There are no exemptions, deprecated commands included, since what
+  a command does to your filesystem is the thing you want written down
+  before you run it. Zero command files found fails. What it cannot check
+  is whether the section is *true*; it checks that the claim exists.
 
-Only `make test` and `make lint` scan files, and both only look at
-git-tracked ones. A brand-new script or test is not picked up until it is
-`git add`ed.
+Only `make test`, `make lint` and `make outputs` scan files, and all three
+only look at git-tracked ones. A brand-new script, test or command is not
+picked up until it is `git add`ed.
 
 New test: put it where that plugin already keeps its tests. `make test`
 picks it up.
@@ -54,7 +64,7 @@ picks it up.
   sections on `command -v gitleaks`. Without the binary those sections do
   not run, and the spec still exits 0 and still prints a passing total, so
   nothing tells you they were skipped. Measured on this tree: **742
-  assertions with gitleaks, 458 without — 284 silently disappear, and both
+  assertions with gitleaks, 458 without. 284 silently disappear, and both
   runs report "0 failed".** Everything about secret detection, history
   scanning and redaction is in the missing 284. `brew install gitleaks`.
 - **shellcheck**, for `make lint` only. `brew install shellcheck`. The
@@ -72,13 +82,23 @@ on a machine missing gitleaks is a smaller green than it looks.
 Read `OUTPUTS.md` before adding anything that writes a file.
 
 - Tied to a task: the task folder.
-- The result of a check: `.reports/` at the root of the code being checked.
+- The result of a check: a report directory that is resolved rather than
+  fixed, out of the audited repository by default. Not `.reports/`, which
+  stopped being the default in v3.9.6 and is now opt-in. `OUTPUTS.md` gives
+  the resolution order.
 - Something the person asked to be made: `outputs/<type>/<date>-<name>/`.
+- Configuration a setup command installs: where the tool expects it, in the
+  project being configured, on the person's confirmation.
+- State shared across projects: `~/.claude/<plugin>/`. Legitimate, and the
+  command's Output section has to name the path.
 - Otherwise print and exit. Do not leave a file nobody asked for.
 
 Anything a machine reads is JSON carrying `status`, `findings`, and
 `timestamp`. Every command that produces something has an `## Output`
-section saying what and where.
+section saying what and where, and `make outputs` fails when one does not.
+That check cannot tell whether a section is true: `OUTPUTS.md` was wrong
+about five plugins, and silent about a sixth, while all of them carried a
+section.
 
 ## Where things live
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,18 @@ picks it up.
   assertions with gitleaks, 458 without. 284 silently disappear, and both
   runs report "0 failed".** Everything about secret detection, history
   scanning and redaction is in the missing 284. `brew install gitleaks`.
+- **pytest**, plus `brand-content-design/scripts/slides/requirements.txt`.
+  Without pytest the ten modules under
+  `brand-content-design/scripts/slides/tests` are reported as one skip.
+  pytest alone is not enough: those modules import `slides.auth`, which
+  imports `googleapiclient` at import time, so collection fails without the
+  requirements too. `pip install pytest -r
+  brand-content-design/scripts/slides/requirements.txt`.
+- **`node_modules` for the infographic generator.** Without it
+  `brand-content-design/skills/infographic-generator/test.js` is reported as
+  one skip. `npm ci` in that folder. Its `svgToPng` launches puppeteer, so
+  the install also has to fetch a browser, which is what makes it slow the
+  first time.
 - **shellcheck**, for `make lint` only. `brew install shellcheck`. The
   version matters: `scripts/lint-baseline.txt` names the version that
   produced it on its first line, and `make lint` says so when yours
@@ -74,8 +86,11 @@ picks it up.
 - **git history.** Some tests compare a file against its version on
   `main`, so a shallow clone fails them.
 
-None of these dependencies fail loudly on their own. A green `make test`
-on a machine missing gitleaks is a smaller green than it looks.
+None of these dependencies fail loudly on their own. The pytest and
+`node_modules` cases at least print a `skip` line and raise the skip count.
+The gitleaks case does not: it reports zero failures with 284 fewer
+assertions and says nothing. A green `make test` on a machine missing
+gitleaks is a smaller green than it looks.
 
 ## Writing output
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ TESTED_PLUGINS := $(sort $(foreach p,$(PLUGINS),\
   $(if $(shell git ls-files '$(p)' 2>/dev/null | grep -E '/tests/.*\.sh$$|-spec\.sh$$|-spec\.mjs$$' | head -1),$(p))))
 UNTESTED_PLUGINS := $(filter-out $(TESTED_PLUGINS),$(PLUGINS))
 
-.PHONY: help test lint lint-baseline validate manifests ci \
+.PHONY: help test lint lint-baseline validate manifests outputs ci \
         $(addprefix test-,$(PLUGINS))
 
 help:
@@ -27,11 +27,13 @@ help:
 	@echo "make lint-baseline     rewrite that baseline (deliberate, then commit)"
 	@echo "make validate          check the catalog and each plugin with the claude CLI"
 	@echo "make manifests         check plugin.json and marketplace.json agree"
-	@echo "make ci                all four checks, same as the PR check"
+	@echo "make outputs           check every command says what it writes"
+	@echo "make ci                all five checks, same as the PR check"
 	@echo ""
 	@echo "lint reports a warning that is not in the baseline as a failure."
 	@echo "A baseline warning that is gone is reported as fixed and passes."
 	@echo "validate fails on errors; warnings print without failing."
+	@echo "outputs fails on a command file with no '## Output' section."
 	@echo ""
 	@echo "make test-<plugin> works for: $(TESTED_PLUGINS)"
 	@echo ""
@@ -63,14 +65,22 @@ validate:
 manifests:
 	@python3 scripts/check-manifests.py
 
-# Runs all four even when one fails, so a single run reports every problem
-# instead of stopping at the first. As prerequisites (ci: manifests lint
-# validate test) make would abort on the first failure and a lint regression
-# would hide whether the tests pass. .github/workflows/ci.yml runs the same
-# four checks the same way, so this really is the PR check.
+# Its own target rather than a rule inside check-manifests.py: that script
+# compares plugin.json against the catalog entry and knows nothing about
+# command bodies, and CLAUDE.md documents each target by what it can fail on,
+# which only works while a target has one subject. Separate also means this
+# can fail on its own line in CI instead of inside a manifest verdict.
+outputs:
+	@bash scripts/check-outputs.sh
+
+# Runs all five even when one fails, so a single run reports every problem
+# instead of stopping at the first. As prerequisites (ci: manifests outputs
+# lint validate test) make would abort on the first failure and a lint
+# regression would hide whether the tests pass. .github/workflows/ci.yml runs
+# the same five checks the same way, so this really is the PR check.
 ci:
 	@fail=""; \
-	for target in manifests lint validate test; do \
+	for target in manifests outputs lint validate test; do \
 	  printf '\n==> make %s\n' "$$target"; \
 	  $(MAKE) --no-print-directory "$$target" || fail="$$fail $$target"; \
 	done; \
@@ -79,4 +89,4 @@ ci:
 	  printf 'ci: FAILED:%s\n' "$$fail" >&2; \
 	  exit 1; \
 	fi; \
-	printf 'ci: all four checks passed\n'
+	printf 'ci: all five checks passed\n'

--- a/OUTPUTS.md
+++ b/OUTPUTS.md
@@ -9,31 +9,110 @@ for new work, and a record of where each plugin writes today.
 1. **Tied to a task** goes in the task folder, under
    `implementation_process/in_progress/<task>/`. Phase artifacts, gate
    results, audit files.
-2. **The result of a check** goes in `.reports/` at the root of the code
-   being checked. One file per tool, named after the tool.
+2. **The result of a check** goes in a report directory that is *resolved*,
+   not fixed, and that sits outside the audited repository by default. See
+   "Where a report directory lands" below for the order. One file per tool,
+   named after the tool.
 3. **Something the person asked to be made** goes in
    `outputs/<type>/<YYYY-MM-DD>-<name>/`. Decks, images, pages.
-4. **Nothing else is written to disk.** If a command only reports, it
-   prints and exits. Do not leave a file behind that nobody asked for.
-5. **Never write outside the project** without saying so in the command's
-   Output section first.
+4. **Configuration a setup command installs** goes where the tool being
+   configured expects it, at the root of the project being configured, and
+   only after the person agrees to it. This is not a report and does not
+   belong in a report directory.
+5. **Machine-level state** goes under `~/.claude/<plugin>/`. Session
+   context, project registries, shared caches: things that outlive one
+   project and are shared across all of them. Writing outside the project is
+   legitimate for this category and only this category, and the command's
+   Output section must name the path. Do not write outside the project for
+   anything a project could own.
+6. **Nothing else is written to disk.** If a command only reports, it prints
+   and exits. Do not leave a file behind that nobody asked for.
+
+## Where a report directory lands
+
+`code-quality-tools/skills/code-quality-audit/scripts/core/report-dir.sh`
+resolves it, and every script honours what it exports. First match wins:
+
+1. `$REPORT_DIR` when the caller set it explicitly.
+2. `<project>/audits/<YYYY-MM-DD>/` when the audited directory belongs to a
+   registered ai-dev-assistant project.
+3. `${XDG_STATE_HOME:-$HOME/.local/state}/code-quality-tools/<project>/<timestamp>/`
+   otherwise.
+4. `.reports/` **only** when `REPORT_DIR_IN_REPO=1` asks for it.
+
+`.reports/` used to be the default and stopped being one in v3.9.6. Reports
+quote audited source and name the files a secret scanner matched in, so they
+are kept out of the audited repository unless someone asks for them there.
+The scripts announce the directory they resolved when they start, so the
+answer for any given run is in that run's output rather than in this page.
+
+Note what case 2 means for rule 1: a report about a registered project lands
+in `<project>/audits/<date>/`, which is a fourth destination. It is not the
+task folder, not `.reports/`, and not `outputs/`. It is where
+`/code-quality-tools:architecture-debate` and
+`/code-quality-tools:security-debate` write by default, since both resolve
+their directory through the same script.
 
 ## What each plugin writes today
 
 | Plugin | Writes | Where |
 |---|---|---|
-| ai-dev-assistant | phase artifacts, gate results | `implementation_process/in_progress/<task>/`, gate JSON under `<task>/validations/latest/` and `<task>/validations/history.jsonl` |
-| code-quality-tools | tool reports, review write-up | `.reports/*.json`, `.reports/*.md`, `REVIEW.md` |
-| code-paper-test | trace report | `<target_dir>/paper-test-team-report.md` and `.json` |
-| brand-content-design | finished content | `outputs/<type>/<YYYY-MM-DD>-<name>/` |
-| plugin-creation-tools | nothing, prints only | terminal |
-| drupal-ai-contrib | evidence artifacts | the contribution working folder |
-| drupal-htmx | nothing, prints only | terminal |
-| dev-guides-navigator | cached guide bodies | the shared content store, outside the project |
+| ai-dev-assistant | phase artifacts, gate results, session state | `implementation_process/in_progress/<task>/`, gate JSON under `<task>/validations/latest/` and `<task>/validations/history.jsonl`; session context at `~/.claude/ai-dev-assistant/sessions/<key>.json` and the project registry at `~/.claude/ai-dev-assistant/active_projects.json` |
+| code-quality-tools | tool reports, review write-up, and the config its setup wizard installs | the resolved report directory (above), `REVIEW.md`; setup writes `.code-quality.json`, and on your confirmation `grumphp.yml` or `.husky/pre-commit`, `.github/workflows/quality.yml` and `quality-pr.yml`, and git hooks under `.git/hooks/` |
+| code-paper-test | trace report plus one analysis file per teammate | `<target_dir>/paper-test-team-report.md`, plus `happy-path-analysis.md`, `edge-case-analysis.md` and `red-team-analysis.md` beside the traced code. `--json` adds a `.json` beside each of those four |
+| brand-content-design | a project tree, brand files, templates, and finished content | `/brand-init` creates `<project>/` in the current directory with `input/`, `assets/`, `templates/`, `presentations/`, `carousels/` and `html-pages/`. Finished content lands in that project, at `presentations/<YYYY-MM-DD>-<name>/`, `carousels/<YYYY-MM-DD>-<name>/`, `infographics/<YYYY-MM-DD>-<name>/`, and `html-pages/` (under the design system's name from `/html-page`, under a dated folder from `/html-page-quick`). Not `outputs/<type>/<date>-<name>/`: that path survives only in the plugin's own `references/output-specs.md` and no command writes it. Templates and design systems go under `templates/<type>/<name>/`; `/brand-extract`, `/brand-assets` and `/brand-palette` rewrite `brand-philosophy.md`, and `/brand-extract` downloads Google Fonts into `assets/fonts/`. `/presentation` and `/template-presentation` also upload to Google Drive under `brand-content/<brand>/` and, on a re-render, default to trashing the previous Drive folder |
+| plugin-creation-tools | nothing by default; `--fix` edits the plugin it validated | terminal. With `--fix`: the validated plugin's manifest, hooks, skills, agents and command bodies rewritten in place, and one line appended to its `.claude-plugin/.validate-fixes.log` |
+| drupal-ai-contrib | no evidence files; a staleness ledger outside the project, and CI config only where you confirm it | terminal for `issue`, `verify`, `review` and `pipeline`. The captured gate output is pasted into the report, never saved, and the three read-only worker skills carry `disallowed-tools: Edit, Write`. Two files sit outside the project, under `${CLAUDE_PLUGIN_DATA}` (`~/.claude/plugins/data/<plugin-id>/`, falling back to `$TMPDIR` when unset): `reverify/<key>.log`, appended by a PostToolUse hook, and `review/<key>.mark`, stamped by `review`. `setup` writes into the project you point it at, on your confirmation: `.gitlab-ci.yml`, `phpcs.xml.dist`, `phpstan.neon`, `phpunit.xml.dist`, `.cspell-project-words.txt`, `require-dev` entries in `composer.json`, plus whatever DDEV and `composer install` leave in the tree. `issue` and `submit` do git work in it: a fork remote, an issue branch, a push, and the merge request on drupal.org |
+| drupal-htmx | nothing, except the migration command, which rewrites your source | terminal for `htmx`, `htmx-analyze`, `htmx-pattern` and `htmx-validate`. `/drupal-htmx:htmx-migrate` edits the files you point it at in place and writes no report, so run it on a clean tree |
+| dev-guides-navigator | cached guide and recipe bodies | the shared store at `~/.claude/dev-guides-store/` (override with `DEV_GUIDES_STORE_DIR`), plus a pinned entry in the project's `dev-guides.lock.json` |
+| drupal-dev-framework | nothing of its own; it is a migration shell | moves `~/.claude/drupal-dev-framework/` to `~/.claude/ai-dev-assistant/`, moves `<project>/.claude/drupal-dev-framework/` in every registered project, and rewrites those projects' `settings.json` in place. Its largest footprint of any plugin here, and all of it outside the current directory |
 
-Rule 3 and rule 2 are already what `brand-content-design` and
-`code-quality-tools` do. `code-paper-test` writes beside the file it
-traced, which predates this page.
+No plugin writes `outputs/<type>/<date>-<name>/`. `brand-content-design`, the
+one this page said matched rule 3 exactly, writes a dated folder per content
+type inside the brand project instead, so rule 3 currently has no
+implementation.
+`code-paper-test` writes beside the file it traced, which predates this page.
+`code-quality-tools` no longer writes to `.reports/` by default, which is why
+rule 2 is written as a resolution rather than a path. `drupal-htmx` and
+`plugin-creation-tools` both read as print-only until you pass the one flag
+or run the one command that rewrites your files, so the row says which.
+
+## Writes that no rule covers
+
+Recorded because they are real, not because they are endorsed. Changing
+either is a decision for the repo owner, not a documentation fix.
+
+- When the report directory is a *relative* path, which now means either
+  `REPORT_DIR_IN_REPO=1` or a relative `$REPORT_DIR` somebody set,
+  `report-dir.sh` appends it to **the audited repository's** `.gitignore`.
+  That is a write into a tree this marketplace does not own. It only ever
+  appends, never writes through a symlink, skips a path git already ignores,
+  and never aborts the audit if it cannot. An absolute `$REPORT_DIR` that
+  points inside the tree gets a printed warning instead of an entry, because
+  a gitignore pattern is repo-relative and rewriting an absolute path into
+  one is not safe to guess.
+- `/code-quality-tools:security-debate` saves the dev-guides content it
+  fetches as `security-context.md` inside the report directory, so its
+  teammates can read it. Rule 5 would put fetched guide content in the
+  navigator's shared store.
+- `drupal-ai-contrib` keeps its two staleness files under
+  `${CLAUDE_PLUGIN_DATA}`, which is `~/.claude/plugins/data/<plugin-id>/`
+  and not the `~/.claude/<plugin>/` rule 5 names, and falls back to
+  `$TMPDIR` when the variable is unset. The ledger half is appended by a
+  `PostToolUse` hook on any `Edit` or `Write` of a matching source
+  extension, so it grows in any project, with no command of this plugin
+  ever run and no command's Output section naming the path.
+- `brand-content-design` writes into its own installed plugin directory:
+  the three infographic commands run `npm install` in
+  `skills/infographic-generator/`, leaving a `node_modules/` that a plugin
+  update wipes. `scripts/icons.py` separately caches converted icon PNGs in
+  `$TMPDIR/brand-content-design-icons/`.
+- `brand-content-design` uploads to Google Drive, under
+  `brand-content/<brand>/`. Re-rendering a presentation or a presentation
+  template defaults to trashing the previous Drive folder, which is a
+  destructive write to a place outside the machine, recoverable from Drive
+  Trash for 30 days. The command asks first and offers a versioned sibling
+  instead.
 
 ## Saying so in the command
 
@@ -42,9 +121,24 @@ what it writes and where. If a command writes nothing, the section says
 so. A person should not have to run a command to find out what it leaves
 behind.
 
+`make outputs` enforces that, so it is a property of the repo rather than
+an instruction here. It fails on any tracked `*/commands/*.md` without a
+line reading exactly `## Output` and some text under it. The heading is
+matched exactly: `## Output Format` describes the shape of a printed
+report, which is a different question, and does not count. What no check
+can tell you is whether a section is accurate, only that someone wrote
+one. This page was itself wrong about five of the rows above and silent
+about a sixth, while every one of those plugins carried a section.
+
 ## Result format
 
 Anything a machine reads is JSON and carries `status`, `findings`, and
 `timestamp`. See
 `ai-dev-assistant/references/validation-gate-result.md` and
 `code-paper-test/skills/paper-test/references/json-output-schema.md`.
+
+The ai-dev-assistant envelope also carries `verdict`, `messages` and
+`run_at`, and documents the two sets as equal. Read that file's "How much of
+that is actually enforced" note before relying on the equality: no code
+builds those envelopes, so it is a convention the docs hold to and the
+runtime does not.

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.23.0",
+  "version": "5.23.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.23.1",
+  "version": "5.24.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/migrate-to-epic.sh` built six delete paths from a variable that, if empty, would have
+  removed the wrong directory. The dangerous half is not the one the linter names: an empty leaf
+  turned `rm -rf "$TEMP_ROOT/$TASK_NAME"` into deleting the whole migration temp folder, which
+  after step 5 holds the only copy of the task being migrated, and turned another into deleting the
+  project's entire `in_progress`. Neither is reachable today, since every one of those variables is
+  already validated before use, but nothing said so at the point of deletion. All six now refuse an
+  empty value with a message naming their own site, and `tests/migrate-to-epic-delete-safety-spec.sh`
+  asserts per site that a refused run leaves the folders intact, which is a different claim from
+  exiting non-zero.
+- `hooks/stop-failure.sh` recorded an empty timestamp on macOS. `date -Iseconds` is GNU-only, and
+  with no `set -e` in the file the failure was silent: every session logged a record with a blank
+  field. The same GNU-only call was still live in `scripts/fm-helpers.sh` and
+  `scripts/session-context-write.sh`, and in the instructions `/install-remembrance-hook` gives an
+  agent. All now use the portable UTC form.
 - A `/validate:all` run where every gate skipped reported `pass`. It reports `skipped`. The
   aggregate summary was the eleventh hand-typed copy of the envelope and had its own rules.
 - `/validate:playbook-adherence` carried `"verdict"` twice where the second should have been

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,17 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.23.1] - 2026-08-13
+## [5.24.0] - 2026-08-17
 
-### Fixed
+### Added
 
-- `/validate:playbook-adherence` documented its result envelope with `"verdict"` twice, where the second entry should have been `"status"`. A consumer reading `status` off that gate got nothing. The template now carries both names, like every other gate.
+- `scripts/validation-envelope-write.sh` builds the result envelope that every `/validate:*` gate
+  produces. It takes the gate, task, verdict, messages and details, and derives `status`,
+  `timestamp` and `findings` itself, so the two sets of names cannot disagree. Unknown gates,
+  unknown verdicts, non-object details and duplicate keys anywhere in the JSON arguments are
+  refused rather than written.
 
 ### Changed
 
-- `## Output` sections on `/migrate-tasks`, `/next`, `/pattern`, `/research-team`, `/status`, `/validate`, `/validate:dry`, `/validate:security`, `/validate:solid` and `/validate:tdd`. Each now says what it writes and where before you run it. The v5.23.0 pass left these ten without one.
-- `references/validation-gate-result.md` now says plainly that `status == verdict` and `timestamp == run_at` are conventions the docs hold to and nothing at runtime enforces. No code builds these envelopes; each `/validate:*` command assembles its own from the templates. Consumers should prefer `status`, `timestamp` and `findings` and fall back to `verdict`, `run_at` and `messages` when absent.
-- `tests/validation-envelope-contract-spec.sh` checks every envelope example and template in that reference and in the `validate-*` commands against the documented invariants. It is what caught the `status` defect above. It cannot check a run, only the templates.
+- The eleven `/validate:*` commands call that script instead of each carrying its own copy of the
+  envelope as a JSON template for the model to fill in. Eleven hand-typed copies were eleven
+  chances to drift, and three of them had. Per-gate `details` shapes are unchanged.
+- `references/validation-gate-result.md` describes what is now enforced and what is not. The
+  script guarantees the envelope's shape; nothing forces a command to call it, and `details` is
+  checked only for being an object and free of duplicate keys, so a per-surface `verdict`/`status`
+  pair inside it remains the command's own responsibility.
+- `tests/validation-envelope-contract-spec.sh` runs the emitter rather than reading templates: 97
+  assertions over 75 static checks, including that no command hand-types an envelope and that
+  every gate a command persists is one the script accepts.
+- `## Output` sections on `/migrate-tasks`, `/next`, `/pattern`, `/research-team`, `/status`,
+  `/validate`, `/validate:dry`, `/validate:security`, `/validate:solid` and `/validate:tdd`. Each
+  says what it writes and where before you run it.
+
+### Fixed
+
+- A `/validate:all` run where every gate skipped reported `pass`. It reports `skipped`. The
+  aggregate summary was the eleventh hand-typed copy of the envelope and had its own rules.
+- `/validate:playbook-adherence` carried `"verdict"` twice where the second should have been
+  `"status"`, so anything reading `status` off that gate got nothing.
+- `/validate:visual-regression` and `/validate:visual-parity` carried duplicate keys inside
+  `details.surfaces[]`.
+- The aggregate example in `references/validation-gate-result.md` contradicted itself, claiming
+  seven gates in a summary above a list of three. It is generated from real output now.
 
 ## [5.23.0] - 2026-08-11
 

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.23.1] - 2026-08-13
+
+### Fixed
+
+- `/validate:playbook-adherence` documented its result envelope with `"verdict"` twice, where the second entry should have been `"status"`. A consumer reading `status` off that gate got nothing. The template now carries both names, like every other gate.
+
+### Changed
+
+- `## Output` sections on `/migrate-tasks`, `/next`, `/pattern`, `/research-team`, `/status`, `/validate`, `/validate:dry`, `/validate:security`, `/validate:solid` and `/validate:tdd`. Each now says what it writes and where before you run it. The v5.23.0 pass left these ten without one.
+- `references/validation-gate-result.md` now says plainly that `status == verdict` and `timestamp == run_at` are conventions the docs hold to and nothing at runtime enforces. No code builds these envelopes; each `/validate:*` command assembles its own from the templates. Consumers should prefer `status`, `timestamp` and `findings` and fall back to `verdict`, `run_at` and `messages` when absent.
+- `tests/validation-envelope-contract-spec.sh` checks every envelope example and template in that reference and in the `validate-*` commands against the documented invariants. It is what caught the `status` defect above. It cannot check a run, only the templates.
+
 ## [5.23.0] - 2026-08-11
 
 ### Changed

--- a/ai-dev-assistant/CONVENTIONS.md
+++ b/ai-dev-assistant/CONVENTIONS.md
@@ -58,7 +58,9 @@ Individual `/validate:*` commands for on-demand quality gates. Replaces `/comple
 - `validate-visual-parity` — **reworked v4.14.0 (Task D)**: registry-driven, runs the committed `tests/parity/` suite on the framework's visual-regression package (installed by the process recipe) + `pixelmatch`; compares the build against an external design reference (`figma` / `react-template` / `html-template` / `image` / `prod-url`); emits a TWO-LAYER diff — a coarse pixel-% plus a structured CSS-actionable diff naming which properties drift; `[g]/[i]/[c]` classification; no positional args (registry-driven); `gate_type: visual_parity`; carries `<!-- visual-review:dispatch-ready -->`. See `## Visual Parity Gate` below.
 - `validate-all` — sequential orchestrator; non-interactive CI mode runs visual-regression with `--ci` (any diff → `fail`, no prompts, no baseline writes); skips visual-parity (design-implementation-scoped — runs via `/review` or standalone)
 
-**Shared result envelope** (per `references/validation-gate-result.md` v1.0): every gate emits `{schema_version, gate, task, run_at, verdict, details, messages}`. Verdicts: `pass | warning | fail | skipped`. Persisted to `<task>/validations/latest/<gate>.json` (overwrite) + `<task>/validations/history.jsonl` (append).
+**Shared result envelope** (per `references/validation-gate-result.md` v1.1): every gate emits `{schema_version, gate, task, run_at, timestamp, verdict, status, details, messages, findings}`. Verdicts: `pass | warning | fail | skipped`. `status` and `timestamp` are the cross-plugin names for `verdict` and `run_at`; `findings[]` is the structured form of `messages[]`, one `{severity, title}` per message with severity from the verdict (`fail`→HIGH, `warning`→MEDIUM, `pass`/`skipped`→INFO).
+
+`scripts/validation-envelope-write.sh` is the single emitter. A gate command calls it with the verdict, the messages and its own `details`; the script derives the paired names and `findings[]` so they cannot disagree, and persists to `<task>/validations/latest/<gate>.json` (overwrite, temp+rename) + `<task>/validations/history.jsonl` (append). Its `aggregate` mode does the same for `_all.json`. Do not hand-type an envelope in a command body — `tests/validation-envelope-contract-spec.sh` fails on it. Unrelated to `scripts/gate-audit-write.sh`, which writes the `_<gate>.json` gate-audit artifact against `references/gate-audit-schema.md`.
 
 **Screenshot store** (per `references/screenshot-store-schema.md` v1.0): **codePath-native since v4.13.0** — baselines are committed Playwright snapshots at `<codePath>/tests/visual/<surface>.spec.ts-snapshots/`, with `.meta.json` provenance sidecars in-tree. The 9-field `.meta.json` schema is unchanged (`role`, `captured_by` enum, `prior_hash`, `source`); only the location moved (and the legacy `.previous` rotation is retired — git holds history). The v3.13.0 memory-project `.screenshots/` store is a migration source only — `migrate-screenshots-to-codepath.sh` imports it.
 
@@ -255,7 +257,7 @@ Two-layer best-practices system:
 2. `TeamCreate` fails → same fallback
 3. Team already resident in session → REFUSE with cleanup guidance (do NOT auto-cleanup)
 
-**Envelope compatibility:** per-gate envelopes stay at v3.13.0 v1.0 unchanged. Aggregate `_all.json` adds only a `source: "validate:team"` marker — same shape `/validate:all` produces.
+**Envelope compatibility:** per-gate envelopes keep the shared v1.1 shape. Aggregate `_all.json` adds only a `source: "validate:team"` marker and a `run_id` — same shape `/validate:all` produces, from the same `scripts/validation-envelope-write.sh aggregate` call.
 
 **When to use:** pre-PR / pre-merge / pre-release honest-validation moments, long conversations where context economy matters. Prefer `/validate:all` for routine use.
 

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -205,7 +205,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.23.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.23.1**.
 
 ## License
 

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -205,7 +205,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.23.1**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.24.0**.
 
 ## License
 

--- a/ai-dev-assistant/commands/install-remembrance-hook.md
+++ b/ai-dev-assistant/commands/install-remembrance-hook.md
@@ -90,7 +90,7 @@ Substitute the placeholders:
 
 | Placeholder | Value |
 |-------------|-------|
-| `{generated_date}` | today's date (`date -I`) |
+| `{generated_date}` | today's UTC date (`date -u +%Y-%m-%d`) |
 | `{project_name}` | confirmed project name |
 | `{memory_path}` | confirmed memory path |
 | `{code_path}` | confirmed code path, or `(docs-only — no separate code path)` |

--- a/ai-dev-assistant/commands/migrate-tasks.md
+++ b/ai-dev-assistant/commands/migrate-tasks.md
@@ -128,3 +128,9 @@ Invokes the `task-folder-migrator` skill in **manual mode**:
 
 - [MIGRATION.md](../MIGRATION.md) - Complete migration guide
 - [README.md](../README.md) - Upgrading to v3.0.0 section
+
+## Output
+
+Rewrites the task tree under `<project>/implementation_process/in_progress/`. For each flat `<task>.md` it creates a `<task>/` folder holding `task.md`, `research.md`, `architecture.md` and `implementation.md`, splitting the original by phase, and leaves the original beside it as `<task>.md.bak`.
+
+Nothing is deleted. The backups stay until you remove them yourself. Migration runs only after you confirm the listed plan.

--- a/ai-dev-assistant/commands/next.md
+++ b/ai-dev-assistant/commands/next.md
@@ -322,3 +322,12 @@ This will:
 - `/ai-dev-assistant:research <task>` - Start/continue Phase 1
 - `/ai-dev-assistant:design <task>` - Start/continue Phase 2
 - `/ai-dev-assistant:implement <task>` - Start/continue Phase 3
+
+## Output
+
+Prints the recommended next action. It writes the session-context file at `~/.claude/ai-dev-assistant/sessions/<hash>.json`, outside the project, recording the resolved project and task.
+
+Two paths write more than that, and both are on your confirmation:
+
+- Naming a project that does not exist creates its folder — `project_state.md`, `architecture/`, `implementation_process/in_progress/`, `implementation_process/completed/` — at the location you choose, and registers it in `~/.claude/ai-dev-assistant/active_projects.json`.
+- Finding tasks in the pre-v3.0.0 flat layout migrates them into task folders, leaving a `.md.bak` beside each one.

--- a/ai-dev-assistant/commands/pattern.md
+++ b/ai-dev-assistant/commands/pattern.md
@@ -82,3 +82,7 @@ This is a **Phase 2** command. Use during Architecture phase.
 ## Integration
 
 Pattern recommendations are added to architecture files for reference during implementation.
+
+## Output
+
+Prints the recommendation. Writes nothing. Carrying a recommendation into `architecture/` is a separate, deliberate step in `/ai-dev-assistant:design`, not something this command does for you.

--- a/ai-dev-assistant/commands/research-team.md
+++ b/ai-dev-assistant/commands/research-team.md
@@ -521,3 +521,13 @@ After research/investigation is complete:
 - `/ai-dev-assistant:research <task>` - Standard single-agent research (fallback)
 - `/ai-dev-assistant:design <task>` - Design architecture (Phase 2)
 - `/ai-dev-assistant:next` - See recommended next action
+
+## Output
+
+Everything lands in the task folder, `<project>/implementation_process/in_progress/<task>/`:
+
+- Feature mode — `prior-art.md`, `canonical-patterns.md` and `challenge-log.md` from the three teammates, then `research.md` synthesized by the lead.
+- Bug mode — `hypothesis-a.md`, `hypothesis-b.md` and `hypothesis-c.md`, then `investigation.md`.
+- `_recipe-load.json`, the recipe-resolution audit, written through `scripts/gate-audit-write.sh`. The same audit the plain `/ai-dev-assistant:research` writes, so the team variant is not a quieter path.
+
+The per-teammate files are left in place rather than cleaned up; they are the evidence behind the synthesis. It also writes the session-context file at `~/.claude/ai-dev-assistant/sessions/<hash>.json`, outside the project.

--- a/ai-dev-assistant/commands/review.md
+++ b/ai-dev-assistant/commands/review.md
@@ -42,7 +42,7 @@ Run in order. Each "gate" step writes audit; non-bypassable unless documented `-
    - `plugin-validate`: merge-base diff includes any plugin file
    - `validate-playbook-adherence`: file `commands/validate-playbook-adherence.md` exists OR mark `verdict: "skipped-not-shipped"` with `bypass_reason: "sibling adherence_gates not yet shipped"`; hardened `validate-guides`: command body contains `<!-- /review:hard-block -->` marker OR fall back to soft mode (note in audit)
 
-5. **Run hard-block gates sequentially.** For each: invoke flow inline (do NOT shell out). Capture per-gate envelope at `<task>/validations/latest/<gate>.json` per `references/validation-gate-result.md` v1.0. Add to `gates_run[]`. Order: tdd → solid → dry → security → guides → validate-playbook-adherence → skill-review (conditional) → plugin-validate (conditional).
+5. **Run hard-block gates sequentially.** For each: invoke flow inline (do NOT shell out). Capture per-gate envelope at `<task>/validations/latest/<gate>.json` per `references/validation-gate-result.md` v1.1. Add to `gates_run[]`. Order: tdd → solid → dry → security → guides → validate-playbook-adherence → skill-review (conditional) → plugin-validate (conditional).
 
    **5.0 Architecture-fit validation against the framework review recipe.** Before the code-quality gates run, validate the change against the documented architecture using the stack's review recipe. Additive — it never replaces or weakens a hard-block gate; it supplies `architecture-validator` the framework-specific BLOCKING checks the generic agent lacks. Follow the shared protocol in `references/recipe-resolution.md` with `phase: review` and the step-2 `<project_folder>`: it invokes `process-recipe-loader`, resolves each framework's review recipe (project_state-first, then source order, else `action:ask-user`), records the source in `project_state.md`, and defines how to follow each result (Read `body_path` — never streamed; follow `verified:true` directly; surface `verified:false` for human review first; `action:ask-user` → ask for a path or to research). Surface loader `warnings[]` (`no_frameworks_defined`, `navigator_unavailable:<framework>`, `recipe_not_published:<framework>`). The COMMAND owns resolution and injects the body; the agent stays generic (no Skill tool).
 
@@ -120,7 +120,7 @@ Audit: {{audit_path}}
 
 ## Pointers
 
-- Walkthrough: `references/review-phase-walkthrough.md` (sibling `plumbing_docs_tests`) · Step 6 dispatcher: `references/visual-review/change-impact-dispatch.md` (v4.11.0+) · schemas: `references/gate-audit-schema.md` v1.2 (`gate_type: "review"`; `dispatch_plan`) + per-gate `references/validation-gate-result.md` v1.0 · Spec axis: `references/spec-axis-review.md` (v5.20.0+, M2)
+- Walkthrough: `references/review-phase-walkthrough.md` (sibling `plumbing_docs_tests`) · Step 6 dispatcher: `references/visual-review/change-impact-dispatch.md` (v4.11.0+) · schemas: `references/gate-audit-schema.md` v1.2 (`gate_type: "review"`; `dispatch_plan`) + per-gate `references/validation-gate-result.md` v1.1 · Spec axis: `references/spec-axis-review.md` (v5.20.0+, M2)
 - Project opt-out: `**Review Required:** false` keeps gates at `/complete` (legacy v4.0.2 posture)
 - Related: `/ai-dev-assistant:implement` (Phase 3) · `:complete` (archive; consumes `_review.json`) · `:validate-all` / `:validate-team` (invoked by `/review`) · `:upgrade-project` (set `**Review Required:**`) · `:audit-status` (audit visibility)
 

--- a/ai-dev-assistant/commands/status.md
+++ b/ai-dev-assistant/commands/status.md
@@ -149,3 +149,7 @@ Empty section if no audit gaps. Mentions `/audit-status <task>` for per-task dri
 - `/ai-dev-assistant:research <task>` - Start research for a task
 - `/ai-dev-assistant:implement <task>` - Continue implementation
 - `/ai-dev-assistant:audit-status [<task>]` - **(v4.0.0+)** Detailed audit-state view; surfaces unaudited gates and bypass reasons
+
+## Output
+
+Prints the status report. The only thing it writes is the session-context file at `~/.claude/ai-dev-assistant/sessions/<hash>.json`, outside the project, recording which project and task are active so the compaction hooks can restore context. It does not change project state or task files.

--- a/ai-dev-assistant/commands/validate-all.md
+++ b/ai-dev-assistant/commands/validate-all.md
@@ -47,41 +47,36 @@ Run every validation gate sequentially against the current task. Aggregate the p
 
    **Non-interactive (CI) mode:** when `/validate:all` runs without a TTY or with `$CI` set (detect via `[ -t 0 ] || [ -n "$CI" ]`), pass `--ci` to `visual-regression-gate.sh`. In `--ci` mode the suite still runs, but any diff is recorded as `fail` with no classification prompt and no baseline write — defaulting to `intentional` would silently move baselines (dangerous); defaulting to `regression` is the honest CI outcome. This matches v3.13.0's CI posture (interactive classification only happens in an interactive session).
 
-5. **Aggregate into the `_all.json` envelope** (per `references/validation-gate-result.md`):
+5. **Aggregate into the `_all.json` envelope** — collect one `{gate, verdict, messages}` object per gate that ran, and pass the list to `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` in `aggregate` mode (Bash). It derives the aggregate status, the summary counts, the prefixed `findings[]` and the `timestamp`/`status` pairs, and persists the result. Do not assemble the aggregate JSON by hand.
 
-   ```json
-   {
-     "schema_version": "1.1",
-     "run_at": "<ISO-8601 UTC>",
-     "timestamp": "<ISO-8601 UTC>",
-     "task": "<task_name>",
-     "status": "fail",
-     "gates": [
-       {"gate": "tdd", "verdict": "pass", "status": "pass"},
-       {"gate": "solid", "verdict": "warning", "status": "warning", "messages": ["..."]},
-       {"gate": "dry", "verdict": "pass", "status": "pass"},
-       {"gate": "security", "verdict": "pass", "status": "pass"},
-       {"gate": "guides", "verdict": "fail", "status": "fail", "messages": ["..."]},
-       {"gate": "visual-regression", "verdict": "skipped", "status": "skipped", "messages": ["No baselines in store"]},
-       {"gate": "visual-parity", "verdict": "skipped", "status": "skipped", "messages": ["design-implementation-scoped — run /validate:visual-parity or let /review auto-run it"]}
-     ],
-     "summary": {"pass": 3, "warning": 1, "fail": 1, "skipped": 2, "total": 7},
-     "findings": [
-       {"severity": "MEDIUM", "title": "solid: ..."},
-       {"severity": "HIGH", "title": "guides: ..."}
-     ],
-     "discoverability_hint": "For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
-   }
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" aggregate \
+     --task "<task_name>" \
+     --task-folder "<abs path to the task folder>" \
+     --gates-json "$(jq -n '[
+        {gate: "tdd",               verdict: "pass",    messages: []},
+        {gate: "solid",             verdict: "warning", messages: ["1 class exceeds 200 lines"]},
+        {gate: "dry",               verdict: "pass",    messages: []},
+        {gate: "security",          verdict: "pass",    messages: []},
+        {gate: "guides",            verdict: "fail",    messages: ["no guide citations in research.md"]},
+        {gate: "visual-regression", verdict: "skipped", messages: ["No baselines in store"]},
+        {gate: "visual-parity",     verdict: "skipped", messages: ["design-implementation-scoped — run /validate:visual-parity or let /review auto-run it"]}
+      ]')" \
+     --hint "For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
    ```
 
    The aggregate's own `status` is the worst gate status present: `fail` if any
-   gate failed, else `warning` if any warned, else `pass`. `findings[]` collects
-   every gate's findings with the gate name prefixed onto each `title`. Both are
-   always present, `findings` always an array.
+   gate failed, else `warning` if any warned, else `pass` if any passed. A run
+   where every gate was skipped aggregates to `skipped`, never `pass` — a run
+   that checked nothing must not read like a run that found nothing wrong.
+   `findings[]` collects every gate's messages with the gate name prefixed onto
+   each `title`, at the severity that gate's verdict implies. `findings` is
+   always an array. An unknown gate name or verdict in `--gates-json` is
+   rejected with exit 2 and nothing is written.
 
-6. **Persist** — write aggregate to:
-   - `<task_folder>/validations/latest/_all.json` (overwrite)
-   - `<task_folder>/validations/history.jsonl` (append)
+6. **Persistence** — the emitter writes both:
+   - `<task_folder>/validations/latest/_all.json` (overwrite, temp+rename)
+   - `<task_folder>/validations/history.jsonl` (one compact line appended)
 
    Note: each individual gate that ran also already persisted its own `latest/<gate>.json`. The `_all.json` is an additional summary, not a replacement.
 

--- a/ai-dev-assistant/commands/validate-dry.md
+++ b/ai-dev-assistant/commands/validate-dry.md
@@ -124,3 +124,7 @@ On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On 
 - `references/validation-gate-result.md` — the shared envelope contract
 - `/code-quality:dry` — the underlying check this command wraps
 - `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage
+
+## Output
+
+Writes the result envelope to `<task_folder>/validations/latest/dry.json`, overwriting the previous run, and appends the same envelope as one line to `<task_folder>/validations/history.jsonl`. The wrapped `/code-quality:dry` flow may also leave `.reports/dry.json` in the code being checked; when it does, its path is recorded in the envelope rather than written by this command. Prints the verdict, the top messages, and both persisted paths.

--- a/ai-dev-assistant/commands/validate-dry.md
+++ b/ai-dev-assistant/commands/validate-dry.md
@@ -6,7 +6,7 @@ argument-hint: "[<task-name>]"
 
 # Validate: DRY
 
-Run the DRY quality gate (DRY — code duplication detection) against the current task. Wraps `/code-quality:dry` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+Run the DRY quality gate (DRY — code duplication detection) against the current task. Wraps `/code-quality:dry` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.1).
 
 ## Usage
 
@@ -31,11 +31,9 @@ Run the DRY quality gate (DRY — code duplication detection) against the curren
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per the "Verdict interpretation" section below. Extract any actionable findings into `messages[]`. If `/code-quality:dry` wrote a JSON report to `.reports/dry.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the dry gate.
+5. **Emit and persist the envelope** — call `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash) with the verdict, the findings and this gate's `details`. See "Emitting the envelope" below. The script builds the envelope and writes both files; do not assemble the JSON by hand.
 
-6. **Persist** — write the envelope to TWO locations:
-   - `<task_folder>/validations/latest/dry.json` — overwrite (most-recent-run lookup)
-   - `<task_folder>/validations/history.jsonl` — append (full run log)
+6. **Check the exit code** — 0 means both writes succeeded. 1 is a write failure (missing task folder, permissions) — carry on and say so in the CLI summary. 2 means the arguments were rejected and nothing was written; fix the call rather than falling back to a hand-written file.
 
 7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
 
@@ -53,35 +51,42 @@ Run the DRY quality gate (DRY — code duplication detection) against the curren
 
 If `/code-quality:dry` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
 
-## Shared envelope shape (per `references/validation-gate-result.md`)
+## Emitting the envelope (per `references/validation-gate-result.md`)
 
-```json
-{
-  "schema_version": "1.1",
-  "gate": "dry",
-  "task": "<task_name>",
-  "run_at": "<ISO-8601 UTC>",
-  "timestamp": "<ISO-8601 UTC>",
-  "verdict": "pass",
-  "status": "pass",
-  "details": {
-    "source": "code-quality-tools:dry",
-    "raw_output_path": "<path to .reports/dry.json if produced, else null>",
-    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
-  },
-  "messages": ["<top findings>"],
-  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
-}
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate dry \
+  --task "<task_name>" \
+  --task-folder "<abs path to the task folder>" \
+  --verdict "<pass|warning|fail|skipped>" \
+  --details "$(jq -n \
+      --arg raw "<path to .reports/dry.json if produced, else empty>" \
+      --arg cqt "<version from plugin.json of code-quality-tools>" \
+      '{source: "code-quality-tools:dry",
+        raw_output_path: (if $raw == "" then null else $raw end),
+        code_quality_tools_version: $cqt}')" \
+  --message "<one finding>" \
+  --message "<the next finding>"
 ```
+
+One `--message` per finding, repeated as many times as there are findings; none
+at all is fine. The script derives `status` from the verdict, `timestamp` from
+one clock read, and one `findings[]` entry per message carrying the severity the
+verdict implies, so those fields cannot disagree with the ones they mirror.
+Message text goes through `jq --arg`, so quotes, newlines and shell
+metacharacters in a tool's output are safe to pass straight through.
+
+`--details` is this gate's own detail object and is passed through verbatim.
 
 ## Persistence
 
-Write order:
-1. `mkdir -p <task_folder>/validations/latest`
-2. Write envelope to `<task_folder>/validations/latest/dry.json` (overwrites prior run)
-3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+`validation-envelope-write.sh` does both writes itself:
 
-`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+1. `<task_folder>/validations/latest/dry.json` — overwritten, via temp file + rename
+2. `<task_folder>/validations/history.jsonl` — one compact line appended
+
+It creates `validations/latest/` when absent. `history.jsonl` is JSON Lines (one
+object per line); append-safe, git-diff-legible, easy to tail.
 
 ## CLI output format
 

--- a/ai-dev-assistant/commands/validate-e2e.md
+++ b/ai-dev-assistant/commands/validate-e2e.md
@@ -78,21 +78,26 @@ Capture stdout (the result JSON) and exit code.
 
 Before proceeding: verify the script's stdout is valid JSON by running `jq empty` on it. If the stdout is empty or not valid JSON (e.g., because the script exited 2 before emitting JSON), surface the script's stderr verbatim and stop — do not attempt to build `_e2e.json` from invalid input. (EC-F21)
 
-Write the result to `<task_folder>/validations/latest/e2e.json` per `references/validation-gate-result.md` v1.0:
-```json
-{
-  "schema_version": "1.1",
-  "gate": "e2e",
-  "task": "<task>",
-  "run_at": "<ISO timestamp>",
-  "timestamp": "<ISO timestamp>",
-  "verdict": "<pass|fail|warning>",
-  "status": "<pass|fail|warning>",
-  "details": "<script result JSON>",
-  "messages": [],
-  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
-}
+Call `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh`, which builds the
+envelope per `references/validation-gate-result.md` and writes it to
+`<task_folder>/validations/latest/e2e.json` plus one line on
+`<task_folder>/validations/history.jsonl`. Do not assemble the envelope JSON by hand.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate e2e \
+  --task "<task>" \
+  --task-folder "<abs task folder>" \
+  --verdict "$(printf '%s' "$RESULT_JSON" | jq -r '.verdict')" \
+  --details "$RESULT_JSON" \
+  --message "<one line per failed test, if any>"
 ```
+
+`$RESULT_JSON` is the script's stdout from Step 4, already verified as valid JSON
+above; it becomes `details` verbatim. `validate-e2e.sh` measures, this command
+owns the envelope — see `references/validation-gate-result.md` §7. The emitter
+derives `status`, `timestamp` and `findings[]`, so those cannot disagree with the
+values they mirror.
 
 ## Step 6: Write gate audit
 

--- a/ai-dev-assistant/commands/validate-guides.md
+++ b/ai-dev-assistant/commands/validate-guides.md
@@ -129,9 +129,19 @@ This gate is **dual-mode** (v4.1.0+): standalone CLI invocation stays soft-nudge
    - `code_inference.inferred_slugs` — flattened slug list extracted from `matcher_output.matched_guides[].slug`.
    - `code_inference.source: "none"` when no files surfaced from any source; `suppressed_by_flag: true` when `--no-code-inference` was passed.
 
-8. **Persist** — write envelope to:
-   - `<task_folder>/validations/latest/guides.json` (overwrite)
-   - `<task_folder>/validations/history.jsonl` (append)
+8. **Emit and persist** — build the `details` above with `jq -n`, then hand it to `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash), which builds the envelope and writes both files. Do not assemble the envelope JSON by hand.
+
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+     --gate guides \
+     --task "<task_name>" \
+     --task-folder "<abs path to the task folder>" \
+     --verdict "<pass|warning|fail|skipped>" \
+     --details "$DETAILS_JSON" \
+     --message "<one finding>"
+   ```
+
+   One `--message` per entry of the "Verdict messages" list below, repeated. The script derives `status`, `timestamp` and `findings[]` from the verdict and the messages, then writes `<task_folder>/validations/latest/guides.json` (overwrite, temp+rename) and appends one compact line to `<task_folder>/validations/history.jsonl`. Guide slugs and matcher output pass through `jq --arg`/`--argjson`, so nothing in them can break the JSON.
 
 9. **Print CLI summary** — show verdict, citations found, per-artifact gaps, and (when present) `domain_coverage_gaps` with the catalog slugs the agent matched but no artifact cites. On `fail` or domain-gap `warning`, suggest `/dev-guides-navigator <slug>` for each gap. On `skipped` due to applicability, print the applicability reason. Non-zero exit (1) only when invoked non-interactively.
 

--- a/ai-dev-assistant/commands/validate-playbook-adherence.md
+++ b/ai-dev-assistant/commands/validate-playbook-adherence.md
@@ -48,28 +48,29 @@ Task name must match `^[a-z0-9_-]+$` (path-traversal mitigation). When `--skip-p
    - `ratio >= 0.5` → `verdict: "warning"` (soft) OR `"fail"` (when `--hard-block` OR `--strict`)
    - `ratio < 0.5` → `verdict: "fail"`
 
-9. **Build envelope** per `references/validation-gate-result.md` v1.0:
+9. **Emit and persist the envelope** — build this gate's `details` with `jq -n`, then hand it to `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash), which builds the envelope per `references/validation-gate-result.md` and writes both files. Do not assemble the envelope JSON by hand.
 
-   ```json
-   {
-     "schema_version": "1.1", "gate": "playbook-adherence", "task": "<name>",
-     "run_at": "<ISO-8601 UTC>", "verdict": "<...>",
-     "timestamp": "<ISO-8601 UTC>", "status": "<...>",
-     "details": {
-       "source": "framework:playbook-adherence",
-       "invoked_by": "review | cli | validate-all | validate-team",
-       "playbook_sets_loaded": [...], "user_playbook_loaded": "<path|null>",
-       "cited_count": <int>, "total_plays": <int>,
-       "uncited": [{"play_id", "filename_slug", "tldr_prefix"}, ...],
-       "cite_locations": {"<play_id>": [{"file","line","match_type"}, ...]},
-       "skipped_sections": [{"file","heading","line_range"}, ...]
-     },
-     "messages": [...],
-     "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
-   }
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+     --gate playbook-adherence \
+     --task "<name>" \
+     --task-folder "<abs path to the task folder>" \
+     --verdict "<pass|warning|fail|skipped>" \
+     --details "$(jq -n ... '{
+        source: "framework:playbook-adherence",
+        invoked_by: "review | cli | validate-all | validate-team",
+        playbook_sets_loaded: [...], user_playbook_loaded: "<path|null>",
+        cited_count: <int>, total_plays: <int>,
+        uncited: [{"play_id", "filename_slug", "tldr_prefix"}, ...],
+        cite_locations: {"<play_id>": [{"file","line","match_type"}, ...]},
+        skipped_sections: [{"file","heading","line_range"}, ...]
+      }')" \
+     --message "<one finding>"
    ```
 
-   `invoked_by`: argv `--invoked-by <source>` (default `cli`). `messages[]` includes per-uncited-play remediation hint (`"Uncited: <slug> — <tldr_prefix>"`); plus implicit-inheritance hint when `playbook_sets_source == "default"`. Write atomically to `<task>/validations/latest/playbook-adherence.json` (overwrite); append to `<task>/validations/history.jsonl`.
+   One `--message` per finding, repeated. The script derives `status`, `timestamp` and `findings[]` from the verdict and the messages, so those cannot disagree; it writes `<task>/validations/latest/playbook-adherence.json` via temp+rename and appends one compact line to `<task>/validations/history.jsonl`. Message text passes through `jq --arg`, so a play title carrying quotes is safe.
+
+   `invoked_by`: argv `--invoked-by <source>` (default `cli`). `messages[]` includes per-uncited-play remediation hint (`"Uncited: <slug> — <tldr_prefix>"`); plus implicit-inheritance hint when `playbook_sets_source == "default"`.
 
 10. **Print CLI summary + exit.** Tabular: verdict, ratio, uncited list, skipped-sections summary. Exit `0` in soft mode (always); exit `1` on `fail` when `--hard-block` OR `--strict` set; exit `2` on invalid args (charset, malformed flags).
 
@@ -81,7 +82,7 @@ Cite-matching is approximate: any-of-three literal-string match. False negatives
 
 ## Pointers
 
-- Per-gate envelope: `references/validation-gate-result.md` v1.0
+- Per-gate envelope: `references/validation-gate-result.md` v1.1
 - Cite-checker algorithm: architecture.md C3 in this subtask's design folder
 - Playbook structure: `references/playbook-schema.md` v1.0
 - Sibling: `/ai-dev-assistant:upgrade-project` (sets explicit `**Playbook Sets:**` per project)

--- a/ai-dev-assistant/commands/validate-playbook-adherence.md
+++ b/ai-dev-assistant/commands/validate-playbook-adherence.md
@@ -54,7 +54,7 @@ Task name must match `^[a-z0-9_-]+$` (path-traversal mitigation). When `--skip-p
    {
      "schema_version": "1.1", "gate": "playbook-adherence", "task": "<name>",
      "run_at": "<ISO-8601 UTC>", "verdict": "<...>",
-     "timestamp": "<ISO-8601 UTC>", "verdict": "<...>",
+     "timestamp": "<ISO-8601 UTC>", "status": "<...>",
      "details": {
        "source": "framework:playbook-adherence",
        "invoked_by": "review | cli | validate-all | validate-team",

--- a/ai-dev-assistant/commands/validate-security.md
+++ b/ai-dev-assistant/commands/validate-security.md
@@ -124,3 +124,7 @@ On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On 
 - `references/validation-gate-result.md` — the shared envelope contract
 - `/code-quality:security` — the underlying check this command wraps
 - `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage
+
+## Output
+
+Writes the result envelope to `<task_folder>/validations/latest/security.json`, overwriting the previous run, and appends the same envelope as one line to `<task_folder>/validations/history.jsonl`. The wrapped `/code-quality:security` flow may also leave `.reports/security.json` in the code being checked; when it does, its path is recorded in the envelope rather than written by this command. Prints the verdict, the top messages, and both persisted paths.

--- a/ai-dev-assistant/commands/validate-security.md
+++ b/ai-dev-assistant/commands/validate-security.md
@@ -6,7 +6,7 @@ argument-hint: "[<task-name>]"
 
 # Validate: Security
 
-Run the Security quality gate (Security — OWASP Top 10 style audit + framework-specific sink checks) against the current task. Wraps `/code-quality:security` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+Run the Security quality gate (Security — OWASP Top 10 style audit + framework-specific sink checks) against the current task. Wraps `/code-quality:security` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.1).
 
 ## Usage
 
@@ -31,11 +31,9 @@ Run the Security quality gate (Security — OWASP Top 10 style audit + framework
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per the "Verdict interpretation" section below. Extract any actionable findings into `messages[]`. If `/code-quality:security` wrote a JSON report to `.reports/security.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the security gate.
+5. **Emit and persist the envelope** — call `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash) with the verdict, the findings and this gate's `details`. See "Emitting the envelope" below. The script builds the envelope and writes both files; do not assemble the JSON by hand.
 
-6. **Persist** — write the envelope to TWO locations:
-   - `<task_folder>/validations/latest/security.json` — overwrite (most-recent-run lookup)
-   - `<task_folder>/validations/history.jsonl` — append (full run log)
+6. **Check the exit code** — 0 means both writes succeeded. 1 is a write failure (missing task folder, permissions) — carry on and say so in the CLI summary. 2 means the arguments were rejected and nothing was written; fix the call rather than falling back to a hand-written file.
 
 7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
 
@@ -53,35 +51,42 @@ Run the Security quality gate (Security — OWASP Top 10 style audit + framework
 
 If `/code-quality:security` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
 
-## Shared envelope shape (per `references/validation-gate-result.md`)
+## Emitting the envelope (per `references/validation-gate-result.md`)
 
-```json
-{
-  "schema_version": "1.1",
-  "gate": "security",
-  "task": "<task_name>",
-  "run_at": "<ISO-8601 UTC>",
-  "timestamp": "<ISO-8601 UTC>",
-  "verdict": "pass",
-  "status": "pass",
-  "details": {
-    "source": "code-quality-tools:security",
-    "raw_output_path": "<path to .reports/security.json if produced, else null>",
-    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
-  },
-  "messages": ["<top findings>"],
-  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
-}
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate security \
+  --task "<task_name>" \
+  --task-folder "<abs path to the task folder>" \
+  --verdict "<pass|warning|fail|skipped>" \
+  --details "$(jq -n \
+      --arg raw "<path to .reports/security.json if produced, else empty>" \
+      --arg cqt "<version from plugin.json of code-quality-tools>" \
+      '{source: "code-quality-tools:security",
+        raw_output_path: (if $raw == "" then null else $raw end),
+        code_quality_tools_version: $cqt}')" \
+  --message "<one finding>" \
+  --message "<the next finding>"
 ```
+
+One `--message` per finding, repeated as many times as there are findings; none
+at all is fine. The script derives `status` from the verdict, `timestamp` from
+one clock read, and one `findings[]` entry per message carrying the severity the
+verdict implies, so those fields cannot disagree with the ones they mirror.
+Message text goes through `jq --arg`, so quotes, newlines and shell
+metacharacters in a tool's output are safe to pass straight through.
+
+`--details` is this gate's own detail object and is passed through verbatim.
 
 ## Persistence
 
-Write order:
-1. `mkdir -p <task_folder>/validations/latest`
-2. Write envelope to `<task_folder>/validations/latest/security.json` (overwrites prior run)
-3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+`validation-envelope-write.sh` does both writes itself:
 
-`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+1. `<task_folder>/validations/latest/security.json` — overwritten, via temp file + rename
+2. `<task_folder>/validations/history.jsonl` — one compact line appended
+
+It creates `validations/latest/` when absent. `history.jsonl` is JSON Lines (one
+object per line); append-safe, git-diff-legible, easy to tail.
 
 ## CLI output format
 

--- a/ai-dev-assistant/commands/validate-solid.md
+++ b/ai-dev-assistant/commands/validate-solid.md
@@ -6,7 +6,7 @@ argument-hint: "[<task-name>]"
 
 # Validate: SOLID
 
-Run the SOLID quality gate (SOLID principles compliance (single responsibility, open-closed, LSP, interface segregation, dependency inversion)) against the current task. Wraps `/code-quality:solid` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+Run the SOLID quality gate (SOLID principles compliance (single responsibility, open-closed, LSP, interface segregation, dependency inversion)) against the current task. Wraps `/code-quality:solid` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.1).
 
 ## Usage
 
@@ -31,11 +31,9 @@ Run the SOLID quality gate (SOLID principles compliance (single responsibility, 
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per the "Verdict interpretation" section below. Extract any actionable findings into `messages[]`. If `/code-quality:solid` wrote a JSON report to `.reports/solid.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the solid gate.
+5. **Emit and persist the envelope** — call `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash) with the verdict, the findings and this gate's `details`. See "Emitting the envelope" below. The script builds the envelope and writes both files; do not assemble the JSON by hand.
 
-6. **Persist** — write the envelope to TWO locations:
-   - `<task_folder>/validations/latest/solid.json` — overwrite (most-recent-run lookup)
-   - `<task_folder>/validations/history.jsonl` — append (full run log)
+6. **Check the exit code** — 0 means both writes succeeded. 1 is a write failure (missing task folder, permissions) — carry on and say so in the CLI summary. 2 means the arguments were rejected and nothing was written; fix the call rather than falling back to a hand-written file.
 
 7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
 
@@ -53,35 +51,42 @@ Run the SOLID quality gate (SOLID principles compliance (single responsibility, 
 
 If `/code-quality:solid` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
 
-## Shared envelope shape (per `references/validation-gate-result.md`)
+## Emitting the envelope (per `references/validation-gate-result.md`)
 
-```json
-{
-  "schema_version": "1.1",
-  "gate": "solid",
-  "task": "<task_name>",
-  "run_at": "<ISO-8601 UTC>",
-  "timestamp": "<ISO-8601 UTC>",
-  "verdict": "pass",
-  "status": "pass",
-  "details": {
-    "source": "code-quality-tools:solid",
-    "raw_output_path": "<path to .reports/solid.json if produced, else null>",
-    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
-  },
-  "messages": ["<top findings>"],
-  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
-}
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate solid \
+  --task "<task_name>" \
+  --task-folder "<abs path to the task folder>" \
+  --verdict "<pass|warning|fail|skipped>" \
+  --details "$(jq -n \
+      --arg raw "<path to .reports/solid.json if produced, else empty>" \
+      --arg cqt "<version from plugin.json of code-quality-tools>" \
+      '{source: "code-quality-tools:solid",
+        raw_output_path: (if $raw == "" then null else $raw end),
+        code_quality_tools_version: $cqt}')" \
+  --message "<one finding>" \
+  --message "<the next finding>"
 ```
+
+One `--message` per finding, repeated as many times as there are findings; none
+at all is fine. The script derives `status` from the verdict, `timestamp` from
+one clock read, and one `findings[]` entry per message carrying the severity the
+verdict implies, so those fields cannot disagree with the ones they mirror.
+Message text goes through `jq --arg`, so quotes, newlines and shell
+metacharacters in a tool's output are safe to pass straight through.
+
+`--details` is this gate's own detail object and is passed through verbatim.
 
 ## Persistence
 
-Write order:
-1. `mkdir -p <task_folder>/validations/latest`
-2. Write envelope to `<task_folder>/validations/latest/solid.json` (overwrites prior run)
-3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+`validation-envelope-write.sh` does both writes itself:
 
-`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+1. `<task_folder>/validations/latest/solid.json` — overwritten, via temp file + rename
+2. `<task_folder>/validations/history.jsonl` — one compact line appended
+
+It creates `validations/latest/` when absent. `history.jsonl` is JSON Lines (one
+object per line); append-safe, git-diff-legible, easy to tail.
 
 ## CLI output format
 

--- a/ai-dev-assistant/commands/validate-solid.md
+++ b/ai-dev-assistant/commands/validate-solid.md
@@ -124,3 +124,7 @@ On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On 
 - `references/validation-gate-result.md` — the shared envelope contract
 - `/code-quality:solid` — the underlying check this command wraps
 - `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage
+
+## Output
+
+Writes the result envelope to `<task_folder>/validations/latest/solid.json`, overwriting the previous run, and appends the same envelope as one line to `<task_folder>/validations/history.jsonl`. The wrapped `/code-quality:solid` flow may also leave `.reports/solid.json` in the code being checked; when it does, its path is recorded in the envelope rather than written by this command. Prints the verdict, the top messages, and both persisted paths.

--- a/ai-dev-assistant/commands/validate-tdd.md
+++ b/ai-dev-assistant/commands/validate-tdd.md
@@ -124,3 +124,7 @@ On `pass`: 0-2 messages (usually "all checks passed" + a brief observation). On 
 - `references/validation-gate-result.md` — the shared envelope contract
 - `/code-quality:tdd` — the underlying check this command wraps
 - `/code-quality:coverage`, `/code-quality:lint`, `/code-quality:review`, `/code-quality:audit`, `/code-quality:ultrareview` — NOT wrapped; invoke directly for deeper coverage
+
+## Output
+
+Writes the result envelope to `<task_folder>/validations/latest/tdd.json`, overwriting the previous run, and appends the same envelope as one line to `<task_folder>/validations/history.jsonl`. The wrapped `/code-quality:tdd` flow may also leave `.reports/tdd.json` in the code being checked; when it does, its path is recorded in the envelope rather than written by this command. Prints the verdict, the top messages, and both persisted paths.

--- a/ai-dev-assistant/commands/validate-tdd.md
+++ b/ai-dev-assistant/commands/validate-tdd.md
@@ -6,7 +6,7 @@ argument-hint: "[<task-name>]"
 
 # Validate: TDD
 
-Run the TDD (Red-Green-Refactor discipline) quality gate against the current task. Wraps `/code-quality:tdd` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.0).
+Run the TDD (Red-Green-Refactor discipline) quality gate against the current task. Wraps `/code-quality:tdd` from the `code-quality-tools` plugin; adds task-context resolution, result persistence to the task folder, and emits the shared result envelope (`references/validation-gate-result.md` v1.1).
 
 ## Usage
 
@@ -31,11 +31,9 @@ Run the TDD (Red-Green-Refactor discipline) quality gate against the current tas
 
 4. **Parse the result** — classify the output into our verdict space (`pass | warning | fail | skipped`) per the "Verdict interpretation" section below. Extract any actionable findings into `messages[]`. If `/code-quality:tdd` wrote a JSON report to `.reports/tdd.json` (disk-read fallback), capture its path.
 
-5. **Emit the shared envelope** — produce a JSON object matching `references/validation-gate-result.md` v1.0 for the tdd gate.
+5. **Emit and persist the envelope** — call `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash) with the verdict, the findings and this gate's `details`. See "Emitting the envelope" below. The script builds the envelope and writes both files; do not assemble the JSON by hand.
 
-6. **Persist** — write the envelope to TWO locations:
-   - `<task_folder>/validations/latest/tdd.json` — overwrite (most-recent-run lookup)
-   - `<task_folder>/validations/history.jsonl` — append (full run log)
+6. **Check the exit code** — 0 means both writes succeeded. 1 is a write failure (missing task folder, permissions) — carry on and say so in the CLI summary. 2 means the arguments were rejected and nothing was written; fix the call rather than falling back to a hand-written file.
 
 7. **Print CLI summary** — show verdict, top 3 messages, and the persisted-result paths. When invoked non-interactively (chained from `/validate:all` or CI equivalents), signal verdict via exit code: 0 for `pass`/`warning`/`skipped`; 1 for `fail`. In interactive use the printed summary IS the signal — Claude does not literally exit the session. User workflow is NEVER blocked regardless of verdict.
 
@@ -53,35 +51,42 @@ Run the TDD (Red-Green-Refactor discipline) quality gate against the current tas
 
 If `/code-quality:tdd` emits JSON via a `--json` flag (future enhancement), prefer structured parsing over heuristics. v1 uses heuristics because no stable JSON surface exists yet upstream.
 
-## Shared envelope shape (per `references/validation-gate-result.md`)
+## Emitting the envelope (per `references/validation-gate-result.md`)
 
-```json
-{
-  "schema_version": "1.1",
-  "gate": "tdd",
-  "task": "<task_name>",
-  "run_at": "<ISO-8601 UTC>",
-  "timestamp": "<ISO-8601 UTC>",
-  "verdict": "pass",
-  "status": "pass",
-  "details": {
-    "source": "code-quality-tools:tdd",
-    "raw_output_path": "<path to .reports/tdd.json if produced, else null>",
-    "code_quality_tools_version": "<version from plugin.json of code-quality-tools>"
-  },
-  "messages": ["<top findings>"],
-  "findings": [{"severity": "<HIGH|MEDIUM|INFO by status>", "title": "<same text as the message>"}]
-}
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate tdd \
+  --task "<task_name>" \
+  --task-folder "<abs path to the task folder>" \
+  --verdict "<pass|warning|fail|skipped>" \
+  --details "$(jq -n \
+      --arg raw "<path to .reports/tdd.json if produced, else empty>" \
+      --arg cqt "<version from plugin.json of code-quality-tools>" \
+      '{source: "code-quality-tools:tdd",
+        raw_output_path: (if $raw == "" then null else $raw end),
+        code_quality_tools_version: $cqt}')" \
+  --message "<one finding>" \
+  --message "<the next finding>"
 ```
+
+One `--message` per finding, repeated as many times as there are findings; none
+at all is fine. The script derives `status` from the verdict, `timestamp` from
+one clock read, and one `findings[]` entry per message carrying the severity the
+verdict implies, so those fields cannot disagree with the ones they mirror.
+Message text goes through `jq --arg`, so quotes, newlines and shell
+metacharacters in a tool's output are safe to pass straight through.
+
+`--details` is this gate's own detail object and is passed through verbatim.
 
 ## Persistence
 
-Write order:
-1. `mkdir -p <task_folder>/validations/latest`
-2. Write envelope to `<task_folder>/validations/latest/tdd.json` (overwrites prior run)
-3. Append envelope (as single line) to `<task_folder>/validations/history.jsonl`
+`validation-envelope-write.sh` does both writes itself:
 
-`history.jsonl` uses JSON Lines format (one object per line, newline-separated). Append-safe; git-diff-legible; easy to tail.
+1. `<task_folder>/validations/latest/tdd.json` — overwritten, via temp file + rename
+2. `<task_folder>/validations/history.jsonl` — one compact line appended
+
+It creates `validations/latest/` when absent. `history.jsonl` is JSON Lines (one
+object per line); append-safe, git-diff-legible, easy to tail.
 
 ## CLI output format
 

--- a/ai-dev-assistant/commands/validate-team.md
+++ b/ai-dev-assistant/commands/validate-team.md
@@ -104,7 +104,7 @@ Roster (from architecture):
 
 Each spawn prompt MUST include the absolute-path reminder (the team-manifest schema):
 
-> When you write `<gate>.json` or append to `history.jsonl`, use the absolute paths in `manifest.envelope.latest_dir` / `manifest.envelope.history_file`. Do NOT use relative paths — you are in a worktree and relative writes will not reach the lead.
+> Your gate command writes its envelope by calling `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh`, which derives `<gate>.json` and `history.jsonl` from the `--task-folder` you pass it. Pass the task folder that `manifest.envelope.latest_dir` / `manifest.envelope.history_file` sit under, as an ABSOLUTE path. Do NOT use a relative path — you are in a worktree and relative writes will not reach the lead. Do not hand-write the envelope files.
 
 Each spawn prompt MUST include the progress-message contract:
 
@@ -136,18 +136,23 @@ Do NOT wait on `TaskCompleted` hook events (deferred to v2 Set B2). The mailbox 
 When all expected gates have reported (or timeout reached — document as manual-recovery scenario):
 
 1. Read each `<task>/validations/latest/<gate>.json` envelope written by teammates.
-2. Assemble `_all.json` using the same aggregation shape `/validate:all` emits (per `references/validation-gate-result.md`), with one addition:
-   ```json
-   "discoverability_hint": "Run produced by /validate:team (source: \"validate:team\"). For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
-   ```
-3. Include an explicit `source: "validate:team"` marker inside the aggregate object so downstream consumers can distinguish team-mode runs from single-session runs:
-   ```json
-   { "source": "validate:team", "schema_version": "1.0", ... }
+2. Assemble the `{gate, verdict, messages}` list from those envelopes and pass it to the same emitter `/validate:all` uses. `--source` records that this was a team run, `--run-id` links the aggregate to the per-gate history lines, and `--hint` carries the discoverability line. Do not assemble the aggregate JSON by hand.
+
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" aggregate \
+     --task "<task_name>" \
+     --task-folder "<abs path to the task folder>" \
+     --gates-json "$GATES_JSON" \
+     --source "validate:team" \
+     --run-id "<run_id from the manifest>" \
+     --hint "Run produced by /validate:team. For deeper coverage, see: /code-quality:lint, /code-quality:coverage, /code-quality:review, /code-quality:audit, /code-quality:ultrareview (not wrapped by /validate:*)"
    ```
 
-Write aggregate to:
-- `<task>/validations/latest/_all.json` (overwrite)
-- `<task>/validations/history.jsonl` (append — note: each teammate already appended its own per-gate line; the `_all.json` aggregate appends one additional summary line)
+   The emitter derives the aggregate status, summary counts and prefixed `findings[]`, and writes both files:
+   - `<task>/validations/latest/_all.json` (overwrite, temp+rename)
+   - `<task>/validations/history.jsonl` (append — note: each teammate already appended its own per-gate line; the `_all.json` aggregate appends one additional summary line)
+
+   A teammate that wrote an envelope this command cannot parse shows up here as a gate whose verdict cannot be read — record it as `fail` with the parse error in its `messages[]`, never omit it. A gate missing from the list is a gate the summary silently does not count.
 
 Print the summary table in the same format as `/validate:all` Step 7.
 
@@ -218,7 +223,7 @@ This separation is what makes `/validate:team` honest where `/validate:all` is e
 ## What this does NOT do
 
 - Does NOT wrap or modify `/validate:all` — sibling command, independent lifecycle
-- Does NOT introduce a new envelope schema — per-gate envelopes stay at v3.13.0 v1.0; the aggregate adds only the `source` marker
+- Does NOT introduce a new envelope schema — per-gate envelopes keep the shared v1.1 shape; the aggregate adds only the `source` marker, and both are built by `scripts/validation-envelope-write.sh`
 - Does NOT support `validate-visual-parity` in the team roster (deferred to v2 Set B5 — parity requires explicit `<reference>` arg)
 - Does NOT offer parallel visual gates (v1 serializes in one visual teammate; deferred to v2 Set B1)
 - Does NOT stream per-gate results via hooks (deferred to v2 Set B2 — mailbox messages cover it for now)
@@ -252,7 +257,8 @@ This command does NOT update `session_context.json`. Validation runs are transie
 - `/ai-dev-assistant:validate-all` — sibling; single-session aggregator. Use this for routine validation
 - `/ai-dev-assistant:validate-tdd` / `:validate-solid` / `:validate-dry` / `:validate-security` / `:validate-guides` / `:validate-visual-regression` — individual gates invoked by teammates
 - `references/team-manifest-schema.md` — canonical `team-manifest.json` v1.0 spec
-- `references/validation-gate-result.md` — per-gate + aggregate envelope schema (v3.13.0 v1.0; unchanged)
+- `references/validation-gate-result.md` — per-gate + aggregate envelope schema (v1.1)
+- `scripts/validation-envelope-write.sh` — the emitter that builds and persists both
 - `references/screenshot-store-schema.md` — screenshot store layout (unchanged)
 
 ## Output

--- a/ai-dev-assistant/commands/validate-visual-parity.md
+++ b/ai-dev-assistant/commands/validate-visual-parity.md
@@ -160,10 +160,24 @@ Write `last_compared_at` (ISO-8601 UTC) onto every compared surface's
 ## Step 9: Aggregate + emit the envelope
 
 Aggregate to the worst verdict across all surfaces (`fail` > `warning` > `pass`;
-`skipped` only if all skipped). Write the standard envelope per
-`references/validation-gate-result.md` to
-`<task>/validations/latest/visual-parity.json` and append
-`<task>/validations/history.jsonl`. The `details` block:
+`skipped` only if all skipped). Build the `details` block below with `jq -n`,
+then hand it to `${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh`
+(Bash), which builds the envelope per
+`references/validation-gate-result.md`, writes
+`<task>/validations/latest/visual-parity.json` and appends
+`<task>/validations/history.jsonl`. Do not assemble the envelope JSON by hand.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate visual-parity \
+  --task "<task>" \
+  --task-folder "<abs task folder>" \
+  --verdict "<the aggregated worst verdict>" \
+  --details "$DETAILS_JSON" \
+  --message "<one line per surface, e.g. 'marketing-landing: fail (4.2%)'>"
+```
+
+The `details` block:
 
 ```json
 "details": {
@@ -173,8 +187,8 @@ Aggregate to the worst verdict across all surfaces (`fail` > `warning` > `pass`;
   "run_dir": "<abs path to parity-results/<run>/>",
   "surfaces": [
     {"id": "marketing-landing", "viewport": "desktop", "reference_type": "html-template",
-     "verdict": "fail", "classification": "build-gap", "reference_updated": false,
-     "status": "fail", "classification": "build-gap", "reference_updated": false,
+     "verdict": "fail", "status": "fail",
+     "classification": "build-gap", "reference_updated": false,
      "pixel_diff_ratio": 0.042, "css_diff_mode": "full", "css_diff_count": 3,
      "css_diff": [
        {"selector": ".hero-title", "property": "font-weight", "build": "400", "reference": "500"}
@@ -186,9 +200,16 @@ Aggregate to the worst verdict across all surfaces (`fail` > `warning` > `pass`;
 }
 ```
 
+Each surface carries the same `verdict`/`status` pair the envelope does. The
+emitter does not reach inside `details`, so keeping a per-surface pair equal is
+this command's job — and one key per field: the pair is two names for one value,
+never a reason to repeat `classification` or `reference_updated`.
+
 `gate` is `"visual-parity"` (hyphen form — matches the command name). A surface whose
 `css_diff_mode` is `build-only` carries `css_diff: []` and a `notes` entry stating the
 reference is a static image — never imply a full comparison ran.
+`visual-parity-gate.sh` measures, this command owns the envelope; its stdout
+becomes `details`. See `references/validation-gate-result.md` §7.
 
 ## Step 10: Write the gate audit
 

--- a/ai-dev-assistant/commands/validate-visual-regression.md
+++ b/ai-dev-assistant/commands/validate-visual-regression.md
@@ -209,10 +209,24 @@ For every surface in the gate output with `verdict: fail`:
 ## Step 10: Aggregate + emit the envelope
 
 Aggregate to the worst verdict across all surfaces (`fail` > `warning` >
-`pass`; `skipped` only if all skipped). Write the standard envelope per
-`references/validation-gate-result.md` to
-`<task>/validations/latest/visual-regression.json` and append
-`<task>/validations/history.jsonl`. The `details` block:
+`pass`; `skipped` only if all skipped). Build the `details` block below with
+`jq -n`, then hand it to
+`${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh` (Bash), which
+builds the envelope per `references/validation-gate-result.md`, writes
+`<task>/validations/latest/visual-regression.json` and appends
+`<task>/validations/history.jsonl`. Do not assemble the envelope JSON by hand.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/validation-envelope-write.sh" gate \
+  --gate visual-regression \
+  --task "<task>" \
+  --task-folder "<abs task folder>" \
+  --verdict "<the aggregated worst verdict>" \
+  --details "$DETAILS_JSON" \
+  --message "<one line per surface, e.g. 'home-hero: pass'>"
+```
+
+The `details` block:
 
 ```json
 "details": {
@@ -221,8 +235,8 @@ Aggregate to the worst verdict across all surfaces (`fail` > `warning` >
   "registry_path": "<abs path to registry.yml>",
   "surfaces": [
     {"id": "home-hero", "url": "/", "viewports": ["desktop","tablet","phone"],
-     "verdict": "pass", "classification": null, "baseline_updated": false,
-     "status": "pass", "classification": null, "baseline_updated": false,
+     "verdict": "pass", "status": "pass",
+     "classification": null, "baseline_updated": false,
      "a11y_diff_path": null}
   ],
   "diff_tolerance": 0.005,
@@ -230,7 +244,14 @@ Aggregate to the worst verdict across all surfaces (`fail` > `warning` >
 }
 ```
 
+Each surface carries the same `verdict`/`status` pair the envelope does. The
+emitter does not reach inside `details`, so keeping a per-surface pair equal is
+this command's job — and one key per field: the pair is two names for one value,
+never a reason to repeat `classification` or `baseline_updated`.
+
 `gate` is `"visual-regression"` (hyphen form — matches the command name).
+`visual-regression-gate.sh` measures, this command owns the envelope; its stdout
+becomes `details`. See `references/validation-gate-result.md` §7.
 
 ## Step 11: Write the gate audit
 

--- a/ai-dev-assistant/commands/validate.md
+++ b/ai-dev-assistant/commands/validate.md
@@ -89,3 +89,7 @@ Validate implementation against architecture and coding standards.
 Works with:
 - `superpowers:verification-before-completion`
 - `superpowers:code-reviewer`
+
+## Output
+
+Prints the validation report. Writes nothing. The gate commands that persist a result envelope are `/ai-dev-assistant:validate-<gate>` and `/ai-dev-assistant:validate-all`.

--- a/ai-dev-assistant/hooks/stop-failure.sh
+++ b/ai-dev-assistant/hooks/stop-failure.sh
@@ -7,7 +7,9 @@ LOG_FILE="$LOG_DIR/failures.log"
 
 mkdir -p "$LOG_DIR"
 
-TIMESTAMP=$(date -Iseconds)
+# Portable strftime, not the GNU-only `date -Iseconds`, which BSD/macOS date
+# rejects. UTC, so the same instant reads the same on every machine.
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 PROJECT_NAME=""
 TASK_NAME=""
 

--- a/ai-dev-assistant/references/validation-gate-result.md
+++ b/ai-dev-assistant/references/validation-gate-result.md
@@ -212,6 +212,37 @@ The aggregate's own `status` is the worst gate status present: `fail` if any gat
 6. `findings[]` is always an array (possibly empty); never absent, never `null`
 7. `status == verdict` and `timestamp == run_at` in every envelope
 
+### How much of that is actually enforced
+
+These are conventions, not guarantees, and the difference matters to anything
+consuming an envelope.
+
+No code builds these envelopes. Each `/validate:*` command assembles the JSON
+itself by following the templates in this file and in its own command body —
+which is what "Owner: `commands/validate-*.md`" at the top of this page means.
+The scripts nearby do something else: `scripts/gate-audit-write.sh` writes the
+separate `_<gate>.json` gate-audit artifact and takes an already-built payload,
+`scripts/wo-review-snapshot.sh` only copies envelopes that already exist, and
+`scripts/validate-e2e.sh` emits the gate-audit shape carrying `verdict` with no
+`status`. There is no single place where an envelope is constructed, so there
+is nothing to unit test and nothing that can refuse to write a malformed one.
+
+`tests/validation-envelope-contract-spec.sh` checks what can be checked
+statically: that every envelope example and template on this page and in the
+`validate-*` commands satisfies the invariants above. It caught a real one —
+`validate-playbook-adherence.md` had `"verdict"` twice where the second should
+have been `"status"`, so that gate's documented envelope carried no `status`
+at all. What it cannot check is a run: an envelope written at runtime that
+contradicts its own template goes unnoticed.
+
+A consumer should therefore read defensively. Prefer `status`, `timestamp` and
+`findings`, fall back to `verdict`, `run_at` and `messages` when they are
+absent, and do not assume a `findings` entry exists for every `messages` entry.
+Making invariant 7 a guarantee means routing every gate through one emitter
+that derives the shared names from the ai-dev-assistant ones; until that
+exists, treat the pairs as a convention the docs enforce and the runtime does
+not.
+
 ## 8. Versioning policy
 
 Matches `code-paper-test`'s policy so both plugins version the same way.

--- a/ai-dev-assistant/references/validation-gate-result.md
+++ b/ai-dev-assistant/references/validation-gate-result.md
@@ -1,7 +1,8 @@
 # Validation Gate Result Envelope v1.1
 
 **Introduced:** ai-dev-assistant v3.13.0
-**Owner:** `commands/validate-*.md`
+**Owner:** `scripts/validation-envelope-write.sh`
+**Producers:** `commands/validate-*.md`, by calling that script
 **Consumers (as of v3.13.0):** `commands/validate-all.md`, `commands/complete.md` (future, when v2 batch-approval lands)
 
 Every `/validate:*` command emits and persists a JSON result object with this shape, regardless of whether it wraps a `code-quality-tools` skill or implements its own check (guides, visual-parity, visual-regression). A shared envelope keeps consumers (`/validate:all`, future reports, `/complete` hooks) simple.
@@ -54,8 +55,8 @@ One difference remains: this envelope's `status` can be `skipped`, which the oth
 
 | Field | Type | Values / constraints |
 |---|---|---|
-| `schema_version` | string | `"1.1"` at v5.22.0. JSON string. Consumers match on major (`^1\.`) |
-| `gate` | string | Gate identifier: `tdd` \| `solid` \| `dry` \| `security` \| `guides` \| `visual-parity` \| `visual-regression`. Matches the `/validate:<gate>` command name |
+| `schema_version` | string | `"1.1"`, unchanged since v5.22.0. JSON string. Consumers match on major (`^1\.`) |
+| `gate` | string | Gate identifier: `tdd` \| `solid` \| `dry` \| `security` \| `guides` \| `playbook-adherence` \| `e2e` \| `visual-parity` \| `visual-regression`. Matches the `/validate:<gate>` command name. The list is a closed set in `scripts/validation-envelope-write.sh`; anything else is rejected |
 | `task` | string | Task folder name the run was scoped to |
 | `run_at` | string | ISO-8601 UTC with `Z` suffix |
 | `timestamp` | string | Same value as `run_at`. The cross-plugin name |
@@ -158,7 +159,9 @@ The `details` object's shape depends on `gate`. Consumers reading it should guar
 
 ## 5. Persistence
 
-Every `/validate:*` command writes the result to TWO locations in the task folder:
+`scripts/validation-envelope-write.sh` writes the result to TWO locations in the
+task folder. A `/validate:*` command does not write these files itself; it calls
+the script:
 
 ```
 <task>/validations/
@@ -167,10 +170,10 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 └── history.jsonl            # appended on each run — one JSON object per line
 ```
 
-- `latest/<gate>.json` — most recent result per gate. `/validate:all` reads these to aggregate. `/complete` (future) may check for pending updates
+- `latest/<gate>.json` — most recent result per gate, written via temp file + rename. `/validate:all` reads these to aggregate. `/complete` (future) may check for pending updates
 - `history.jsonl` — full run log, newest at the bottom. JSONL (one object per line) makes append cheap and git-diff legible
 
-`/validate:all` ALSO writes an aggregate `<task>/validations/latest/_all.json` with a summary envelope (see the aggregate envelope section).
+`/validate:all` ALSO writes an aggregate `<task>/validations/latest/_all.json` with a summary envelope (see the aggregate envelope section), through the same script in its `aggregate` mode.
 
 ## 6. Aggregate envelope (`/validate:all`)
 
@@ -180,19 +183,23 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
   "run_at": "2026-04-24T15:30:00Z",
   "timestamp": "2026-04-24T15:30:00Z",
   "task": "dev_framework_granular_validation",
+  "verdict": "warning",
   "status": "warning",
   "gates": [
-    {"gate": "tdd", "verdict": "pass", "status": "pass"},
+    {"gate": "tdd", "verdict": "pass", "status": "pass", "messages": []},
     {"gate": "solid", "verdict": "warning", "status": "warning", "messages": ["1 class exceeds 200 lines"]},
-    {"gate": "visual-regression", "verdict": "pass", "status": "pass"}
+    {"gate": "visual-regression", "verdict": "pass", "status": "pass", "messages": []}
   ],
   "summary": {
-    "pass": 5,
+    "pass": 2,
     "warning": 1,
     "fail": 0,
-    "skipped": 1,
-    "total": 7
+    "skipped": 0,
+    "total": 3
   },
+  "messages": [
+    "solid: 1 class exceeds 200 lines"
+  ],
   "findings": [
     {"severity": "MEDIUM", "title": "solid: 1 class exceeds 200 lines"}
   ],
@@ -200,48 +207,92 @@ Every `/validate:*` command writes the result to TWO locations in the task folde
 }
 ```
 
-The aggregate's own `status` is the worst gate status present: `fail` if any gate failed, else `warning` if any warned, else `pass`. Its `findings[]` collects every gate's findings, each `title` prefixed with the gate name.
+The aggregate's own `status` is the worst gate status present: `fail` if any gate
+failed, else `warning` if any warned, else `pass` if any passed. **A run in which
+every gate was skipped aggregates to `skipped`, not `pass`** — a run that checked
+nothing must not read like a run that found nothing wrong. Its `findings[]`
+collects every gate's messages, each `title` prefixed with the gate name and its
+severity taken from that gate's own verdict, so one failing gate's findings stay
+HIGH inside a `warning` aggregate.
+
+The aggregate carries no top-level `gate` field; it is identified by its `gates[]`
+array and by its `_all.json` filename. It does carry `verdict` alongside `status`,
+like every other envelope. Optional `source` and `run_id` fields appear when the
+caller supplies them (`/validate:team` sets both).
+
+Every example in this file was produced by running the emitter, not typed. What
+matches is the field set and the values; the whitespace does not, because these
+examples keep short arrays on one line for reading and `jq` expands them. A
+reader comparing an example against live output should compare values, not bytes.
+`tests/validation-envelope-contract-spec.sh` re-derives this aggregate's
+`summary`, `status`, `messages` and `findings` from its own `gates[]` using the
+emitter's rules, so an example that stops agreeing with the code fails the suite.
 
 ## 7. Invariants
 
 1. `schema_version` is always present and matches `^1\.`
-2. `gate` matches one of the 7 known IDs OR `_all` for aggregate
+2. `gate` matches one of the 9 known IDs: `tdd`, `solid`, `dry`, `security`, `guides`, `playbook-adherence`, `e2e`, `visual-parity`, `visual-regression`. The aggregate has no `gate` field — it is identified by `gates[]` and by its `_all.json` filename
 3. `verdict` is one of the 4 enum values
 4. `details.source` prefix identifies provenance: `code-quality-tools:*` for wrappers, `framework:*` for owned gates
 5. `messages[]` is always an array (possibly empty); never absent
 6. `findings[]` is always an array (possibly empty); never absent, never `null`
 7. `status == verdict` and `timestamp == run_at` in every envelope
+8. `findings[]` has exactly one entry per `messages[]` entry, in the same order, each `title` repeating its message and each `severity` derived from the verdict
 
-### How much of that is actually enforced
+### How much of that is enforced, and where the gap still is
 
-These are conventions, not guarantees, and the difference matters to anything
-consuming an envelope.
+`scripts/validation-envelope-write.sh` is the only place an envelope is built.
+It takes a gate, a task, a verdict, zero or more messages and the gate's own
+`details`, and **derives** the rest: `status` is written from the same variable
+as `verdict`, `timestamp` from the same clock read as `run_at`, and `findings[]`
+is generated from `messages[]` by one jq expression that applies the single
+severity mapping in the file. Invariants 5 through 8 hold because there is no
+code path that can produce anything else — not because a template says so.
+Invariants 2 and 3 are checked against closed lists and rejected with exit 2,
+so a typo fails loudly instead of writing a malformed envelope. Every value
+reaches jq through `--arg` / `--argjson`, so a finding containing quotes,
+newlines or shell metacharacters cannot corrupt the output.
 
-No code builds these envelopes. Each `/validate:*` command assembles the JSON
-itself by following the templates in this file and in its own command body —
-which is what "Owner: `commands/validate-*.md`" at the top of this page means.
-The scripts nearby do something else: `scripts/gate-audit-write.sh` writes the
-separate `_<gate>.json` gate-audit artifact and takes an already-built payload,
-`scripts/wo-review-snapshot.sh` only copies envelopes that already exist, and
-`scripts/validate-e2e.sh` emits the gate-audit shape carrying `verdict` with no
-`status`. There is no single place where an envelope is constructed, so there
-is nothing to unit test and nothing that can refuse to write a malformed one.
+**How far the guarantee reaches into `details`.** Not far, and the limit is
+worth stating exactly. `details` is the gate's own object and every gate has
+its own shape, so the emitter does not validate that shape. It enforces two
+things: `details` must be a JSON object, and it must carry no duplicate key at
+any depth. The second is not cosmetic — jq resolves a duplicate key by keeping
+the last one and reporting nothing, and two of the three drifts that motivated
+this script were duplicate keys inside `details.surfaces[]`. The emitter now
+parses the raw text with a parser that refuses duplicates before jq sees it,
+and rejects with exit 2. That check needs python3; where python3 is missing the
+script prints on stderr that it did not run, so the absence is never silent.
 
-`tests/validation-envelope-contract-spec.sh` checks what can be checked
-statically: that every envelope example and template on this page and in the
-`validate-*` commands satisfies the invariants above. It caught a real one —
-`validate-playbook-adherence.md` had `"verdict"` twice where the second should
-have been `"status"`, so that gate's documented envelope carried no `status`
-at all. What it cannot check is a run: an envelope written at runtime that
-contradicts its own template goes unnoticed.
+What remains yours: everything else about `details`. A per-surface
+`verdict`/`status` pair inside `details.surfaces[]` is the command's to keep
+consistent — the emitter pairs the envelope's own top-level `verdict`/`status`
+and no others, and it will not notice a surface whose two disagree. The same
+key appearing in two sibling objects is ordinary data and is accepted.
 
-A consumer should therefore read defensively. Prefer `status`, `timestamp` and
-`findings`, fall back to `verdict`, `run_at` and `messages` when they are
-absent, and do not assume a `findings` entry exists for every `messages` entry.
-Making invariant 7 a guarantee means routing every gate through one emitter
-that derives the shared names from the ai-dev-assistant ones; until that
-exists, treat the pairs as a convention the docs enforce and the runtime does
-not.
+`scripts/gate-audit-write.sh` is a different artifact and not a variant of this
+one: it writes `<task>/_<gate>.json` against `references/gate-audit-schema.md`
+from an already-built payload, keyed on `gate_type` and requiring `fired_at` and
+`gate_specific`. `scripts/wo-review-snapshot.sh` only copies envelopes that
+already exist. `scripts/validate-e2e.sh`, `scripts/visual-parity-gate.sh` and
+`scripts/visual-regression-gate.sh` measure — they take a code path and a
+registry, know nothing of a task folder, and their per-surface output is not a
+verdict until the calling command has classified it. Their stdout becomes the
+envelope's `details`; they do not call the emitter.
+
+**The gap that remains:** nothing forces a gate to call the emitter. Each
+`validate-*.md` command *instructs* a model to invoke the script, and a model
+that ignores the instruction and writes a file by hand produces an envelope with
+no guarantees at all. `tests/validation-envelope-contract-spec.sh` narrows this
+from the other side — it fails if any command file hand-types an envelope — but
+that is a check on the instructions, not on a run. The shape is guaranteed; the
+calling is not.
+
+A consumer can rely on the paired names agreeing in any envelope the emitter
+produced. Reading defensively still costs nothing: prefer `status`, `timestamp`
+and `findings`, and fall back to `verdict`, `run_at` and `messages`. Envelopes
+written before this script existed are still on disk in older task folders and
+carry only the conventions of their day.
 
 ## 8. Versioning policy
 
@@ -375,6 +426,8 @@ jq -e '.schema_version | test("^1\\.")' <envelope> >/dev/null || exit 1
 
 ## 10. See also
 
+- `scripts/validation-envelope-write.sh` — the emitter that owns this shape
+- `tests/validation-envelope-contract-spec.sh` — runs the emitter, checks the invariants above against its real output, and fails if a command file hand-types an envelope
 - `references/screenshot-store-schema.md` — the `.meta.json` schema referenced by visual gate details
 - `commands/validate-all.md` — the orchestrator that consumes per-gate envelopes and emits the aggregate
 - `commands/validate-tdd.md` (et al) — the per-gate commands that produce envelopes

--- a/ai-dev-assistant/scripts/fm-helpers.sh
+++ b/ai-dev-assistant/scripts/fm-helpers.sh
@@ -190,7 +190,7 @@ $fm
 
 # $child
 
-**Created:** $(date -I)
+**Created:** $(date -u +%Y-%m-%d)
 **Parent epic:** $parent
 
 ## Goal
@@ -203,6 +203,6 @@ $fm
 - [ ] Phase 4: Review (_review.json)
 
 ## Notes
-Stub scaffolded by \`/ai-dev-assistant:migrate-to-epic\` on $(date -I).
+Stub scaffolded by \`/ai-dev-assistant:migrate-to-epic\` on $(date -u +%Y-%m-%d).
 EOF
 }

--- a/ai-dev-assistant/scripts/migrate-to-epic.sh
+++ b/ai-dev-assistant/scripts/migrate-to-epic.sh
@@ -365,7 +365,7 @@ if [ "$EXPANSION_MODE" = "true" ]; then
   # shared/, phase artifacts, audit JSONs) into temp, then merge in the new
   # children. `/.` copies directory contents (including _*.json) into the
   # already-created atomic-lock dir.
-  cp -r "$TASK_DIR"/. "$TEMP_ROOT/$TASK_NAME/" || { rm -rf "$TEMP_ROOT/$TASK_NAME"; abort "failed to copy epic into temp"; }
+  cp -r "$TASK_DIR"/. "$TEMP_ROOT/$TASK_NAME/" || { rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after a failed epic copy}"; abort "failed to copy epic into temp"; }
   mkdir -p "$TEMP_ROOT/$TASK_NAME/shared" "$TEMP_ROOT/$TASK_NAME/in_progress" "$TEMP_ROOT/$TASK_NAME/completed"
   # Merged children[] = existing (from frontmatter, local: prefix stripped) + new.
   EXISTING_BARE=()
@@ -468,7 +468,7 @@ if [ ${#CHILDREN[@]} -gt 0 ]; then
         apply_frontmatter "$TEMP_ROOT/$TASK_NAME/completed/$child/task.md" "$SUB_FM"
         ;;
       *)
-        rm -rf "$TEMP_ROOT/$TASK_NAME"
+        rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after an unknown child kind}"
         abort "unknown kind '$kind' for child '$child' — shell-array indexing bug"
         ;;
     esac
@@ -493,7 +493,7 @@ while IFS= read -r -d '' taskmd; do
 done < <(find "$TEMP_ROOT/$TASK_NAME" -maxdepth 3 -name task.md -print0)
 
 if [ "$VALIDATION_FAILED" = "true" ]; then
-  rm -rf "$TEMP_ROOT/$TASK_NAME"
+  rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after failed validation}"
   abort "validation failed; temp cleaned up; original untouched"
 fi
 echo "  OK"
@@ -508,7 +508,7 @@ mv "$TASK_DIR" "$TEMP_ROOT/.old-$TASK_NAME" \
 mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {
   # Paper-test Flaw 2 (MAJOR) fix: also clean up partial temp if the mv left it.
   mv "$TEMP_ROOT/.old-$TASK_NAME" "$TASK_DIR"
-  rm -rf "$TEMP_ROOT/$TASK_NAME"
+  rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after a failed swap}"
   abort "failed to swap in new structure; restored original and cleaned temp"
 }
 
@@ -521,10 +521,13 @@ if [ ${#CHILDREN[@]} -gt 0 ]; then
     kind=$(child_kind_at $idx)
     case "$kind" in
       move_existing)
-        rm -rf "$CHILD_IN_PROGRESS_ROOT/$child"
+        # Both halves are guarded: an empty child name collapses this onto the
+        # project's whole in_progress/ root and erases every task under it.
+        rm -rf "${CHILD_IN_PROGRESS_ROOT:?empty, refusing rm -rf}/${child:?empty, refusing rm -rf of the whole in_progress root}"
         ;;
       already_completed)
-        rm -rf "$CHILD_COMPLETED_ROOT/$child"
+        # Same hazard against the completed/ root.
+        rm -rf "${CHILD_COMPLETED_ROOT:?empty, refusing rm -rf}/${child:?empty, refusing rm -rf of the whole completed root}"
         ;;
     esac
     idx=$((idx + 1))

--- a/ai-dev-assistant/scripts/session-context-write.sh
+++ b/ai-dev-assistant/scripts/session-context-write.sh
@@ -55,7 +55,7 @@ NEW_CORE=$(jq -n \
   --arg projectPath "$PROJECT_PATH" \
   --arg task "$TASK_ARG" \
   --arg taskPath "$TASK_PATH_ARG" \
-  --arg updatedAt "$(date -I)" \
+  --arg updatedAt "$(date -u +%Y-%m-%d)" \
   '{
     workspace: $workspace,
     project: $project,

--- a/ai-dev-assistant/scripts/validation-envelope-write.sh
+++ b/ai-dev-assistant/scripts/validation-envelope-write.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# validation-envelope-write.sh — the one place a validation gate result envelope
+# is built and persisted.
+#
+# Before this script, `references/validation-gate-result.md` described the
+# envelope and ten `validate-*.md` command bodies each carried their own
+# hand-typed copy of the JSON for a model to fill in at runtime. Ten copies of
+# one object is ten chances to drift, and three had drifted: one gate's template
+# said `"verdict"` twice where the second should have been `"status"`, and two
+# carried duplicate keys inside `details.surfaces[]`.
+#
+# What this script guarantees, because it derives rather than copies:
+#   status    == verdict          (one input, written to both keys)
+#   timestamp == run_at           (one clock read, written to both keys)
+#   findings  mirrors messages     one {severity,title} per message, in order
+#   findings  is always an array   [] on a run with no messages; never null
+#   severity  comes from the verdict via ONE mapping used by both modes
+#
+# Raw JSON arguments (--details, --gates-json, --messages-json) are rejected
+# when they carry a duplicate key at any depth. jq keeps the last of a
+# duplicate pair silently, and two of the three original drifts were exactly
+# that: duplicate keys inside `details.surfaces[]`. The check needs python3;
+# without it the script says on stderr that it did not run.
+#
+# What it does NOT guarantee: that a gate calls it. The commands instruct a
+# model to invoke this script; nothing forces the model to. That gap is real
+# and is stated in references/validation-gate-result.md §7 rather than papered
+# over here. Nor does it validate the SHAPE of `details` beyond requiring a
+# JSON object with no duplicate keys — each gate owns its own detail shape,
+# and a per-surface verdict/status pair inside it stays the command's
+# responsibility, not this script's.
+#
+# Usage:
+#   validation-envelope-write.sh gate \
+#     --gate <id> --task <name> --task-folder <abs path> --verdict <v> \
+#     [--details <json object>] [--message <text>]... [--messages-json <array>] \
+#     [--stdout-only]
+#
+#   validation-envelope-write.sh aggregate \
+#     --task <name> --task-folder <abs path> --gates-json <array> \
+#     [--hint <text>] [--source <text>] [--run-id <text>] [--stdout-only]
+#
+#   <id>       one of: tdd solid dry security guides playbook-adherence e2e
+#              visual-parity visual-regression
+#   <v>        one of: pass warning fail skipped
+#   --details  the gate's own detail object, passed through verbatim. Each gate
+#              has its own shape; this script does not inspect or normalise it.
+#              It requires only that the object be valid JSON and free of
+#              duplicate keys at any depth.
+#   --message  repeatable. Arbitrary text — quotes, newlines and shell
+#              metacharacters are safe, every value reaches jq through --arg.
+#   --gates-json  [{"gate":<id>,"verdict":<v>,"messages":[<text>,...]}, ...]
+#
+# Output: the envelope, pretty-printed, on stdout. Progress and errors on
+# stderr, so stdout stays machine-readable.
+#
+# Persistence (unless --stdout-only):
+#   <task_folder>/validations/latest/<gate>.json   overwritten, temp+rename
+#   <task_folder>/validations/latest/_all.json     the aggregate mode's target
+#   <task_folder>/validations/history.jsonl        one compact line appended
+#
+# Relationship to scripts/gate-audit-write.sh: a different artifact, not a
+# variant of this one. That script writes `<task>/_<gate>.json` against
+# references/gate-audit-schema.md — a payload it receives already built, keyed
+# on `gate_type`, requiring `fired_at` and `gate_specific`. None of those fields
+# exist here and none of this envelope's fields exist there, so there is nothing
+# to share beyond the write technique. The technique IS shared deliberately:
+# same temp+rename, same jq-parse-before-write, same exit codes, so the two
+# behave alike when a disk fills or a payload is malformed.
+#
+# Exit codes:
+#   0 — envelope built (and written, unless --stdout-only)
+#   1 — write failure (missing task folder, permissions, disk)
+#   2 — invalid input (unknown gate or verdict, malformed JSON, missing arg)
+#
+# bash 3.2 compatible: no associative arrays, no mapfile, no ${var^^}, and
+# `date -u +%Y-%m-%dT%H:%M:%SZ` rather than the GNU-only `date -Iseconds`.
+
+set -uo pipefail
+
+SELF="validation-envelope-write"
+SCHEMA_VERSION="1.1"
+
+# The gates that emit a per-gate envelope. Keep in lockstep with the `gate`
+# row of references/validation-gate-result.md §2 and with the commands/
+# directory: a new validate-* command that persists an envelope belongs here.
+KNOWN_GATES="tdd solid dry security guides playbook-adherence e2e visual-parity visual-regression"
+KNOWN_VERDICTS="pass warning fail skipped"
+
+# The severity mapping, defined once. Both modes call it; nothing else maps a
+# verdict to a severity. references/validation-gate-result.md §0 documents it.
+JQ_DEFS='
+def severity_of:
+  if . == "fail" then "HIGH"
+  elif . == "warning" then "MEDIUM"
+  elif . == "pass" then "INFO"
+  elif . == "skipped" then "INFO"
+  else error("unknown verdict: " + tostring)
+  end;
+def rank_of:
+  if . == "fail" then 3
+  elif . == "warning" then 2
+  elif . == "pass" then 1
+  elif . == "skipped" then 0
+  else error("unknown verdict: " + tostring)
+  end;
+'
+
+die_input() { echo "$SELF: $1" >&2; exit 2; }
+die_write() { echo "$SELF: $1" >&2; exit 1; }
+
+in_list() {
+  # in_list <needle> <space-separated haystack>
+  needle="$1"
+  for item in $2; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+require_value() {
+  # require_value <flag> <count-of-remaining-args>
+  [ "$2" -ge 2 ] || die_input "$1 requires a value"
+}
+
+json_type_of() {
+  # Echoes the JSON type, or nothing when the input does not parse.
+  printf '%s' "$1" | jq -r 'type' 2>/dev/null
+}
+
+# jq resolves a duplicate key by keeping the last one, silently. Two of the
+# three drifts this script was written to end were duplicate keys inside
+# `details.surfaces[]` — a surface carrying `"verdict":"pass"` and then
+# `"verdict":"fail"` reaches jq as `fail` with nothing said. Passing the raw
+# text through a parser that refuses duplicates, BEFORE jq sees it, is what
+# turns that into an error. The check is recursive, so it reaches a duplicate
+# at any depth, and it is per-object, so the same key in two sibling objects
+# is fine.
+#
+# This needs python3. jq cannot do it — its parser is where the keys are lost.
+# When python3 is absent the check does not run, and the script says so on
+# stderr rather than leaving the caller to assume it ran.
+DUPKEY_PY='
+import json, sys
+
+class Dup(Exception):
+    pass
+
+def hook(pairs):
+    seen = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise Dup(key)
+        seen.add(key)
+    return dict(pairs)
+
+try:
+    json.loads(sys.stdin.read(), object_pairs_hook=hook)
+except Dup as exc:
+    sys.stdout.write(str(exc))
+    sys.exit(3)
+except Exception:
+    # Malformed JSON is not this checks business; the jq type check that
+    # follows reports it with a better message.
+    sys.exit(0)
+sys.exit(0)
+'
+
+DUPKEY_CHECKED=0
+if command -v python3 >/dev/null 2>&1; then
+  DUPKEY_CHECKED=1
+fi
+
+reject_duplicate_keys() {
+  # reject_duplicate_keys <label> <json text>
+  [ "$DUPKEY_CHECKED" -eq 1 ] || return 0
+  dup_out=$(printf '%s' "$2" | python3 -c "$DUPKEY_PY")
+  dup_rc=$?
+  if [ "$dup_rc" -eq 3 ]; then
+    die_input "$1 contains a duplicate key: \"$dup_out\". jq would keep the last one silently; fix the caller."
+  fi
+  return 0
+}
+
+MODE="${1:-}"
+case "$MODE" in
+  gate|aggregate) shift ;;
+  "") die_input "mode required: gate | aggregate" ;;
+  *) die_input "unknown mode: $MODE (expected gate | aggregate)" ;;
+esac
+
+GATE=""
+TASK=""
+TASK_FOLDER=""
+VERDICT=""
+DETAILS="{}"
+MESSAGES_JSON="[]"
+GATES_JSON=""
+HINT=""
+SOURCE=""
+RUN_ID=""
+STDOUT_ONLY=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --gate)          require_value "$1" "$#"; GATE="$2"; shift 2 ;;
+    --task)          require_value "$1" "$#"; TASK="$2"; shift 2 ;;
+    --task-folder)   require_value "$1" "$#"; TASK_FOLDER="$2"; shift 2 ;;
+    --verdict)       require_value "$1" "$#"; VERDICT="$2"; shift 2 ;;
+    --details)       require_value "$1" "$#"; DETAILS="$2"; shift 2 ;;
+    --gates-json)    require_value "$1" "$#"; GATES_JSON="$2"; shift 2 ;;
+    --hint)          require_value "$1" "$#"; HINT="$2"; shift 2 ;;
+    --source)        require_value "$1" "$#"; SOURCE="$2"; shift 2 ;;
+    --run-id)        require_value "$1" "$#"; RUN_ID="$2"; shift 2 ;;
+    --stdout-only)   STDOUT_ONLY=1; shift ;;
+    --message)
+      require_value "$1" "$#"
+      MESSAGES_JSON=$(printf '%s' "$MESSAGES_JSON" \
+        | jq --arg m "$2" '. + [$m]' 2>/dev/null) \
+        || die_input "failed to add --message to the message list"
+      shift 2
+      ;;
+    --messages-json)
+      require_value "$1" "$#"
+      case "$(json_type_of "$2")" in
+        array) ;;
+        "") die_input "--messages-json is not valid JSON" ;;
+        *) die_input "--messages-json must be a JSON array of strings" ;;
+      esac
+      printf '%s' "$2" | jq -e 'all(.[]; type == "string")' >/dev/null 2>&1 \
+        || die_input "--messages-json must contain only strings"
+      reject_duplicate_keys "--messages-json" "$2"
+      MESSAGES_JSON=$(printf '%s' "$MESSAGES_JSON" \
+        | jq --argjson add "$2" '. + $add' 2>/dev/null) \
+        || die_input "failed to merge --messages-json into the message list"
+      shift 2
+      ;;
+    *) die_input "unknown argument: $1" ;;
+  esac
+done
+
+# ─── shared validation ───────────────────────────────────────────────────────
+
+[ -n "$TASK" ] || die_input "--task is required"
+[ -n "$TASK_FOLDER" ] || die_input "--task-folder is required"
+
+if [ "$STDOUT_ONLY" -eq 0 ] && [ ! -d "$TASK_FOLDER" ]; then
+  die_write "task folder does not exist: $TASK_FOLDER"
+fi
+
+if [ "$DUPKEY_CHECKED" -eq 0 ]; then
+  echo "$SELF: python3 not found; raw JSON inputs were NOT checked for duplicate keys. A duplicate inside --details survives as its last value." >&2
+fi
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ─── build ───────────────────────────────────────────────────────────────────
+
+if [ "$MODE" = "gate" ]; then
+  [ -n "$GATE" ] || die_input "--gate is required"
+  in_list "$GATE" "$KNOWN_GATES" \
+    || die_input "unknown gate: $GATE (expected one of: $KNOWN_GATES)"
+
+  [ -n "$VERDICT" ] || die_input "--verdict is required"
+  in_list "$VERDICT" "$KNOWN_VERDICTS" \
+    || die_input "unknown verdict: $VERDICT (expected one of: $KNOWN_VERDICTS)"
+
+  case "$(json_type_of "$DETAILS")" in
+    object) ;;
+    "") die_input "--details is not valid JSON" ;;
+    *) die_input "--details must be a JSON object, got $(json_type_of "$DETAILS")" ;;
+  esac
+  reject_duplicate_keys "--details" "$DETAILS"
+
+  # Flags that belong to the other mode are rejected, never silently ignored.
+  [ -n "$GATES_JSON" ] && die_input "--gates-json belongs to aggregate mode"
+  [ -n "$HINT" ] && die_input "--hint belongs to aggregate mode"
+  [ -n "$SOURCE" ] && die_input "--source belongs to aggregate mode"
+  [ -n "$RUN_ID" ] && die_input "--run-id belongs to aggregate mode"
+
+  ENVELOPE=$(jq -n \
+    --arg schema_version "$SCHEMA_VERSION" \
+    --arg gate "$GATE" \
+    --arg task "$TASK" \
+    --arg ts "$TS" \
+    --arg verdict "$VERDICT" \
+    --argjson details "$DETAILS" \
+    --argjson messages "$MESSAGES_JSON" \
+    "$JQ_DEFS"'
+    {
+      schema_version: $schema_version,
+      gate: $gate,
+      task: $task,
+      run_at: $ts,
+      timestamp: $ts,
+      verdict: $verdict,
+      status: $verdict,
+      details: $details,
+      messages: $messages,
+      findings: [$messages[] | {severity: ($verdict | severity_of), title: .}]
+    }') || die_input "failed to build the envelope"
+
+  OUT_NAME="$GATE.json"
+else
+  [ -n "$GATES_JSON" ] || die_input "--gates-json is required in aggregate mode"
+  [ -n "$GATE" ] && die_input "--gate belongs to gate mode"
+  [ -n "$VERDICT" ] && die_input "--verdict belongs to gate mode; aggregate status is derived from --gates-json"
+  [ "$DETAILS" != "{}" ] && die_input "--details belongs to gate mode"
+  [ "$MESSAGES_JSON" != "[]" ] && die_input "--message/--messages-json belong to gate mode; aggregate messages come from --gates-json"
+
+  case "$(json_type_of "$GATES_JSON")" in
+    array) ;;
+    "") die_input "--gates-json is not valid JSON" ;;
+    *) die_input "--gates-json must be a JSON array" ;;
+  esac
+  reject_duplicate_keys "--gates-json" "$GATES_JSON"
+
+  # Validate every element before deriving anything from it, so a typo in one
+  # gate name fails loudly instead of producing an aggregate that silently
+  # omits or mislabels a gate.
+  GATE_COUNT=$(printf '%s' "$GATES_JSON" | jq 'length')
+  i=0
+  while [ "$i" -lt "$GATE_COUNT" ]; do
+    ELEM=$(printf '%s' "$GATES_JSON" | jq -c --argjson i "$i" '.[$i]')
+    [ "$(json_type_of "$ELEM")" = "object" ] \
+      || die_input "--gates-json[$i] must be an object"
+    E_GATE=$(printf '%s' "$ELEM" | jq -r '.gate // ""')
+    E_VERDICT=$(printf '%s' "$ELEM" | jq -r '.verdict // ""')
+    in_list "$E_GATE" "$KNOWN_GATES" \
+      || die_input "--gates-json[$i] has unknown gate: $E_GATE (expected one of: $KNOWN_GATES)"
+    in_list "$E_VERDICT" "$KNOWN_VERDICTS" \
+      || die_input "--gates-json[$i] ($E_GATE) has unknown verdict: $E_VERDICT (expected one of: $KNOWN_VERDICTS)"
+    printf '%s' "$ELEM" | jq -e '(.messages // []) | type == "array" and all(.[]; type == "string")' >/dev/null 2>&1 \
+      || die_input "--gates-json[$i] ($E_GATE) messages must be an array of strings"
+    i=$((i + 1))
+  done
+
+  # The aggregate status is the worst gate status present. `skipped` ranks
+  # BELOW `pass`, and an all-skipped run aggregates to `skipped`, not `pass`:
+  # a run where nothing was checked must never read as a run where everything
+  # passed. A mix of pass and skipped still aggregates to `pass` — something
+  # was checked and nothing objected.
+  ENVELOPE=$(jq -n \
+    --arg schema_version "$SCHEMA_VERSION" \
+    --arg task "$TASK" \
+    --arg ts "$TS" \
+    --arg hint "$HINT" \
+    --arg source "$SOURCE" \
+    --arg run_id "$RUN_ID" \
+    --argjson gates "$GATES_JSON" \
+    "$JQ_DEFS"'
+    ($gates | map(.verdict)) as $verdicts
+    | (if ($verdicts | length) == 0 then "skipped"
+       else ([$verdicts[] | rank_of] | max) as $worst
+       | (if $worst == 3 then "fail"
+          elif $worst == 2 then "warning"
+          elif $worst == 1 then "pass"
+          else "skipped" end)
+       end) as $status
+    | {
+        schema_version: $schema_version,
+        run_at: $ts,
+        timestamp: $ts,
+        task: $task,
+        verdict: $status,
+        status: $status,
+        gates: [$gates[] | {
+          gate: .gate,
+          verdict: .verdict,
+          status: .verdict,
+          messages: (.messages // [])
+        }],
+        summary: {
+          pass:    ([$verdicts[] | select(. == "pass")]    | length),
+          warning: ([$verdicts[] | select(. == "warning")] | length),
+          fail:    ([$verdicts[] | select(. == "fail")]    | length),
+          skipped: ([$verdicts[] | select(. == "skipped")] | length),
+          total:   ($verdicts | length)
+        },
+        messages: [$gates[] | . as $g | (.messages // [])[] | "\($g.gate): \(.)"],
+        findings: [$gates[] | . as $g | (.messages // [])[]
+                   | {severity: ($g.verdict | severity_of), title: "\($g.gate): \(.)"}]
+      }
+    | (if $hint == "" then . else . + {discoverability_hint: $hint} end)
+    | (if $source == "" then . else . + {source: $source} end)
+    | (if $run_id == "" then . else . + {run_id: $run_id} end)
+    ') || die_input "failed to build the aggregate envelope"
+
+  OUT_NAME="_all.json"
+fi
+
+# ─── persist ─────────────────────────────────────────────────────────────────
+
+printf '%s\n' "$ENVELOPE"
+
+if [ "$STDOUT_ONLY" -eq 1 ]; then
+  exit 0
+fi
+
+LATEST_DIR="$TASK_FOLDER/validations/latest"
+mkdir -p "$LATEST_DIR" || die_write "failed to create $LATEST_DIR"
+
+OUT_FILE="$LATEST_DIR/$OUT_NAME"
+TMP_FILE="$OUT_FILE.tmp.$$"
+
+if ! printf '%s\n' "$ENVELOPE" > "$TMP_FILE" 2>/dev/null; then
+  rm -f "$TMP_FILE"
+  die_write "failed to write temp file $TMP_FILE"
+fi
+
+if ! mv "$TMP_FILE" "$OUT_FILE"; then
+  rm -f "$TMP_FILE"
+  die_write "failed to rename temp to $OUT_FILE"
+fi
+
+HISTORY_FILE="$TASK_FOLDER/validations/history.jsonl"
+LINE=$(printf '%s' "$ENVELOPE" | jq -c .) \
+  || die_write "failed to compact the envelope for $HISTORY_FILE"
+
+if ! printf '%s\n' "$LINE" >> "$HISTORY_FILE"; then
+  die_write "failed to append to $HISTORY_FILE"
+fi
+
+echo "$SELF: wrote $OUT_FILE, appended $HISTORY_FILE" >&2
+exit 0

--- a/ai-dev-assistant/tests/migrate-to-epic-delete-safety-spec.sh
+++ b/ai-dev-assistant/tests/migrate-to-epic-delete-safety-spec.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# migrate-to-epic-delete-safety-spec.sh — behavioural spec for the six `rm -rf`
+# sites in scripts/migrate-to-epic.sh.
+#
+# Each of those six deletes a path built as "<base>/<leaf>". If either half is
+# empty the path collapses onto something far larger than the intended target:
+# an empty leaf turns `rm -rf "$TEMP_ROOT/$TASK_NAME"` into `rm -rf` of the whole
+# .migration-tmp/ (which holds the 24h rollback copy of the user's task, and any
+# other migration's temp), and turns `rm -rf "$CHILD_IN_PROGRESS_ROOT/$child"`
+# into `rm -rf` of the project's entire in_progress/ folder. The script moves and
+# deletes real task folders, so that is data loss, not a wrong message.
+#
+# Every site now guards both halves with ${var:?...}, which makes bash refuse the
+# expansion and exit rather than run the rm. This spec proves the refusal is real:
+# for each site it blanks the variable on the way into that site in a throwaway
+# copy of the script, runs the copy against a throwaway fixture, and asserts BOTH
+# that the run exited non-zero AND that the folder the unguarded form would have
+# erased is still there. Those are two different claims and only the second one
+# matters.
+#
+# The blanking is done with count-asserted literal injections: each anchor must
+# occur exactly once in the script or the case fails outright, so an anchor that
+# drifts out of the script is reported instead of silently testing nothing. No
+# anchor quotes the guard text itself, so removing a guard does not disarm the
+# injection that is supposed to catch it. Deleting any one of the six guards was
+# confirmed to fail this spec on a survival assertion, not just a missing anchor.
+#
+# Case 0 is the control: an uninjected run must still succeed and must still
+# delete the peer folders it is supposed to delete, so the guards cannot pass by
+# turning the script into a no-op.
+
+set -uo pipefail
+SPEC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SCRIPTS_SRC="$SPEC_DIR/../scripts"
+
+OK=0; FAIL=0
+ok(){ printf 'OK   %s\n' "$1"; OK=$((OK + 1)); }
+bad(){ printf 'FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
+chk(){ if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+WORK="$(mktemp -d)"
+# Guarded the same way as the script under test: an empty WORK here would take
+# out the whole of /.
+trap 'rm -rf "${WORK:?spec cleanup refused, WORK is empty}"' EXIT
+FAKE_HOME="$WORK/home"
+mkdir -p "$FAKE_HOME"
+
+# --- literal-text tooling ----------------------------------------------------
+# Occurrences (not matching lines) of a literal needle in a file.
+count_occ() { # <needle> <file>
+  awk -v ndl="$1" '
+    BEGIN { c = 0 }
+    { s = $0; while ((i = index(s, ndl)) > 0) { c++; s = substr(s, i + length(ndl)) } }
+    END { print c + 0 }' "$2"
+}
+
+# Replace the single occurrence of a literal needle. Fails the case when the
+# needle does not occur exactly once, so a drifted anchor is loud.
+replace_once() { # <file> <needle> <repl> <label>
+  local f="$1" ndl="$2" rpl="$3" label="$4" n
+  n=$(count_occ "$ndl" "$f")
+  if [ "$n" -ne 1 ]; then
+    bad "$label: anchor occurs $n time(s) in the script, want exactly 1"
+    return 1
+  fi
+  ok "$label: anchor occurs exactly 1 time"
+  awk -v ndl="$ndl" -v rpl="$rpl" '
+    !done { i = index($0, ndl); if (i > 0) { $0 = substr($0, 1, i - 1) rpl substr($0, i + length(ndl)); done = 1 } }
+    { print }' "$f" > "$f.mut" && mv "$f.mut" "$f"
+}
+
+# Insert a line immediately before the single line holding a literal anchor.
+insert_before() { # <file> <anchor> <line> <label>
+  local f="$1" anchor="$2" line="$3" label="$4" n
+  n=$(count_occ "$anchor" "$f")
+  if [ "$n" -ne 1 ]; then
+    bad "$label: anchor occurs $n time(s) in the script, want exactly 1"
+    return 1
+  fi
+  ok "$label: anchor occurs exactly 1 time"
+  awk -v a="$anchor" -v ins="$line" '
+    !done && index($0, a) { print ins; done = 1 }
+    { print }' "$f" > "$f.mut" && mv "$f.mut" "$f"
+}
+
+# --- fixtures ----------------------------------------------------------------
+mk_flat_task() { # <dir> <name> [status]
+  mkdir -p "$1"
+  cat > "$1/task.md" <<EOF
+---
+id: local:$2
+kind: flat
+parent: null
+children: null
+blocks: []
+blocked_by: []
+external_ids: {}
+status: ${3:-draft}
+---
+
+# Task: $2
+EOF
+  printf 'marker for %s\n' "$2" > "$1/marker.txt"
+}
+
+# A project with a flat task to promote, one in-progress peer (move_existing),
+# one completed peer (already_completed), a bystander in each of those two
+# folders, and an unrelated rollback dir already sitting in .migration-tmp/.
+# The bystanders and the unrelated rollback dir are the survival witnesses: the
+# script never touches them, so if one disappears the rm collapsed onto its root.
+mk_project() { # <dir>
+  local p="$1" ip cp_
+  ip="$p/implementation_process/in_progress"
+  cp_="$p/implementation_process/completed"
+  mk_flat_task "$ip/demo" demo in_progress
+  mk_flat_task "$ip/peer" peer in_progress
+  mk_flat_task "$ip/bystander" bystander in_progress
+  mk_flat_task "$cp_/donechild" donechild completed
+  mk_flat_task "$cp_/bystander_done" bystander_done completed
+  mkdir -p "$ip/.migration-tmp/.old-unrelated"
+  printf 'another migration rollback copy\n' > "$ip/.migration-tmp/.old-unrelated/keepme.txt"
+}
+
+# A project whose task is ALREADY an epic, so the run takes the expansion path
+# (the only path that reaches the copy-failure cleanup).
+mk_epic_project() { # <dir>
+  local p="$1" ip
+  ip="$p/implementation_process/in_progress"
+  mkdir -p "$ip/theepic/in_progress/existing_a" "$ip/theepic/shared" "$ip/theepic/completed"
+  cat > "$ip/theepic/task.md" <<'EOF'
+---
+id: local:theepic
+kind: epic
+parent: null
+children:
+- local:existing_a
+blocks: []
+blocked_by: []
+external_ids: {}
+status: in_progress
+---
+
+# Epic: theepic
+EOF
+  cat > "$ip/theepic/in_progress/existing_a/task.md" <<'EOF'
+---
+id: local:existing_a
+kind: subtask
+parent: local:theepic
+children: null
+blocks: []
+blocked_by: []
+external_ids: {}
+status: in_progress
+---
+
+# Task: existing_a
+EOF
+  printf 'epic-wide notes\n' > "$ip/theepic/shared/notes.md"
+  mkdir -p "$ip/.migration-tmp/.old-unrelated"
+  printf 'another migration rollback copy\n' > "$ip/.migration-tmp/.old-unrelated/keepme.txt"
+}
+
+# Fresh throwaway copy of the scripts the migration sources, so injections never
+# touch the repository copy.
+mk_scripts() { # <dir>
+  mkdir -p "$1"
+  cp "$SCRIPTS_SRC/migrate-to-epic.sh" "$SCRIPTS_SRC/fm-helpers.sh" \
+     "$SCRIPTS_SRC/session-paths.sh" "$1/"
+}
+
+RC=0
+run_migrate() { # <scripts_dir> <out_file> <project> <task> [children...]
+  local sd="$1" out="$2"; shift 2
+  # Separate process, not a subshell: `set -e` semantics do not leak either way,
+  # and $? here is the script's own status with no pipeline in between.
+  HOME="$FAKE_HOME" bash "$sd/migrate-to-epic.sh" "$@" > "$out" 2>&1
+  RC=$?
+}
+
+# Exit-status assertions get their own helpers rather than going through chk's
+# eval, so RC is a plain reference the linter can see.
+chk_rc_zero()    { if [ "$RC" -eq 0 ]; then ok "$1"; else bad "$1 (rc=$RC)"; fi; }
+chk_rc_nonzero() { if [ "$RC" -ne 0 ]; then ok "$1"; else bad "$1 (rc=$RC)"; fi; }
+
+# The exact guarded lines, used both as injection anchors and as the static
+# check that every site still carries both halves of the guard.
+RM_COPY='rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after a failed epic copy}"'
+RM_KIND='rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after an unknown child kind}"'
+RM_VALID='rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after failed validation}"'
+RM_SWAP='rm -rf "${TEMP_ROOT:?empty, refusing rm -rf}/${TASK_NAME:?empty, refusing rm -rf of the whole temp root after a failed swap}"'
+RM_INPROG='rm -rf "${CHILD_IN_PROGRESS_ROOT:?empty, refusing rm -rf}/${child:?empty, refusing rm -rf of the whole in_progress root}"'
+RM_DONE='rm -rf "${CHILD_COMPLETED_ROOT:?empty, refusing rm -rf}/${child:?empty, refusing rm -rf of the whole completed root}"'
+
+# --- static: all six sites present, exactly once each ------------------------
+echo "--- guards present in the shipped script"
+SRC="$SCRIPTS_SRC/migrate-to-epic.sh"
+for pair in "epic copy:$RM_COPY" "unknown child kind:$RM_KIND" "failed validation:$RM_VALID" \
+            "failed swap:$RM_SWAP" "in_progress child:$RM_INPROG" "completed child:$RM_DONE"; do
+  label="${pair%%:*}"; needle="${pair#*:}"
+  n=$(count_occ "$needle" "$SRC")
+  chk "guarded rm site present exactly once: $label" '[ "$n" -eq 1 ]'
+done
+# The invariant behind the six, so a seventh rm -rf added later is caught too:
+# every `rm -rf "` line must carry at least two `:?` guards, one per half of the
+# path it builds. Reports the offending line rather than just a count.
+UNGUARDED=$(awk '
+  /rm -rf "/ { c = 0; s = $0; while ((i = index(s, ":?")) > 0) { c++; s = substr(s, i + 2) }
+               if (c < 2) print FNR ": " $0 }' "$SRC")
+if [ -z "$UNGUARDED" ]; then
+  ok "every rm -rf line guards both halves of its path"
+else
+  bad "every rm -rf line guards both halves of its path"
+  printf '     %s\n' "$UNGUARDED"
+fi
+
+# --- case 0: control, the valid path is unchanged ----------------------------
+echo "--- case 0: control (no injection)"
+C0="$WORK/case0"; mk_project "$C0"; mk_scripts "$C0/scripts"
+run_migrate "$C0/scripts" "$C0/out.txt" "$C0" demo peer donechild
+chk_rc_zero "control run exits 0"
+chk "control: epic built at in_progress/demo" '[ -f "$C0/implementation_process/in_progress/demo/task.md" ]'
+chk "control: peer moved inside the epic"     '[ -f "$C0/implementation_process/in_progress/demo/in_progress/peer/task.md" ]'
+chk "control: donechild moved inside the epic" '[ -f "$C0/implementation_process/in_progress/demo/completed/donechild/task.md" ]'
+chk "control: original peer folder IS deleted"      '[ ! -d "$C0/implementation_process/in_progress/peer" ]'
+chk "control: original donechild folder IS deleted" '[ ! -d "$C0/implementation_process/completed/donechild" ]'
+chk "control: bystanders untouched" '[ -f "$C0/implementation_process/in_progress/bystander/task.md" ] && [ -f "$C0/implementation_process/completed/bystander_done/task.md" ]'
+
+# --- case A: empty child at the in_progress delete ---------------------------
+echo "--- case A: empty child name at the in_progress peer delete"
+CA="$WORK/caseA"; mk_project "$CA"; mk_scripts "$CA/scripts"
+insert_before "$CA/scripts/migrate-to-epic.sh" \
+  '# project'"'"'s whole in_progress/ root and erases every task under it.' \
+  '        child=""' "case A injection"
+run_migrate "$CA/scripts" "$CA/out.txt" "$CA" demo peer donechild
+chk_rc_nonzero "A: run refused, exit non-zero"
+chk "A: refusal names the in_progress root" 'grep -q "refusing rm -rf of the whole in_progress root" "$CA/out.txt"'
+chk "A: in_progress/ root still exists"     '[ -d "$CA/implementation_process/in_progress" ]'
+chk "A: bystander task survives (WOULD HAVE BEEN ERASED)" '[ -f "$CA/implementation_process/in_progress/bystander/task.md" ]'
+chk "A: peer task survives"                 '[ -f "$CA/implementation_process/in_progress/peer/task.md" ]'
+chk "A: the migrated epic survives"         '[ -f "$CA/implementation_process/in_progress/demo/task.md" ]'
+
+# --- case B: empty child at the completed delete -----------------------------
+echo "--- case B: empty child name at the completed peer delete"
+CB="$WORK/caseB"; mk_project "$CB"; mk_scripts "$CB/scripts"
+insert_before "$CB/scripts/migrate-to-epic.sh" \
+  '# Same hazard against the completed/ root.' \
+  '        child=""' "case B injection"
+run_migrate "$CB/scripts" "$CB/out.txt" "$CB" demo peer donechild
+chk_rc_nonzero "B: run refused, exit non-zero"
+chk "B: refusal names the completed root" 'grep -q "refusing rm -rf of the whole completed root" "$CB/out.txt"'
+chk "B: completed/ root still exists"     '[ -d "$CB/implementation_process/completed" ]'
+chk "B: bystander_done survives (WOULD HAVE BEEN ERASED)" '[ -f "$CB/implementation_process/completed/bystander_done/task.md" ]'
+chk "B: donechild source survives"        '[ -f "$CB/implementation_process/completed/donechild/task.md" ]'
+
+# --- case C: empty task name at the failed-validation cleanup ----------------
+echo "--- case C: empty task name at the failed-validation temp cleanup"
+CC="$WORK/caseC"; mk_project "$CC"; mk_scripts "$CC/scripts"
+replace_once "$CC/scripts/migrate-to-epic.sh" \
+  'if [ "$VALIDATION_FAILED" = "true" ]; then' \
+  'VALIDATION_FAILED=true; if [ "$VALIDATION_FAILED" = "true" ]; then TASK_NAME="";' \
+  "case C injection"
+run_migrate "$CC/scripts" "$CC/out.txt" "$CC" demo peer donechild
+chk_rc_nonzero "C: run refused, exit non-zero"
+chk "C: refusal names the failed-validation cleanup" 'grep -q "temp root after failed validation" "$CC/out.txt"'
+chk "C: unrelated rollback dir survives (WOULD HAVE BEEN ERASED)" '[ -f "$CC/implementation_process/in_progress/.migration-tmp/.old-unrelated/keepme.txt" ]'
+chk "C: the built temp dir is still there"  '[ -d "$CC/implementation_process/in_progress/.migration-tmp/demo" ]'
+chk "C: original task untouched"            '[ -f "$CC/implementation_process/in_progress/demo/marker.txt" ]'
+chk "C: peer untouched"                     '[ -f "$CC/implementation_process/in_progress/peer/task.md" ]'
+
+# --- case D: empty task name at the failed-swap cleanup ----------------------
+echo "--- case D: empty task name at the failed-swap temp cleanup"
+CD="$WORK/caseD"; mk_project "$CD"; mk_scripts "$CD/scripts"
+# Forcing the swap to fail AND blanking the name in one injection, so the anchor
+# does not mention the guard. The blanking also defeats the restore mv on the
+# line above, which leaves .old-demo as the ONLY copy of the user's task: the
+# unguarded form erases the whole temp root, and that copy with it.
+replace_once "$CD/scripts/migrate-to-epic.sh" \
+  'mv "$TEMP_ROOT/$TASK_NAME" "$TASK_DIR" || {' \
+  'false || { TASK_NAME="";' \
+  "case D injection"
+run_migrate "$CD/scripts" "$CD/out.txt" "$CD" demo peer donechild
+chk_rc_nonzero "D: run refused, exit non-zero"
+chk "D: refusal names the failed-swap cleanup" 'grep -q "temp root after a failed swap" "$CD/out.txt"'
+chk "D: unrelated rollback dir survives (WOULD HAVE BEEN ERASED)" '[ -f "$CD/implementation_process/in_progress/.migration-tmp/.old-unrelated/keepme.txt" ]'
+chk "D: the only copy of the task survives in .old-demo (WOULD HAVE BEEN ERASED)" '[ -f "$CD/implementation_process/in_progress/.migration-tmp/.old-demo/marker.txt" ]'
+chk "D: peer untouched"                        '[ -f "$CD/implementation_process/in_progress/peer/task.md" ]'
+
+# --- case E: empty task name at the unknown-child-kind cleanup ---------------
+echo "--- case E: empty task name at the unknown-child-kind temp cleanup"
+CE="$WORK/caseE"; mk_project "$CE"; mk_scripts "$CE/scripts"
+replace_once "$CE/scripts/migrate-to-epic.sh" \
+  'local k="${CHILD_KINDS[$i]:-}"' \
+  'local k="bogus"' \
+  "case E branch injection"
+# Blanked at the top of the add-children block rather than at the rm line, so the
+# anchor is independent of the guard. Nothing between there and the catch-all
+# branch reads TASK_NAME.
+insert_before "$CE/scripts/migrate-to-epic.sh" \
+  '# Add the NEW children (both promotion and expansion). Existing epic children' \
+  'TASK_NAME=""' "case E blanking injection"
+run_migrate "$CE/scripts" "$CE/out.txt" "$CE" demo peer donechild
+chk_rc_nonzero "E: run refused, exit non-zero"
+chk "E: refusal names the unknown-child-kind cleanup" 'grep -q "temp root after an unknown child kind" "$CE/out.txt"'
+chk "E: unrelated rollback dir survives (WOULD HAVE BEEN ERASED)" '[ -f "$CE/implementation_process/in_progress/.migration-tmp/.old-unrelated/keepme.txt" ]'
+chk "E: original task untouched" '[ -f "$CE/implementation_process/in_progress/demo/marker.txt" ]'
+chk "E: peer untouched"          '[ -f "$CE/implementation_process/in_progress/peer/task.md" ]'
+
+# --- case F: empty task name at the failed-epic-copy cleanup -----------------
+echo "--- case F: empty task name at the failed-epic-copy temp cleanup"
+CF="$WORK/caseF"; mk_epic_project "$CF"; mk_scripts "$CF/scripts"
+replace_once "$CF/scripts/migrate-to-epic.sh" \
+  'cp -r "$TASK_DIR"/. "$TEMP_ROOT/$TASK_NAME/" || {' \
+  'TASK_NAME=""; false || {' \
+  "case F injection"
+run_migrate "$CF/scripts" "$CF/out.txt" "$CF" theepic newchild
+chk_rc_nonzero "F: run refused, exit non-zero"
+chk "F: refusal names the failed-epic-copy cleanup" 'grep -q "temp root after a failed epic copy" "$CF/out.txt"'
+chk "F: unrelated rollback dir survives (WOULD HAVE BEEN ERASED)" '[ -f "$CF/implementation_process/in_progress/.migration-tmp/.old-unrelated/keepme.txt" ]'
+chk "F: existing epic untouched"          '[ -f "$CF/implementation_process/in_progress/theepic/task.md" ]'
+chk "F: its existing child untouched"     '[ -f "$CF/implementation_process/in_progress/theepic/in_progress/existing_a/task.md" ]'
+
+printf '\n%d OK, %d FAIL\n' "$OK" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/ai-dev-assistant/tests/validation-envelope-contract-spec.sh
+++ b/ai-dev-assistant/tests/validation-envelope-contract-spec.sh
@@ -1,218 +1,642 @@
 #!/usr/bin/env bash
-# Doc-contract spec for the validation gate result envelope.
+# Contract spec for the validation gate result envelope.
 #
-# references/validation-gate-result.md §7 promises, of every envelope:
-#   status == verdict, timestamp == run_at, and findings[] mirroring
-#   messages[] one for one, severity derived from the verdict
-#   (fail -> HIGH, warning -> MEDIUM, pass and skipped -> INFO), findings
-#   always an array.
+# WHAT THIS COVERS, stated plainly because the previous version of this file
+# could not cover it and said so:
 #
-# WHAT THIS CAN AND CANNOT PROVE, stated plainly because the difference is
-# the whole point:
+#   1. The emitter's real behaviour. `scripts/validation-envelope-write.sh` is
+#      run, for every verdict, and its OUTPUT is checked against
+#      references/validation-gate-result.md §7: status == verdict,
+#      timestamp == run_at, findings[] mirroring messages[] one for one in
+#      order, severity derived from the verdict (fail -> HIGH,
+#      warning -> MEDIUM, pass and skipped -> INFO), findings always an array
+#      including on a run with no messages at all.
+#   2. That arbitrary message text survives. Quotes, newlines, backslashes and
+#      shell metacharacters go in and come back out byte-identical, because
+#      every value reaches jq through --arg.
+#   3. That the emitter refuses bad input rather than writing a bad envelope:
+#      unknown gate, unknown verdict, non-object details, malformed JSON, and
+#      a duplicate key at any depth in a raw JSON argument — which jq would
+#      otherwise resolve to the last value in silence.
+#   4. Persistence: latest/<gate>.json overwritten, history.jsonl appended one
+#      valid JSON object per run.
+#   5. Aggregate mode: derived status, summary counts, per-gate severity in the
+#      collected findings, and an all-skipped run aggregating to `skipped`
+#      rather than `pass`.
+#   6. That no command file hand-types an envelope any more. This is the check
+#      that stops the old failure mode returning: ten hand-typed copies of one
+#      object, three of which had drifted. A `validate-*.md` that stops calling
+#      the emitter and writes JSON itself fails here — in any fence, tagged or
+#      not, and whether or not it still calls the object a `gate`.
+#   7. That every gate a command persists an envelope for is a gate the emitter
+#      knows, so adding a gate without registering it fails.
+#   8. That the examples in references/validation-gate-result.md still satisfy
+#      the invariants they document — the aggregate example included, whose
+#      summary counts and derived fields are re-derived from its own gates[]
+#      the way the emitter derives them.
 #
-# There is no emitter to test. Nothing in this plugin builds the envelope in
-# code. `scripts/gate-audit-write.sh` writes a different artifact
-# (`_<gate>.json`, the gate-audit schema) and takes an already-built payload.
-# `scripts/wo-review-snapshot.sh` only copies envelopes that already exist.
-# `scripts/validate-e2e.sh` emits the gate-audit shape and carries `verdict`
-# with no `status` at all. The envelope itself is assembled by the model
-# following prose in `commands/validate-*.md`, which the reference doc says
-# outright: "Owner: commands/validate-*.md".
+# WHAT IT STILL CANNOT COVER: whether a model actually calls the emitter at
+# runtime. The commands instruct it to; nothing forces it. Check 6 narrows that
+# from the instruction side, not the run side.
 #
-# So the thing a test can reach is not the envelope but the TEMPLATE the
-# model copies. That is what this checks, and it is not nothing: the
-# templates are the closest thing to an emitter that exists, and this spec
-# was written after finding `validate-playbook-adherence.md` carrying
-# `"verdict"` twice where the second should have been `"status"` — the v1.1
-# cross-plugin rename applied to the duplicated line but not to its key, so
-# that gate's envelope had no `status` at all.
-#
-# What stays unenforced: whether a run actually produces what the template
-# describes. Closing that needs one deterministic emitter the commands call,
-# which is a bigger change than adding this spec.
-#
-# Exit: 0 = every checked block satisfies the contract; 1 = a violation, or
-# nothing was checked.
+# Exit: 0 = every assertion held; 1 = a failure, or nothing was checked.
 
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(dirname "$HERE")"
+EMITTER="$ROOT/scripts/validation-envelope-write.sh"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required. Skipping would report a pass without checking anything."
+  exit 1
+fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "FAIL: python3 is required to parse the JSON blocks out of the markdown."
   echo "      Skipping would report a pass without checking anything."
   exit 1
 fi
+if [ ! -x "$EMITTER" ]; then
+  echo "FAIL: $EMITTER is missing or not executable. The contract has no owner."
+  exit 1
+fi
+
+PASSED=0
+FAILED=0
+
+ok() { PASSED=$((PASSED + 1)); }
+
+bad() {
+  FAILED=$((FAILED + 1))
+  echo "FAIL: $1"
+}
+
+eq() {
+  # eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    ok
+  else
+    bad "$1: expected [$2], got [$3]"
+  fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+TASK_DIR="$WORK/task"
+mkdir -p "$TASK_DIR"
+
+# ── 1. the paired names and the derived findings, per verdict ────────────────
+#
+# Assertions are against LITERALS, never against the other half of the pair.
+# Comparing .status to .verdict passes when both are wrong.
+
+for verdict in pass warning fail skipped; do
+  case "$verdict" in
+    fail) expect_sev="HIGH" ;;
+    warning) expect_sev="MEDIUM" ;;
+    *) expect_sev="INFO" ;;
+  esac
+
+  out="$(bash "$EMITTER" gate \
+    --gate tdd --task envelope_spec --task-folder "$TASK_DIR" \
+    --verdict "$verdict" \
+    --details '{"source":"code-quality-tools:tdd"}' \
+    --message "first finding" \
+    --message "second finding" 2>/dev/null)"
+  rc=$?
+
+  eq "emitter exit code ($verdict)" "0" "$rc"
+  eq "verdict ($verdict)" "$verdict" "$(printf '%s' "$out" | jq -r '.verdict')"
+  eq "status ($verdict)" "$verdict" "$(printf '%s' "$out" | jq -r '.status')"
+  eq "gate ($verdict)" "tdd" "$(printf '%s' "$out" | jq -r '.gate')"
+  eq "schema_version ($verdict)" "1.1" "$(printf '%s' "$out" | jq -r '.schema_version')"
+
+  eq "run_at is ISO-8601 UTC ($verdict)" "true" \
+    "$(printf '%s' "$out" | jq -r '.run_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")')"
+  eq "timestamp equals run_at ($verdict)" "true" \
+    "$(printf '%s' "$out" | jq -r '.timestamp == .run_at')"
+
+  eq "findings is an array ($verdict)" "array" \
+    "$(printf '%s' "$out" | jq -r '.findings | type')"
+  eq "findings mirrors messages one for one, in order ($verdict)" "true" \
+    "$(printf '%s' "$out" | jq -r '[.findings[].title] == .messages')"
+  eq "findings count matches messages count ($verdict)" "2" \
+    "$(printf '%s' "$out" | jq -r '.findings | length')"
+
+  eq "severity derived from verdict ($verdict)" "true" \
+    "$(printf '%s' "$out" | jq -r --arg s "$expect_sev" 'all(.findings[]; .severity == $s)')"
+
+  eq "details passed through verbatim ($verdict)" "code-quality-tools:tdd" \
+    "$(printf '%s' "$out" | jq -r '.details.source')"
+done
+
+# ── 2. a clean run: findings is [] and not null, not absent ──────────────────
+
+clean="$(bash "$EMITTER" gate \
+  --gate guides --task envelope_spec --task-folder "$TASK_DIR" \
+  --verdict pass 2>/dev/null)"
+
+eq "clean run: messages is an array" "array" "$(printf '%s' "$clean" | jq -r '.messages | type')"
+eq "clean run: findings is an array" "array" "$(printf '%s' "$clean" | jq -r '.findings | type')"
+eq "clean run: findings is empty, not null" "0" "$(printf '%s' "$clean" | jq -r '.findings | length')"
+eq "clean run: jq '.findings[]' is safe" "0" \
+  "$(printf '%s' "$clean" | jq -r '[.findings[]] | length')"
+eq "clean run: details defaults to an object" "object" \
+  "$(printf '%s' "$clean" | jq -r '.details | type')"
+
+# ── 3. arbitrary message text survives ──────────────────────────────────────
+#
+# A gate's messages are whatever the wrapped tool printed. If the emitter built
+# JSON by concatenating strings, any of these would break it.
+
+# shellcheck disable=SC2016  # the $HOME and backticks are literal test data,
+# not something to expand — expanding them would test a different string.
+NASTY='he said "no"; rm -rf $HOME `whoami` '"'"'quoted'"'"' \back\slash
+and a second line'
+
+nasty_out="$(bash "$EMITTER" gate \
+  --gate security --task envelope_spec --task-folder "$TASK_DIR" \
+  --verdict fail --message "$NASTY" 2>/dev/null)"
+rc=$?
+
+eq "hostile message: emitter still exits 0" "0" "$rc"
+eq "hostile message: round-trips byte-identical" "$NASTY" \
+  "$(printf '%s' "$nasty_out" | jq -r '.messages[0]')"
+eq "hostile message: finding title matches it" "$NASTY" \
+  "$(printf '%s' "$nasty_out" | jq -r '.findings[0].title')"
+
+# ── 4. bad input is refused, not written ────────────────────────────────────
+#
+# Each case runs in its own process, so a `set -e` suppression inside a tested
+# command cannot leak into the next one.
+
+refuses() {
+  # refuses <label> <expected exit code> <args...>
+  label="$1"; expect="$2"; shift 2
+  bash "$EMITTER" "$@" >/dev/null 2>&1
+  got=$?
+  eq "refuses $label" "$expect" "$got"
+}
+
+refuses "an unknown gate"          2 gate --gate bogus --task t --task-folder "$TASK_DIR" --verdict pass
+refuses "an unknown verdict"       2 gate --gate tdd --task t --task-folder "$TASK_DIR" --verdict green
+refuses "details that is an array" 2 gate --gate tdd --task t --task-folder "$TASK_DIR" --verdict pass --details '["a"]'
+refuses "details that is not JSON" 2 gate --gate tdd --task t --task-folder "$TASK_DIR" --verdict pass --details '{oops'
+refuses "a missing mode"           2
+refuses "an unknown mode"          2 frobnicate --task t --task-folder "$TASK_DIR"
+refuses "a flag with no value"     2 gate --gate
+refuses "an unknown gate in the aggregate" 2 aggregate --task t --task-folder "$TASK_DIR" --gates-json '[{"gate":"nope","verdict":"pass"}]'
+refuses "a missing task folder"    1 gate --gate tdd --task t --task-folder "$WORK/nope" --verdict pass
+
+# Duplicate keys. jq keeps the last of a duplicate pair and says nothing, so
+# without this the drift is invisible: two of the three original drifts were
+# duplicate keys inside `details.surfaces[]`, which is the first case here.
+# The spec hard-requires python3 above, so these never silently no-op.
+refuses "duplicate keys inside details.surfaces[]" 2 \
+  gate --gate tdd --task t --task-folder "$TASK_DIR" --verdict pass \
+  --details '{"surfaces":[{"id":"a","verdict":"pass","verdict":"fail"}]}'
+refuses "duplicate keys at the top of details" 2 \
+  gate --gate tdd --task t --task-folder "$TASK_DIR" --verdict pass \
+  --details '{"source":"a","source":"b"}'
+refuses "duplicate keys in the aggregate gate list" 2 \
+  aggregate --task t --task-folder "$TASK_DIR" \
+  --gates-json '[{"gate":"tdd","verdict":"pass","verdict":"fail"}]'
+
+# The other direction: the same key in two SIBLING objects is ordinary data,
+# not a duplicate, and must still be accepted. A check that rejected this
+# would break every multi-surface visual gate.
+siblings="$(bash "$EMITTER" gate \
+  --gate visual-regression --task envelope_spec --task-folder "$TASK_DIR" \
+  --verdict pass --stdout-only \
+  --details '{"surfaces":[{"id":"a","verdict":"pass"},{"id":"b","verdict":"fail"}]}' 2>/dev/null)"
+rc=$?
+eq "the same key in sibling objects is accepted" "0" "$rc"
+eq "both sibling surfaces survive" "pass fail" \
+  "$(printf '%s' "$siblings" | jq -r '[.details.surfaces[].verdict] | join(" ")')"
+
+# Nothing the refused calls touched should exist.
+if [ -f "$TASK_DIR/validations/latest/bogus.json" ]; then
+  bad "a refused call left bogus.json behind"
+else
+  ok
+fi
+
+# ── 5. persistence ──────────────────────────────────────────────────────────
+
+PERSIST_DIR="$WORK/persist"
+mkdir -p "$PERSIST_DIR"
+
+bash "$EMITTER" gate --gate dry --task envelope_spec --task-folder "$PERSIST_DIR" \
+  --verdict pass --message "first run" >/dev/null 2>&1
+bash "$EMITTER" gate --gate dry --task envelope_spec --task-folder "$PERSIST_DIR" \
+  --verdict fail --message "second run" >/dev/null 2>&1
+
+LATEST="$PERSIST_DIR/validations/latest/dry.json"
+HISTORY="$PERSIST_DIR/validations/history.jsonl"
+
+if [ -f "$LATEST" ]; then ok; else bad "no envelope written to $LATEST"; fi
+if [ -f "$HISTORY" ]; then ok; else bad "no history written to $HISTORY"; fi
+
+eq "latest holds the most recent run only" "fail" "$(jq -r '.verdict' "$LATEST")"
+eq "history keeps both runs" "2" "$(jq -s 'length' "$HISTORY")"
+eq "every history line is one valid JSON object" "true" \
+  "$(jq -s 'all(.[]; type == "object")' "$HISTORY")"
+eq "history preserves the first run" "first run" "$(jq -s -r '.[0].messages[0]' "$HISTORY")"
+eq "history lines keep the pairs" "true" \
+  "$(jq -s 'all(.[]; .status == .verdict and .timestamp == .run_at)' "$HISTORY")"
+
+# ── 6. aggregate mode ───────────────────────────────────────────────────────
+
+agg="$(bash "$EMITTER" aggregate \
+  --task envelope_spec --task-folder "$PERSIST_DIR" \
+  --gates-json '[
+    {"gate":"tdd","verdict":"pass","messages":[]},
+    {"gate":"solid","verdict":"warning","messages":["1 class exceeds 200 lines"]},
+    {"gate":"guides","verdict":"fail","messages":["no citations"]},
+    {"gate":"e2e","verdict":"skipped","messages":["not set up"]}
+  ]' --hint "see also" 2>/dev/null)"
+rc=$?
+
+eq "aggregate exit code" "0" "$rc"
+eq "aggregate status is the worst verdict present" "fail" "$(printf '%s' "$agg" | jq -r '.status')"
+eq "aggregate verdict mirrors its status" "true" "$(printf '%s' "$agg" | jq -r '.verdict == .status')"
+eq "aggregate timestamp equals run_at" "true" "$(printf '%s' "$agg" | jq -r '.timestamp == .run_at')"
+eq "aggregate summary counts pass" "1" "$(printf '%s' "$agg" | jq -r '.summary.pass')"
+eq "aggregate summary counts warning" "1" "$(printf '%s' "$agg" | jq -r '.summary.warning')"
+eq "aggregate summary counts fail" "1" "$(printf '%s' "$agg" | jq -r '.summary.fail')"
+eq "aggregate summary counts skipped" "1" "$(printf '%s' "$agg" | jq -r '.summary.skipped')"
+eq "aggregate summary total" "4" "$(printf '%s' "$agg" | jq -r '.summary.total')"
+eq "each gate entry carries its own status pair" "true" \
+  "$(printf '%s' "$agg" | jq -r 'all(.gates[]; .status == .verdict)')"
+eq "aggregate findings are prefixed with the gate name" "guides: no citations" \
+  "$(printf '%s' "$agg" | jq -r '.findings[] | select(.title | startswith("guides")) | .title')"
+eq "a failing gate's finding stays HIGH inside a mixed aggregate" "HIGH" \
+  "$(printf '%s' "$agg" | jq -r '.findings[] | select(.title | startswith("guides")) | .severity')"
+eq "a warning gate's finding is MEDIUM" "MEDIUM" \
+  "$(printf '%s' "$agg" | jq -r '.findings[] | select(.title | startswith("solid")) | .severity')"
+eq "a skipped gate's finding is INFO" "INFO" \
+  "$(printf '%s' "$agg" | jq -r '.findings[] | select(.title | startswith("e2e")) | .severity')"
+eq "aggregate findings mirror aggregate messages" "true" \
+  "$(printf '%s' "$agg" | jq -r '[.findings[].title] == .messages')"
+eq "aggregate is written to _all.json" "fail" \
+  "$(jq -r '.status' "$PERSIST_DIR/validations/latest/_all.json")"
+
+allskipped="$(bash "$EMITTER" aggregate \
+  --task envelope_spec --task-folder "$PERSIST_DIR" --stdout-only \
+  --gates-json '[{"gate":"tdd","verdict":"skipped"},{"gate":"solid","verdict":"skipped"}]' 2>/dev/null)"
+eq "a run where every gate was skipped does not read as pass" "skipped" \
+  "$(printf '%s' "$allskipped" | jq -r '.status')"
+
+mixed="$(bash "$EMITTER" aggregate \
+  --task envelope_spec --task-folder "$PERSIST_DIR" --stdout-only \
+  --gates-json '[{"gate":"tdd","verdict":"pass"},{"gate":"solid","verdict":"skipped"}]' 2>/dev/null)"
+eq "pass beats skipped when something was checked" "pass" \
+  "$(printf '%s' "$mixed" | jq -r '.status')"
+
+# ── 7-9. the static checks over the command files and the reference doc ─────
 
 python3 - "$ROOT" <<'PY'
 import glob
 import json
 import os
 import re
+import subprocess
 import sys
 
 root = sys.argv[1]
 
 SEVERITY = {"fail": "HIGH", "warning": "MEDIUM", "pass": "INFO", "skipped": "INFO"}
+RANK = {"skipped": 0, "pass": 1, "warning": 2, "fail": 3}
 PAIRS = (("verdict", "status"), ("run_at", "timestamp"))
 REQUIRED = ("verdict", "status", "run_at", "timestamp", "messages", "findings")
+REQUIRED_AGGREGATE = REQUIRED + ("gates", "summary")
 
-reference = os.path.join(root, "references", "validation-gate-result.md")
-commands = sorted(glob.glob(os.path.join(root, "commands", "validate-*.md")))
-targets = [reference] + commands
+# Every top-level name the envelope owns. Two of them in one object is an
+# envelope, whatever else it calls itself. The threshold is what keeps the
+# legitimate payloads in these same files out: a gate-audit object carries
+# exactly one (`schema_version`, beside `gate_type`, `fired_at` and
+# `gate_specific`, and with its verdict/status nested inside `gate_specific`
+# rather than at the top level), so it stays below the line.
+ENVELOPE_FIELDS = {"schema_version", "gate", "gates", "verdict", "status",
+                   "run_at", "timestamp", "messages", "findings", "details"}
+EMITTER = "validation-envelope-write.sh"
 
 failures = []
-concrete = 0
-template = 0
-
-
-def rel(path):
-    return os.path.relpath(path, root)
+checks = 0
 
 
 def bad(msg):
     failures.append(msg)
 
 
-def is_template(node):
-    """True when any string in the block is wholly a <placeholder>.
-
-    Matched anchored, not anywhere in the string. An earlier version of this
-    used a substring search, and the guides example — whose message reads
-    "typically loads <framework>/entities/* guides" — was classed as a
-    template on the strength of that one word. It stopped being checked
-    without saying so, and a deliberately wrong severity planted in it went
-    undetected. A check that quietly narrows is the thing this file exists
-    to prevent, so the rule is anchored: a placeholder stands alone as the
-    whole value, prose that merely contains angle brackets does not count.
-    """
-    if isinstance(node, str):
-        return re.fullmatch(r"<[^<>]*>", node) is not None
-    if isinstance(node, dict):
-        return any(is_template(value) for value in node.values())
-    if isinstance(node, list):
-        return any(is_template(item) for item in node)
-    return False
+def rel(path):
+    return os.path.relpath(path, root)
 
 
-if not os.path.isfile(reference):
-    bad(f"{rel(reference)} not found; the contract it documents cannot be checked")
+# git ls-files, not find: only tracked files are the ones the other repo checks
+# see, and an untracked scratch copy of a command must not be able to fail this.
+listing = subprocess.run(
+    ["git", "ls-files", "commands/*.md"],
+    cwd=root, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+)
+commands = [
+    os.path.join(root, name)
+    for name in listing.stdout.decode("utf-8").split("\n")
+    if name.strip()
+]
+validate_commands = [p for p in commands if os.path.basename(p).startswith("validate-")]
 
 if not commands:
-    bad("no commands/validate-*.md files found")
+    bad("git ls-files found no commands/*.md; nothing was scanned")
+if not validate_commands:
+    bad("git ls-files found no commands/validate-*.md; nothing was scanned")
 
-# ── the JSON blocks ──────────────────────────────────────────────────────────
-#
-# Only blocks that are a top-level object carrying `gate` plus one of the
-# paired verdict names are per-gate envelopes. That deliberately skips the
-# aggregate envelope (`_all.json`, which has a `gates` array instead) and the
-# `details`-only fragments, both of which have a different shape.
-#
-# A block is CONCRETE when no value contains a <placeholder>; those get the
-# full invariant. A block with placeholders is a TEMPLATE and can only be
-# checked for the presence of both names in each pair, since its values are
-# descriptions rather than data.
 
-for path in targets:
-    if not os.path.isfile(path):
-        continue
-    with open(path, encoding="utf-8") as fh:
-        source = fh.read()
+def json_blocks(source):
+    """Every fenced block that parses as JSON, whatever its language tag.
 
-    for block in re.findall(r"^```json\n(.*?)^```", source, re.S | re.M):
+    The tag is a hint to a renderer, not a contract. An envelope hand-typed
+    inside an untagged fence drifts exactly as readily as one inside a ```json
+    fence, and untagged is the majority case here: 109 of the 166 fences in
+    these command files carry no tag at all. Matching only ```json left that
+    majority unscanned.
+
+    A block that does not parse is skipped, and that is the remaining hole:
+    a template using bare `<n>` for a number is not JSON and cannot be read
+    as one. The envelopes this check exists to stop were all valid JSON —
+    their placeholders were quoted strings — so the hole is narrower than it
+    sounds, but it is real.
+    """
+    for block in re.findall(r"^```[A-Za-z0-9_+-]*\n(.*?)^```", source, re.S | re.M):
         try:
             obj = json.loads(block)
         except ValueError:
             continue
-        if not isinstance(obj, dict):
-            continue
-        if "gate" not in obj or not ({"verdict", "status"} & set(obj)):
-            continue
+        yield obj
 
-        where = f"{rel(path)} (gate {obj.get('gate')!r})"
 
-        missing = [key for key in REQUIRED if key not in obj]
-        if missing:
-            bad(f"{where}: envelope omits {', '.join(missing)}")
-
-        if "findings" in obj and not isinstance(obj["findings"], list):
-            bad(f"{where}: findings must be an array, got {type(obj['findings']).__name__}")
-
-        if is_template(obj):
-            template += 1
-            continue
-
-        concrete += 1
-
-        for ours, shared in PAIRS:
-            if obj.get(ours) != obj.get(shared):
-                bad(f"{where}: {ours}={obj.get(ours)!r} but {shared}={obj.get(shared)!r}")
-
-        messages = obj.get("messages")
-        findings = obj.get("findings")
-        if not isinstance(messages, list) or not isinstance(findings, list):
-            continue
-
-        if len(messages) != len(findings):
-            bad(
-                f"{where}: {len(messages)} message(s) but {len(findings)} finding(s); "
-                "they mirror one for one"
-            )
-
-        expected = SEVERITY.get(obj.get("verdict"))
-        for i, (message, finding) in enumerate(zip(messages, findings)):
-            if not isinstance(finding, dict):
-                bad(f"{where}: findings[{i}] is not an object")
-                continue
-            if finding.get("title") != message:
-                bad(f"{where}: findings[{i}].title does not repeat messages[{i}]")
-            if expected and finding.get("severity") != expected:
-                bad(
-                    f"{where}: findings[{i}].severity is {finding.get('severity')!r}, "
-                    f"but verdict {obj.get('verdict')!r} makes it {expected!r}"
-                )
-
-# ── the paired names, textually ──────────────────────────────────────────────
+# ── check 6: no command file hand-types an envelope ─────────────────────────
 #
-# The check above only sees blocks that parse. A template written across two
-# lines, or one carrying a trailing comma, does not, and that is exactly where
-# the playbook-adherence defect lived. So: any validate-* command naming one
-# half of a pair must name the other half somewhere too.
+# An envelope is any top-level object carrying two or more of the envelope's
+# own top-level field names. Keying on `gate`/`gates` was too narrow twice
+# over: it read only ```json fences, and it let a complete envelope through
+# once the `gate` key was deleted from it.
+#
+# What legitimately survives the widened rule, verified against this tree
+# rather than assumed:
+#   - the gate-audit payloads in validate-e2e / -visual-parity /
+#     -visual-regression. A different artifact (references/gate-audit-schema.md,
+#     keyed on `gate_type`, written by scripts/gate-audit-write.sh). Their
+#     verdict/status live inside `gate_specific`, so at the top level they
+#     carry one envelope field, `schema_version`.
+#   - the `"details": {...}` fragments, which are not standalone objects and
+#     do not parse as JSON at all.
+# Counting only TOP-LEVEL keys is what separates the two: nesting a verdict
+# under `gate_specific` is what makes a gate-audit payload not an envelope.
 
 for path in commands:
     with open(path, encoding="utf-8") as fh:
         source = fh.read()
-    for ours, shared in PAIRS + (("messages", "findings"),):
-        if f'"{ours}"' in source and f'"{shared}"' not in source:
+    checks += 1
+    for obj in json_blocks(source):
+        if not isinstance(obj, dict):
+            continue
+        present = ENVELOPE_FIELDS & set(obj)
+        if len(present) >= 2:
             bad(
-                f"{rel(path)}: names \"{ours}\" but never \"{shared}\". "
-                "Every envelope carries both halves of the pair."
+                "%s hand-types a result envelope (top-level envelope fields: %s). "
+                "Call %s instead — a copy of the envelope is a copy that can drift."
+                % (rel(path), ", ".join(sorted(present)), EMITTER)
             )
 
-# ── report ───────────────────────────────────────────────────────────────────
+# ── check 7: a command that persists an envelope calls the emitter ──────────
 
-checked = concrete + template
-print(f"envelope blocks checked: {checked} ({concrete} concrete, {template} template)")
+for path in validate_commands:
+    with open(path, encoding="utf-8") as fh:
+        source = fh.read()
+    if "validations/latest/" not in source:
+        continue
+    checks += 1
+    if EMITTER not in source:
+        bad(
+            "%s persists an envelope to validations/latest/ but never names %s"
+            % (rel(path), EMITTER)
+        )
 
-if checked == 0:
-    print("FAIL: no envelope blocks were found. Nothing was checked, so nothing passed.")
-    print("      Either the docs moved or the block format changed; this spec is stale.")
-    sys.exit(1)
+# ── check 8: every persisted gate is a gate the emitter knows ───────────────
 
-if concrete == 0:
-    print("FAIL: no concrete envelope example was found.")
-    print("      Templates alone only prove the field names exist, never that")
-    print("      the values agree, so a run of only templates is not a pass.")
-    sys.exit(1)
+emitter_path = os.path.join(root, "scripts", EMITTER)
+with open(emitter_path, encoding="utf-8") as fh:
+    emitter_source = fh.read()
+match = re.search(r'^KNOWN_GATES="([^"]*)"', emitter_source, re.M)
+if not match:
+    bad("could not read KNOWN_GATES out of scripts/%s" % EMITTER)
+    known_gates = set()
+else:
+    known_gates = set(match.group(1).split())
+    checks += 1
 
+persisted = set()
+for path in validate_commands:
+    with open(path, encoding="utf-8") as fh:
+        source = fh.read()
+    for name in re.findall(r"validations/latest/([a-z0-9-]+)\.json", source):
+        persisted.add(name)
+
+for name in sorted(persisted):
+    checks += 1
+    if name not in known_gates:
+        bad(
+            "commands persist validations/latest/%s.json but %r is not in "
+            "KNOWN_GATES in scripts/%s, so the emitter would refuse it"
+            % (name, name, EMITTER)
+        )
+
+if not persisted:
+    bad("no validations/latest/<gate>.json target found in any validate-* command")
+
+# ── check 9: the reference doc's own examples satisfy the invariants ────────
+
+reference = os.path.join(root, "references", "validation-gate-result.md")
+if not os.path.isfile(reference):
+    bad("references/validation-gate-result.md not found")
+else:
+    with open(reference, encoding="utf-8") as fh:
+        source = fh.read()
+
+    # A placeholder stands alone as a whole value. Prose that merely contains
+    # angle brackets — "typically loads <framework>/entities/* guides" — is
+    # data, not a template, and stays checked.
+    def is_template(node):
+        if isinstance(node, str):
+            return re.fullmatch(r"<[^<>]*>", node) is not None
+        if isinstance(node, dict):
+            return any(is_template(v) for v in node.values())
+        if isinstance(node, list):
+            return any(is_template(i) for i in node)
+        return False
+
+    def check_pairs(obj, where):
+        for ours, shared in PAIRS:
+            if obj.get(ours) != obj.get(shared):
+                bad("%s: %s=%r but %s=%r" % (where, ours, obj.get(ours), shared, obj.get(shared)))
+
+    concrete = 0
+    aggregates = 0
+    for obj in json_blocks(source):
+        if not isinstance(obj, dict):
+            continue
+
+        # The aggregate is selected on `gates`, the per-gate envelope on
+        # `gate`. Selecting on `gate` alone is how the aggregate example went
+        # unchecked while its summary claimed 7 gates over a list of 3.
+        is_aggregate = "gates" in obj
+        if not is_aggregate and "gate" not in obj:
+            continue
+        if not ({"verdict", "status"} & set(obj)):
+            continue
+
+        if is_template(obj):
+            continue
+
+        if is_aggregate:
+            where = "references/validation-gate-result.md (aggregate)"
+
+            missing = [key for key in REQUIRED_AGGREGATE if key not in obj]
+            if missing:
+                bad("%s: aggregate omits %s" % (where, ", ".join(missing)))
+
+            gates = obj.get("gates")
+            if not isinstance(gates, list):
+                bad("%s: gates must be an array" % where)
+                continue
+
+            aggregates += 1
+            checks += 1
+
+            check_pairs(obj, where)
+
+            verdicts = [g.get("verdict") for g in gates if isinstance(g, dict)]
+            if len(verdicts) != len(gates):
+                bad("%s: every gates[] entry must be an object with a verdict" % where)
+                continue
+            unknown = [v for v in verdicts if v not in RANK]
+            if unknown:
+                bad("%s: gates[] carries unknown verdict(s) %s" % (where, unknown))
+                continue
+
+            # Every derived field re-derived from gates[], the way the emitter
+            # derives it. This is the assertion the old check could not make.
+            for i, gate in enumerate(gates):
+                if gate.get("status") != gate.get("verdict"):
+                    bad("%s: gates[%d] (%r) has verdict=%r but status=%r"
+                        % (where, i, gate.get("gate"), gate.get("verdict"), gate.get("status")))
+
+            expected_status = ("skipped" if not verdicts
+                               else max(verdicts, key=lambda v: RANK[v]))
+            if obj.get("status") != expected_status:
+                bad("%s: status is %r, but the worst of %d gate verdict(s) is %r"
+                    % (where, obj.get("status"), len(verdicts), expected_status))
+
+            expected_summary = {
+                "pass": verdicts.count("pass"),
+                "warning": verdicts.count("warning"),
+                "fail": verdicts.count("fail"),
+                "skipped": verdicts.count("skipped"),
+                "total": len(verdicts),
+            }
+            summary = obj.get("summary")
+            if not isinstance(summary, dict):
+                bad("%s: summary must be an object" % where)
+            elif summary != expected_summary:
+                bad("%s: summary is %r, but gates[] holds %r"
+                    % (where, summary, expected_summary))
+
+            expected_messages = [
+                "%s: %s" % (g.get("gate"), m)
+                for g in gates for m in (g.get("messages") or [])
+            ]
+            expected_findings = [
+                {"severity": SEVERITY[g["verdict"]], "title": "%s: %s" % (g.get("gate"), m)}
+                for g in gates for m in (g.get("messages") or [])
+            ]
+            if obj.get("messages") != expected_messages:
+                bad("%s: messages is %r, but gates[] yields %r"
+                    % (where, obj.get("messages"), expected_messages))
+            if obj.get("findings") != expected_findings:
+                bad("%s: findings is %r, but gates[] yields %r"
+                    % (where, obj.get("findings"), expected_findings))
+            continue
+
+        where = "references/validation-gate-result.md (gate %r)" % obj.get("gate")
+
+        missing = [key for key in REQUIRED if key not in obj]
+        if missing:
+            bad("%s: envelope omits %s" % (where, ", ".join(missing)))
+
+        concrete += 1
+        checks += 1
+
+        check_pairs(obj, where)
+
+        messages = obj.get("messages")
+        findings = obj.get("findings")
+        if not isinstance(findings, list):
+            bad("%s: findings must be an array" % where)
+            continue
+        if not isinstance(messages, list):
+            continue
+        if len(messages) != len(findings):
+            bad("%s: %d message(s) but %d finding(s); they mirror one for one"
+                % (where, len(messages), len(findings)))
+        expected = SEVERITY.get(obj.get("verdict"))
+        for i, (message, finding) in enumerate(zip(messages, findings)):
+            if not isinstance(finding, dict):
+                bad("%s: findings[%d] is not an object" % (where, i))
+                continue
+            if finding.get("title") != message:
+                bad("%s: findings[%d].title does not repeat messages[%d]" % (where, i, i))
+            if expected and finding.get("severity") != expected:
+                bad("%s: findings[%d].severity is %r, but verdict %r makes it %r"
+                    % (where, i, finding.get("severity"), obj.get("verdict"), expected))
+
+    if concrete == 0:
+        bad("references/validation-gate-result.md has no concrete envelope example left "
+            "to check; templates alone never prove the values agree")
+    if aggregates == 0:
+        bad("references/validation-gate-result.md has no concrete aggregate example left "
+            "to check; the aggregate is the one shape /validate:all emits")
+
+print("static checks run: %d over %d command file(s)" % (checks, len(commands)))
 for failure in failures:
-    print(f"FAIL: {failure}")
-
-if failures:
-    print(f"{len(failures)} violation(s) of references/validation-gate-result.md §7")
-    sys.exit(1)
-
-print("PASS: status/verdict, timestamp/run_at and findings/messages agree in every block")
-sys.exit(0)
+    print("FAIL: %s" % failure)
+sys.exit(1 if failures else 0)
 PY
+
+STATIC_RC=$?
+
+if [ "$STATIC_RC" -eq 0 ]; then
+  ok
+else
+  FAILED=$((FAILED + 1))
+fi
+
+# ── report ──────────────────────────────────────────────────────────────────
+
+TOTAL=$((PASSED + FAILED))
+echo "tests: ${TOTAL} run, ${PASSED} passed, ${FAILED} failed"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "FAIL: nothing was checked, so nothing passed."
+  exit 1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "${FAILED} violation(s) of references/validation-gate-result.md §7"
+  exit 1
+fi
+
+echo "PASS: the emitter derives status, timestamp and findings so they cannot"
+echo "      disagree, and no command file hand-types an envelope."
+exit 0

--- a/ai-dev-assistant/tests/validation-envelope-contract-spec.sh
+++ b/ai-dev-assistant/tests/validation-envelope-contract-spec.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Doc-contract spec for the validation gate result envelope.
+#
+# references/validation-gate-result.md §7 promises, of every envelope:
+#   status == verdict, timestamp == run_at, and findings[] mirroring
+#   messages[] one for one, severity derived from the verdict
+#   (fail -> HIGH, warning -> MEDIUM, pass and skipped -> INFO), findings
+#   always an array.
+#
+# WHAT THIS CAN AND CANNOT PROVE, stated plainly because the difference is
+# the whole point:
+#
+# There is no emitter to test. Nothing in this plugin builds the envelope in
+# code. `scripts/gate-audit-write.sh` writes a different artifact
+# (`_<gate>.json`, the gate-audit schema) and takes an already-built payload.
+# `scripts/wo-review-snapshot.sh` only copies envelopes that already exist.
+# `scripts/validate-e2e.sh` emits the gate-audit shape and carries `verdict`
+# with no `status` at all. The envelope itself is assembled by the model
+# following prose in `commands/validate-*.md`, which the reference doc says
+# outright: "Owner: commands/validate-*.md".
+#
+# So the thing a test can reach is not the envelope but the TEMPLATE the
+# model copies. That is what this checks, and it is not nothing: the
+# templates are the closest thing to an emitter that exists, and this spec
+# was written after finding `validate-playbook-adherence.md` carrying
+# `"verdict"` twice where the second should have been `"status"` — the v1.1
+# cross-plugin rename applied to the duplicated line but not to its key, so
+# that gate's envelope had no `status` at all.
+#
+# What stays unenforced: whether a run actually produces what the template
+# describes. Closing that needs one deterministic emitter the commands call,
+# which is a bigger change than adding this spec.
+#
+# Exit: 0 = every checked block satisfies the contract; 1 = a violation, or
+# nothing was checked.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$HERE")"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FAIL: python3 is required to parse the JSON blocks out of the markdown."
+  echo "      Skipping would report a pass without checking anything."
+  exit 1
+fi
+
+python3 - "$ROOT" <<'PY'
+import glob
+import json
+import os
+import re
+import sys
+
+root = sys.argv[1]
+
+SEVERITY = {"fail": "HIGH", "warning": "MEDIUM", "pass": "INFO", "skipped": "INFO"}
+PAIRS = (("verdict", "status"), ("run_at", "timestamp"))
+REQUIRED = ("verdict", "status", "run_at", "timestamp", "messages", "findings")
+
+reference = os.path.join(root, "references", "validation-gate-result.md")
+commands = sorted(glob.glob(os.path.join(root, "commands", "validate-*.md")))
+targets = [reference] + commands
+
+failures = []
+concrete = 0
+template = 0
+
+
+def rel(path):
+    return os.path.relpath(path, root)
+
+
+def bad(msg):
+    failures.append(msg)
+
+
+def is_template(node):
+    """True when any string in the block is wholly a <placeholder>.
+
+    Matched anchored, not anywhere in the string. An earlier version of this
+    used a substring search, and the guides example — whose message reads
+    "typically loads <framework>/entities/* guides" — was classed as a
+    template on the strength of that one word. It stopped being checked
+    without saying so, and a deliberately wrong severity planted in it went
+    undetected. A check that quietly narrows is the thing this file exists
+    to prevent, so the rule is anchored: a placeholder stands alone as the
+    whole value, prose that merely contains angle brackets does not count.
+    """
+    if isinstance(node, str):
+        return re.fullmatch(r"<[^<>]*>", node) is not None
+    if isinstance(node, dict):
+        return any(is_template(value) for value in node.values())
+    if isinstance(node, list):
+        return any(is_template(item) for item in node)
+    return False
+
+
+if not os.path.isfile(reference):
+    bad(f"{rel(reference)} not found; the contract it documents cannot be checked")
+
+if not commands:
+    bad("no commands/validate-*.md files found")
+
+# ── the JSON blocks ──────────────────────────────────────────────────────────
+#
+# Only blocks that are a top-level object carrying `gate` plus one of the
+# paired verdict names are per-gate envelopes. That deliberately skips the
+# aggregate envelope (`_all.json`, which has a `gates` array instead) and the
+# `details`-only fragments, both of which have a different shape.
+#
+# A block is CONCRETE when no value contains a <placeholder>; those get the
+# full invariant. A block with placeholders is a TEMPLATE and can only be
+# checked for the presence of both names in each pair, since its values are
+# descriptions rather than data.
+
+for path in targets:
+    if not os.path.isfile(path):
+        continue
+    with open(path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    for block in re.findall(r"^```json\n(.*?)^```", source, re.S | re.M):
+        try:
+            obj = json.loads(block)
+        except ValueError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if "gate" not in obj or not ({"verdict", "status"} & set(obj)):
+            continue
+
+        where = f"{rel(path)} (gate {obj.get('gate')!r})"
+
+        missing = [key for key in REQUIRED if key not in obj]
+        if missing:
+            bad(f"{where}: envelope omits {', '.join(missing)}")
+
+        if "findings" in obj and not isinstance(obj["findings"], list):
+            bad(f"{where}: findings must be an array, got {type(obj['findings']).__name__}")
+
+        if is_template(obj):
+            template += 1
+            continue
+
+        concrete += 1
+
+        for ours, shared in PAIRS:
+            if obj.get(ours) != obj.get(shared):
+                bad(f"{where}: {ours}={obj.get(ours)!r} but {shared}={obj.get(shared)!r}")
+
+        messages = obj.get("messages")
+        findings = obj.get("findings")
+        if not isinstance(messages, list) or not isinstance(findings, list):
+            continue
+
+        if len(messages) != len(findings):
+            bad(
+                f"{where}: {len(messages)} message(s) but {len(findings)} finding(s); "
+                "they mirror one for one"
+            )
+
+        expected = SEVERITY.get(obj.get("verdict"))
+        for i, (message, finding) in enumerate(zip(messages, findings)):
+            if not isinstance(finding, dict):
+                bad(f"{where}: findings[{i}] is not an object")
+                continue
+            if finding.get("title") != message:
+                bad(f"{where}: findings[{i}].title does not repeat messages[{i}]")
+            if expected and finding.get("severity") != expected:
+                bad(
+                    f"{where}: findings[{i}].severity is {finding.get('severity')!r}, "
+                    f"but verdict {obj.get('verdict')!r} makes it {expected!r}"
+                )
+
+# ── the paired names, textually ──────────────────────────────────────────────
+#
+# The check above only sees blocks that parse. A template written across two
+# lines, or one carrying a trailing comma, does not, and that is exactly where
+# the playbook-adherence defect lived. So: any validate-* command naming one
+# half of a pair must name the other half somewhere too.
+
+for path in commands:
+    with open(path, encoding="utf-8") as fh:
+        source = fh.read()
+    for ours, shared in PAIRS + (("messages", "findings"),):
+        if f'"{ours}"' in source and f'"{shared}"' not in source:
+            bad(
+                f"{rel(path)}: names \"{ours}\" but never \"{shared}\". "
+                "Every envelope carries both halves of the pair."
+            )
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+checked = concrete + template
+print(f"envelope blocks checked: {checked} ({concrete} concrete, {template} template)")
+
+if checked == 0:
+    print("FAIL: no envelope blocks were found. Nothing was checked, so nothing passed.")
+    print("      Either the docs moved or the block format changed; this spec is stale.")
+    sys.exit(1)
+
+if concrete == 0:
+    print("FAIL: no concrete envelope example was found.")
+    print("      Templates alone only prove the field names exist, never that")
+    print("      the values agree, so a run of only templates is not a pass.")
+    sys.exit(1)
+
+for failure in failures:
+    print(f"FAIL: {failure}")
+
+if failures:
+    print(f"{len(failures)} violation(s) of references/validation-gate-result.md §7")
+    sys.exit(1)
+
+print("PASS: status/verdict, timestamp/run_at and findings/messages agree in every block")
+sys.exit(0)
+PY

--- a/code-paper-test/.claude-plugin/plugin.json
+++ b/code-paper-test/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-paper-test",
   "description": "Systematic testing through mental execution - trace code, skills, commands, and configs line-by-line with concrete values to find bugs, missing logic, edge cases, and AI hallucinations",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": {
     "name": "camoa"
   },

--- a/code-paper-test/CHANGELOG.md
+++ b/code-paper-test/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the code-paper-test plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-08-13
+
+### Changed
+- `/test-team` now names the files it leaves beside the code under test: `paper-test-team-report.md`, the three per-tester analysis files it does not clean up, and a matching `.json` for each when `--json` is passed. Writing beside the traced file predates `OUTPUTS.md`, which records it as the one plugin that does not put results in a report directory.
+
 ## [0.11.1] - 2026-07-13
 
 ### Changed — docs

--- a/code-paper-test/commands/test-team.md
+++ b/code-paper-test/commands/test-team.md
@@ -540,6 +540,17 @@ Output: {"continue": false}
 
 ---
 
+## Output
+
+Writes into `{target_dir}`, the directory holding the code under test:
+
+- `paper-test-team-report.md` — the synthesized report, always
+- `paper-test-team-report.json` — the same result structured, when `--json` is passed
+- `happy-path-analysis.md`, `edge-case-analysis.md`, `red-team-analysis.md` — one per tester, left in place rather than cleaned up
+- a matching `.json` beside each of those three, when `--json` is passed
+
+Writing beside the traced file predates `OUTPUTS.md` and is noted there as the one plugin that does not follow rule 2.
+
 ## Output Format
 
 The Synthesizer (Teammate 4) synthesizes into `{target_dir}/paper-test-team-report.md`:

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.8] - 2026-08-13
+
+### Changed
+
+- `/architecture-debate`, `/security-debate` and `/setup` now document what they write and where. The two debate commands name the report directory the run resolves rather than `.reports/`, which stopped being the default in 3.9.6, and list the per-teammate analysis files they leave beside the synthesis. `/setup` names everything it puts in your project, including the git hooks and CI workflows you have to accept first, and the baseline audit it leaves in the resolved report directory.
+
 ## [3.9.7] - 2026-08-11
 
 ### Changed

--- a/code-quality-tools/commands/architecture-debate.md
+++ b/code-quality-tools/commands/architecture-debate.md
@@ -328,6 +328,13 @@ Mark your task as completed.
 
 ---
 
+## Output
+
+Writes into `{report_dir}`, the audit report directory this run resolves:
+
+- `architecture-debate.md` — the lead's synthesis
+- `pragmatist-analysis.md`, `purist-analysis.md`, `maintainer-analysis.md` — one per teammate, left in place as the evidence behind the synthesis
+
 ## Output Format
 
 The lead synthesizes into `{report_dir}/architecture-debate.md`:

--- a/code-quality-tools/commands/security-debate.md
+++ b/code-quality-tools/commands/security-debate.md
@@ -311,6 +311,16 @@ Mark your task as completed.
 
 ---
 
+## Output
+
+Writes into `{report_dir}`, the directory holding the `security-report.json` this run debates:
+
+- `security-debate.md` — the lead's synthesis
+- `defender-analysis.md`, `red-team-analysis.md`, `compliance-analysis.md` — one per teammate, left in place as the evidence behind the synthesis
+- `security-context.md` — the dev-guides content fetched for this run, saved so the teammates can read it. `OUTPUTS.md` notes this as a write no rule covers: fetched guide content otherwise belongs in the navigator's shared store.
+
+It does not modify `security-report.json`.
+
 ## Output Format
 
 The lead synthesizes into `{report_dir}/security-debate.md`:

--- a/code-quality-tools/commands/setup.md
+++ b/code-quality-tools/commands/setup.md
@@ -257,7 +257,17 @@ After installation, runs initial audit to establish baseline:
 
 Baseline saved to `$REPORT_DIR/baseline.json`, where `$REPORT_DIR` is what the scripts resolve and announce on start. There is no report-directory key in `.code-quality.json`: the location is decided by `scripts/core/report-dir.sh` and overridden with the `REPORT_DIR` environment variable, or with `REPORT_DIR_IN_REPO=1` to opt back in to an in-repo `.reports/`. It is out of the repository by default because reports quote audited source and name the files a secret scanner matched in.
 
-## Output & Next Steps
+## Output
+
+This one changes the project rather than reporting on it, all of it at the project root and all of it on your confirmation:
+
+- `.code-quality.json` — the configuration it generates, always.
+- `composer.json` / `package.json` and their lock files and installed trees, from the tool installs.
+- `grumphp.yml` (Drupal) or `.husky/pre-commit` (Next.js), plus the git hooks themselves under `.git/hooks/`, only if you accept the hooks prompt. It defaults to no and never installs them silently.
+- `.github/workflows/quality.yml` and `.github/workflows/quality-pr.yml`, each opt-in and independent of the other.
+- The baseline audit it runs at the end leaves that run's reports and `baseline.json` in the resolved report directory, the same place `/code-quality-tools:audit` writes. That is outside the repository by default; `scripts/core/report-dir.sh` decides and announces it.
+
+It installs nothing outside the project. The optional `security-guidance` plugin is a suggestion the wizard prints for you to run yourself, not something it installs.
 
 ```
 ✅ Setup Complete!

--- a/drupal-dev-framework/.claude-plugin/plugin.json
+++ b/drupal-dev-framework/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-dev-framework",
   "description": "DEPRECATED — renamed to ai-dev-assistant. This shell remains installable only to run a one-time upgrade: it repoints your project store at the new plugin and re-stamps per-project session-remembrance hooks to the new paths, then is safe to uninstall. Install ai-dev-assistant going forward.",
-  "version": "4.24.1",
+  "version": "4.24.2",
   "author": {
     "name": "camoa"
   },

--- a/drupal-dev-framework/CHANGELOG.md
+++ b/drupal-dev-framework/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this plugin are documented here.
 
+## [4.24.2] - 2026-08-13 - Output section on the upgrade command
+
+`/upgrade` now names everything it changes before you run it: the move of
+`~/.claude/drupal-dev-framework/` to `~/.claude/ai-dev-assistant/`, the same
+move inside every registered project, the two hook command strings it rewrites
+in each project's `settings.json`, and the `Skill(...)` tokens it touches only
+with `--permissions`. It writes no report and keeps no backup copy, so that
+list is worth reading first; `--dry-run` prints it and writes nothing. Every
+other `/drupal-dev-framework:*` command is a symlink to this file, so the
+section covers all of them.
+
 ## [4.24.1] — Deprecation-notice docs tightening
 
 Tightened the deprecation-notice README (problem-first, no em dashes). Positioning pass.

--- a/drupal-dev-framework/commands/upgrade.md
+++ b/drupal-dev-framework/commands/upgrade.md
@@ -74,6 +74,30 @@ Tell the user:
 - **This plugin is now safe to uninstall.** Use `ai-dev-assistant` going forward
   (`/ai-dev-assistant:next` to resume work).
 
+## Output
+
+This command changes your machine, not a report. Every other
+`/drupal-dev-framework:*` command is a symlink to this file, so this is what
+all of them do.
+
+`--dry-run` writes nothing at all and prints the same list of changes. The
+real run, after your confirmation:
+
+- **Outside any project** — moves the directory `~/.claude/drupal-dev-framework/`
+  to `~/.claude/ai-dev-assistant/`, carrying the project registry, sessions and
+  logs with it.
+- **In each registered project** — moves `<project>/.claude/drupal-dev-framework/`
+  to `<project>/.claude/ai-dev-assistant/`, and rewrites the two hook command
+  strings inside `<project>/.claude/settings.json` in place.
+- **Only with `--permissions`** — rewrites `Skill(drupal-dev-framework:*)` tokens
+  to `Skill(ai-dev-assistant:*)` inside each project's `settings.local.json` and
+  `settings.json`.
+
+It writes no report and leaves no backup copy. Every JSON file is validated
+before it is saved, and one that would come out invalid is left untouched. A
+directory that has already been migrated is flagged rather than overwritten,
+which is what makes a second run a no-op.
+
 ## Notes
 
 - The script reads the registry from the old store first, falling back to the

--- a/drupal-htmx/.claude-plugin/plugin.json
+++ b/drupal-htmx/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-htmx",
   "description": "HTMX development guidance and AJAX-to-HTMX migration tools for Drupal 11.3+. Includes analyzers, pattern recommendations, and validation.",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "author": {
     "name": "camoa"
   },

--- a/drupal-htmx/CHANGELOG.md
+++ b/drupal-htmx/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.3] - 2026-08-13
+
+### Changed
+
+- `/htmx-analyze`, `/htmx-pattern` and `/htmx-validate` now state up front that they print their report to the terminal and write no files. The section they carried was headed `Expected Output` and described the shape of the printed report, which is a different question from what lands on disk.
+
 ## [1.6.2] - 2026-08-11
 
 ### Changed

--- a/drupal-htmx/commands/htmx-analyze.md
+++ b/drupal-htmx/commands/htmx-analyze.md
@@ -44,7 +44,9 @@ Use the Task tool to invoke the ajax-analyzer agent:
 - prompt: "Analyze [module-path] for AJAX patterns and generate migration report"
 ```
 
-## Expected Output
+## Output
+
+Prints the analysis report below to the terminal. Writes no files.
 
 ```markdown
 ## AJAX Analysis Report: my_module

--- a/drupal-htmx/commands/htmx-pattern.md
+++ b/drupal-htmx/commands/htmx-pattern.md
@@ -52,7 +52,9 @@ Use the Task tool to invoke the htmx-recommender agent:
 - prompt: "Recommend HTMX pattern for: [use-case]"
 ```
 
-## Expected Output
+## Output
+
+Prints the pattern recommendation below to the terminal. Writes no files.
 
 ```markdown
 ## Recommended Pattern: Dependent Dropdown

--- a/drupal-htmx/commands/htmx-validate.md
+++ b/drupal-htmx/commands/htmx-validate.md
@@ -45,7 +45,9 @@ Use the Task tool to invoke the htmx-validator agent:
 - prompt: "Validate HTMX implementation in [module-path]"
 ```
 
-## Expected Output
+## Output
+
+Prints the validation report below to the terminal. Writes no files.
 
 ```markdown
 ## HTMX Validation Report: my_module

--- a/plugin-creation-tools/.claude-plugin/plugin.json
+++ b/plugin-creation-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-creation-tools",
   "description": "Authoring toolkit and quality gate for Claude Code plugins. Scaffolds and audits every component — skills, commands, agents, hooks, MCP servers, themes, dependencies, userConfig, and Routines — with a deterministic `validate` command (opt-in auto-fix), a pre-publish containment scan that catches leaked home paths and secrets, and the `plugin-creation` authoring skill. Tracks the current plugin spec: hook handler types and pre-spawn filters, exec-form args, JSON output controls, subfolder agent scoping, single-skill auto-discovery, and cross-marketplace dependencies.",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "author": {
     "name": "camoa"
   },

--- a/plugin-creation-tools/CHANGELOG.md
+++ b/plugin-creation-tools/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.1] - 2026-08-13
+
+### Changed
+
+- `/validate` now documents what it writes. Without `--fix` it writes nothing. With `--fix` it edits the plugin files it migrates in place and appends one line per applied migration to `.claude-plugin/.validate-fixes.log` in the plugin being validated; `--fix --dry-run` reports the same migrations and writes nothing.
+- The two commands in the `full-featured-plugin` example gained the same section, since that example is what someone copies when writing their own.
+
 ## [3.12.0] - 2026-08-11
 
 ### Changed

--- a/plugin-creation-tools/commands/validate.md
+++ b/plugin-creation-tools/commands/validate.md
@@ -520,7 +520,11 @@ A plugin may ship a `<plugin>/.containment-allow` file (one ERE per line, `#` co
 - [ ] Skill descriptions preserve `PROACTIVELY`, `MUST`, and `NEVER` imperatives from prior versions when present (do not auto-strip)
 - [ ] Skill descriptions preserve `` !`command` `` dynamic-context injections when present (these are a documented Claude Code feature — do not treat as noise)
 
-## Output Format
+## Output
+
+Without `--fix`, prints the report below and writes nothing.
+
+With `--fix`, it also edits the plugin files it migrates, in place and atomically (tempfile then rename), and appends one line per applied migration to `.claude-plugin/.validate-fixes.log` in the plugin being validated. `--fix --dry-run` reports the same migrations and writes nothing.
 
 ```
 ## Plugin Validation: {name} v{version}

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/review.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/review.md
@@ -26,7 +26,9 @@ If no file specified:
 2. Review each changed file
 3. Report findings per file
 
-## Output Format
+## Output
+
+Prints the review below to the terminal. Writes no files.
 
 ```
 ## File: [filename]

--- a/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/status.md
+++ b/plugin-creation-tools/skills/plugin-creation/examples/full-featured-plugin/commands/status.md
@@ -14,7 +14,9 @@ Provide a comprehensive status report for the current project.
 3. Check for TODO comments in code: `grep -r "TODO" --include="*.py" --include="*.js" --include="*.ts" .`
 4. Summarize findings in a clear format
 
-## Output Format
+## Output
+
+Prints the status report below to the terminal. Writes no files.
 
 ```
 ## Git Status

--- a/plugin-creation-tools/skills/plugin-creation/templates/remembrance-hooks/install-remembrance-hook.md.template
+++ b/plugin-creation-tools/skills/plugin-creation/templates/remembrance-hooks/install-remembrance-hook.md.template
@@ -86,7 +86,7 @@ Substitute the placeholders:
 | Placeholder | Value |
 |-------------|-------|
 | `{plugin_name}` | `{plugin-name}` |
-| `{generated_date}` | today's date (`date -I`) |
+| `{generated_date}` | today's UTC date (`date -u +%Y-%m-%d`) |
 | `{project_name}` | confirmed project name |
 | `{state_path}` | confirmed plugin state path |
 | `{resume_hint}` | a one-line "how to resume" instruction for your plugin |

--- a/scripts/check-outputs.sh
+++ b/scripts/check-outputs.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Checks that every command file says what it writes and where.
+#
+# OUTPUTS.md and CLAUDE.md both state the rule: every command carries an
+# "## Output" section naming what it leaves behind, and a command that writes
+# nothing says so. Until this script there was nothing holding anyone to it,
+# so the rule was a sentence in a document rather than a property of the repo.
+#
+# The rule enforced here, stated exactly:
+#
+#   Every git-tracked file matching */commands/*.md contains a line that is
+#   exactly "## Output", outside any fenced code block, followed by at least
+#   one non-blank line before the next "## " heading or the end of the file.
+#
+# Exact heading, not a prefix. "## Output Format" is a different section: it
+# shows the shape of a printed report, which is not the same question as what
+# the command leaves on disk. Eleven files had "## Output Format" and no
+# "## Output", and one of them (migrate-tasks) moves task folders around on
+# disk while documenting only its terminal output. Accepting the prefix would
+# have passed all eleven, which is the failure this check exists to prevent.
+# Three drupal-htmx files spelled it "## Expected Output"; those were
+# normalised to the one spelling rather than accepted as a second one, so
+# there is a single string to grep for.
+#
+# Outside a code fence, because command files quote their own printed reports
+# in fenced blocks and those quoted reports contain h2 headings. A "## Output"
+# inside a fence is an example of what the command prints, not the section
+# this rule asks for, and counting it would be a false pass.
+#
+# The non-blank-body requirement is there because a bare heading satisfies the
+# letter of the rule while telling a reader nothing.
+#
+# There are NO exemptions. Deprecated plugins are not exempt: what a
+# deprecated command does to your filesystem is exactly the thing you want
+# written down before you run it. The 44 symlinked command files in
+# drupal-dev-framework are not exempt either — awk reads through a symlink, so
+# they are satisfied by the section in the file they point at, which is
+# deduplication rather than an exception.
+#
+# Written for bash 3.2 so it behaves the same on macOS and CI.
+
+set -uo pipefail
+
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+HEADING='## Output'
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  IN_GIT=1
+else
+  IN_GIT=0
+fi
+
+LIST=$(mktemp)
+GONE=$(mktemp)
+trap 'rm -f "$LIST" "$GONE"' EXIT
+
+# Mirrors discover() in scripts/lint-shell.sh and scripts/run-tests.sh on
+# purpose. Inside a git work tree the list comes from `git ls-files`, so
+# ignored and untracked paths are excluded by construction: .worktrees/ and
+# .claude/worktrees/ hold whole stale copies of this repo, and a plain `find`
+# would scan those copies too and report their command files as failures.
+# Outside a work tree (an extracted tarball) it falls back to `find` with the
+# same directories pruned.
+#
+# Consequence worth knowing, same as the other two: a brand-new command file
+# is not checked until it is `git add`ed. On CI every file is tracked.
+#
+# Paths are NUL-separated so a name containing a newline survives discovery.
+# `sort -z` is GNU-only, so nothing here pipes through sort.
+#
+# Unreadable paths go to $GONE rather than to stderr, so a warning printed by
+# git itself cannot be mistaken for one.
+discover() {
+  if [ "$IN_GIT" -eq 1 ]; then
+    git ls-files -z
+  else
+    find . \
+      \( -path ./.git -o -path ./.claude -o -path ./.worktrees \) -prune -o \
+      -type f -print0
+  fi | while IFS= read -r -d '' p; do
+    p="${p#./}"
+    case "$p" in
+      */commands/*.md) ;;
+      *) continue ;;
+    esac
+    # `git ls-files` still lists a tracked file deleted from the work tree,
+    # and a symlink can dangle. Either would otherwise be reported as a
+    # missing section, which is a confusing way to say "this file is gone".
+    if [ ! -r "$p" ]; then
+      printf '%s\n' "$p" >> "$GONE"
+      continue
+    fi
+    printf '%s\0' "$p"
+  done
+}
+
+# Classifies one file. Prints exactly one of:
+#   ok
+#   empty
+#   missing <nearest near-miss heading, or "-">
+#
+# One awk pass per file, reading the file directly. Nothing is piped into
+# anything that exits early: under `pipefail` a reader that stops at the first
+# match kills the writer with SIGPIPE and the pipeline reports 141, which
+# surfaces as an intermittent failure on long files only.
+classify() {
+  awk -v want="$HEADING" '
+    # Fence state first, so everything below only ever sees prose. Both ``` and
+    # ~~~ open a fence; an info string may follow the opener.
+    /^[ \t]*(```|~~~)/ { fence = !fence; next }
+    fence { next }
+
+    # The exact heading. Handled before the near-miss rule below so an exact
+    # match can never also register as a near miss.
+    $0 == want { have = 1; insec = 1; next }
+
+    # Any other h2 ends the section being measured.
+    /^## / {
+      if (insec) insec = 0
+      if (near == "" && $0 ~ /^## (Output|Expected[ \t]+Output)/) near = $0
+      next
+    }
+
+    insec && $0 ~ /[^ \t]/ { body = 1 }
+
+    END {
+      if (!have) { print "missing " (near == "" ? "-" : near); exit }
+      if (!body) { print "empty"; exit }
+      print "ok"
+    }
+  ' "$1"
+}
+
+discover > "$LIST"
+
+if [ -s "$GONE" ]; then
+  printf 'outputs: FAILED, a tracked command file cannot be read:\n' >&2
+  sed 's/^/  /' "$GONE" >&2
+  printf 'outputs: a dangling symlink, or tracked but deleted from the work\n' >&2
+  printf 'outputs: tree. Restore it or "git rm" it. A file that is not there\n' >&2
+  printf 'outputs: cannot be checked, and skipping it is not a pass.\n' >&2
+  exit 1
+fi
+
+TOTAL=0
+LINKS=0
+BAD=0
+BADLIST=""
+
+note_bad() {
+  BAD=$((BAD + 1))
+  BADLIST="${BADLIST}  FAIL  ${1}"$'\n'
+  BADLIST="${BADLIST}          ${2}"$'\n'
+}
+
+while IFS= read -r -d '' f; do
+  [ -n "$f" ] || continue
+  TOTAL=$((TOTAL + 1))
+  if [ -L "$f" ]; then
+    LINKS=$((LINKS + 1))
+  fi
+
+  verdict=$(classify "$f")
+  case "$verdict" in
+    ok)
+      ;;
+    empty)
+      note_bad "$f" "has \"${HEADING}\" but nothing under it"
+      ;;
+    "missing -")
+      note_bad "$f" "no \"${HEADING}\" section"
+      ;;
+    missing\ *)
+      note_bad "$f" "has \"${verdict#missing }\", which is not \"${HEADING}\""
+      ;;
+    *)
+      note_bad "$f" "could not be classified (awk said: \"${verdict}\")"
+      ;;
+  esac
+done < "$LIST"
+
+if [ "$TOTAL" -eq 0 ]; then
+  printf 'outputs: FAILED, no command files were found.\n' >&2
+  printf 'outputs: nothing was checked, so nothing passed. This check expects\n' >&2
+  printf 'outputs: tracked files matching */commands/*.md.\n' >&2
+  exit 1
+fi
+
+printf 'outputs: %s command file(s) checked (%s of them symlinks to another command)\n' \
+  "$TOTAL" "$LINKS"
+
+if [ "$BAD" -gt 0 ]; then
+  printf '%s' "$BADLIST" >&2
+  printf 'outputs: %s command file(s) do not say what they write.\n' "$BAD" >&2
+  printf 'outputs: add a "%s" section naming what the command leaves behind\n' "$HEADING" >&2
+  printf 'outputs: and where. If it writes nothing, say so. See OUTPUTS.md.\n' >&2
+  exit 1
+fi
+
+printf 'outputs: every command says what it writes\n'
+exit 0

--- a/scripts/lint-baseline.txt
+++ b/scripts/lint-baseline.txt
@@ -2,7 +2,6 @@
 ai-dev-assistant/hooks/phase-command-bypass.sh:SC2221
 ai-dev-assistant/hooks/phase-command-bypass.sh:SC2222
 ai-dev-assistant/scripts/dev-guides-detect.sh:SC2034
-ai-dev-assistant/scripts/migrate-to-epic.sh:SC2115
 ai-dev-assistant/scripts/playbook-read.sh:SC2034
 ai-dev-assistant/scripts/visual-parity-gate.sh:SC2034
 ai-dev-assistant/scripts/wo-parallel-batch.sh:SC2034


### PR DESCRIPTION
The last three pull requests wrote down two rules and enforced neither. This adds the checks, and
corrects the document that turned out to describe a marketplace that does not exist.

**Look at `OUTPUTS.md` first.** It was wrong about every plugin it described, and one of its three
rules named a path nothing writes to. It now has six rules because reality has six, a section on
how a report directory is actually resolved since `.reports/` stopped being the default in 3.9.6,
and a section recording four writes that fit no rule at all.

`make outputs` fails on any command without a section saying what it writes. There are no
exemptions, deprecated commands included, since what a command does to your filesystem is what you
want written down before you run it. 22 commands did not have one.

A new spec checks the JSON templates in the `validate-*` commands. No code builds those result
envelopes, so the shared field names are eleven hand-typed chances to get it wrong, and three had
already drifted. It found a real one: the playbook-adherence gate emitted `verdict` twice where the
second should have been `status`, so anything reading `status` from that gate got nothing.

**What is risky.** The new check proves a section exists, not that it is true. This branch is the
evidence for that distinction: every plugin carried a section while the page describing them was
wrong about all of them. The envelope spec has the same limit, one level down. It checks the
templates a model copies, never what the model actually writes. Closing that needs a script that
derives the second field set from the first, which is a larger change than this one.

**What is deliberately untouched.** Four writes now recorded rather than fixed: a report directory
appended to the audited repository's `.gitignore`, fetched guide content parked in a report
directory, a ledger written by a session hook in projects where the plugin was never run, and decks
uploaded to Google Drive with the previous render folder trashed by default. Each is a behaviour
decision, not a documentation fix.

Six patch bumps for the plugins whose command files changed.

To verify: `make ci` from a clean checkout with gitleaks and shellcheck installed. Expect five
checks green and 76 tests.
