### PR TITLE
eslint could pass locally while CI's real config disagreed, and pipeline had no fix path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.40"
+    "version": "2.0.41"
   },
   "plugins": [
     {
@@ -120,7 +120,7 @@
       "name": "drupal-ai-contrib",
       "source": "./drupal-ai-contrib",
       "description": "AI-assisted Drupal contribution quality \u2014 evidence over assertion: every gate passes on a captured artifact, never an AI claim. 6 commands for the contribution arc (setup, issue, verify, review, submit, pipeline) with a local drupalci-parity gate set plus AI-policy and eval gates, and 3 read-only fresh-context review agents. Authenticated GitLab writes delegate to the drupal-gitlab skill (glab); drupalorg-cli covers no-auth reads and the legacy queue. A quality layer outside ai-dev-assistant, built on the camoa/dev-guides contribution guides.",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "author": {
         "name": "camoa"
       },

--- a/drupal-ai-contrib/.claude-plugin/plugin.json
+++ b/drupal-ai-contrib/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "drupal-ai-contrib",
   "description": "AI-assisted Drupal contribution quality — evidence over assertion. Mirrors the drupalci pipeline locally at CI strictness, gates on the adopted AI-contribution policy, reviews work in fresh-context agents, and confirms the real GitLab pipeline so AI-assisted contributions pass drupalci and survive maintainer review.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "camoa"
   },

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3] - 2026-08-27
+
+Eslint/stylelint CI-parity gap: `verify`'s environment-match stopped at PHP/core
+version, and `pipeline` had no recovery path once a locally-clean lint run reached CI
+red.
+
+### Fixed
+
+- **`contribution-verify` §1 didn't environment-match JS/CSS tooling.** The shared
+  `gitlab_templates` eslint job merges core's linked `.eslintrc.passing.json` (+ jquery
+  variant) with the project's own `.eslintrc.json` via ESLint's own config cascade, plus
+  core's `.prettierrc.json` when absent — none of which a hand-rebuilt local eslint
+  command reproduces. Added the same environment-match discipline already applied to
+  PHP/core version. The `eslint`/`stylelint` gate-table row in §3 now points at it.
+- **`contribution-pipeline` §3 had no recovery path for a lint failure.** The eslint job
+  always uploads `_eslint.patch` as a job artifact (even empty) — the exact diff its own
+  `--fix` run produced. Added fetch-and-apply instructions, plus the caution against a
+  broad local `--fix` reformatting files outside the contribution (the shared job's own
+  `--fix` is scoped to files with real content diffs; a local one has no such filter).
+  `stylelint` has no equivalent patch artifact — only a `gl-codequality.json` findings
+  report — documented as its own case, not folded into the eslint instructions.
+- **The `.prettierrc.json` fallback in §1 was a fact, not a command.** Found by loading
+  this branch via `--plugin-dir` and running `/drupal-ai-contrib:verify` for real
+  against a live contribution: the eslint config resolved correctly, but Prettier
+  resolves its own config independently of eslint's `--config` flag, so the run silently
+  fell back to Prettier's default (`singleQuote: false`) and reported the reverse of the
+  project's real quote convention. Replaced the sentence with the literal three-line
+  symlink sequence the real CI job runs.
+
+### Verified
+
+- Both jobs' real behavior confirmed against `includes/include.drupalci.main.yml` in
+  `project/gitlab_templates` (the `eslint` and `stylelint` job blocks) — not assumed
+  from memory.
+- Live-tested against a real contribution via `--plugin-dir` + `/drupal-ai-contrib:verify`
+  (see the §1 fix above — that's how the fallback gap was found). Also confirmed against
+  a real historical CI failure (`ai_metering` job `10995315`, MR !31: pipeline "success",
+  job `status: failed`, `_eslint.patch` still fetchable today) and the config-cascade
+  merge on two published contrib modules with their own `.eslintrc.json`
+  (`ai_agents`, `ai_context`).
+
+### Bumped
+
+- Plugin `0.4.2` → `0.4.3`. Root `marketplace.json` entry `0.4.2` → `0.4.3` and
+  `metadata.version` `2.0.40` → `2.0.41`.
+
 ## [0.4.2] - 2026-08-11
 
 ### Changed

--- a/drupal-ai-contrib/CHANGELOG.md
+++ b/drupal-ai-contrib/CHANGELOG.md
@@ -48,6 +48,21 @@ red.
 - Plugin `0.4.2` → `0.4.3`. Root `marketplace.json` entry `0.4.2` → `0.4.3` and
   `metadata.version` `2.0.40` → `2.0.41`.
 
+### Review follow-ups, same PR
+
+- The eslint reproduction now quotes the job's own full invocation rather than a shortened
+  one. `--ext=.js,.yml` is the load-bearing flag: given a directory, ESLint lints `.js` only
+  by default while CI also lints `*.info.yml`, `*.libraries.yml` and `*.services.yml`, so a
+  run without it reports clean on files CI checks. That was the same false clean this change
+  set out to close, one level down. `--ignore-pattern="*.es6.js"` and the `.prettierignore`
+  step are included for the same reason.
+- The config symlinks use `-f` so a re-run does not fail, and the `.prettierrc.json` link,
+  which lands inside the contribution repo rather than above it, is now called out for
+  removal so it cannot be committed by accident.
+- Corrected the claim about the job's `--fix` scope. It runs `--fix .` project-wide; its
+  patch is narrow because the project was otherwise clean, not because the run was scoped.
+- Clarified that stylelint's lack of a fallback is about the config cascade, not Prettier.
+
 ## [0.4.2] - 2026-08-11
 
 ### Changed

--- a/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
@@ -60,6 +60,26 @@ A pipeline reported "passed" can still hide problems. Inspect **every job**:
   manual trigger. An un-run manual job is **not coverage**. Report it explicitly as
   not run — never imply a green pipeline means those variants passed.
 
+**A failed `eslint` job ships its own fix — `stylelint` does not.** The shared
+`gitlab_templates` eslint job always uploads `_eslint.patch` as a job artifact (empty
+when there's nothing to fix) — the exact diff its own `--fix` run produced. Get the job
+ID from `glab ci view`, then fetch and apply the patch directly:
+
+    glab api …/jobs/<id>/artifacts/_eslint.patch > _eslint.patch
+    git apply _eslint.patch
+
+`stylelint` publishes findings only (`gl-codequality.json`), never a patch — there is
+nothing to fetch and apply. Read the report, or reproduce `stylelint --fix` locally
+against whichever config actually applies (project's own, or core's only if absent).
+
+**Never re-derive an eslint fix by running `--fix` on the whole project "to see what
+breaks".** The shared job's own `--fix` run is scoped to only the changed `.js`/`.yml`
+files with real content diffs — a broad local `--fix` has no such filter and reformats
+every drifted file the job would also flag, most of them outside the current
+contribution. If `_eslint.patch` is unavailable, scope any local `--fix` to the single
+failing file and run `git diff --stat` immediately after to catch an abnormal blast
+radius before committing.
+
 ### 4. Gate
 
 The contribution is **done** only when: every blocking job is green, every
@@ -100,3 +120,5 @@ is the pipeline's — never assert "should pass".
 | Pipeline still running | Report in-progress; the gate is not satisfied until jobs finish. |
 | Pipeline needs re-running | Triggers are blocked on `git.drupalcode.org` — push a commit (`--allow-empty` if no code change); pipelines fire on push only. |
 | A blocking job failed | Diagnose against the reproduction dev-guide; route back to development → `verify`. |
+| `eslint` job failed, local run was clean | Local eslint likely isn't using core's linked config + pinned binary (`contribution-verify` §1) — don't re-guess; fetch `_eslint.patch` from the job instead. |
+| `stylelint` job failed | No patch artifact exists for stylelint — read `gl-codequality.json` from the job, or reproduce `stylelint --fix` locally scoped to the failing file(s). |

--- a/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-pipeline/SKILL.md
@@ -73,10 +73,12 @@ nothing to fetch and apply. Read the report, or reproduce `stylelint --fix` loca
 against whichever config actually applies (project's own, or core's only if absent).
 
 **Never re-derive an eslint fix by running `--fix` on the whole project "to see what
-breaks".** The shared job's own `--fix` run is scoped to only the changed `.js`/`.yml`
-files with real content diffs — a broad local `--fix` has no such filter and reformats
-every drifted file the job would also flag, most of them outside the current
-contribution. If `_eslint.patch` is unavailable, scope any local `--fix` to the single
+breaks".** The job runs `--fix .` across the whole project, so its patch is not narrow
+by scoping; it is narrow because the project was already clean apart from the change. A
+local `--fix` on a project that has drifted since reformats every drifted file at once,
+most of them outside the current contribution. The patch artifact is the safe path
+precisely because it is the diff the job produced against that state, not one you
+regenerate against yours. If `_eslint.patch` is unavailable, scope any local `--fix` to the single
 failing file and run `git diff --stat` immediately after to catch an abnormal blast
 radius before committing.
 

--- a/drupal-ai-contrib/skills/contribution-verify/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-verify/SKILL.md
@@ -35,6 +35,25 @@ Read from `.gitlab-ci.yml`: `_TARGET_CORE`, `_TARGET_PHP`, `_GITLAB_TEMPLATES_RE
 are **resolved, never baked in**. If the environment is not matched, say so — local
 green on mismatched versions is not evidence.
 
+JS/CSS tooling needs the same discipline — as a command, not just a principle.
+Prettier resolves its own config independently of ESLint's `--config` / `--no-eslintrc`
+flags, so pointing `eslint` at core's linked config is not enough by itself: a run that
+never resolves the project's (or core's) `.prettierrc.json` still executes cleanly and
+reports a verdict — it just silently falls back to Prettier's own default
+(`singleQuote: false`), the **opposite** of core's convention, and flags the **opposite**
+set of quote violations from CI's real one. Reproduce what the shared `gitlab_templates`
+job actually does before running `eslint`:
+
+    ln -sv <core>/.eslintrc.passing.json <project>/../.eslintrc.json
+    ln -sv <core>/.eslintrc.jquery.json <project>/../.eslintrc.jquery.json
+    test -e <project>/.prettierrc.json || ln -sv <core>/.prettierrc.json <project>/.prettierrc.json
+
+then run `<core>/node_modules/.bin/eslint` from inside `<project>` with
+`--resolve-plugins-relative-to=<core>` — the same binary and the same merged config CI
+uses, not a hand-assembled command. `stylelint` has no such fallback: it uses the
+project's own `.stylelintrc*` when present, core's only when absent — confirm which one
+actually applies before assuming either.
+
 ### 2. Parse the enabled gate set
 
 `.gitlab-ci.yml` `include`s the `gitlab_templates` files. Determine which jobs are
@@ -52,7 +71,7 @@ Run each enabled job locally at CI strictness; capture each one's output as the 
 | `phpstan` | `phpstan analyse` with the project's `phpstan.neon` (`phpstan-drupal`). **`allow_failure: true` by default** — report it, flagged non-blocking. |
 | `phpunit` | Run with the **core config**: `vendor/bin/phpunit -c web/core/phpunit.xml.dist --webroot=web`, switching to `core/scripts/run-tests.sh` when `_PHPUNIT_CONCURRENT: 1`. The core `phpunit.xml.dist` carries `failOnWarning` / `failOnPhpunitWarning` — that is what fails on warnings. Pass = zero failures, zero warnings, zero deprecations. |
 | `cspell` | `cspell` with the project's `.cspell-project-words.txt` loaded |
-| `eslint` / `stylelint` | only when JS/CSS present and not `SKIP_ESLINT` / `SKIP_STYLELINT` |
+| `eslint` / `stylelint` | only when JS/CSS present and not `SKIP_ESLINT` / `SKIP_STYLELINT`; resolve the project's own merged config, never a rebuilt command (§1) |
 
 **Opt-in variants** — `OPT_IN_TEST_PREVIOUS_MAJOR` / `_PREVIOUS_MINOR` / `_NEXT_MINOR` /
 `_MAX_PHP`. `gitlab_templates` v1.15.0+ moved these to **manual trigger** — they do not

--- a/drupal-ai-contrib/skills/contribution-verify/SKILL.md
+++ b/drupal-ai-contrib/skills/contribution-verify/SKILL.md
@@ -44,15 +44,34 @@ reports a verdict — it just silently falls back to Prettier's own default
 set of quote violations from CI's real one. Reproduce what the shared `gitlab_templates`
 job actually does before running `eslint`:
 
-    ln -sv <core>/.eslintrc.passing.json <project>/../.eslintrc.json
-    ln -sv <core>/.eslintrc.jquery.json <project>/../.eslintrc.jquery.json
-    test -e <project>/.prettierrc.json || ln -sv <core>/.prettierrc.json <project>/.prettierrc.json
+    ln -sfv <core>/.eslintrc.passing.json <project>/../.eslintrc.json
+    ln -sfv <core>/.eslintrc.jquery.json <project>/../.eslintrc.jquery.json
+    test -e <project>/.prettierrc.json || ln -sfv <core>/.prettierrc.json <project>/.prettierrc.json
 
-then run `<core>/node_modules/.bin/eslint` from inside `<project>` with
-`--resolve-plugins-relative-to=<core>` — the same binary and the same merged config CI
-uses, not a hand-assembled command. `stylelint` has no such fallback: it uses the
-project's own `.stylelintrc*` when present, core's only when absent — confirm which one
-actually applies before assuming either.
+The first two land **above** the contribution repo, so they never enter the MR. The third
+lands **inside** it: remove it when you are done, or it will show up in `git status` and can
+be committed by accident. `-f` so a re-run does not fail on an existing link.
+
+CI also writes a `.prettierignore` when the project has none, which exempts YAML from
+Prettier's rules:
+
+    test -e <project>/.prettierignore || echo '*.yml' > <project>/.prettierignore
+
+Then run the job's **own** invocation, not a shortened one. Missing flags reproduce the
+config and lose the scope, which is the same false clean in a different place:
+
+    <core>/node_modules/.bin/eslint --no-error-on-unmatched-pattern \
+      --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=<core> \
+      --ext=.js,.yml .
+
+`--ext=.js,.yml` is the one that matters most: given a directory, ESLint lints `.js` only by
+default, while CI also lints `*.info.yml`, `*.libraries.yml` and `*.services.yml`. Drop it and
+the local run reports clean on files CI checks. `--ignore-pattern="*.es6.js"` skips legacy
+files CI skips, so dropping it produces a false red instead. Same binary, same merged config,
+same scope. `stylelint` resolves differently: it uses the project's own
+`.stylelintrc*` when present and core's only when absent, so there is no merged cascade to
+reproduce — confirm which single config applies before assuming either. That is a statement
+about the config cascade, not about Prettier, which stylelint does not involve.
 
 ### 2. Parse the enabled gate set
 


### PR DESCRIPTION
Two defects, both surfaced by the same incident: a JS file passed a locally-reconstructed `eslint` check clean, then failed the real CI job on the opposite rule.

**`contribution-verify` environment-matches PHP and core version but not JS/CSS tooling.** §1 resolves `_TARGET_CORE` / `_TARGET_PHP` before any gate runs, on the stated principle that "local green on mismatched versions is not evidence" — but the `eslint` / `stylelint` row in §3 just said "run it", with no instruction to resolve the project's own config first. A hand-rebuilt lint command can disagree with the project's real `.eslintrc` on something as basic as quote style and report clean anyway. The shared `gitlab_templates` eslint job actually merges two layers — core's linked `.eslintrc.passing.json` (+ jquery variant) with the project's own `.eslintrc.json`, via ESLint's own config cascade, plus core's `.prettierrc.json` when absent — verified against `includes/include.drupalci.main.yml` in `project/gitlab_templates`, not assumed.

**`contribution-pipeline` had no recovery path once that false clean reaches CI.** §3 already knows to surface a red `allow_failure` job rather than hide it, but gave no next step for a lint failure specifically. The eslint job always uploads `_eslint.patch` as a job artifact (even empty) — the exact diff its own `--fix` run produced. Nothing pointed at it. `stylelint` has no equivalent: it only produces a `gl-codequality.json` findings report (no `--fix`, no patch), so it's documented as its own case rather than folded into the eslint instructions — an earlier version of this fix conflated the two, which would have been a false instruction.

## What to look at first

`skills/contribution-verify/SKILL.md` §1 (environment match) and §3's `eslint` / `stylelint` table row — config resolution added alongside the existing PHP/core version resolution.

`skills/contribution-pipeline/SKILL.md` §3 ("Read the pipeline honestly") — the patch-artifact fetch as the diagnosis step for an eslint failure, the stylelint-has-no-patch case documented separately, and the risk of a broad `--fix` reformatting files outside the contribution's scope.

## Risk

Both edits are additive prose in existing procedure sections — no script, no schema, no frontmatter change. Nothing currently passing is affected; the new instructions apply only when JS/CSS is present, which is already the existing gate's own condition.

## Verify

No test harness exists for this plugin (`drupal-ai-contrib` is on the Makefile's untested-plugins list). Verified against the real `project/gitlab_templates` source (the `eslint` and `stylelint` job blocks in `includes/include.drupalci.main.yml`) rather than assumed from memory, and `claude plugin validate ./drupal-ai-contrib` passes clean on the patched tree.

Also reproduced live, not just read from source: on a real Drupal 11 site with `ai_metering` checked out and core's node dependencies installed (`yarn install` in `web/core`), I deliberately flipped one correct single-quoted string to double-quoted in a real module JS file, then ran the actual `core/node_modules/.bin/eslint` binary two ways. Without core's `.prettierrc.json` resolved, the check flagged 24 *other*, already-correct lines as errors (wanting to replace their correct single quotes with double) and said nothing about the one real violation — it happened to match the wrong default. With core's `.prettierrc.json` resolved (as the real CI job does), the same run reported exactly one error, on exactly the flipped line, and zero once reverted. That is the false-clean mechanism this PR documents, reproduced on real code rather than asserted.

The `_eslint.patch` fetch instruction isn't hypothetical either. `ai_metering` had a real failed eslint job before this exact bug got fixed upstream: job `10995315` on an earlier pipeline for the same MR that introduced the quote-style file (pipeline status reads "success" overall — eslint is `allow_failure` — but the job itself is `status: failed`). Fetching `.../jobs/10995315/artifacts/_eslint.patch` today still returns it: HTTP 200, a 5498-byte patch converting the exact same double-quoted strings back to single quotes, on the same file this PR's other reproduction touches. The instruction fetches a real artifact, not a hypothetical one.

The config-cascade claim in the first paragraph — core's linked config merging with a project's *own* `.eslintrc.json` — is verified on real code too, not only on the `gitlab_templates` comment that states it. `ai_metering` has no `.eslintrc.json` of its own, so it doesn't exercise that branch; two published contrib modules do (`ai_agents`, `ai_context`). Reproducing the CI job's symlink step against `ai_agents` and running eslint with no forced config — natural cascade discovery, the same resolution CI relies on for a project that ships its own config — surfaced both `func-names` (a core-only rule, absent from `ai_agents`'s own three-line config) and `prettier/prettier` (core's single-quote rule) in one run, against a file that currently uses double quotes throughout. Both layers apply together, on a real project, not only in theory.

**A second commit fixes a gap the first one had**, found by the most direct test available: loading this exact branch via `--plugin-dir` and running `/drupal-ai-contrib:verify` for real against `ai_metering`. The eslint half of §1 worked as written — it correctly resolved core's linked `.eslintrc.passing.json`. But the run reported ~70 errors wanting to replace the module's correct single quotes with double, the reverse of its real convention. Cause: Prettier resolves its own config independently of eslint's `--config` / `--no-eslintrc` flags, and the first commit named the `.prettierrc.json` fallback as a fact about the mechanism without giving a command for it — an agent following it precisely still fell back to Prettier's own default. Second commit replaces that sentence with the literal three-line symlink sequence the real CI job runs, so there's a command to follow, not just a fact to know. Caught before anything was written to real files — no `--fix` was run.

## Not covered

Doesn't touch `contribution-guardrails`'s `--fix` blast-radius caution as a standalone rule — folded into the pipeline diagnosis step instead, since that's where the temptation to guess actually happens.

Doesn't address the `phpstan` `allow_failure` drift-diagnosis gap or issue-drafting privacy — separate PRs, same shape, following if this one lands.

## Bumped

Plugin `0.4.2` → `0.4.3`. Root `marketplace.json` entry `0.4.2` → `0.4.3` and `metadata.version` `2.0.40` → `2.0.41`.

## AI assistance

Written with Claude Code (research, source verification against `project/gitlab_templates`, the live reproduction above, and this PR's text) under my direction and review.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)