### PR TITLE
A finished task and a never-started one read the same

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.37"
+    "version": "2.0.38"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.30.3",
+      "version": "5.30.4",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.30.3",
+  "version": "5.30.4",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.30.4] - 2026-08-25
+
+### Fixed
+- A finished task and a never-started one read the same. `fm_read` returned the string `draft`
+  in five places: four where the read had failed or the file carried no frontmatter, and once as
+  the default for an absent key. The no-frontmatter path also returned `warnings: []`, so nothing
+  in the object said a read had not happened. Observed on a task that had just passed review:
+  `status: draft`, no warnings. `status` is now `null` wherever nothing on disk said otherwise,
+  and the no-frontmatter path carries a `frontmatter_absent` warning. `kind` follows the same
+  rule but keeps `flat` where the file was read and declared no hierarchy, because that is a fact
+  about the file rather than a fallback; where nothing was read at all, `kind` is `null` too.
+  `migrate-to-epic.sh` resolves a null status before writing it into a new epic's frontmatter, so
+  an unknown does not become a recorded value on the way through.
+
 ## [5.30.3] - 2026-08-25
 
 ### Fixed

--- a/ai-dev-assistant/scripts/fm-helpers.sh
+++ b/ai-dev-assistant/scripts/fm-helpers.sh
@@ -15,14 +15,14 @@ fm_read() {
 
   if [ ! -d "$task_dir" ]; then
     jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
-      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "folder_missing", detail: "task folder does not exist"}]}'
+      '{id: $id, kind: null, parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: null, mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "folder_missing", detail: "task folder does not exist"}]}'
     return 0
   fi
 
   local task_md="$task_dir/task.md"
   if [ ! -f "$task_md" ]; then
     jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
-      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "task_md_missing", detail: "task.md not found in folder"}]}'
+      '{id: $id, kind: null, parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: null, mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "task_md_missing", detail: "task.md not found in folder"}]}'
     return 0
   fi
 
@@ -31,7 +31,7 @@ fm_read() {
 
   if [ -z "$fm" ]; then
     jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
-      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", mechanism_hints: [], run_mode: null, folder: $dir, warnings: []}'
+      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: null, mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "frontmatter_absent", detail: "task.md has no frontmatter block; kind defaults to flat, status is unknown"}]}'
     return 0
   fi
 
@@ -50,7 +50,7 @@ except Exception as e:
 
   if [ -z "$parsed" ]; then
     jq -nc --arg id "local:$folder_name" --arg dir "$task_dir" \
-      '{id: $id, kind: "flat", parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: "draft", mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "parser_unavailable", detail: "python3 missing or failed"}]}'
+      '{id: $id, kind: null, parent: null, children: [], blocks: [], blocked_by: [], external_ids: {}, status: null, mechanism_hints: [], run_mode: null, folder: $dir, warnings: [{code: "parser_unavailable", detail: "python3 missing or failed"}]}'
     return 0
   fi
 
@@ -65,7 +65,7 @@ except Exception as e:
         blocks: ($d.blocks // []),
         blocked_by: ($d.blocked_by // []),
         external_ids: ($d.external_ids // {}),
-        status: ($d.status // "draft"),
+        status: ($d.status // null),
         mechanism_hints: ($d.mechanism_hints // []),
         run_mode: ($d.run_mode // null),
         folder: $dir,
@@ -80,7 +80,7 @@ except Exception as e:
         blocks: [],
         blocked_by: [],
         external_ids: {},
-        status: "draft",
+        status: null,
         mechanism_hints: [],
         run_mode: null,
         folder: $dir,
@@ -88,6 +88,18 @@ except Exception as e:
       }
     end' <<<"$parsed"
 }
+
+# `status` is null when nothing on disk said otherwise (v5.30.4+).
+#
+# It used to be the string "draft" in five places: four where the read had failed or the file
+# carried no frontmatter, and once as the default for an absent key. A finished task and a
+# never-started one came back identical, and the no-frontmatter path also returned
+# `warnings: []`, so nothing anywhere in the object said a read had not happened. Observed on a
+# task that had just passed review: `status: draft`, no warnings.
+#
+# `kind` follows the same rule but keeps "flat" where the file was read and declared no
+# hierarchy, because that is a fact about the file rather than a fallback. Where nothing was
+# read at all, kind is null too.
 
 # write_epic_frontmatter <task_name> <current_status> [<child1> <child2> ...]
 # Prints a canonical YAML frontmatter block (including --- delimiters) to stdout.

--- a/ai-dev-assistant/scripts/migrate-to-epic.sh
+++ b/ai-dev-assistant/scripts/migrate-to-epic.sh
@@ -178,6 +178,9 @@ echo "[1/8] Preflight"
 READER=$(fm_read "$TASK_DIR")
 CURRENT_KIND=$(jq -r '.kind' <<<"$READER")
 CURRENT_STATUS=$(jq -r '.status' <<<"$READER")
+# fm_read returns a null status when nothing on disk said otherwise. Writing the literal
+# "null" into a new epic's frontmatter would turn an unknown into a recorded value.
+[ "$CURRENT_STATUS" = "null" ] && CURRENT_STATUS="in_progress"
 
 # Expansion mode: the resolved task is ALREADY an epic/sub_epic. With children
 # passed, expand it in place instead of aborting; with none, exit with a hint.
@@ -450,6 +453,7 @@ if [ ${#CHILDREN[@]} -gt 0 ]; then
         cp -r "$CHILD_IN_PROGRESS_ROOT/$child" "$TEMP_ROOT/$TASK_NAME/in_progress/$child"
         CHILD_READER=$(fm_read "$TEMP_ROOT/$TASK_NAME/in_progress/$child")
         CHILD_STATUS=$(jq -r '.status' <<<"$CHILD_READER")
+        [ "$CHILD_STATUS" = "null" ] && CHILD_STATUS="in_progress"
         SUB_FM=$(write_subtask_frontmatter "$child" "$TASK_NAME" "$CHILD_STATUS")
         apply_frontmatter "$TEMP_ROOT/$TASK_NAME/in_progress/$child/task.md" "$SUB_FM"
         ;;
@@ -463,6 +467,7 @@ if [ ${#CHILDREN[@]} -gt 0 ]; then
         cp -r "$CHILD_COMPLETED_ROOT/$child" "$TEMP_ROOT/$TASK_NAME/completed/$child"
         CHILD_READER=$(fm_read "$TEMP_ROOT/$TASK_NAME/completed/$child")
         CHILD_STATUS=$(jq -r '.status' <<<"$CHILD_READER")
+        [ "$CHILD_STATUS" = "null" ] && CHILD_STATUS="in_progress"
         # Force status=completed regardless of what frontmatter said (authoritative by location)
         SUB_FM=$(write_subtask_frontmatter "$child" "$TASK_NAME" "completed")
         apply_frontmatter "$TEMP_ROOT/$TASK_NAME/completed/$child/task.md" "$SUB_FM"

--- a/ai-dev-assistant/tests/fm-read-status-spec.sh
+++ b/ai-dev-assistant/tests/fm-read-status-spec.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# fm-read-status-spec.sh — a finished task and a never-started one read the same.
+#
+# fm_read returned the string "draft" in five places: four where the read had failed or the
+# file carried no frontmatter, and once as the default for an absent key. The no-frontmatter
+# path also returned `warnings: []`, so nothing in the object said a read had not happened.
+# Observed on a task that had just passed review: `status: draft`, no warnings.
+
+set -eu
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+K="$PLUGIN_ROOT/scripts/fm-read.sh"
+
+FAIL=0
+fail_check() { printf 'FAIL: %s\n' "$1" >&2; FAIL=1; }
+pass_check() { printf 'OK   %s\n' "$1"; }
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/plain"; printf '# Task\n\nno frontmatter here\n' > "$TMP/plain/task.md"
+OUT=$(bash "$K" "$TMP/plain")
+[ "$(printf '%s' "$OUT" | jq -r .status)" = "null" ] \
+  && pass_check "a task with no frontmatter has an unknown status, not a draft one" \
+  || fail_check "a finished task still reads as draft"
+[ "$(printf '%s' "$OUT" | jq -r '.warnings|length')" -gt 0 ] \
+  && pass_check "the absent frontmatter is warned about rather than passed over silently" \
+  || fail_check "the one path that fabricated a status also reported no warnings"
+[ "$(printf '%s' "$OUT" | jq -r .kind)" = "flat" ] \
+  && pass_check "kind stays flat, which the file being read actually establishes" \
+  || fail_check "kind stopped reporting the hierarchy the file does declare"
+
+mkdir -p "$TMP/real"
+printf -- '---\nid: local:x\nkind: flat\nstatus: in_progress\n---\n\n# Task\n' > "$TMP/real/task.md"
+[ "$(bash "$K" "$TMP/real" | jq -r .status)" = "in_progress" ] \
+  && pass_check "a recorded status is still read back" \
+  || fail_check "a real status was lost"
+
+OUT=$(bash "$K" "$TMP/nope")
+[ "$(printf '%s' "$OUT" | jq -r .status)" = "null" ] && [ "$(printf '%s' "$OUT" | jq -r .kind)" = "null" ] \
+  && pass_check "a folder that was never read reports neither a kind nor a status" \
+  || fail_check "a failed read still returned a kind and a status it never saw"
+
+# migrate-to-epic writes this value into a new epic's frontmatter. An unknown must not become
+# a recorded one on the way through.
+grep -q 'CURRENT_STATUS="in_progress"' "$PLUGIN_ROOT/scripts/migrate-to-epic.sh" \
+  && pass_check "a null status is resolved before it is written into a real record" \
+  || fail_check "migrate-to-epic would write the literal null into frontmatter"
+
+printf '\n'
+[ "$FAIL" -eq 0 ] && { printf 'fm-read-status-spec: all checks passed\n'; exit 0; }
+printf 'fm-read-status-spec: FAILURES\n' >&2; exit 1


### PR DESCRIPTION
`fm_read` returned the string `draft` in five places: four where the read had failed or the file carried no frontmatter, and once as the default for an absent key. The no-frontmatter path also returned `warnings: []`, so nothing in the object said a read had not happened. It showed up on a task that had just passed review, reading `status: draft` with no warnings.

`status` is now `null` wherever nothing on disk said so, with a `frontmatter_absent` warning on the path that had none. `kind` keeps `flat` where the file was read and declared no hierarchy — that is a fact about the file, and every normal task here has no frontmatter, so making it null would have broken epic candidate enumeration for all of them.

The one thing to look at is the `migrate-to-epic.sh` guard: without it my change would have written the literal string `null` into a new epic's frontmatter, turning an unknown into a recorded value.

Verify with `make ci`.