### PR TITLE
Fix the two defects round 4 exposed: a name that read as no-frameworks, and research offered before scope

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.27.0",
+      "version": "5.27.1",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.27.0",
+  "version": "5.27.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [5.27.1] - 2026-08-24
+
+### Fixed
+- `project-state-read.sh` given a project name returned an answer that looked legitimate and was
+  wrong. It takes a folder path; a name fell through to `folder_missing` with every field at its
+  empty default, so `frameworks` came back `[]` — indistinguishable from a project that genuinely
+  declares no frameworks. The recipe-adoption sweep is guarded on exactly that field, and a caller
+  reading `frameworks` without also reading `warnings` would have skipped the sweep silently. Seen
+  live on a real project setup, caught only because the operator found `[]` suspicious. A bare name
+  is now resolved through the registry, with a `resolved_from_registry` warning; an unregistered name
+  still misses loudly, and an explicit path is never redirected by a registry entry of the same name.
+- A finished project setup offered to start the first task at research. A task with no folder starts
+  at Phase 0 scope, where the four-field contract Phase 4 checks against gets written; `/research` on
+  a new task stops and authors that contract anyway, so offering research first either detours
+  through scope or reads as though scope were optional. The rule was written down nowhere — the
+  skill's closing line said only "run `/next`" — so the session filled the gap with its own wording.
+  `project-initializer` step 10(c) now names `/scope`, states the phase, and offers the candidate
+  tasks without creating them. `tests/project-initializer-handoff-contract-spec.sh` holds the line.
+- `references/recipe-adoption-sweep.md` still described itself as `/upgrade-project` step 4b after
+  5.27.0 gave it a second caller at project creation. Both callers are now named.
+
 ## [5.27.0] - 2026-08-24
 
 ### Fixed

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.27.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.27.1**.
 
 ## License
 

--- a/ai-dev-assistant/references/recipe-adoption-sweep.md
+++ b/ai-dev-assistant/references/recipe-adoption-sweep.md
@@ -1,8 +1,12 @@
-# Recipe-adoption sweep (`/upgrade-project` Step 4b)
+# Recipe-adoption sweep
+
+Two callers, one procedure: `/upgrade-project` step 4b (retrofitting an existing project)
+and `skills/project-initializer` step 10(a) (a project being created). Everything below
+applies identically to both; where the text says `/upgrade-project`, read "the caller".
 
 The eager on-ramp that complements the lazy point-of-need recipe trigger: after the project-state pass, once `**Frameworks:**` is known, `/upgrade-project` resolves + **records** process recipes for ALL applicable lifecycle phases in one pass so the coverage map is visible up front, instead of being discovered one phase at a time mid-work.
 
-**It records source decisions and reports coverage; it does NOT pre-cache or follow recipe bodies, and it does NOT approve unverified recipes** — bodies are still Read and followed lazily per-phase at use-time, and `verified:false` recipes still get human review then. This is a recording + visibility pass, not an execution commitment. Runs after Step 4, part of the project-level work (so it runs even with `--skip-tasks`); skipped only when frameworks are empty.
+**It records source decisions and reports coverage; it does NOT pre-cache or follow recipe bodies, and it does NOT approve unverified recipes** — bodies are still Read and followed lazily per-phase at use-time, and `verified:false` recipes still get human review then. This is a recording + visibility pass, not an execution commitment. Under `/upgrade-project` it runs after step 4, part of the project-level work (so it runs even with `--skip-tasks`); at creation it runs once requirements are gathered and `**Frameworks:**` is written. Either way it is skipped only when frameworks are empty.
 
 - **Guard.** Re-run `bash scripts/project-state-read.sh <project>` to read the now-current `.frameworks` and `.processRecipes`. If `.frameworks == []` (no codePath, undetectable stack, or user declined the Frameworks gap in Step 4), SKIP the sweep with a one-line note ("recipe-adoption sweep skipped: no **Frameworks:** set"). Never fail.
 - **Snapshot for idempotency.** Capture the set of already-recorded keys from `.processRecipes` (each entry's `key`) BEFORE driving the loader. A key resolved during the sweep that is in this snapshot is reported "already"; one not in it is "newly recorded". The loader's `write_source_record` is itself idempotent (an unchanged line is a no-op — rc 3 — so re-running the sweep produces no churn); this snapshot only labels the report.

--- a/ai-dev-assistant/scripts/project-state-read.sh
+++ b/ai-dev-assistant/scripts/project-state-read.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # project-state-read.sh — parse a project's project_state.md header block.
 #
-# Usage: project-state-read.sh <project_folder>
+# Usage: project-state-read.sh <project_folder|project_name>
+#
+# A bare name (no "/") that is not a directory is looked up in the registry
+# by exact name and replaced with its recorded path, with a
+# resolved_from_registry warning.
 #
 # Always emits a single-line JSON to stdout. Exit 0 regardless of input
 # (warnings surface via the warnings[] array). Mirrors the defensive posture
@@ -35,6 +39,7 @@
 # Warning codes:
 #   missing_arg                — script called without $1 (defensive; emit + exit 0)
 #   folder_missing             — project folder does not exist
+#   resolved_from_registry     — arg was a project name; resolved to its registered path
 #   project_state_md_missing   — project_state.md not in folder
 #   code_path_unknown          — project_state.md has no Code path line (first-use case)
 #   code_path_missing          — Code path declares a directory that does not exist
@@ -68,6 +73,27 @@ set -uo pipefail
 # Defensive contract: emit JSON-stdout + exit 0 always, even on bad inputs.
 # Mirrors task-frontmatter-reader. Caller (e.g., upgrade-project.md) trusts exit 0.
 PROJECT_DIR="${1:-}"
+
+# A bare project NAME is accepted as well as a folder path. The registry is the
+# authority on where a project lives, so a name is resolved through it rather
+# than falling through to folder_missing with every field at its empty default.
+# That empty reading is the hazard: a caller that checks `frameworks` and not
+# `warnings` reads [] as "this project has no frameworks" and silently skips the
+# work it guards. A wrong answer shaped like a legitimate one is worse than a
+# loud miss.
+REGISTRY_RESOLVED=""
+if [ -n "$PROJECT_DIR" ] && [ ! -d "$PROJECT_DIR" ] && [ "${PROJECT_DIR#*/}" = "$PROJECT_DIR" ]; then
+  _REG="${AIDA_REGISTRY:-$HOME/.claude/ai-dev-assistant/active_projects.json}"
+  if [ -r "$_REG" ] && command -v jq >/dev/null 2>&1; then
+    _HIT=$(jq -r --arg n "$PROJECT_DIR" \
+      '[.projects[]? | select(.name == $n) | .path // empty] | first // empty' \
+      "$_REG" 2>/dev/null) || _HIT=""
+    if [ -n "$_HIT" ] && [ -d "$_HIT" ]; then
+      REGISTRY_RESOLVED="$PROJECT_DIR"
+      PROJECT_DIR="$_HIT"
+    fi
+  fi
+fi
 FOLDER_NAME=$(basename "${PROJECT_DIR:-(missing)}")
 PROJECT_STATE="${PROJECT_DIR}/project_state.md"
 
@@ -202,6 +228,10 @@ else
     WARNINGS=$(jq -c -n --arg p "$CODE_PATH_NORM" '[{code: "code_path_missing", detail: ("directory does not exist: " + $p)}]')
   fi
   CODE_PATH_OUT="$CODE_PATH_NORM"
+fi
+
+if [ -n "$REGISTRY_RESOLVED" ]; then
+  add_warning "resolved_from_registry" "'$REGISTRY_RESOLVED' is a project name, not a folder path; resolved via the registry to $PROJECT_DIR"
 fi
 
 # === Playbook Sets parsing ===

--- a/ai-dev-assistant/skills/project-initializer/SKILL.md
+++ b/ai-dev-assistant/skills/project-initializer/SKILL.md
@@ -108,7 +108,7 @@ Working on: None - define tasks after requirements are gathered
 File: -
 
 ## Up Next
-Queued: {Tasks to work on after current task}
+Queued: {candidate first tasks once requirements surface them; see step 10(c)}
 
 ## Completed Implementation Tasks
 {Empty initially}
@@ -233,15 +233,40 @@ here and do not hand off — this step records and shows, nothing more.
 
 This nudge is the canonical surface for new-project playbook discoverability — `/new` and `/next` (inline-create path) both invoke this skill, so the nudge fires for every caller. Do NOT duplicate this text in caller commands.
 
-**(c) Final handoff:**
+**(c) Final handoff — offer the candidate tasks, and enter at scope.**
+
+Requirements gathering usually surfaces one or more candidate first tasks, and by this point you have
+often written one into `## Current Focus` in prose. Offer them. **Do not create them** — a task folder
+is the user's decision, and a project that creates its own backlog has decided for them.
+
+Record the candidates in `## Up Next` (that field exists for exactly this, and must not be left
+holding its `{...}` placeholder) and print:
 
 ```
 Requirements gathering complete.
 
-Run `/ai-dev-assistant:next` to get your next recommended action.
+Candidate first tasks:
+  - <task-name> — <one line on what it settles>
+  - <task-name> — <one line on what it settles>
+
+Say which one to start and I'll open it with `/ai-dev-assistant:scope <task-name>`,
+or run `/ai-dev-assistant:next` to see the full picture first.
 ```
 
-Do NOT manually list commands like `/research` or `/design`. Always direct to `/next` for intelligent routing.
+**A task that does not exist yet starts at Phase 0 scope, not Phase 1 research.** This is a rule about
+what you do, not a phrase to print. When the user picks a candidate, run `/ai-dev-assistant:scope
+<task>` — never `/ai-dev-assistant:research <task>`, and never offer research as the entry point.
+Phase 0 writes the four-field contract (Goal / Expected result / Success criteria / Non-goals) that
+Phase 4 later checks the change against; `/research` on a new task stops and authors that contract
+anyway, so naming research first either detours through scope or reads to the user as though scope
+were optional. `/next` routes new tasks the same way (`commands/next.md`, "Scope contract for
+brand-new tasks"), so the two agree.
+
+When requirements surfaced no clear candidate, drop the list and hand off to `/next` alone. Do not
+invent a task to fill the slot.
+
+Beyond `/scope` and `/next`, do not list further commands like `/design` or `/implement` — `/next`
+routes those.
 
 ## Stop Points
 

--- a/ai-dev-assistant/tests/project-initializer-handoff-contract-spec.sh
+++ b/ai-dev-assistant/tests/project-initializer-handoff-contract-spec.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# project-initializer-handoff-contract-spec.sh — the entry phase a new project offers.
+#
+# Observed live: a session finished creating a project, correctly named the first
+# task in prose, and then offered to "start its research phase". A task with no
+# folder starts at Phase 0 scope — /research on a new task stops and authors the
+# scope contract anyway, so offering research first either detours or reads as
+# though scope were optional. The rule lived nowhere; the skill's closing line
+# said only "run /next", and the session filled the gap with its own wording.
+#
+# These assertions pin the closing handoff: it names scope, it does not offer
+# research, and it does not create the task on the user's behalf.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="${PLUGIN_ROOT}/skills/project-initializer/SKILL.md"
+
+FAIL=0
+fail_check() { printf 'FAIL: %s\n' "$1" >&2; FAIL=1; }
+pass_check() { printf 'OK   %s\n' "$1"; }
+
+[ -f "$SKILL" ] || { printf 'FAIL: %s not found\n' "$SKILL" >&2; exit 1; }
+
+# The handoff section is everything from step 10(c) to the end of step 10.
+HANDOFF=$(awk '/^\*\*\(c\) Final handoff/{f=1} /^## Stop Points/{f=0} f' "$SKILL")
+[ -n "$HANDOFF" ] || { printf 'FAIL: step 10(c) handoff section not found in %s\n' "$SKILL" >&2; exit 1; }
+
+printf '%s' "$HANDOFF" | grep -q 'ai-dev-assistant:scope' \
+  && pass_check "the handoff names /scope as the entry command" \
+  || fail_check "the handoff must name /scope — a new task enters at Phase 0"
+
+printf '%s' "$HANDOFF" | grep -q 'Phase 0' \
+  && pass_check "the handoff says which phase a new task starts at" \
+  || fail_check "the handoff must state that a new task starts at Phase 0"
+
+# /research may be MENTIONED (the text explains why it is wrong), but never as
+# the thing offered. Guard the offer, not the word: no line may pair an
+# imperative with the research command.
+if printf '%s' "$HANDOFF" | grep -Eq '(Start|Run|run|start|open|Open|offer) .{0,40}ai-dev-assistant:research'; then
+  fail_check "the handoff must not offer /research as the entry point for a new task"
+else
+  pass_check "the handoff never offers /research as the entry point"
+fi
+
+printf '%s' "$HANDOFF" | grep -qi 'do not create' \
+  && pass_check "the handoff offers candidate tasks rather than creating them" \
+  || fail_check "the handoff must say the candidate tasks are offered, not created"
+
+# The printed template must not leave the Up Next placeholder unfilled, which is
+# what the live run shipped: a state file whose queue field still read
+# "{Tasks to work on after current task}" while the queue sat in prose above it.
+grep -q 'Queued: {Tasks to work on after current task}' "$SKILL" \
+  && fail_check "the project_state template still carries the inert Up Next placeholder" \
+  || pass_check "the Up Next placeholder tells the author what to put there"
+
+if [ "$FAIL" -ne 0 ]; then
+  printf '\nSome invariants FAILED for skills/project-initializer/SKILL.md.\n' >&2
+  exit 1
+fi
+
+printf '\nAll invariants pass for the project-initializer handoff.\n'
+exit 0

--- a/ai-dev-assistant/tests/project-state-read-spec.sh
+++ b/ai-dev-assistant/tests/project-state-read-spec.sh
@@ -271,6 +271,63 @@ PR_OUT="$("$READER" "$PR_DIR/p" 2>/dev/null)"
   || fail_check "a source that parses must not warn"
 rm -rf "$PR_DIR"
 
+# === Test: a bare project NAME resolves through the registry ===
+# The hazard this closes, observed live: the reader was called with a project
+# name instead of a folder path, returned frameworks:[] with a folder_missing
+# warning, and the caller — which read frameworks and not warnings — took the
+# empty list as "this project declares no frameworks" and nearly skipped the
+# recipe sweep it guards. An empty reading that looks legitimate is the failure.
+NAME_HOME=$(mktemp -d)
+NAME_PROJ="$NAME_HOME/projects/registered_name"
+mkdir -p "$NAME_PROJ" "$NAME_HOME/reg"
+cat > "$NAME_PROJ/project_state.md" <<EOF
+# Registered Name
+**Frameworks:** drupal, nextjs
+EOF
+cat > "$NAME_HOME/reg/active_projects.json" <<EOF
+{"projects":[{"name":"registered_name","path":"$NAME_PROJ","codePath":"$NAME_HOME/code"}]}
+EOF
+
+NAME_OUT=$(AIDA_REGISTRY="$NAME_HOME/reg/active_projects.json" bash "$READER" registered_name 2>/dev/null)
+[ "$(printf '%s' "$NAME_OUT" | jq -r '.frameworks | join(",")')" = "drupal,nextjs" ] \
+  && pass_check "a bare project name reads the real frameworks, not []" \
+  || fail_check "a bare project name must resolve via the registry"
+[ "$(printf '%s' "$NAME_OUT" | jq -r '.folder')" = "$NAME_PROJ" ] \
+  && pass_check "the resolved folder is the registered path" \
+  || fail_check "resolved folder must be the registered path"
+[ "$(printf '%s' "$NAME_OUT" | jq -r '[.warnings[].code] | index("resolved_from_registry") // "none"')" != "none" ] \
+  && pass_check "name resolution is recorded as a warning, never silent" \
+  || fail_check "resolving a name must record resolved_from_registry"
+[ "$(printf '%s' "$NAME_OUT" | jq -r '[.warnings[].code] | index("folder_missing") // "none"')" = "none" ] \
+  && pass_check "a resolved name does not also report folder_missing" \
+  || fail_check "a successfully resolved name must not warn folder_missing"
+
+# An unregistered name must still miss LOUDLY — resolution is not a guess.
+UNREG=$(AIDA_REGISTRY="$NAME_HOME/reg/active_projects.json" bash "$READER" no_such_project 2>/dev/null)
+[ "$(printf '%s' "$UNREG" | jq -r '[.warnings[].code] | index("folder_missing") // "none"')" != "none" ] \
+  && pass_check "an unregistered name still reports folder_missing" \
+  || fail_check "an unregistered name must not be silently accepted"
+
+# A PATH argument must never consult the registry, even when a project of that
+# basename is registered — the path is the caller being explicit.
+PATH_DIR="$NAME_HOME/elsewhere/registered_name"
+mkdir -p "$PATH_DIR"
+cat > "$PATH_DIR/project_state.md" <<EOF
+# Elsewhere
+**Frameworks:** symfony
+EOF
+PATH_OUT=$(AIDA_REGISTRY="$NAME_HOME/reg/active_projects.json" bash "$READER" "$PATH_DIR" 2>/dev/null)
+[ "$(printf '%s' "$PATH_OUT" | jq -r '.frameworks | join(",")')" = "symfony" ] \
+  && pass_check "an explicit path is read as given, not redirected by name" \
+  || fail_check "a path argument must never be overridden by a registry entry"
+
+# A missing or unreadable registry degrades to the old behaviour, never crashes.
+NOREG=$(AIDA_REGISTRY="$NAME_HOME/reg/does-not-exist.json" bash "$READER" registered_name 2>/dev/null)
+[ "$(printf '%s' "$NOREG" | jq -r '.warnings | length')" -gt 0 ] \
+  && pass_check "a missing registry degrades to a warning, still valid JSON" \
+  || fail_check "a missing registry must still emit warnings and valid JSON"
+rm -rf "$NAME_HOME"
+
 if [ "$FAIL" -ne 0 ]; then
   printf '\nSome invariants FAILED for scripts/project-state-read.sh.\n' >&2
   exit 1


### PR DESCRIPTION
Two defects from running project creation on a real dormant Drupal site. Both were invisible in tests and only showed up on live data.

Look at `scripts/project-state-read.sh` first. It takes a folder path, and a project name fell through to `folder_missing` with every field at its empty default — so `frameworks` came back `[]`, which is the same shape a project that genuinely declares no frameworks produces. The recipe-adoption sweep is guarded on that field. The live session caught it only because `[]` looked wrong on a site it had just detected Drupal in. A bare name now resolves through the registry.

The second is in `skills/project-initializer/SKILL.md`: setup finished by offering to start the first task at research. A task with no folder starts at Phase 0, and `/research` on a new task stops and authors the scope contract anyway. The rule existed in `/next` and nowhere in the skill, whose closing line said only "run `/next`" — so the session wrote its own ending. Step 10(c) now names `/scope` and offers candidate tasks without creating them.

Unresolved: this is the fourth run of the same prompt on the same site and the fixes have not been tested from scratch yet. The offer wording is prose a session can still work around; the contract spec pins what the file says, not what a session does with it.

To verify: `make ci` (90 tests). Both specs are mutation-verified — reverting the registry resolution fails exactly 4 assertions, reverting the handoff to its shipped wording fails exactly 3.