### PR TITLE
A signal that fired on our own file, and a contract that missed the unskippable gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.35"
+    "version": "2.0.36"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.30.1",
+      "version": "5.30.2",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.30.1",
+  "version": "5.30.2",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [5.30.2] - 2026-08-25
+
+### Fixed
+- The worktree signal fired on the framework's own footprint. `dirty_tree` counted every line of
+  `git status --porcelain`, untracked files included, while the script's own contract said it
+  meant "modified files matching another task's tracked files". One untracked file made it fire,
+  made strength `high`, and recommended isolating the work in a worktree. The framework then
+  supplied that file itself: `install-task-rule` writes `CLAUDE.md` into the code repository and
+  does not commit it, so a live run was told to take a worktree for a three-line configuration
+  edit on the strength of a file this plugin had put there. The signal now counts uncommitted
+  changes to tracked files; untracked files are still counted and reported in `signal_details`
+  and never fire it on their own. The header contract was rewritten to describe what the code
+  actually computes.
+- `/implement` documented a one-argument call to a script that requires two. `worktree-signals.sh`
+  needs `<project_folder> <task_name>`, the walkthrough reference had it right, and the command
+  body said `<task>`, so a session following the command verbatim could not run it. That is where
+  the bug was; the error message was only how it surfaced.
+- `worktree-signals.sh` called with too few arguments printed bash's own `line 32: 2: task name
+  required`, where the number is the name of the positional parameter. Same class as the
+  `analysis-agent-normalize.sh` message fixed in 5.30.1, found the same way.
+
 ## [5.30.1] - 2026-08-25
 
 ### Fixed

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -13,6 +13,14 @@
   changes to tracked files; untracked files are still counted and reported in `signal_details`
   and never fire it on their own. The header contract was rewritten to describe what the code
   actually computes.
+- The record contracts added in 5.30.1 were derived by reading the command bodies rather than by
+  watching a run, and the next live phase found what that missed. `/implement` calls the
+  mechanism challenge "the unskippable catch" and writes its record either way; the contract did
+  not list that record at all, so a phase that skipped an unskippable gate still read `complete`.
+  The design entry had it as conditional when its step is equally unconditional. Both are required
+  now. `_pre-analysis.json` was listed for both phases and belongs to neither — the epic check
+  they run branches and stays silent, and nothing in either command writes it. A contract answers
+  what that phase owes, so a record it never produces has no place in it.
 - `/implement` documented a one-argument call to a script that requires two. `worktree-signals.sh`
   needs `<project_folder> <task_name>`, the walkthrough reference had it right, and the command
   body said `<task>`, so a session following the command verbatim could not run it. That is where

--- a/ai-dev-assistant/commands/implement.md
+++ b/ai-dev-assistant/commands/implement.md
@@ -26,7 +26,7 @@ Phase 3 of a task. Behavior current as of v4.0.2; full prose / examples / versio
    - Both `[x]` → silent.
    Never block.
 
-2. **Worktree signals (v3.16.0+).** Run `${CLAUDE_PLUGIN_ROOT}/scripts/worktree-signals.sh <task>`. On HIGH-strength signal (`another_task_active`, `dirty_tree`, `--worktree` flag, or `worktreeByDefault: true`), print soft-nudge offering `/worktree <task>`. Suppress when already inside a worktree. Never block.
+2. **Worktree signals (v3.16.0+).** Run `${CLAUDE_PLUGIN_ROOT}/scripts/worktree-signals.sh "<project_folder>" "<task_name>"` (Bash). **Both arguments are required** — `<project_folder>` is the task's project folder, not the code repository, and a one-argument call fails. On HIGH-strength signal (`another_task_active`, `dirty_tree`, `--worktree` flag, or `worktreeByDefault: true`), print soft-nudge offering `/worktree <task>`. `dirty_tree` counts uncommitted changes to **tracked** files only; untracked files are reported in `signal_details` and never fire it. Suppress when already inside a worktree. Never block.
 
 2b. **Work-order build-path offer (v4.19.0+, conditional).** Check whether `<task>/work-orders/wo-*.md` exist (Bash glob). **SILENT when absent — do not print anything if no work-orders are found.** When files are found, print ONE soft-nudge:
 

--- a/ai-dev-assistant/scripts/phase-records-check.sh
+++ b/ai-dev-assistant/scripts/phase-records-check.sh
@@ -35,6 +35,16 @@
 # useless: the one guardrail that had already found a real gap could not look at the phase that
 # came next, or at implementation after it. An honest `unknown` on every phase but one is a check
 # that has stopped checking. Design and implement now carry contracts too.
+#
+# Those two contracts were then derived by reading the command bodies rather than by watching a
+# run, and the next live phase found what that missed. `/implement` calls the mechanism challenge
+# "the unskippable catch" and writes its record either way, and the contract did not list the
+# record at all, so a phase that skipped an unskippable gate still read `complete`. The design
+# entry had it as conditional when its step is equally unconditional. Both are required now.
+#
+# `_pre-analysis.json` was listed for both and belongs to neither: the epic check those phases run
+# branches and stays silent, and nothing in either command writes that record. A contract answers
+# what THIS phase owes, so a record it never produces has no place in it.
 set -uo pipefail
 
 TASK_DIR="${1:-}"; PHASE="research"
@@ -88,16 +98,15 @@ _dev-guides-load.json|required|dev-guides-detect.sh plus the guides-matcher agen
 _playbook-load.json|required|playbook-load-deterministic.sh|step 3
 architecture.md|required|the architecture-drafter agent|step 5
 _recipe-load.json|conditional|the process-recipe-loader skill, when frameworks are defined|step 2
-_mechanism-challenge.json|conditional|the mechanism-challenge refresh, when the design commits to a mechanism|step 5
-_pre-analysis.json|conditional|analysis-agent (folder mode), the post-design epic check|step 6
+_mechanism-challenge.json|required|the mechanism-challenge refresh, which the design step runs unconditionally|step 4
 _create-on-miss.json|conditional|the maintainer create-on-miss offer, on a genuine domain miss|step 2
 _distill.json|conditional|the distill-agent, when the end-of-phase seam is accepted|step 11' ;;
   implement) CONTRACT='_phase-active.json|required|phase-active-write.sh with the task folder|step 0
 _dev-guides-load.json|required|dev-guides-detect.sh plus the guides-matcher agent|step 3
 _playbook-load.json|required|playbook-load-deterministic.sh|step 4
 implementation.md|required|the phase itself|step 7
+_mechanism-challenge.json|required|the mechanism-challenge backstop, which runs the full challenge when the record is absent|step 6
 _recipe-load.json|conditional|the process-recipe-loader skill, when frameworks are defined|step 3
-_pre-analysis.json|conditional|analysis-agent (folder mode), the post-plan epic check|step 8
 _create-on-miss.json|conditional|the maintainer create-on-miss offer, on a genuine domain miss|step 3
 _distill.json|conditional|the distill-agent, when the end-of-phase seam is accepted|end of phase' ;;
   *) add_warn "no_record_contract_for_phase:$PHASE"

--- a/ai-dev-assistant/scripts/worktree-signals.sh
+++ b/ai-dev-assistant/scripts/worktree-signals.sh
@@ -21,15 +21,26 @@
 #   - another_task_active: another task folder has implementation.md AND
 #     git log --since="2 hours" --name-only shows files matching that task's
 #     Files Created/Modified list
-#   - dirty_tree: git status --porcelain shows modified files matching another
-#     task's tracked files
+#   - dirty_tree: uncommitted changes to TRACKED files. Untracked files are counted and
+#     reported in signal_details, and never fire the signal: the framework writes an
+#     untracked CLAUDE.md into the repository itself, so firing on one meant recommending
+#     a worktree on the strength of this plugin's own footprint.
 #   - multi_session: 2+ session-context files reference the same project
 #   - project_opt_in: project_state.md has **Worktree By Default:** true
 
 set -uo pipefail
 
-PROJECT_DIR="${1:?project folder required}"
-TASK_NAME="${2:?task name required}"
+# `${1:?...}` prints bash's own "line N: 1: ..." prefix, where the number is the positional
+# parameter's name. A live run called this with one argument and got `line 32: 2: task name
+# required`, which says nothing about what to pass.
+if [ $# -lt 2 ]; then
+  echo "usage: worktree-signals.sh <project_folder> <task_name>" >&2
+  echo "  project_folder is the task's project folder under the projects base," >&2
+  echo "  not the code repository. Both arguments are required." >&2
+  exit 1
+fi
+PROJECT_DIR="$1"
+TASK_NAME="$2"
 
 SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 DETECT_SH="$SCRIPT_DIR/worktree-detect.sh"
@@ -130,15 +141,31 @@ if [ "$ANOTHER_TASK_FIRED" = "true" ]; then
     '{another_task_active: {task: $t, recent_commits: $c, since: "2 hours"}}')
 fi
 
-# Step 4: dirty_tree signal — any uncommitted changes
+# Step 4: dirty_tree signal — uncommitted changes to TRACKED files
+#
+# This counted every line of `git status --porcelain`, untracked files included, while its own
+# contract above said "modified files matching another task's tracked files". One untracked file
+# made the signal fire, made strength `high`, and recommended isolating the work in a worktree.
+#
+# The framework then supplied that file itself. `install-task-rule` writes CLAUDE.md into the
+# code repository and does not commit it, so a live run recommended a worktree for a three-line
+# config edit on the strength of a file this plugin had put there. A signal that fires on its own
+# footprint is not evidence about the tree.
+#
+# Tracked modifications are the thing a worktree actually isolates you from. Untracked files are
+# counted and reported so the number is still visible, and they never fire the signal on their own.
 DIRTY_FIRED=false
 if git -C "$GIT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  DIRTY_COUNT=$(git -C "$GIT_DIR" status --porcelain 2>/dev/null | wc -l)
-  if [ "$DIRTY_COUNT" -gt 0 ]; then
+  PORCELAIN=$(git -C "$GIT_DIR" status --porcelain 2>/dev/null)
+  TRACKED_COUNT=$(printf '%s\n' "$PORCELAIN" | grep -c '^[^?]' || true)
+  UNTRACKED_COUNT=$(printf '%s\n' "$PORCELAIN" | grep -c '^??' || true)
+  if [ "$TRACKED_COUNT" -gt 0 ]; then
     DIRTY_FIRED=true
     SIGNALS+=("dirty_tree")
-    SIGNAL_DETAILS=$(echo "$SIGNAL_DETAILS" | jq -c --argjson c "$DIRTY_COUNT" '. + {dirty_tree: {modified_files: $c}}')
   fi
+  SIGNAL_DETAILS=$(echo "$SIGNAL_DETAILS" | jq -c \
+    --argjson t "$TRACKED_COUNT" --argjson u "$UNTRACKED_COUNT" --argjson f "$DIRTY_FIRED" \
+    '. + {dirty_tree: {modified_tracked_files: $t, untracked_files: $u, fired: $f}}')
 fi
 
 # Step 5: multi_session signal — 2+ session-context files reference same project

--- a/ai-dev-assistant/tests/phase-records-check-spec.sh
+++ b/ai-dev-assistant/tests/phase-records-check-spec.sh
@@ -84,8 +84,8 @@ OUT=$(bash "$K" "$(mk cond $REQUIRED)" --phase research)
 # Research was the only phase with a contract until v5.30.1. A live design phase ran this and
 # got `unknown`: honest, and useless. The guardrail that had already caught one skipped gate
 # could not look at the phase after it, or at implementation after that.
-DESIGN_REQ="_phase-active.json _dev-guides-load.json _playbook-load.json architecture.md"
-IMPL_REQ="_phase-active.json _dev-guides-load.json _playbook-load.json implementation.md"
+DESIGN_REQ="_phase-active.json _dev-guides-load.json _playbook-load.json architecture.md _mechanism-challenge.json"
+IMPL_REQ="_phase-active.json _dev-guides-load.json _playbook-load.json implementation.md _mechanism-challenge.json"
 
 # shellcheck disable=SC2086
 [ "$(bash "$K" "$(mk dfull $DESIGN_REQ)" --phase design | jq -r .verdict)" = "complete" ] \
@@ -107,6 +107,32 @@ DOUT=$(bash "$K" "$(mk dgap _dev-guides-load.json _playbook-load.json architectu
   = "phase-active-write.sh with the task folder" ] \
   && pass_check "the missing design record names who was supposed to write it" \
   || fail_check "a missing design record is a puzzle rather than an instruction"
+
+# The gate `/implement` calls "the unskippable catch" was not in its contract at all, so a phase
+# that skipped it still read complete. Both phases run the challenge unconditionally.
+for ph in design implement; do
+  case "$ph" in
+    design) OTHERS="_phase-active.json _dev-guides-load.json _playbook-load.json architecture.md" ;;
+    *)      OTHERS="_phase-active.json _dev-guides-load.json _playbook-load.json implementation.md" ;;
+  esac
+  # shellcheck disable=SC2086
+  MOUT=$(bash "$K" "$(mk "nomech-$ph" $OTHERS)" --phase "$ph")
+  [ "$(printf '%s' "$MOUT" | jq -r .verdict)" = "incomplete" ] \
+    && pass_check "a $ph phase with no mechanism-challenge record reports incomplete" \
+    || fail_check "a $ph phase skipped the unskippable challenge and read complete"
+  [ "$(printf '%s' "$MOUT" | jq -r '.records[]|select(.name=="_mechanism-challenge.json")|.requirement')" = "required" ] \
+    && pass_check "the mechanism-challenge record is required for $ph, not conditional" \
+    || fail_check "the mechanism-challenge record is not required for $ph, so its absence never counts"
+done
+
+# A contract answers what THIS phase owes. The epic check these phases run branches and stays
+# silent; nothing in either command writes _pre-analysis.json, so listing it was a category error.
+for ph in design implement; do
+  [ "$(bash "$K" "$(mk "pa-$ph" _phase-active.json)" --phase "$ph" \
+       | jq -r '[.records[]|select(.name=="_pre-analysis.json")]|length')" = "0" ] \
+    && pass_check "$ph does not claim a record it never writes" \
+    || fail_check "$ph's contract lists _pre-analysis.json, which belongs to research"
+done
 
 # Neither phase may report complete on an empty task folder.
 for ph in design implement; do

--- a/ai-dev-assistant/tests/worktree-signals-spec.sh
+++ b/ai-dev-assistant/tests/worktree-signals-spec.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# worktree-signals-spec.sh — a signal that fired on the framework's own footprint.
+#
+# `dirty_tree` counted every line of `git status --porcelain`, untracked files included, while
+# the script's own contract said it meant "modified files matching another task's tracked files".
+# One untracked file made it fire, made strength `high`, and recommended isolating the work in a
+# worktree.
+#
+# The framework supplied that file itself. `install-task-rule` writes CLAUDE.md into the code
+# repository and does not commit it, so a live run was told to take a worktree for a three-line
+# config edit on the strength of a file this plugin had put there. A signal that fires on its own
+# footprint is not evidence about the tree.
+#
+# The other half: the command body documented a one-argument call for a script that needs two,
+# so a session following it verbatim got bash naming the positional parameter.
+
+set -eu
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+K="$PLUGIN_ROOT/scripts/worktree-signals.sh"
+
+FAIL=0
+fail_check() { printf 'FAIL: %s\n' "$1" >&2; FAIL=1; }
+pass_check() { printf 'OK   %s\n' "$1"; }
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# A code repo and a project folder pointing at it.
+REPO="$TMP/repo"; mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+echo base > "$REPO/tracked.txt"
+git -C "$REPO" add tracked.txt
+git -C "$REPO" commit -qm base
+
+PROJ="$TMP/proj"; mkdir -p "$PROJ"
+printf '# Project: t\n**Code Path:** %s\n' "$REPO" > "$PROJ/project_state.md"
+
+sig() { bash "$K" "$PROJ" sometask 2>/dev/null; }
+
+# --- the live case: only an untracked file --------------------------------------------
+
+echo "rule" > "$REPO/CLAUDE.md"          # exactly what install-task-rule leaves behind
+OUT=$(sig)
+[ "$(printf '%s' "$OUT" | jq -r '.signal_details.dirty_tree.fired')" = "false" ] \
+  && pass_check "an untracked file alone does not fire the tree signal" \
+  || fail_check "an untracked file fired the signal, as the framework's own CLAUDE.md did"
+
+[ "$(printf '%s' "$OUT" | jq -r .strength)" = "none" ] \
+  && pass_check "an untracked file alone does not recommend a worktree" \
+  || fail_check "a worktree was recommended on the strength of one untracked file"
+
+[ "$(printf '%s' "$OUT" | jq -r '.signal_details.dirty_tree.untracked_files')" = "1" ] \
+  && pass_check "the untracked file is still counted and visible" \
+  || fail_check "the untracked file vanished from the record instead of being reported"
+
+# --- a genuinely dirty tree still fires ------------------------------------------------
+
+echo changed >> "$REPO/tracked.txt"
+OUT=$(sig)
+[ "$(printf '%s' "$OUT" | jq -r '.signal_details.dirty_tree.fired')" = "true" ] \
+  && pass_check "an uncommitted change to a tracked file fires the signal" \
+  || fail_check "real uncommitted work no longer fires the signal"
+
+[ "$(printf '%s' "$OUT" | jq -r .strength)" = "high" ] \
+  && pass_check "real uncommitted work still reads as high strength" \
+  || fail_check "real uncommitted work stopped recommending a worktree"
+
+[ "$(printf '%s' "$OUT" | jq -r '.signal_details.dirty_tree.modified_tracked_files')" = "1" ] \
+  && pass_check "the tracked count is what the signal is based on" \
+  || fail_check "the tracked count does not match what fired"
+
+# A staged change is uncommitted work too.
+git -C "$REPO" add tracked.txt
+[ "$(sig | jq -r '.signal_details.dirty_tree.fired')" = "true" ] \
+  && pass_check "a staged change counts as uncommitted work" \
+  || fail_check "staging a change made the signal stop seeing it"
+
+# --- a clean tree ----------------------------------------------------------------------
+
+git -C "$REPO" commit -qm change
+rm -f "$REPO/CLAUDE.md"
+OUT=$(sig)
+[ "$(printf '%s' "$OUT" | jq -r .strength)" = "none" ] \
+  && pass_check "a clean tree recommends nothing" \
+  || fail_check "a clean tree recommended a worktree"
+printf '%s' "$OUT" | jq empty >/dev/null 2>&1 \
+  && pass_check "output is valid JSON" \
+  || fail_check "output is not valid JSON"
+
+# --- the error a person reads ----------------------------------------------------------
+
+set +e
+ERR=$(bash "$K" "$PROJ" 2>&1 >/dev/null); RC=$?
+set -e
+[ "$RC" -eq 1 ] && pass_check "a one-argument call exits 1" || fail_check "a one-argument call exited $RC"
+case "$ERR" in
+  *"line "*) fail_check "the one-argument error still shows bash internals: $ERR" ;;
+  usage:*)   pass_check "the one-argument error is a usage line and nothing else" ;;
+  *)         fail_check "the one-argument error does not start with a usage line: $ERR" ;;
+esac
+
+# --- the command body's call must be runnable -------------------------------------------
+
+# The bug was here, not in the script: implement.md documented a one-argument call.
+CMD="$PLUGIN_ROOT/commands/implement.md"
+if grep -q 'worktree-signals\.sh "<project_folder>" "<task_name>"' "$CMD"; then
+  pass_check "the command body documents both arguments"
+else
+  fail_check "the command body's documented call does not pass both arguments, so following it fails"
+fi
+
+# The contract in the script header has to describe what the code does.
+if grep -q 'uncommitted changes to TRACKED files' "$K"; then
+  pass_check "the documented signal matches what the code counts"
+else
+  fail_check "the header describes a signal the code does not compute"
+fi
+
+printf '\n'
+[ "$FAIL" -eq 0 ] && { printf 'worktree-signals-spec: all checks passed\n'; exit 0; }
+printf 'worktree-signals-spec: FAILURES\n' >&2; exit 1


### PR DESCRIPTION
Four defects the live implementation round walked into. The worktree signal counted untracked files as evidence of uncommitted work, so the `CLAUDE.md` that `install-task-rule` writes and never commits made the framework recommend a worktree for a three-line config edit. `/implement` documented a one-argument call to a script needing two, so following the command body verbatim could not work. And the record contracts shipped yesterday omitted the very gate `/implement` calls unskippable, so skipping it still read as complete.

Start with the `dirty_tree` block in `scripts/worktree-signals.sh` and the two contracts in `scripts/phase-records-check.sh`. Both had a header describing something the code did not do.

Worth knowing: yesterday's contracts were written by reading the command bodies instead of watching a phase run, which is exactly why they were wrong. The corrected ones were checked against a real completed design and implementation.

Unresolved: `install-task-rule` still leaves its file untracked, so a repository the framework configures never looks clean to a plain `git status`. Committing it, ignoring it, or leaving it are all defensible and none is chosen.

Verify with `make ci`. The specs are `tests/worktree-signals-spec.sh`, which builds a real repository and reproduces the case that misfired, and `tests/phase-records-check-spec.sh`; reverting any single change fails the checks that cover it.