### PR TITLE
Accept-verdict decisions become callable functions (aida 5.42.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.42.0",
+      "version": "5.42.1",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.42.0",
+  "version": "5.42.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [5.42.1] - 2026-08-31
+
+### Changed
+- **The accept-verdict decisions are now callable functions instead of a linear flow.**
+  `scripts/build-critique-assert.sh` held eight jq computations inline, so the only way to test them
+  was to run the whole 1,106-line script and match the sentences it printed. They move to a new
+  sourceable `scripts/accept-verdict.sh` as eight functions that each take the payload and return a
+  JSON value or the `__jq_error__` sentinel. The jq queries moved verbatim.
+
+  Behaviour did not move. Every message string, evidence key, exit code and the order of the eight
+  checks are byte-for-byte identical, and the order is load-bearing: `emit` exits on the first trip,
+  so a record with two defects still reports the same one it reported before. The 118-assertion
+  black-box spec was not edited and stays green, which is the evidence for that claim rather than a
+  description of it.
+
+### Added
+- `tests/accept-verdict-unit-spec.sh`, 26 assertions that call the eight functions directly and
+  assert on returned values. It never runs `build-critique-assert.sh` and contains no assertions on
+  message text. It is the second spec in the plugin to call functions rather than drive a process.
+
+### Fixed
+- A failure counter in the new spec reported a flag as a count. `FAIL=1` meant the summary read
+  "1 failed" however many assertions failed, and the pass total was overstated by the same amount.
+  The exit status was always correct, so the numbers were the part that lied. Now increments with
+  `FAIL=$((FAIL+1))`, not `((FAIL++))`, which returns 1 when the result is 0.
+
 ## [5.42.0] - 2026-08-31
 
 ### Added

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.42.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.42.1**.
 
 ## License
 

--- a/ai-dev-assistant/scripts/accept-verdict.sh
+++ b/ai-dev-assistant/scripts/accept-verdict.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# accept-verdict.sh — the 8 pure decisions behind the repair accept verdict block in
+# build-critique-assert.sh (the section commented "the repair accept verdict (v5.42.0+)").
+#
+# SOURCE this file (do not execute it). Each function takes the record's PAYLOAD as $1 and
+# nothing else, and answers ONE of the 8 questions build-critique-assert.sh's accept block
+# asks: is a field readable, and if so, which components trip it. Nothing here formats a
+# message, sets an evidence key, or exits — that stays in the caller, exactly as
+# architecture.md for the `tdd_knowledge_ownership` task requires. A function that both
+# decided and called emit would not be a unit, it would be the whole check with a name.
+#
+# THE RETURN CONVENTION, stated once and applied eight times: echo the JSON value, or echo
+# the literal $JQ_ERR sentinel, and return 0 either way. Never signal the jq failure with a
+# non-zero exit status — the caller compares the returned STRING against $JQ_ERR, and nothing
+# here reads a bash exit code.
+#
+# Every jq query below is moved verbatim from build-critique-assert.sh. Not retyped, not
+# tidied, not reformatted — a reformatted query is an unreviewable diff, and the whole claim
+# of this file is that behaviour did not move. See
+# research/subject-accept-block-anatomy.md and architecture.md in the
+# `tdd_knowledge_ownership` task for the anatomy this was extracted from.
+
+ACCEPT_ACTIONS='["accepted","not_accepted","cannot_judge"]'
+ACCEPT_SUITES='["green","red","not_run"]'
+ACCEPT_DECIDERS='["suite_and_motion","motion","none"]'
+
+# A JQ ERROR IS NOT AN EMPTY RESULT SET. See build-critique-assert.sh's own comment above the
+# block this was lifted from: a fallback of '[]' on a jq failure reads as "I looked and found
+# nothing wrong", which is a silent pass on a block whose entire purpose is to refuse silent
+# passes. JQ_ERR is hoisted here, unconditional, because build-critique-assert.sh reuses this
+# same sentinel outside the accept block (its deferred-findings section) — one sentinel, one
+# home, rather than two definitions of the same marker string.
+JQ_ERR="__jq_error__"
+
+# accept_bad_action_components <payload>
+# Components carrying an accept object whose .accept.action is outside the three-value enum,
+# or whose .accept is present but not an object at all. Replaces BAD_ACTION.
+accept_bad_action_components() {
+  local out
+  out=$(jq -c --argjson ok "$ACCEPT_ACTIONS" \
+    '[(.components // [])[]
+      | select(has("accept"))
+      | select(if (.accept | type) != "object" then true
+               else (((.accept.action // "") | tostring) as $a
+                     | ($ok | index($a)) == null) end)
+      | (.component // "unnamed")]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_bad_suite_components <payload>
+# Components with an accept object whose .accept.suite is outside the three-value enum.
+# Replaces BAD_SUITE.
+accept_bad_suite_components() {
+  local out
+  out=$(jq -c --argjson ok "$ACCEPT_SUITES" \
+    '[(.components // [])[]
+      | select(has("accept") and ((.accept | type) == "object"))
+      | select((((.accept.suite // "") | tostring) as $s | ($ok | index($s)) == null))
+      | (.component // "unnamed")]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_bad_basis_components <payload>
+# Components with an accept object where .accept.decided_by is outside the three-value enum,
+# OR .accept.reason trims to empty. Replaces BAD_BASIS. Known ceiling, not fixed here: this
+# ORs two distinct facts into one list, so the result cannot say which of the two tripped for
+# a given component (research/decisions-and-findings.md, F1).
+accept_bad_basis_components() {
+  local out
+  out=$(jq -c --argjson ok "$ACCEPT_DECIDERS" \
+    '[(.components // [])[]
+      | select(has("accept") and ((.accept | type) == "object"))
+      | select(((((.accept.decided_by // "") | tostring) as $d | ($ok | index($d)) == null))
+               or ((((.accept.reason // "") | tostring) | gsub("^\\s+|\\s+$";"")) == ""))
+      | (.component // "unnamed")]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_unreadable_repair_components <payload>
+# Components with no accept key that HAVE a non-null rounds field whose type is not number.
+# Replaces UNREADABLE_REPAIR.
+accept_unreadable_repair_components() {
+  local out
+  out=$(jq -c \
+    '[(.components // [])[]
+      | select((has("accept") | not) and has("rounds") and (.rounds != null)
+               and ((.rounds | type) != "number"))
+      | (.component // "unnamed")]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_unreadable_round_components <payload>
+# Components with no accept, component-row rounds<=1 (default 1), no matching rounds[] entry
+# with a numeric round>1, but WITH a matching rounds[] entry whose round is present and
+# non-numeric — ambiguous whether that entry is round 1 or a repair. Replaces UNREADABLE_ROUND.
+accept_unreadable_round_components() {
+  local out
+  out=$(jq -c \
+    '(.rounds // []) as $r
+     | [(.components // [])[]
+        | . as $c
+        | select(has("accept") | not)
+        | (($c.component // "unnamed") | tostring) as $name
+        | select(((($c.rounds // 1) | if type == "number" then . else 1 end)) <= 1)
+        | select(any($r[]?; ((.component // .wo // "") | tostring) == $name
+                            and ((.round | type) == "number") and (.round > 1)) | not)
+        | select(any($r[]?; ((.component // .wo // "") | tostring) == $name
+                            and ((.round | type) != "number")))
+        | $name]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_missing_verdict_components <payload>
+# Components with no accept, where component-row rounds>1 OR a rounds[] entry names them with
+# numeric round>1 — disk evidence says repaired but no verdict recorded. Replaces NO_ACCEPT.
+accept_missing_verdict_components() {
+  local out
+  out=$(jq -c \
+    '(.rounds // []) as $r
+     | [(.components // [])[]
+        | . as $c
+        | select(has("accept") | not)
+        | (($c.component // "unnamed") | tostring) as $name
+        | select((((($c.rounds // 1) | if type == "number" then . else 1 end)) > 1)
+                 or any($r[]?; ((.component // .wo // "") | tostring) == $name
+                               and ((.round | type) == "number") and (.round > 1)))
+        | $name]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_unaccepted_components <payload>
+# Components with an accept object whose .accept.action != "accepted". Replaces UNACCEPTED.
+accept_unaccepted_components() {
+  local out
+  out=$(jq -c \
+    '[(.components // [])[]
+      | select(has("accept") and ((.accept | type) == "object"))
+      | select(((.accept.action // "") | tostring) != "accepted")
+      | (.component // "unnamed")]' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# accept_escalation_reason <payload>
+# Record-wide, not per-component: the trimmed top-level .escalation.reason, else the last
+# non-blank .rounds[].resolution. Replaces ESC. KNOWN CEILING, inherited unchanged: one
+# recorded decision clears every unaccepted component in the record.
+accept_escalation_reason() {
+  local out
+  out=$(jq -r 'def trim: gsub("^\\s+|\\s+$";"");
+                 ((.escalation.reason // "") | tostring | trim) as $top
+                 | if $top != "" then $top
+                   else ([(.rounds // [])[] | (.resolution // empty) | tostring | trim]
+                         | map(select(. != "")) | last // "")
+                   end' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}

--- a/ai-dev-assistant/scripts/build-critique-assert.sh
+++ b/ai-dev-assistant/scripts/build-critique-assert.sh
@@ -49,6 +49,9 @@
 #   2 — usage: no task folder, or not a directory
 set -uo pipefail
 
+# shellcheck source=./accept-verdict.sh
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/accept-verdict.sh"
+
 TASK_DIR="${1:-}"
 CHANGE_SET_EMPTY=0
 CHANGE_SET_FILE=""
@@ -353,30 +356,10 @@ if [ -e "$REC" ]; then
   # The reads below run malformed-first: a verdict that cannot be read and a repair nobody
   # recorded are both `unresolved`, and both would otherwise fall through to the decision
   # demand and clear on an escalation reason written for something else.
-  ACCEPT_ACTIONS='["accepted","not_accepted","cannot_judge"]'
-  ACCEPT_SUITES='["green","red","not_run"]'
-  ACCEPT_DECIDERS='["suite_and_motion","motion","none"]'
-
-  # A JQ ERROR IS NOT AN EMPTY RESULT SET. Every read below used to end `2>/dev/null) || VAR='[]'`,
-  # which routed a jq failure into the same value as "I looked and found nothing wrong". That is
-  # a silent pass on a block whose entire purpose is to refuse silent passes, and it has already
-  # cost this file two checks: the first version of the suite and basis reads evaluated `.accept`
-  # against an array, jq exited 5 on every record, and both checks passed every fixture while
-  # enforcing nothing. Each read now falls back to this sentinel and is reported as unresolved,
-  # naming which read failed. It is the same sentinel and the same shape the deferral check
-  # further down already used; there is one mechanism here, not two.
-  JQ_ERR="__jq_error__"
-
   # An action outside the enum is a verdict nobody can read. It is not the same as
   # `not_accepted`: a typo and a refusal are different states, and picking one of them here
   # would be the guess this file refuses everywhere else.
-  BAD_ACTION=$(jq -c --argjson ok "$ACCEPT_ACTIONS" \
-    '[(.components // [])[]
-      | select(has("accept"))
-      | select(if (.accept | type) != "object" then true
-               else (((.accept.action // "") | tostring) as $a
-                     | ($ok | index($a)) == null) end)
-      | (.component // "unnamed")]' <<<"$PAYLOAD" 2>/dev/null) || BAD_ACTION="$JQ_ERR"
+  BAD_ACTION=$(accept_bad_action_components "$PAYLOAD")
   if [ "$BAD_ACTION" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the accept action enum could not be read, so whether any repair was accepted is unknown"
@@ -393,11 +376,7 @@ if [ -e "$REC" ]; then
   # suite result it weighed is a verdict about nothing. Absent and off-enum are one answer here
   # -- both leave the value unreadable, and neither is `not_run`, which is a real result a
   # builder states on purpose.
-  BAD_SUITE=$(jq -c --argjson ok "$ACCEPT_SUITES" \
-    '[(.components // [])[]
-      | select(has("accept") and ((.accept | type) == "object"))
-      | select((((.accept.suite // "") | tostring) as $s | ($ok | index($s)) == null))
-      | (.component // "unnamed")]' <<<"$PAYLOAD" 2>/dev/null) || BAD_SUITE="$JQ_ERR"
+  BAD_SUITE=$(accept_bad_suite_components "$PAYLOAD")
   if [ "$BAD_SUITE" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the accept suite field could not be read, so what suite result each verdict weighed is unknown"
@@ -414,12 +393,7 @@ if [ -e "$REC" ]; then
   # emits on every run. `reason` is the sentence carrying why; a blank one collapses a stated
   # decision into a recorded shrug, which is why the two checks further down this file reject a
   # blank `closing_fixes.reason` and a blank `why_now_is_wrong` on a deferral.
-  BAD_BASIS=$(jq -c --argjson ok "$ACCEPT_DECIDERS" \
-    '[(.components // [])[]
-      | select(has("accept") and ((.accept | type) == "object"))
-      | select(((((.accept.decided_by // "") | tostring) as $d | ($ok | index($d)) == null))
-               or ((((.accept.reason // "") | tostring) | gsub("^\\s+|\\s+$";"")) == ""))
-      | (.component // "unnamed")]' <<<"$PAYLOAD" 2>/dev/null) || BAD_BASIS="$JQ_ERR"
+  BAD_BASIS=$(accept_bad_basis_components "$PAYLOAD")
   if [ "$BAD_BASIS" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the accept decided_by and reason fields could not be read, so what drove each action is unknown"
@@ -435,11 +409,7 @@ if [ -e "$REC" ]; then
   # `rounds` count above one on the component row, and a top-level `rounds[]` entry naming the
   # component. A non-numeric count answers neither, and is reported as a repair state that
   # could not be established rather than folded into the clean set.
-  UNREADABLE_REPAIR=$(jq -c \
-    '[(.components // [])[]
-      | select((has("accept") | not) and has("rounds") and (.rounds != null)
-               and ((.rounds | type) != "number"))
-      | (.component // "unnamed")]' <<<"$PAYLOAD" 2>/dev/null) || UNREADABLE_REPAIR="$JQ_ERR"
+  UNREADABLE_REPAIR=$(accept_unreadable_repair_components "$PAYLOAD")
   if [ "$UNREADABLE_REPAIR" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the component rounds counts could not be read, so which components were repaired is unknown"
@@ -464,18 +434,7 @@ if [ -e "$REC" ]; then
   # silently is the guess this block refuses on `accept.action` twenty lines up. It is reported
   # only when nothing else already settled the component's repair state, so a readable round-2
   # entry beside a malformed one is still read as the repair it is.
-  UNREADABLE_ROUND=$(jq -c \
-    '(.rounds // []) as $r
-     | [(.components // [])[]
-        | . as $c
-        | select(has("accept") | not)
-        | (($c.component // "unnamed") | tostring) as $name
-        | select(((($c.rounds // 1) | if type == "number" then . else 1 end)) <= 1)
-        | select(any($r[]?; ((.component // .wo // "") | tostring) == $name
-                            and ((.round | type) == "number") and (.round > 1)) | not)
-        | select(any($r[]?; ((.component // .wo // "") | tostring) == $name
-                            and ((.round | type) != "number")))
-        | $name]' <<<"$PAYLOAD" 2>/dev/null) || UNREADABLE_ROUND="$JQ_ERR"
+  UNREADABLE_ROUND=$(accept_unreadable_round_components "$PAYLOAD")
   if [ "$UNREADABLE_ROUND" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the rounds[] entries could not be read, so whether each names a first critique or a repair is unknown"
@@ -487,16 +446,7 @@ if [ -e "$REC" ]; then
     emit fail true "" 1
   fi
 
-  NO_ACCEPT=$(jq -c \
-    '(.rounds // []) as $r
-     | [(.components // [])[]
-        | . as $c
-        | select(has("accept") | not)
-        | (($c.component // "unnamed") | tostring) as $name
-        | select((((($c.rounds // 1) | if type == "number" then . else 1 end)) > 1)
-                 or any($r[]?; ((.component // .wo // "") | tostring) == $name
-                               and ((.round | type) == "number") and (.round > 1)))
-        | $name]' <<<"$PAYLOAD" 2>/dev/null) || NO_ACCEPT="$JQ_ERR"
+  NO_ACCEPT=$(accept_missing_verdict_components "$PAYLOAD")
   if [ "$NO_ACCEPT" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the set of components carrying no accept verdict could not be read, so whether a repair went unrecorded is unknown"
@@ -510,11 +460,7 @@ if [ -e "$REC" ]; then
     emit fail true "" 1
   fi
 
-  UNACCEPTED=$(jq -c \
-    '[(.components // [])[]
-      | select(has("accept") and ((.accept | type) == "object"))
-      | select(((.accept.action // "") | tostring) != "accepted")
-      | (.component // "unnamed")]' <<<"$PAYLOAD" 2>/dev/null) || UNACCEPTED="$JQ_ERR"
+  UNACCEPTED=$(accept_unaccepted_components "$PAYLOAD")
   if [ "$UNACCEPTED" = "$JQ_ERR" ]; then
     set_ev_s accept_check "unreadable"
     add_msg "the set of components ending on a non-acceptance could not be read, so whether any component shipped unaccepted is unknown"
@@ -535,12 +481,7 @@ if [ -e "$REC" ]; then
     # was the loosest read in the block sitting on the widest blast radius. Trimmed for the
     # comparison AND for what gets reported: the message prints the reason back, and a decision
     # padded with newlines reads as a decision nobody wrote.
-    ESC=$(jq -r 'def trim: gsub("^\\s+|\\s+$";"");
-                 ((.escalation.reason // "") | tostring | trim) as $top
-                 | if $top != "" then $top
-                   else ([(.rounds // [])[] | (.resolution // empty) | tostring | trim]
-                         | map(select(. != "")) | last // "")
-                   end' <<<"$PAYLOAD" 2>/dev/null) || ESC="$JQ_ERR"
+    ESC=$(accept_escalation_reason "$PAYLOAD")
     if [ "$ESC" = "$JQ_ERR" ]; then
       # This read is the one place an empty result and a jq error already differed, and the
       # difference ran the wrong way: an unreadable `escalation` or `rounds[]` produced an

--- a/ai-dev-assistant/tests/accept-verdict-unit-spec.sh
+++ b/ai-dev-assistant/tests/accept-verdict-unit-spec.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# accept-verdict-unit-spec.sh — unit spec for scripts/accept-verdict.sh, the 8 pure decisions
+# extracted from the repair accept verdict block in build-critique-assert.sh.
+#
+# THIS SPEC SOURCES scripts/accept-verdict.sh AND NOTHING ELSE. It calls the 8 functions
+# directly and asserts on their returned values; it invokes build-critique-assert.sh as a
+# process zero times. The whole-block, first-hit-wins behaviour that block still owns is
+# proven by tests/repair-accept-gate-spec.sh, which this file does not touch and does not
+# duplicate.
+#
+# MESSAGES and EVIDENCE are left unset on purpose. build-critique-assert.sh mutates those two
+# globals through add_msg/set_ev/set_ev_s; if any function under test read either one, `set -u`
+# below would fail the run at that call rather than let a stale value pass silently.
+set -u
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UNIT="${PLUGIN_ROOT}/scripts/accept-verdict.sh"
+
+if [ ! -f "$UNIT" ]; then
+  printf 'FAIL: %s not found\n' "$UNIT" >&2
+  exit 1
+fi
+
+# shellcheck source=../scripts/accept-verdict.sh
+. "$UNIT"
+
+FAIL=0
+ASSERTIONS=0
+fail_check() { ASSERTIONS=$((ASSERTIONS+1)); printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL+1)); }
+pass_check() { ASSERTIONS=$((ASSERTIONS+1)); printf 'OK   %s\n' "$1"; }
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  if [ "$2" = "$3" ]; then pass_check "$1"; else fail_check "$1 — expected [$2] got [$3]"; fi
+}
+
+MALFORMED='not json at all'
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. accept_bad_action_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_ACTION='{"components":[{"component":"a","accept":{"action":"accepted"}}]}'
+assert_eq "bad_action: a component with a clean accepted action trips nothing" \
+  '[]' "$(accept_bad_action_components "$CLEAN_ACTION")"
+
+TRIP_ACTION='{"components":[{"component":"a","accept":{"action":"maybe"}}]}'
+assert_eq "bad_action: an off-enum action names the component" \
+  '["a"]' "$(accept_bad_action_components "$TRIP_ACTION")"
+
+assert_eq "bad_action: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_bad_action_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. accept_bad_suite_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_SUITE='{"components":[{"component":"a","accept":{"suite":"green"}}]}'
+assert_eq "bad_suite: a component with a clean green suite trips nothing" \
+  '[]' "$(accept_bad_suite_components "$CLEAN_SUITE")"
+
+TRIP_SUITE='{"components":[{"component":"a","accept":{"suite":"yellow"}}]}'
+assert_eq "bad_suite: an off-enum suite names the component" \
+  '["a"]' "$(accept_bad_suite_components "$TRIP_SUITE")"
+
+assert_eq "bad_suite: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_bad_suite_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. accept_bad_basis_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_BASIS='{"components":[{"component":"a","accept":{"decided_by":"motion","reason":"the suite was green"}}]}'
+assert_eq "bad_basis: a readable decided_by and a non-blank reason trip nothing" \
+  '[]' "$(accept_bad_basis_components "$CLEAN_BASIS")"
+
+TRIP_BASIS_ENUM='{"components":[{"component":"a","accept":{"decided_by":"vibes","reason":"the suite was green"}}]}'
+assert_eq "bad_basis: an off-enum decided_by names the component" \
+  '["a"]' "$(accept_bad_basis_components "$TRIP_BASIS_ENUM")"
+
+TRIP_BASIS_BLANK='{"components":[{"component":"a","accept":{"decided_by":"motion","reason":"   "}}]}'
+assert_eq "bad_basis: a whitespace-only reason names the component" \
+  '["a"]' "$(accept_bad_basis_components "$TRIP_BASIS_BLANK")"
+
+assert_eq "bad_basis: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_bad_basis_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. accept_unreadable_repair_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_REPAIR='{"components":[{"component":"a","rounds":2}]}'
+assert_eq "unreadable_repair: a numeric rounds count trips nothing" \
+  '[]' "$(accept_unreadable_repair_components "$CLEAN_REPAIR")"
+
+TRIP_REPAIR='{"components":[{"component":"a","rounds":"two"}]}'
+assert_eq "unreadable_repair: a non-numeric rounds count with no accept verdict names the component" \
+  '["a"]' "$(accept_unreadable_repair_components "$TRIP_REPAIR")"
+
+assert_eq "unreadable_repair: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_unreadable_repair_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. accept_unreadable_round_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_ROUND='{"components":[{"component":"a"}],"rounds":[{"component":"a","round":2}]}'
+assert_eq "unreadable_round: a readable round-2 entry trips nothing" \
+  '[]' "$(accept_unreadable_round_components "$CLEAN_ROUND")"
+
+TRIP_ROUND='{"components":[{"component":"a"}],"rounds":[{"component":"a","round":"two"}]}'
+assert_eq "unreadable_round: a non-numeric round on the only entry names the component" \
+  '["a"]' "$(accept_unreadable_round_components "$TRIP_ROUND")"
+
+assert_eq "unreadable_round: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_unreadable_round_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. accept_missing_verdict_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_MISSING='{"components":[{"component":"a","rounds":1}]}'
+assert_eq "missing_verdict: an untouched round-1 component trips nothing" \
+  '[]' "$(accept_missing_verdict_components "$CLEAN_MISSING")"
+
+TRIP_MISSING='{"components":[{"component":"a","rounds":3}]}'
+assert_eq "missing_verdict: a repaired component with no accept verdict names the component" \
+  '["a"]' "$(accept_missing_verdict_components "$TRIP_MISSING")"
+
+assert_eq "missing_verdict: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_missing_verdict_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. accept_unaccepted_components
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_UNACC='{"components":[{"component":"a","accept":{"action":"accepted"}}]}'
+assert_eq "unaccepted: an accepted verdict trips nothing" \
+  '[]' "$(accept_unaccepted_components "$CLEAN_UNACC")"
+
+TRIP_UNACC='{"components":[{"component":"a","accept":{"action":"not_accepted"}}]}'
+assert_eq "unaccepted: a non-accepted verdict names the component" \
+  '["a"]' "$(accept_unaccepted_components "$TRIP_UNACC")"
+
+assert_eq "unaccepted: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_unaccepted_components "$MALFORMED")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. accept_escalation_reason
+# ═══════════════════════════════════════════════════════════════════════════
+
+CLEAN_ESC='{"escalation":{"reason":"operator accepted the red suite"}}'
+assert_eq "escalation_reason: a top-level escalation reason is returned trimmed" \
+  "operator accepted the red suite" "$(accept_escalation_reason "$CLEAN_ESC")"
+
+NO_ESC='{"escalation":{"reason":""},"rounds":[]}'
+assert_eq "escalation_reason: no escalation and no round resolution returns empty" \
+  "" "$(accept_escalation_reason "$NO_ESC")"
+
+FALLBACK_ESC='{"escalation":{"reason":""},"rounds":[{"resolution":"shipped on the round that settled it"}]}'
+assert_eq "escalation_reason: falls back to the last non-blank round resolution" \
+  "shipped on the round that settled it" "$(accept_escalation_reason "$FALLBACK_ESC")"
+
+assert_eq "escalation_reason: malformed JSON returns the sentinel" \
+  "$JQ_ERR" "$(accept_escalation_reason "$MALFORMED")"
+
+# --- a spec that checked nothing has not passed ---
+# 3 cases each for the 6 functions with one tripping condition, 4 cases each for the 2
+# functions with two independent cases beyond clean/malformed (bad_basis: off-enum decided_by
+# AND blank reason; escalation_reason: no decision recorded AND the round-resolution fallback).
+# (3 x 6) + (4 x 2) = 26.
+EXPECTED=26
+[ "$ASSERTIONS" -eq "$EXPECTED" ] && pass_check "ran the expected $EXPECTED assertions" \
+  || fail_check "expected $EXPECTED assertions, ran $ASSERTIONS (a skipped block reads as green)"
+
+echo "----"; echo "accept-verdict-unit-spec: $((ASSERTIONS - FAIL)) passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The eight jq computations in `build-critique-assert.sh`'s accept-verdict block were inline in a 1,106-line script, so the only way to test them was to run the whole thing and match printed sentences. They move to a sourceable `scripts/accept-verdict.sh` as eight functions that take the payload and return a JSON value or the sentinel, with the queries moved verbatim.

Behaviour did not move, and the evidence is that the 118-assertion black-box spec was not edited and stays green. Every message, evidence key, exit code and the check order are byte-for-byte identical; the order matters because `emit` exits on the first trip.

The new `tests/accept-verdict-unit-spec.sh` has 26 assertions that call the functions directly, never invoke the gate, and match no message text. It is the second spec of 138 to call functions rather than drive a process. Building it surfaced a counter in itself that reported a flag as a count, fixed here.

Full suite 138 passed, 0 failed. Two mutations confirmed the new spec can fail, with landing proven first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)