### PR TITLE
Four agents were granted Write and denied it in the same frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.58"
+    "version": "2.0.59"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.37.0",
+      "version": "5.37.1",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.37.0",
+  "version": "5.37.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [5.37.1] - 2026-08-31
+
+### Fixed
+- **The four agents 5.37.0 made deliver by file could not write.** `analysis-agent`,
+  `prior-art-researcher`, `guides-matcher` and `ai-test-selector` carried `Write` in `tools:` and
+  `Write` in `disallowedTools:` at the same time. `disallowedTools` wins, so every one of them ran
+  without the tool the release had just granted it, and delivered by message exactly as before.
+  The feature did not work for any of them, in any session, from the moment it shipped.
+
+  Measured on a live dispatch: `guides-matcher` reported `No such tool available: Write`, while a
+  general-purpose agent with no `disallowedTools` wrote a file in the same session seconds later.
+  The only difference between them is the denial.
+
+  Consequence while it was broken: the `no_return` paths the same release added fired on every one
+  of these dispatches. A caller could not tell a tool restriction from an agent that found nothing,
+  which is the confusion the release was written to remove.
+
+- **One spec required the contradiction; another already forbade it.**
+  `tests/ai-test-selector-contract-spec.sh` asserted that `disallowedTools` must include *Edit and
+  Write*. So when 5.37.0 granted `Write`, that clause forced the denial to stay: removing it would
+  have turned the suite red, and the only way to pass was to ship both. The suite did not miss the
+  defect, it demanded it. The clause is now inverted, `Edit` denied and `Write` not, with a
+  `check_not` helper the file previously lacked, which is part of why it was written the wrong way
+  round.
+
+  `tests/sidecar-contract-spec.sh` checked only that `Write` appears in `tools:`, and printed on
+  failure that `disallowedTools` "does not bind on an explicit Task dispatch". That claim is false.
+  It now also fails when a load-bearing agent denies the `Write` it was granted, and the false
+  comment is gone.
+
+  `tests/gate-verdict-sidecar-spec.sh` has stated the correct rule since it was written, and
+  `tests/distill-agent-spec.sh` asserts it for one agent. Neither fired here: the first derives its
+  set from agents `/review` dispatches, and these four are dispatched by `/research` and
+  `/implement`. That is the limit `sidecar-contract-spec.sh` names in its own header, that it
+  cannot check whether the SET is right.
+
+  Both corrected specs were watched failing before the fix. `sidecar-contract-spec.sh` red on
+  exactly the four agents, with 4 of 4 fixes caught when removed one at a time;
+  `ai-test-selector-contract-spec.sh` red on a seeded denial and green on restore.
+
+### Note on verification
+The frontmatter fix is verified by the spec and by the runtime difference between an agent that
+denies `Write` and one that does not. It has **not** been re-confirmed by a live dispatch of a
+fixed agent, because a session resolves its agent definitions at start and cannot pick up an edit
+made mid-session. First run in a fresh session is the confirmation.
+
 ## [5.37.0] - 2026-08-30
 
 ### Added

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.37.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.37.1**.
 
 ## License
 

--- a/ai-dev-assistant/agents/ai-test-selector.md
+++ b/ai-dev-assistant/agents/ai-test-selector.md
@@ -5,7 +5,7 @@ capabilities: ["affected-surface-selection", "registry-parse", "diff-analysis", 
 version: 0.1.0
 model: sonnet
 tools: Read, Grep, Glob, Bash, Write
-disallowedTools: Edit, Write
+disallowedTools: Edit
 maxTurns: 10
 ---
 

--- a/ai-dev-assistant/agents/analysis-agent.md
+++ b/ai-dev-assistant/agents/analysis-agent.md
@@ -5,7 +5,7 @@ capabilities: ["task-analysis", "scope-assessment", "epic-proposal", "sub-task-d
 version: 1.1.1
 model: sonnet
 tools: Read, Grep, Glob, Bash, Write
-disallowedTools: Edit, Write, Bash(rm:*), Bash(mv:*), Bash(cp:*), Bash(sed:*), Bash(tee:*), Bash(dd:*), Bash(chmod:*), Bash(chown:*)
+disallowedTools: Edit, Bash(rm:*), Bash(mv:*), Bash(cp:*), Bash(sed:*), Bash(tee:*), Bash(dd:*), Bash(chmod:*), Bash(chown:*)
 maxTurns: 10
 ---
 

--- a/ai-dev-assistant/agents/guides-matcher.md
+++ b/ai-dev-assistant/agents/guides-matcher.md
@@ -5,7 +5,7 @@ capabilities: ["catalog-match", "guide-discovery", "domain-coverage-inference", 
 version: 1.1.0
 model: haiku
 tools: Read, Glob, Write
-disallowedTools: Edit, Write, Bash
+disallowedTools: Edit, Bash
 maxTurns: 5
 ---
 

--- a/ai-dev-assistant/agents/prior-art-researcher.md
+++ b/ai-dev-assistant/agents/prior-art-researcher.md
@@ -5,7 +5,7 @@ capabilities: ["existing-solution-search", "prior-art-analysis", "pattern-extrac
 version: 1.0.0
 model: sonnet
 tools: Read, Grep, Glob, WebFetch, WebSearch, Write
-disallowedTools: Edit, Write, Bash
+disallowedTools: Edit, Bash
 maxTurns: 15
 ---
 

--- a/ai-dev-assistant/tests/ai-test-selector-contract-spec.sh
+++ b/ai-dev-assistant/tests/ai-test-selector-contract-spec.sh
@@ -7,7 +7,8 @@
 # against prose regressions that would silently re-break the selection wiring.
 #
 # Coverage:
-#   wo-01 — agent frontmatter (read-only disallowedTools: Edit,Write + model: sonnet),
+#   wo-01 — agent frontmatter (disallowedTools: Edit, and NOT Write: the agent is read-only on the
+#            project but writes its own sidecar, so denying Write silently removes that channel),
 #            I/O contract, err-toward-inclusion, degraded fallback, schema doc present.
 #   wo-02 — dispatch step 6.2a invokes selector for e2e+VR (NOT parity), shows
 #            recommendation+selection together in step 6.3, --full-<gate>/
@@ -47,6 +48,15 @@ check() { # <description> <file> <grep -E pattern>
   fi
 }
 
+check_not() { # <description> <file> <grep -E pattern that must NOT match>
+  if grep -Eq "$3" "$2"; then
+    echo "FAIL: $1  (forbidden pattern present: $3)"
+    fail=1
+  else
+    echo "PASS: $1"
+  fi
+}
+
 # ── File presence ─────────────────────────────────────────────────────────────
 echo "--- file presence ---"
 for f in "$AGENT" "$SCHEMA" "$DISPATCH" "$VR_CMD" "$AUDIT_SCHEMA"; do
@@ -56,8 +66,20 @@ done
 # ── wo-01: Agent frontmatter — read-only ──────────────────────────────────────
 echo "--- wo-01: agent frontmatter ---"
 
-check "agent disallowedTools includes Edit and Write" "$AGENT" \
-  'disallowedTools:.*Edit.*Write|disallowedTools:.*Write.*Edit'
+check "agent disallowedTools includes Edit" "$AGENT" \
+  '^disallowedTools:.*Edit'
+
+# This clause used to REQUIRE Write in disallowedTools, and that is how 5.37.0 shipped an agent
+# granted Write in `tools:` and denied it in the same frontmatter. `disallowedTools` wins, so the
+# agent ran without the tool its own body tells it to use and delivered by message instead.
+# Measured: it reported "No such tool available: Write" on a live dispatch. The agent is still
+# read-only on the project; its ONE write is its own sidecar, which is why Edit stays denied and
+# Write must not be.
+check_not "agent does not deny the Write it is granted" "$AGENT" \
+  '^disallowedTools:.*(^|[,[:space:]])Write([,[:space:]]|$)'
+
+check "agent grants Write for its sidecar" "$AGENT" \
+  '^tools:.*Write'
 
 check "agent model is sonnet" "$AGENT" \
   '^model: sonnet'

--- a/ai-dev-assistant/tests/sidecar-contract-spec.sh
+++ b/ai-dev-assistant/tests/sidecar-contract-spec.sh
@@ -56,10 +56,23 @@ for entry in $LOAD_BEARING; do
 
   TOOLS=$(grep -m1 '^tools:' "$f" | sed 's/^tools: *//')
   case ",${TOOLS// /}," in
-    *,Write,*) echo "PASS: $a can write" ;;
+    *,Write,*) echo "PASS: $a grants Write in tools:" ;;
     *) echo "FAIL: $a is load-bearing and has no Write in tools:, so it cannot write a sidecar"
-       echo "      (disallowedTools is NOT the blocker here: it does not bind on an explicit Task dispatch)"
        fail=1 ;;
+  esac
+
+  # Granting Write is not the same as having it. `disallowedTools` DOES bind on an explicit
+  # dispatch, and it wins over `tools:`. This spec asserted the opposite in a comment, and four
+  # agents shipped in 5.37.0 carrying Write in both lists: the release that made them deliver by
+  # file left every one of them unable to write. Measured on a live dispatch: the agent reported
+  # "No such tool available: Write", and a general-purpose agent in the same session wrote fine.
+  # Reading one line and not the line under it is how a grant and a denial coexist.
+  DISALLOWED=$(grep -m1 '^disallowedTools:' "$f" | sed 's/^disallowedTools: *//')
+  case ",${DISALLOWED// /}," in
+    *,Write,*) echo "FAIL: $a grants Write in tools: and denies it in disallowedTools:, which wins."
+               echo "      The agent runs without Write and cannot write its sidecar $token."
+               fail=1 ;;
+    *) echo "PASS: $a does not deny the Write it was granted" ;;
   esac
 
   HITS=$(grep -rlF -- "$token" "$REFS" 2>/dev/null | head -1)


### PR DESCRIPTION
The release that made `analysis-agent`, `prior-art-researcher`, `guides-matcher` and `ai-test-selector` deliver by file gave each one `Write` in `tools:` and left `Write` in `disallowedTools:`. The denial wins, so all four ran without the tool and kept delivering by message. The feature never worked in any session.

**Look at the specs first, not the agents.** `ai-test-selector-contract-spec.sh` asserted that `disallowedTools` must include Edit *and Write*, so removing the denial would have turned the suite red. The suite did not miss this defect, it required it. `sidecar-contract-spec.sh` checked only the `tools:` half and gave, as its failure message, the false claim that `disallowedTools` does not bind on an explicit dispatch.

Risk: `ai-test-selector-contract-spec.sh` gained a `check_not` helper it did not have, which is worth a glance since its absence is part of why the clause was written backwards. Unresolved: the frontmatter fix is verified by the specs and by a live dispatch showing an agent with the denial fails while one without it writes, but it has not been confirmed by dispatching a fixed agent, because a session resolves agent definitions at start. First run on a fresh session is the confirmation, and the changelog says so.

Verify with `make test-ai-dev-assistant` (130 passed, 0 failed) and by seeding the defect back: put `Write` into any of the four `disallowedTools` lines and both specs go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)