### PR TITLE
Record php-security-linter's absence where the probe fails

### DIFF
--- a/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
+++ b/code-quality-tools/skills/code-quality-audit/scripts/drupal/security-check.sh
@@ -1206,6 +1206,15 @@ if resolve_analyzer php-security-linter; then
 else
     PHPCS_SEC_PRESENT=0
     PHPCS_SEC_CMD=()
+    # Recorded here, in the branch the probe's failure opens, rather than in the distant
+    # else below. Both are reached on exactly the same condition, but only this one says so
+    # to a reader walking outward from the push: the coverage walker in
+    # ai-dev-assistant/tests/gate-verdict-resolve-spec.sh asks whether the control flow a
+    # push sits in establishes that THIS tool is absent, and a probe whose result was
+    # captured into a variable several branches earlier does not answer that question.
+    echo -e "  ${YELLOW}[SKIP]${NC} php-security-linter not installed (tool absent)"
+    SKIPPED_TOOLS+=("php-security-linter")
+    ABSENT_TOOLS+=("php-security-linter")
 fi
 
 if [ "$PHPCS_SEC_PRESENT" -eq 1 ] && [ "${#SEC_SCAN_PATHS[@]}" -eq 0 ]; then
@@ -1262,9 +1271,7 @@ elif [ "$PHPCS_SEC_PRESENT" -eq 1 ]; then
         fi
     fi
 else
-    echo -e "  ${YELLOW}[SKIP]${NC} php-security-linter not installed (tool absent)"
-    SKIPPED_TOOLS+=("php-security-linter")
-    ABSENT_TOOLS+=("php-security-linter")
+    # Absence is recorded at the probe above; this arm only needs the empty result.
     PHPCS_ISSUES="[]"
 fi
 


### PR DESCRIPTION
CI on `2729f09` failed `gate-verdict-resolve-spec.sh`. It checks that a `tools_absent[]` push sits in control flow proving that tool is absent, walking outward for a branch a probe's failure opened. It is a cross-plugin check, so the plugin-scoped suite #280 was verified against does not run it.

#280 replaced a `test -f vendor/bin/...` probe with the shared resolver and captured the result into a variable, so the branches below test the variable. The probe is real and resolving once is deliberate, since resolving twice let the psalm block clobber the shared command variable. But the evidence ends up several branches from the push, which a walker cannot distinguish from a scope test.

## What to look at first

That the code was right before the spec was blamed. `PHPCS_SEC_PRESENT` is set 1/0 solely by `if resolve_analyzer php-security-linter`, and present-but-nothing-to-scan is already separated from absent, so the final else did mean absent. The spec was not changed to accept the new shape; the recording moved into the else the probe's own failure opens.

## How to verify

`false-clean-spec` unchanged at 1291 passed, including the three assertions covering these paths, so behaviour did not move. `coverage-roster-spec` 6, `gate-verdict-resolve-spec` green, and the six other `make ci` checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)