### PR TITLE
fix(ai-dev-assistant): correct alignment-reader SKILL.md against the shipped resolver (5.44.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.44.1",
+      "version": "5.44.2",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.44.1",
+  "version": "5.44.2",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [5.44.2] - 2026-09-02
+
+### Fixed
+- **`alignment-reader`'s SKILL.md described a resolution rule the shipped script does not have.**
+  The one sentence 5.44.0 added said a `null` per-criterion `id` sends `contract-resolve.sh` to
+  `task.md`. It does not: the fallback fires only when *no* Task-Level criterion carries an id, and a
+  file where some do resolves from `alignment.md` with the rest counted as `unmarked` and invisible
+  to coverage. The same sentence documented `id` as an ordinary `success_criteria[]` field on all
+  four sections, while `contract-resolve.sh:40` reads `task_level` only, so an id written on a phase
+  criterion does nothing. Both were measured against fixtures before and after the repair. Found by
+  the `skill-review` gate, which 5.44.0's review recorded as unresolved because it was never run.
+- The `criterion_id_duplicate` row said "two criteria in one section". Detection is document-wide:
+  `ids_seen` in the reader is global, which the reader's own comment states is deliberate.
+- The warning table listed 11 of the 13 codes the parser emits, omitting `section_empty_stub` and
+  `section_unparsed_body`; the field list omitted `success_criteria_prose` and `non_goals_prose`;
+  the consumers list predated `/review`, `spec-axis-reviewer`, `contract-resolve.sh` and
+  `criterion-provenance.sh`.
+- `references/alignment-contract.md`'s title still read "Grammar v1.3" while its own body documented
+  the v1.4 `id` marker.
+
 ## [5.44.1] - 2026-09-02
 
 ### Fixed

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.44.1**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.44.2**.
 
 ## License
 

--- a/ai-dev-assistant/references/alignment-contract.md
+++ b/ai-dev-assistant/references/alignment-contract.md
@@ -1,4 +1,4 @@
-# Alignment Contract — `alignment.md` Grammar v1.3
+# Alignment Contract — `alignment.md` Grammar v1.4
 
 **Introduced:** ai-dev-assistant v3.12.0
 **v1.1 adds optional per-criterion `verification`** — a success-criterion line MAY carry a trailing ` — verify: <how>` suffix capturing how it will be checked. Additive within v1.x (the emitted `schema_version` JSON value stays `"1.0"`; see §9). Consumers that ignore unknown keys are unaffected.

--- a/ai-dev-assistant/skills/alignment-reader/SKILL.md
+++ b/ai-dev-assistant/skills/alignment-reader/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: alignment-reader
 description: Use when a framework command needs to parse a task's alignment.md (the scope contract — Goal / Expected result / Success criteria / Non-goals per section). Reads defensively via scripts/alignment-read.sh and returns structured JSON with warnings. Never blocks on malformed input.
-version: 1.2.0
+version: 1.3.0
 user-invocable: false
 model: inherit
 allowed-tools: Bash
@@ -10,7 +10,7 @@ disallowed-tools: Write, Edit
 
 # Alignment Reader
 
-Thin wrapper around `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh`. The script parses `alignment.md` per the canonical grammar in `references/alignment-contract.md` v1.3 and emits structured JSON. This skill gives the parser a Skill-tool-callable name and documents the invocation contract.
+Thin wrapper around `${CLAUDE_PLUGIN_ROOT}/scripts/alignment-read.sh`. The script parses `alignment.md` per the canonical grammar in `references/alignment-contract.md` v1.4 and emits structured JSON. This skill gives the parser a Skill-tool-callable name and documents the invocation contract.
 
 ## Contract
 
@@ -24,8 +24,10 @@ Fields:
 - `task_name` — from H1 `# Alignment: <name>` line (or `**Task:**` metadata fallback)
 - `created` — from `**Created:** <YYYY-MM-DD>` metadata
 - `schema_version` — JSON string, currently `"1.0"`
-- `sections.{task_level,phase_1,phase_2,phase_3}` — each either `{present: false}` or a populated object with `goal`, `expected_result`, `success_criteria[]`, `non_goals[]`, `extras[]`, `fields_missing[]`
-  - Each `success_criteria[]` item: `{text, checked, verification, author, id}`. `verification` is a string or `null` (v1.1, from ` — verify: <how>`). `author` is `"owner"`, `"designer"`, or `null` (v1.3, from ` — by: <owner|designer>`) — `null` means no author was recorded, not that the owner wrote it. `id` is `"c<n>"` or `null` (v1.4, from ` — id: c<n>`); `null` means no id was recorded, and `scripts/contract-resolve.sh` then falls back to `task.md`.
+- `sections.{task_level,phase_1,phase_2,phase_3}` — each either `{present: false}` or a populated object with `goal`, `expected_result`, `success_criteria[]`, `success_criteria_prose`, `non_goals[]`, `non_goals_prose`, `extras[]`, `fields_missing[]`. The two `*_prose` fields hold the raw body when it was written as prose instead of a list, and are `null` otherwise.
+  - Each `success_criteria[]` item: `{text, checked, verification, author, id}`. `verification` is a string or `null` (v1.1, from ` — verify: <how>`). `author` is `"owner"`, `"designer"`, or `null` (v1.3, from ` — by: <owner|designer>`) — `null` means no author was recorded, not that the owner wrote it. `id` is `"c<n>"` or `null` (v1.4, from ` — id: c<n>`); `null` means no id was recorded on that criterion.
+
+**A `null` id does not by itself send a resolver to `task.md`.** `scripts/contract-resolve.sh` reads **Task-Level ids only**. It resolves from `alignment.md` when at least one Task-Level criterion carries an id, and reports the rest as `unmarked` — criteria that are invisible to coverage. It falls back to `task.md` only when *no* Task-Level criterion carries one. An id on a phase section is parsed and returned here, but no resolver reads it, so putting ids on phase criteria has no effect.
 - `warnings[]` — array of `{code, …}` observations
 
 ## Defensive posture (never throws)
@@ -41,7 +43,9 @@ Fields:
 | `Non-goals` body is prose, not a bulleted list | `non_goals_not_bulleted` |
 | ` — by:` marker present with a value other than `owner`/`designer` | `criterion_author_unrecognized` |
 | ` — id:` marker present with a value that is not `c<n>` (or a near-miss such as a wrong dash) | `criterion_id_unrecognized` |
-| Two criteria in one section carry the same id | `criterion_id_duplicate` |
+| Two criteria anywhere in the document carry the same id — the reader is the only place every id is seen together, so detection spans sections | `criterion_id_duplicate` |
+| Recognized H2 present but the whole section body is empty | `section_empty_stub` |
+| Recognized H2 present with a body that matched no canonical H3 | `section_unparsed_body` |
 | Unrecoverable read failure (permission, IO) | `error` (only case with non-zero exit) |
 
 ## Invocation
@@ -74,7 +78,11 @@ Consumers checking "is the Phase 2 contract authored yet?" should test `.section
 - `/ai-dev-assistant:design` — Phase 2 sub-step appends Phase 2 section
 - `/ai-dev-assistant:implement` — Phase 3 sub-step appends Phase 3 section
 - `/ai-dev-assistant:complete` — (future) may surface unchecked success criteria
+- `/ai-dev-assistant:review` — Spec axis reads the Task-Level contract
 - `analysis-agent` — indirectly informs `scope_contract_recommended` signal (caller reads this skill's output)
+- `spec-axis-reviewer` — judges a change against the Task-Level success criteria
+- `scripts/contract-resolve.sh` — resolves the criteria list, `alignment.md` Task-Level ids first, then `task.md`
+- `scripts/criterion-provenance.sh` — reads the ` — by:` author marker
 
 Future consumers needing scope-contract data should call this skill rather than parsing `alignment.md` directly.
 


### PR DESCRIPTION
The skill-review gate was never run during 5.44.0's review, which recorded it as unresolved. Running it found two blocking errors in the one sentence 5.44.0 added to `skills/alignment-reader/SKILL.md`: a null per-criterion `id` was documented as sending `contract-resolve.sh` to `task.md` (the fallback actually fires only when no Task-Level criterion carries an id), and `id` was documented as working on all four sections (`contract-resolve.sh:40` reads `task_level` only). Both were reproduced against fixtures before repair and measured again after.

The same pass found four pieces of drift in that file and a stale version stamp on the contract's title, all corrected here. No script changed, so behaviour is unaffected; what changed is that the documentation now matches it.

Worth noting for the epic this came out of: no spec asserts anything about this skill's content, so nothing could have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)