### PR TITLE
ai-dev-assistant 5.34.1 — passed_first_run failed two things, one of which is not a defect

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.43"
+    "version": "2.0.44"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.34.0",
+      "version": "5.34.1",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.34.0",
+  "version": "5.34.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [5.34.1] - 2026-08-28
+
+### Fixed
+- **`passed_first_run` failed two different things and only one was a defect.** v5.34.0 made any
+  `passed_first_run > 0` a hard fail with no reason path, on the strength of `tdd-companion`
+  calling it a blocking violation. That is right for a test written test-first that passes
+  immediately: it asserts nothing about the behavior it claims to test. It is wrong for a
+  characterization or regression test written deliberately against code that already exists,
+  which passes on its first run by design and is worth having — locking in behavior, or
+  reproducing a defect a critic just found.
+
+  A live build hit this within an hour of the release. Several tests added during its repair
+  rounds were written against existing code and passed first time, and the rule would have made
+  the honest record a violation. A gate that punishes the true answer teaches a builder to write
+  a different one, which is the opposite of what this block is for.
+
+  `passed_first_run > 0` now behaves like every other state in the rung: it needs a `reason`
+  saying which kind of test it was, and passes with one. Unexplained, it is `unresolved: true`
+  rather than a settled violation, because without the reason the gate genuinely cannot tell the
+  two apart. The gate checks that the question was answered, not that the answer is true — the
+  same limit already documented for `unobserved` and for contract changes.
+
 ## [5.34.0] - 2026-08-28
 
 ### Fixed

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.34.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.34.1**.
 
 ## License
 

--- a/ai-dev-assistant/references/build-critique.md
+++ b/ai-dev-assistant/references/build-critique.md
@@ -235,15 +235,25 @@ written anyway. The enforcement that actually stops a review is downstream, in
 |---|---|---|---|
 | `tdd` key absent | fail | `true` | 1 |
 | `red_observed` / `passed_first_run` / `unobserved` — any missing | fail | `true` | 1 |
-| `passed_first_run > 0` | fail | `false` | 1 |
+| `passed_first_run > 0`, no `reason` | fail | `true` | 1 |
+| `passed_first_run > 0` with a `reason` | pass | `false` | 0 |
 | `unobserved` non-empty, `reason` empty or absent | fail | `true` | 1 |
 | `unobserved` non-empty, `reason` populated | pass | — | 0 |
 | all present, `unobserved` empty | pass | — | 0 |
 
-`passed_first_run > 0` is `unresolved: false` on purpose — it isn't an unknown, it's a named
-violation: a test that passed before the code existed asserts nothing about the behavior it
-claims to test. Everything else that's wrong with the block is a "could not tell," so it
-reads `unresolved: true` instead. **Applies to the in-session build path only** — see below.
+**Two different things pass on a first run, and only one is a defect.** A test written
+test-first that passes immediately is `tdd-companion`'s named violation: it asserts nothing
+about the behavior it claims to test. A characterization or regression test written
+deliberately against code that already exists passes on its first run by design, and is worth
+having — locking in behavior, or reproducing a defect a critic just found. Both land in
+`passed_first_run`, and the `reason` says which.
+
+v5.34.0 failed both with no reason path at all. A live build hit it immediately: several tests
+added during repair rounds were written against existing code and passed first time, and the
+rule would have made the honest record a violation. A gate that punishes the true answer
+teaches a builder to write a different one. As everywhere else in this rung, the gate checks
+that the question was answered, not that the answer is true. **Applies to the in-session build
+path only** — see below.
 
 ## The contract baseline — Runtime Step 11, before any code exists
 

--- a/ai-dev-assistant/references/tdd-workflow.md
+++ b/ai-dev-assistant/references/tdd-workflow.md
@@ -102,7 +102,7 @@ value that must be written down rather than implied by silence:
 | Value | Meaning |
 |---|---|
 | `observed` | The test was run before the implementation existed and failed **at its own assertion, for the reason it names** |
-| `passed_first_run` | It was run and it passed, so the test is wrong (`tdd-companion`'s blocking violation) |
+| `passed_first_run` | It was run and it passed. The reason says which kind: a test-first test that passes immediately is wrong (`tdd-companion`'s named violation); a characterization or regression test written against existing code passes by design |
 | `unobserved` | Nobody ran it. Legal to record, never legal to leave unsaid |
 
 **A failure is not automatically a RED.** A test that dies in `setUp` — a missing schema, an

--- a/ai-dev-assistant/scripts/build-critique-assert.sh
+++ b/ai-dev-assistant/scripts/build-critique-assert.sh
@@ -217,11 +217,24 @@ if [ -e "$REC" ]; then
     emit fail true "" 1
   fi
 
+  if [ "$FIRSTRUN_N" -gt 0 ] && [ -z "$TDD_REASON" ]; then
+    # Two different things pass on their first run and only one is a defect.
+    #
+    # A test written test-first that passes immediately is the blocking violation
+    # `tdd-companion` names: it is not evidence the behaviour works, it is evidence the test
+    # does not test it. A characterization or regression test deliberately written against
+    # code that already exists passes on its first run BY DESIGN, and is worth having --
+    # locking in behaviour, or reproducing a defect a critic just found.
+    #
+    # The first release of this block failed both, with no reason path. That would have forced
+    # a live build to record a violation for tests that were not violations, which teaches a
+    # builder that the honest answer is the expensive one. Say which kind it was; the gate
+    # checks that the question was answered, not that the answer is true.
+    add_msg "$FIRSTRUN_N test(s) passed on their first run with no reason recorded; say whether the test is wrong or was written deliberately against existing code"
+    emit fail true "" 1
+  fi
   if [ "$FIRSTRUN_N" -gt 0 ]; then
-    # tdd-companion already calls this a blocking violation: a test that passes on its first
-    # run is not evidence the behaviour works, it is evidence the test does not test it.
-    add_msg "$FIRSTRUN_N test(s) passed on their first run, so those tests assert nothing about the behaviour they name"
-    emit fail false "" 1
+    add_msg "$FIRSTRUN_N test(s) passed on their first run: $TDD_REASON"
   fi
 
   if [ "$UNOBS_N" -gt 0 ] && [ -z "$TDD_REASON" ]; then

--- a/ai-dev-assistant/tests/tdd-red-observation-spec.sh
+++ b/ai-dev-assistant/tests/tdd-red-observation-spec.sh
@@ -96,13 +96,25 @@ msg_has "3 criterion/criteria were seen to fail" "the RED count is surfaced in t
 
 # --------------------------------------------- 3. a test that passed on its first run
 
+# Two different things pass on a first run and only one is a defect: a test-first test that
+# passes immediately is broken, a characterization test written against existing code passes
+# by design. v5.34.0 failed both with no reason path, which would have made a live build
+# record a violation for tests that were not violations.
 D=$(mktask tdd_firstrun)
 write_record "$D" '.tdd={"red_observed":3,"passed_first_run":1,"unobserved":[]}'
 run "$D"
-verdict_is fail "a test that passed on its first run fails the gate"
-unresolved_is false "a first-run pass is a clean, non-blocking-record fail, not unresolved"
-rc_is 1 "a first-run pass exits 1"
-msg_has "passed on their first run" "the message names which check failed"
+verdict_is fail "a first-run pass with no reason fails the gate"
+unresolved_is true "an unexplained first-run pass is a could-not-tell, not a settled violation"
+rc_is 1 "an unexplained first-run pass exits 1"
+msg_has "no reason recorded" "the message asks which kind of test it was"
+
+D=$(mktask tdd_firstrun_reason)
+write_record "$D" '.tdd={"red_observed":3,"passed_first_run":1,"unobserved":[],
+  "reason":"two characterization tests written against existing code during a repair round"}'
+run "$D"
+verdict_is pass "a first-run pass passes once the reason says which kind of test it was"
+unresolved_is false "an explained first-run pass is not unresolved"
+rc_is 0 "an explained first-run pass exits 0"
 
 # ------------------------------------------- 4. unobserved criteria with no reason
 


### PR DESCRIPTION
A one-hour-old rule from #270 was wrong, and a live build found it by being honest.

## What changed

v5.34.0 made any `passed_first_run > 0` a hard fail with no reason path, because `tdd-companion` calls a first-run pass a blocking violation. That holds for a test written test-first that passes immediately — it asserts nothing about the behavior it names. It does not hold for a characterization or regression test written deliberately against code that already exists. Those pass on the first run by design, and they are worth having: locking in behavior, or reproducing a defect a critic just found so the fix has something to turn green.

The live build hit it immediately. Several tests added during its repair rounds were written against existing code and passed first time. Under the old rule the honest record was a violation, so the gate was teaching the builder that the true answer is the expensive one.

`passed_first_run > 0` now takes a `reason` saying which kind it was, and passes with one. Unexplained it is `unresolved: true` rather than a settled violation, because without the reason the gate genuinely cannot tell the two apart — the same posture as `unobserved` and as a recorded contract change.

## Look at first

`scripts/build-critique-assert.sh`, the `FIRSTRUN_N` branch. The judgement worth checking is that this is `unresolved: true` rather than `false`. It is not a named violation any more; it is a state the record failed to disambiguate.

## Risky or unresolved

The `reason` is prose nothing verifies, so a builder can call a broken test a characterization test. That limit is already documented for `unobserved` and contract changes and now applies here too: the gate checks that the question was answered, not that the answer is true. Making it stronger needs the test runner's real exit code, which nothing captures.

## Verify

`make ci` passes: 119 tests, 0 failed, all five checks, no new lint warnings.

`tests/tdd-red-observation-spec.sh` is at 48 assertions, covering both directions. Removing the new reason guard fails 4 of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
