### PR TITLE
the scope contract could not tell its author what was wrong

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.30.5",
+      "version": "5.30.6",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.30.5",
+  "version": "5.30.6",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## [5.30.6] - 2026-08-25
 
 ### Fixed
+- `/scope` never showed the shape of the artifact it exists to write. Three hundred lines
+  instructing the author to produce a four-field contract, and not one occurrence of `### Goal`
+  anywhere in them — the "Writing `alignment.md`" section showed the H1 and metadata lines and
+  then a bare `<section>` placeholder. A live run wrote the four fields as bold labels, which the
+  reader does not parse, and had to go read `references/alignment-contract.md` to find out why.
+  The command now renders the full section template, states outright that the field names are H3
+  headings and never bold labels, and says what goes wrong when they are not: the section parses
+  as having no fields, `present` comes back `false`, and the contract is invisible to `/research`,
+  `/design` and `/implement` while the file sits there full of content.
+- The reader named the wrong problem when it could not parse a section. A `## Task-Level` carrying
+  two kilobytes of content in an unrecognized shape reported `section_empty_stub` — the same code
+  as a heading with nothing under it at all. "Empty" sends an author hunting for content they can
+  see on the screen instead of at the heading level, which is exactly the detour the live run took.
+  Body text inside a recognized H2 that sits under no recognized H3 is now counted, and such a
+  section reports `section_unparsed_body` instead. `present` stays `false` for both, because
+  neither yields usable fields; the codes differ because the thing to go and fix differs. A
+  well-formed section with a line of preamble before its first H3 raises neither, since it parsed.
 - A success criterion that wrapped onto a second line was silently truncated to its first line,
   and a `— verify:` note that wrapped was lost or cut mid-sentence. `alignment-read.sh` walked the
   section buffer one line at a time: a line matching `- [ ]` became a criterion and a continuation

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [5.30.6] - 2026-08-25
+
+### Fixed
+- A success criterion that wrapped onto a second line was silently truncated to its first line,
+  and a `— verify:` note that wrapped was lost or cut mid-sentence. `alignment-read.sh` walked the
+  section buffer one line at a time: a line matching `- [ ]` became a criterion and a continuation
+  line matched nothing and was discarded, with `warnings` left empty, so a contract that read as
+  complete was missing most of what it said. Found by feeding the reader a real scope contract
+  before it was written: one criterion listing six required fixture cases came back as the fragment
+  "A repeatable fixture set exists before implementation, created through the", with
+  `verification: null` against a file that plainly stated one. This is load-bearing — the Phase 4
+  spec review judges the finished change against these criteria, so it would have checked a
+  sentence that asserts nothing. Wrapped items are ordinary markdown and render as one item; the
+  reader now joins continuation lines before parsing, and a blank line or a new list item closes
+  the open one. Non-goals had the same defect and the same fix. `references/alignment-contract.md`
+  §5.2 and §5.3 sanctioned the old behavior ("each item is on its own line", "per line") and now
+  describe the joining, at grammar v1.2.
+- The goal-seeding rule added in 5.30.5 only fired when `/scope` scaffolded the task folder in
+  that same run. A folder left behind by an interrupted `/scope` — stub `task.md`, placeholder
+  `## Goal`, no `alignment.md` — matched the resolution row "Folder exists with `task.md` →
+  proceed normally, the task is established," so a re-run with the same description discarded it
+  again through a different branch. Found immediately: the run that exposed 5.30.5 was interrupted
+  after scaffolding, leaving exactly that folder. The resolution table now separates an authored
+  `task.md` from a stub, recognised by the same marker family `/research` step 2 and
+  `/migrate-to-epic` already read, and the seeding rule applies to a stub however it got there.
+  The folder existing is not evidence the task was authored; only content that is not the stub is.
+
 ## [5.30.5] - 2026-08-25
 
 ### Fixed

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.30.5**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.30.6**.
 
 ## License
 

--- a/ai-dev-assistant/commands/scope.md
+++ b/ai-dev-assistant/commands/scope.md
@@ -202,7 +202,30 @@ Create the file with:
 <section>
 ```
 
-Where `<section>` is the H2 block you just authored.
+Where `<section>` is the H2 block you just authored, in exactly this shape:
+
+```markdown
+## Task-Level
+
+### Goal
+
+<prose>
+
+### Expected result
+
+<prose>
+
+### Success criteria
+
+- [ ] <falsifiable statement> — verify: <how it will be checked>
+- [ ] <falsifiable statement>
+
+### Non-goals
+
+- <thing explicitly out of scope>
+```
+
+**The four field names are H3 headings (`### Goal`), never bold labels (`**Goal**`).** The reader keys on the heading level: a section written with bold labels parses as having no fields at all, so `present` comes back `false` and the whole contract is invisible to `/research`, `/design` and `/implement` even though the file is full of content. Phase sections use the same four H3s under `## Phase 1 — Research` / `## Phase 2 — Architecture` / `## Phase 3 — Implementation`. Full grammar, including the optional `— verify:` suffix and every warning code, is in `references/alignment-contract.md`.
 
 **Success-criterion format.** Write each criterion as a task-list line `- [ ] <text>`. When the user declared how a criterion will be verified, append the optional suffix `- [ ] <text> — verify: <how>` (space, em-dash, space, `verify:`, space). Omit the suffix when no verification note was given. The reader parses it into `{text, checked, verification}` per `references/alignment-contract.md` §5.2.
 

--- a/ai-dev-assistant/commands/scope.md
+++ b/ai-dev-assistant/commands/scope.md
@@ -41,7 +41,8 @@ Accept task names in these forms:
 
 | Outcome | Behavior |
 |---|---|
-| Folder exists with `task.md` | Proceed normally — the task is established |
+| Folder exists with an authored `task.md` | Proceed normally — the task is established |
+| Folder exists but `task.md` is **a stub** (`Current Phase: Phase 0 — Scope`, or the `Stub scaffolded by ` note — the same marker family `/research` step 2 and `/migrate-to-epic` read) | Proceed, and apply the goal-seeding rule below exactly as if the folder had just been scaffolded. A stub is a placeholder, not an authored task |
 | Folder absent, name validates (`^[A-Za-z0-9_][A-Za-z0-9._-]*$`, no path separators, not `.`/`..`) | **Scaffold a minimal task stub** at `implementation_process/in_progress/<task_name>/task.md` so the scope conversation has a home. See "Stub scaffolding" below. |
 | Folder absent, name invalid | Report the validation error and abort. Do not scaffold. |
 | Ambiguous match (e.g., same name in two epics) | Report candidate matches and abort. |
@@ -76,7 +77,7 @@ _To be authored via `/ai-dev-assistant:scope`. `/ai-dev-assistant:research` will
 Stub scaffolded by `/ai-dev-assistant:scope` on <YYYY-MM-DD>.
 ```
 
-**Seed `## Goal` from the invocation.** When `/scope` was invoked with a description after the task name, write that description into `## Goal` **verbatim, in the user's words**, and drop the placeholder line. Do not paraphrase it, do not reshape it into the 4-field contract here — that is Step 3's job with the user in the loop. Only when the invocation carried nothing beyond the task name does the placeholder get written. Writing the placeholder over a stated goal loses the user's words and mis-classifies the task as empty at Step 2.
+**Seed `## Goal` from the invocation.** This rule applies whenever `task.md` is a stub — whether this run scaffolded it or an earlier interrupted run left it behind. When `/scope` was invoked with a description after the task name, write that description into `## Goal` **verbatim, in the user's words**, and drop the placeholder line. Do not paraphrase it, do not reshape it into the 4-field contract here — that is Step 3's job with the user in the loop. Only when the invocation carried nothing beyond the task name does the placeholder get written. Writing the placeholder over a stated goal loses the user's words and mis-classifies the task as empty at Step 2. **Leaving an existing stub's placeholder in place loses them the same way**: a `/scope` that was interrupted after scaffolding, or that the user re-runs with a fuller description, must seed the goal on that run too. The folder existing is not evidence the task was authored — only content that is not the stub is.
 
 `/research` step 2 ("Create task scaffolding") MUST detect this stub (`Current Phase: Phase 0 — Scope` line or the explicit "Stub scaffolded by " note — the same marker family `/migrate-to-epic` stubs carry) and overwrite it with the full template rather than aborting on a pre-existing folder.
 

--- a/ai-dev-assistant/references/alignment-contract.md
+++ b/ai-dev-assistant/references/alignment-contract.md
@@ -100,14 +100,16 @@ Empty body → `{present: true, body: ""}` + warning `empty_field`.
 
 ### 5.2 `Success criteria`
 
-Expected as a markdown task-list where each item is on its own line:
+Expected as a markdown task-list:
 
 - `- [ ] <text>` → `{text: "<text>", checked: false, verification: null}`
 - `- [x] <text>` or `- [X] <text>` → `{text: "<text>", checked: true, verification: null}`
 
-Parser regex: `^\s*-\s+\[([ xX])\]\s+(.+?)\s*$` (per line).
+Parser regex: `^\s*-\s+\[([ xX])\]\s+(.+?)\s*$`, applied after line-joining (below).
 
-Lines matching the regex are extracted into `success_criteria[]` in document order. Lines that don't match (e.g., stray prose, blank lines) are ignored.
+Matching items are extracted into `success_criteria[]` in document order. Content that is not part of any item (stray prose before the first item, blank lines) is ignored.
+
+**Wrapped items (v1.2+).** An item MAY span several lines. A line that does not itself start a list item, is not blank, and follows an open item is a **continuation**: it is trimmed and joined to that item with a single space before the regex and the verification split run. A blank line, or a line starting a new list item, closes the open item. This is ordinary markdown — a wrapped item renders as one item — and authored contracts routinely wrap, so the reader must not treat a wrapped item as a one-line item plus discarded text. Before v1.2 it did, and the consequences were silent: a criterion was truncated to its first line, a `— verify:` note that wrapped was lost or cut mid-sentence, and `warnings` stayed empty, so a contract that read as complete was missing most of what it said. Joining is not itself a warning condition; wrapping is legitimate.
 
 **Optional verification suffix (v1.1+).** A criterion line MAY declare *how* it will be verified by appending a trailing suffix:
 
@@ -115,7 +117,7 @@ Lines matching the regex are extracted into `success_criteria[]` in document ord
 - [ ] <criterion text> — verify: <how it will be verified>
 ```
 
-The delimiter is ` — verify: ` (space, em-dash U+2014, space, the literal `verify:`, space). For tolerance the reader ALSO accepts en-dash `–` and hyphen `-` in the delimiter position (matching the phase-header dash tolerance in §3), but the lowercase `verify: ` token is required. The split happens on the **first** delimiter occurrence: the text before it becomes `text` (trimmed); the text after becomes `verification` (trimmed). When no delimiter is present, `verification` is `null` and `text` is the whole line (the pre-v1.1 behavior, unchanged).
+The suffix may begin on a continuation line — after joining, the delimiter is preceded by the join space, so ` — verify: ` still matches. The delimiter is ` — verify: ` (space, em-dash U+2014, space, the literal `verify:`, space). For tolerance the reader ALSO accepts en-dash `–` and hyphen `-` in the delimiter position (matching the phase-header dash tolerance in §3), but the lowercase `verify: ` token is required. The split happens on the **first** delimiter occurrence: the text before it becomes `text` (trimmed); the text after becomes `verification` (trimmed). When no delimiter is present, `verification` is `null` and `text` is the whole line (the pre-v1.1 behavior, unchanged).
 
 Captured up-front at scope time, the suffix lets each criterion declare its verification strategy rather than deferring it to Phase 4. It is always optional; a criterion whose `text` legitimately contains an em-dash but no `verify:` token is left intact with `verification: null`.
 
@@ -128,9 +130,9 @@ If the body contains prose only (no task-list lines at all), emit warning `succe
 
 ### 5.3 `Non-goals`
 
-Expected as a bulleted list. Parser regex: `^\s*-\s+(.+?)\s*$`.
+Expected as a bulleted list. Parser regex: `^\s*-\s+(.+?)\s*$`, applied after the same line-joining as §5.2.
 
-Lines matching → extracted into `non_goals[]` in document order. If body is prose only, emit `non_goals_not_bulleted` warning and place prose in `non_goals_prose`.
+Matching items → extracted into `non_goals[]` in document order. **Wrapped items (v1.2+)** follow §5.2 exactly: a non-blank line that does not start a list item is joined to the open item with a single space, so a non-goal that wraps keeps its whole text instead of being truncated to its first line. If body is prose only, emit `non_goals_not_bulleted` warning and place prose in `non_goals_prose`.
 
 ## 6. Warning codes
 

--- a/ai-dev-assistant/references/alignment-contract.md
+++ b/ai-dev-assistant/references/alignment-contract.md
@@ -62,7 +62,7 @@ Sibling to `task.md`, `research.md`, `architecture.md`, `implementation.md` in t
 
 Phase sections are OPTIONAL — a brand-new task's `alignment.md` may contain only `## Task-Level`; phase sections are appended as the task enters each phase.
 
-**Section presence semantics (v3.13.2+):** a section is `present: true` in the parsed output **only when the H2 heading exists AND at least one of its four canonical fields carries non-empty content** (populated prose body, ≥1 task-list criterion, ≥1 non-goal bullet, or any fallback prose body). An H2 with no H3s, or with all H3s empty, is a **stub** — the parser emits `present: false` for that section and adds a `section_empty_stub` warning. This matches consumer intent: `/research`, `/design`, `/implement` use `present: true` to decide "scope exists, skip the offer" — a stub H2 shouldn't satisfy that check. Before v3.13.2 the reader reported `present: true` for stub H2s, causing phase commands to silently skip legitimate alignment offers.
+**Section presence semantics (v3.13.2+):** a section is `present: true` in the parsed output **only when the H2 heading exists AND at least one of its four canonical fields carries non-empty content** (populated prose body, ≥1 task-list criterion, ≥1 non-goal bullet, or any fallback prose body). An H2 with no H3s, or with all H3s empty, is a **stub** — the parser emits `present: false` for that section and adds a `section_empty_stub` warning. **(v1.2+)** When such a section nonetheless carries non-blank body content that sits under no recognized H3, the warning is `section_unparsed_body` instead: `present` is still `false`, but the author wrote something and the grammar did not recognize its shape, which is a different thing to go and fix. This matches consumer intent: `/research`, `/design`, `/implement` use `present: true` to decide "scope exists, skip the offer" — a stub H2 shouldn't satisfy that check. Before v3.13.2 the reader reported `present: true` for stub H2s, causing phase commands to silently skip legitimate alignment offers.
 
 ## 3. Recognized H2 section headings
 
@@ -145,7 +145,8 @@ Reader emits all applicable warnings in a single `warnings[]` array. Never abort
 | `missing_field` | Expected H3 not found inside a recognized H2 |
 | `unknown_field` | H3 present but not one of the 4 canonical field names |
 | `empty_field` | Recognized H3 present but body is blank |
-| `section_empty_stub` | **(v3.13.2+)** H2 section heading exists but no H3 fields carry any content — the section is a stub. `sections.<key>.present` is `false` in this case. |
+| `section_empty_stub` | **(v3.13.2+)** H2 section heading exists and nothing was written under it — the section is a stub. `sections.<key>.present` is `false` in this case. |
+| `section_unparsed_body` | **(v1.2+)** H2 section heading exists and carries body content, but none of it sits under a recognized H3 field, so nothing parsed. Almost always a shape error rather than a missing-content one — bold labels (`**Goal**`) where H3 headings (`### Goal`) are required is the common case. `sections.<key>.present` is `false`, same as a stub; the two are separated because "empty" sends an author looking for content they already wrote instead of at the heading level. |
 | `success_criteria_not_checklist` | `Success criteria` body is prose instead of `- [ ]` task-list |
 | `non_goals_not_bulleted` | `Non-goals` body is prose instead of `- …` bulleted list |
 | `error` | Unrecoverable read failure (permission denied, invalid UTF-8). Only case producing non-zero exit. |

--- a/ai-dev-assistant/scripts/alignment-read.sh
+++ b/ai-dev-assistant/scripts/alignment-read.sh
@@ -107,7 +107,20 @@ RECORDS=$(awk '
     }
   }
   function flush_field(   i, body, had_item, verif, has_verif, best, dl, p1, p2, p3, d1, d2, d3) {
-    if (cur_section == "" || cur_field == "") return
+    if (cur_section == "" || cur_field == "") {
+      # An H2 whose body sits under no recognized H3 field. Emitting nothing
+      # here makes the section read as an empty stub, which names the wrong
+      # problem: the author wrote the fields in a shape the grammar does not
+      # recognize (bold labels instead of H3 headings is the common one), and
+      # being told the section is empty sends them hunting for missing content
+      # rather than a wrong heading level. Recorded so the warning can say
+      # which of the two it actually is.
+      if (cur_section != "" && orphan_n > 0) {
+        printf "{\"kind\":\"orphan_body\",\"section\":\"%s\"}\n", cur_section
+        orphan_n = 0
+      }
+      return
+    }
     if (cur_field == "success_criteria") {
       had_item = 0
       join_wrapped()
@@ -196,6 +209,7 @@ RECORDS=$(awk '
     cur_section = ""
     cur_field = ""
     buf_n = 0
+    orphan_n = 0
     seen_h1 = 0
   }
   # H1: task title (first line only)
@@ -235,6 +249,7 @@ RECORDS=$(awk '
     }
     cur_field = ""
     buf_n = 0
+    orphan_n = 0
     next
   }
   # H3: field (only meaningful within a recognized section)
@@ -259,6 +274,13 @@ RECORDS=$(awk '
   # accumulate body lines for the current field
   cur_field != "" {
     buf[++buf_n] = $0
+  }
+  # Non-blank body inside a recognized H2 but under no recognized H3. Counted,
+  # never kept: enough to tell a section written in a shape the grammar does not
+  # recognize from a section nobody wrote at all. In a well-formed file only
+  # blank lines sit here, so the count stays zero.
+  cur_section != "" && cur_field == "" && /[^[:space:]]/ {
+    orphan_n++
   }
   END {
     flush_field()
@@ -357,8 +379,14 @@ printf '%s\n' "$RECORDS" | jq -cs --arg fp "$ALIGNMENT_MD" '
   (map(select(.kind == "criteria_prose"))  | map({code: "success_criteria_not_checklist", section: .section})) as $w_crit_prose |
   (map(select(.kind == "non_goals_prose")) | map({code: "non_goals_not_bulleted", section: .section})) as $w_ngoal_prose |
 
-  # section_empty_stub warnings: H2 exists but zero content records
-  ($empty_stub_keys | map({code: "section_empty_stub", section: .})) as $w_empty_stub |
+  # An H2 with zero parsed content splits two ways, and the difference is the
+  # whole diagnostic: nothing was written, or something was written in a shape
+  # the grammar does not recognize.
+  (map(select(.kind == "orphan_body")) | map(.section) | unique) as $orphan_keys |
+  ($empty_stub_keys - $orphan_keys) as $truly_empty_keys |
+  ($empty_stub_keys - $truly_empty_keys) as $unparsed_keys |
+  ($truly_empty_keys | map({code: "section_empty_stub", section: .})) as $w_empty_stub |
+  ($unparsed_keys | map({code: "section_unparsed_body", section: .})) as $w_unparsed |
 
   # missing_field warnings from sections_final.fields_missing (truly absent H3s)
   ([$sections_final | to_entries[] | select(.value.present) | {sk: .key, fm: .value.fields_missing}]
@@ -371,6 +399,6 @@ printf '%s\n' "$RECORDS" | jq -cs --arg fp "$ALIGNMENT_MD" '
     created: ($meta_created.created // null),
     schema_version: "1.0",
     sections: $sections_final,
-    warnings: ($w_unk_sec + $w_unk_field + $w_empty + $w_crit_prose + $w_ngoal_prose + $w_empty_stub + $w_missing)
+    warnings: ($w_unk_sec + $w_unk_field + $w_empty + $w_crit_prose + $w_ngoal_prose + $w_empty_stub + $w_unparsed + $w_missing)
   }
 '

--- a/ai-dev-assistant/scripts/alignment-read.sh
+++ b/ai-dev-assistant/scripts/alignment-read.sh
@@ -84,12 +84,35 @@ RECORDS=$(awk '
     if (match(h, /^Phase 3 (—|–|-) Implementation$/)) return "phase_3"
     return ""
   }
+  # Fold markdown list-item continuation lines into the item they belong to.
+  # A "- [ ] ..." or "- ..." item wraps onto any following non-blank line that
+  # does not itself start a list item; a blank line closes it. Without this the
+  # per-line scan below keeps only the FIRST line of an item and silently drops the
+  # rest, so a wrapped criterion becomes a sentence fragment and a "— verify:"
+  # note that wrapped is lost entirely — with no warning to say so. Wrapping is
+  # ordinary markdown and renders as one item, so the writer produces it.
+  # Populates jn[1..jn_n]; buf stays untouched for the prose fallback.
+  function join_wrapped(   i, l, open) {
+    jn_n = 0; open = 0
+    for (i = 1; i <= buf_n; i++) {
+      l = buf[i]
+      if (match(l, /^[[:space:]]*-[[:space:]]+/)) {
+        jn[++jn_n] = l; open = 1
+      } else if (open && l ~ /[^[:space:]]/) {
+        jn[jn_n] = jn[jn_n] " " trim(l)
+      } else {
+        jn[++jn_n] = l
+        if (!(l ~ /[^[:space:]]/)) open = 0
+      }
+    }
+  }
   function flush_field(   i, body, had_item, verif, has_verif, best, dl, p1, p2, p3, d1, d2, d3) {
     if (cur_section == "" || cur_field == "") return
     if (cur_field == "success_criteria") {
       had_item = 0
-      for (i = 1; i <= buf_n; i++) {
-        line = buf[i]
+      join_wrapped()
+      for (i = 1; i <= jn_n; i++) {
+        line = jn[i]
         if (match(line, /^[[:space:]]*-[[:space:]]+\[[[:space:]xX]\][[:space:]]+.+$/)) {
           text = line
           sub(/^[[:space:]]*-[[:space:]]+\[/, "", text)
@@ -133,8 +156,9 @@ RECORDS=$(awk '
       }
     } else if (cur_field == "non_goals") {
       had_item = 0
-      for (i = 1; i <= buf_n; i++) {
-        line = buf[i]
+      join_wrapped()
+      for (i = 1; i <= jn_n; i++) {
+        line = jn[i]
         # bullet but not a task-list item
         if (match(line, /^[[:space:]]*-[[:space:]]+/) && !match(line, /^[[:space:]]*-[[:space:]]+\[[[:space:]xX]\]/)) {
           text = line

--- a/ai-dev-assistant/tests/alignment-read-spec.sh
+++ b/ai-dev-assistant/tests/alignment-read-spec.sh
@@ -375,6 +375,96 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# A section with zero parsed content splits two ways (v1.2). Before this, both
+# reported section_empty_stub — so an author who wrote the four fields as bold
+# labels instead of H3 headings was told the section was empty while looking at
+# a screen full of their own text, and had to go read the grammar to find out
+# what was actually wrong.
+
+# T14: body content present, no recognized H3 → section_unparsed_body
+D="$(mkalign t14 <<'EOF'
+# Alignment: t14
+
+**Task:** t14
+**Created:** 2026-08-25
+
+## Task-Level
+
+**Goal**
+
+Published items whose dates have passed stay published indefinitely.
+
+**Success criteria**
+
+- [ ] A past item is unpublished automatically
+EOF
+)"
+arun "$D"
+W="$(jq -r '[.warnings[].code] | join(",")' <<<"$OUT")"
+if [ "$RC" -eq 0 ] \
+  && [ "$W" = "section_unparsed_body" ] \
+  && [ "$(jq -r '.sections.task_level.present' <<<"$OUT")" = "false" ]; then
+  pass_check "T14 bold labels: section_unparsed_body, not section_empty_stub"
+else
+  fail_check "T14 bold labels: section_unparsed_body, not section_empty_stub" \
+    "warnings=$W present=$(jq -r '.sections.task_level.present' <<<"$OUT") rc=$RC"
+fi
+
+# T15: H2 with genuinely nothing under it keeps section_empty_stub
+D="$(mkalign t15 <<'EOF'
+# Alignment: t15
+
+**Task:** t15
+**Created:** 2026-08-25
+
+## Task-Level
+EOF
+)"
+arun "$D"
+W="$(jq -r '[.warnings[].code] | join(",")' <<<"$OUT")"
+if [ "$RC" -eq 0 ] \
+  && [ "$W" = "section_empty_stub" ] \
+  && [ "$(jq -r '.sections.task_level.present' <<<"$OUT")" = "false" ]; then
+  pass_check "T15 genuinely empty H2 still reports section_empty_stub"
+else
+  fail_check "T15 genuinely empty H2 still reports section_empty_stub" \
+    "warnings=$W present=$(jq -r '.sections.task_level.present' <<<"$OUT") rc=$RC"
+fi
+
+# T16: a well-formed section with a line of preamble under the H2 before the
+# first H3 is NOT flagged — it parsed fine, so neither warning applies
+D="$(mkalign t16 <<'EOF'
+# Alignment: t16
+
+**Task:** t16
+**Created:** 2026-08-25
+
+## Task-Level
+
+A sentence of preamble that belongs to no field.
+
+### Goal
+
+g
+
+### Success criteria
+
+- [ ] a criterion
+EOF
+)"
+arun "$D"
+W="$(jq -r '[.warnings[].code] | join(",")' <<<"$OUT")"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.sections.task_level.present' <<<"$OUT")" = "true" ] \
+  && [[ "$W" != *"section_unparsed_body"* ]] \
+  && [[ "$W" != *"section_empty_stub"* ]]; then
+  pass_check "T16 preamble under a populated H2 raises neither stub warning"
+else
+  fail_check "T16 preamble under a populated H2 raises neither stub warning" \
+    "warnings=$W present=$(jq -r '.sections.task_level.present' <<<"$OUT") rc=$RC"
+fi
+
+# ---------------------------------------------------------------------------
 echo "----"
 echo "alignment-read-spec: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/ai-dev-assistant/tests/alignment-read-spec.sh
+++ b/ai-dev-assistant/tests/alignment-read-spec.sh
@@ -194,6 +194,187 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Wrapped list items (v1.2). A "- [ ] ..." item that continues on the next line
+# is ordinary markdown and renders as one item, and the writer produces them —
+# but the per-line scan kept only the first line and dropped the rest with no
+# warning, so a criterion became a sentence fragment and a wrapped "— verify:"
+# note vanished. Found by feeding the reader a real scope contract.
+
+# T8: criterion wraps, and the verify note starts on a continuation line
+D="$(mkalign t8 <<'EOF'
+# Alignment: t8
+
+**Task:** t8
+**Created:** 2026-08-25
+
+## Task-Level
+
+### Goal
+g
+
+### Success criteria
+- [ ] A fixture set exists, covering: an item wholly in the past; an item wholly
+      in the future; a recurring item with past and future occurrences
+      — verify: running the routine on a clean database produces all three
+EOF
+)"
+arun "$D"
+WANT_T8="A fixture set exists, covering: an item wholly in the past; an item wholly in the future; a recurring item with past and future occurrences"
+if [ "$RC" -eq 0 ] \
+  && [ "$(tlcrit 0 text)" = "$WANT_T8" ] \
+  && [ "$(tlcrit 0 verification)" = "running the routine on a clean database produces all three" ] \
+  && [ "$(jq -r '.sections.task_level.success_criteria | length' <<<"$OUT")" = "1" ]; then
+  pass_check "T8 wrapped criterion: whole text joined, wrapped verify note captured"
+else
+  fail_check "T8 wrapped criterion: whole text joined, wrapped verify note captured" \
+    "text=$(tlcrit 0 text) verif=$(tlcrit 0 verification) rc=$RC"
+fi
+
+# T9: criterion wraps mid-sentence with no verify suffix at all
+D="$(mkalign t9 <<'EOF'
+# Alignment: t9
+
+**Task:** t9
+**Created:** 2026-08-25
+
+## Task-Level
+
+### Goal
+g
+
+### Success criteria
+- [ ] Events are unpublished, never deleted, and the node count is
+      unchanged afterwards
+EOF
+)"
+arun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(tlcrit 0 text)" = "Events are unpublished, never deleted, and the node count is unchanged afterwards" ] \
+  && [ "$(tlcrit 0 verification)" = "null" ]; then
+  pass_check "T9 wrapped criterion, no verify suffix: whole text joined"
+else
+  fail_check "T9 wrapped criterion, no verify suffix: whole text joined" \
+    "text=$(tlcrit 0 text) verif=$(tlcrit 0 verification) rc=$RC"
+fi
+
+# T10: the verify NOTE itself wraps — the tail of the note must not be cut
+D="$(mkalign t10 <<'EOF'
+# Alignment: t10
+
+**Task:** t10
+**Created:** 2026-08-25
+
+## Task-Level
+
+### Goal
+g
+
+### Success criteria
+- [ ] An already-unpublished item is left untouched — verify: no re-save, no
+      new log entry on a second run
+EOF
+)"
+arun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(tlcrit 0 text)" = "An already-unpublished item is left untouched" ] \
+  && [ "$(tlcrit 0 verification)" = "no re-save, no new log entry on a second run" ]; then
+  pass_check "T10 wrapped verify note: full note captured, not cut mid-sentence"
+else
+  fail_check "T10 wrapped verify note: full note captured, not cut mid-sentence" \
+    "text=$(tlcrit 0 text) verif=$(tlcrit 0 verification) rc=$RC"
+fi
+
+# T11: non-goals wrap the same way and lost their tails the same way
+D="$(mkalign t11 <<'EOF'
+# Alignment: t11
+
+**Task:** t11
+**Created:** 2026-08-25
+
+## Task-Level
+
+### Goal
+g
+
+### Non-goals
+- Changing how items are displayed. The view, its blocks, and the
+  calendar are untouched.
+- Deleting items.
+EOF
+)"
+arun "$D"
+NG0="$(jq -r '.sections.task_level.non_goals[0]' <<<"$OUT")"
+if [ "$RC" -eq 0 ] \
+  && [ "$NG0" = "Changing how items are displayed. The view, its blocks, and the calendar are untouched." ] \
+  && [ "$(jq -r '.sections.task_level.non_goals | length' <<<"$OUT")" = "2" ]; then
+  pass_check "T11 wrapped non-goal: whole text joined, count unchanged"
+else
+  fail_check "T11 wrapped non-goal: whole text joined, count unchanged" \
+    "ng0=$NG0 len=$(jq -r '.sections.task_level.non_goals | length' <<<"$OUT") rc=$RC"
+fi
+
+# T12: a following line that itself starts a list item is a NEW item, never a
+# continuation — two wrapped criteria must stay two criteria
+D="$(mkalign t12 <<'EOF'
+# Alignment: t12
+
+**Task:** t12
+**Created:** 2026-08-25
+
+## Task-Level
+
+### Goal
+g
+
+### Success criteria
+- [ ] First criterion that wraps onto
+      a second line
+- [ ] Second criterion that wraps onto
+      a second line
+EOF
+)"
+arun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.sections.task_level.success_criteria | length' <<<"$OUT")" = "2" ] \
+  && [ "$(tlcrit 0 text)" = "First criterion that wraps onto a second line" ] \
+  && [ "$(tlcrit 1 text)" = "Second criterion that wraps onto a second line" ]; then
+  pass_check "T12 adjacent wrapped items stay separate items"
+else
+  fail_check "T12 adjacent wrapped items stay separate items" \
+    "len=$(jq -r '.sections.task_level.success_criteria | length' <<<"$OUT") t0=$(tlcrit 0 text) t1=$(tlcrit 1 text)"
+fi
+
+# T13: a blank line closes an item — trailing prose after it is not swallowed
+# into the last criterion
+D="$(mkalign t13 <<'EOF'
+# Alignment: t13
+
+**Task:** t13
+**Created:** 2026-08-25
+
+## Task-Level
+
+### Goal
+g
+
+### Success criteria
+- [ ] A criterion that wraps onto
+      a second line
+
+Some trailing note that belongs to nobody.
+EOF
+)"
+arun "$D"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.sections.task_level.success_criteria | length' <<<"$OUT")" = "1" ] \
+  && [ "$(tlcrit 0 text)" = "A criterion that wraps onto a second line" ]; then
+  pass_check "T13 blank line closes the item; trailing prose not absorbed"
+else
+  fail_check "T13 blank line closes the item; trailing prose not absorbed" \
+    "len=$(jq -r '.sections.task_level.success_criteria | length' <<<"$OUT") t0=$(tlcrit 0 text)"
+fi
+
+# ---------------------------------------------------------------------------
 echo "----"
 echo "alignment-read-spec: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/ai-dev-assistant/tests/scope-reads-invocation-spec.sh
+++ b/ai-dev-assistant/tests/scope-reads-invocation-spec.sh
@@ -41,6 +41,11 @@ have   scope.md "stub: seeded verbatim, in the user's words"               'verb
 have   scope.md "stub: no paraphrase at scaffold time"                     'Do not paraphrase it'
 have   scope.md "stub: placeholder is the no-description branch only"      'Only when the invocation carried nothing'
 have   scope.md "stub: template shows the conditional goal line"           'the invocation description verbatim, if one was given'
+have   scope.md "stub: seeding applies to a stub an earlier run left behind" 'whether this run scaffolded it or an earlier interrupted run'
+have   scope.md "stub: an existing placeholder loses the words the same way" 'Leaving an existing stub.s placeholder in place'
+have   scope.md "stub: folder existing is not evidence of authorship"        'not evidence the task was authored'
+have   scope.md "resolution: a stub row exists distinct from an authored one" 'Folder exists but .task.md. is \*\*a stub\*\*'
+have   scope.md "resolution: authored task.md is what proceeds normally"     'Folder exists with an authored .task.md.'
 
 # --- Defect 1: mode selection counts both sources ---
 have   scope.md "mode: classified on invocation AND task.md together"      'counted together'

--- a/ai-dev-assistant/tests/scope-reads-invocation-spec.sh
+++ b/ai-dev-assistant/tests/scope-reads-invocation-spec.sh
@@ -56,6 +56,13 @@ have   scope.md "mode: reaching open exploration by drift is a bug"        'is a
 absent scope.md "mode: disk-only table header is gone"                     '^\| task\.md state \| Mode \|'
 absent scope.md "mode: unconditional empty-stub row is gone"               '^\| Stub / empty \| \*\*Open exploration\*\*'
 
+# --- The command renders the artifact's shape, so it need not be recalled ---
+have   scope.md "template: shows the H3 field headings"                     '^### Goal$'
+have   scope.md "template: shows all four fields"                           '^### Non-goals$'
+have   scope.md "template: shows the verify suffix in place"                'verify: <how it will be checked>'
+have   scope.md "template: H3 vs bold labels is stated outright"            'never bold labels'
+have   scope.md "template: says what breaks — the contract goes invisible"  'invisible to'
+
 # --- Defect 2: the phase boundary is stated ---
 have   scope.md "boundary: investigating the codebase is prohibited here"  'Do not investigate the codebase to answer the scope questions'
 have   scope.md "boundary: named as Phase 1 / research work"               'is Phase 1'


### PR DESCRIPTION
Four defects, all surfaced by one live `/scope` run reaching its contract.

**`/scope` never showed the shape of the artifact it exists to write.** Three hundred lines instructing the author to produce a four-field contract, and not one occurrence of `### Goal` in any of them — the "Writing `alignment.md`" section renders the H1 and metadata lines, then a bare `<section>` placeholder. The run wrote the four fields as bold labels, the reader parsed nothing, and it had to go open `references/alignment-contract.md` to find out why. Same family as the retyped-prompt defects: the command mandates an artifact and never renders its form.

**The reader then named the wrong problem.** A `## Task-Level` carrying two kilobytes of content in an unrecognized shape reported `section_empty_stub` — the same code as a heading with nothing under it. "Empty" sends an author hunting for content they can see on their screen instead of at the heading level, which is exactly the detour that run took.

**A wrapped success criterion is silently truncated, and a wrapped verify note is lost or cut.** Found by feeding the reader a wrapped variant of the real contract before it was written: a criterion listing six fixture cases came back as `"A repeatable fixture set exists before implementation, created through the"` with `verification: null`. `warnings` was empty. `spec-axis-reviewer` judges the finished change against these criteria, so Phase 4 would have checked a fragment that asserts nothing.

**The 5.30.5 goal-seeding rule missed the folder it was about to meet** — it fired only when `/scope` scaffolded the folder in that same run, so an interrupted run's leftover stub took the "task is established" branch and discarded the description again.

## What to look at first

`commands/scope.md` — the full section template, the H3-not-bold rule stated outright with the consequence named, and the resolution table separating an authored `task.md` from a stub.

`scripts/alignment-read.sh` — `join_wrapped()` folds continuation lines into their item before the regex and verification split; a blank line or a new list item closes the open one. Separately, non-blank body inside a recognized H2 that sits under no recognized H3 is counted, so `section_unparsed_body` and `section_empty_stub` are now distinct.

`references/alignment-contract.md` — grammar v1.2. §5.2/§5.3 had sanctioned the truncation in so many words ("each item is on its own line", "(per line)") and now describe the joining; §6 gains the new warning code.

## Risk

`present` stays `false` for both stub cases, so no consumer's skip-the-offer logic changes — only which warning it sees. Joining changes what the reader returns for any contract with wrapped items, which is the fix; contracts without them parse identically, and the original 7 spec cases pass unchanged.

## Verify

`tests/alignment-read-spec.sh` 7 → 16 cases; `tests/scope-reads-invocation-spec.sh` 21 → 31. Mutation-verified: the 6 wrapping cases fail against the pre-fix reader with the original 7 green, T14 fails against the pre-fix warning logic, and all 5 template assertions fail against the pre-fix command. T15 and T16 pass both ways by design — they guard that a genuinely empty section keeps its old code and a populated section with preamble is not newly flagged. `make ci` passes all five checks.

## Not covered

The truncation did not fire on the live contract — that run wrote every criterion as one long line, so nothing was lost on disk. The bug is real and silent for anyone who wraps while editing the file, which is why it is fixed here, but this PR corrects a hazard rather than recovering lost data.

I did not audit the other readers in `scripts/` for the same line-at-a-time assumption, and nothing warns if a future writer emits a shape that is neither line-based nor wrap-based — the reader would again return what it can and say nothing about the rest.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)