### PR TITLE
A delegated build owes a TDD record (ai-dev-assistant 5.48.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.69"
+    "version": "2.0.70"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.47.0",
+      "version": "5.48.0",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.47.0",
+  "version": "5.48.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [5.48.0] - 2026-09-02
+
+### Added
+- **A delegated build owes a TDD record, per work-order.** Until now `/review`'s build-critique
+  gate demanded a `tdd` block of the in-session `_build-critique.json` and of nothing else, so a
+  build that went through `/run-work-orders` owed no statement about whether any test was watched
+  failing before the code existed. Since the orchestration rules route real builds to delegated
+  agents, following them routed every real build around the test-first rung by construction.
+  Measured on a live build: three components built, reviewed and merged with no TDD record of any
+  kind, and every downstream check satisfied, because each one read a record nobody was asked to
+  write.
+
+  The record now travels as a sidecar file. `work-order-builder` names
+  `<WO_DIR>/wo-NN.tdd.json` in the prompt it hands the builder; the builder writes one JSON object
+  there; the loop computes the same path from the work-order id it is already iterating and passes
+  it to `wo-run-state.sh collect --tdd-file`, which parses and type-checks before storing and
+  refuses a malformed one with exit 2 and the run record untouched. A file rather than a line in
+  the builder's reply, because every other subagent-produced value in this plugin already moves
+  this way, and because a Task response that truncates in transit has already cost this framework
+  a verdict once. The build atom neither reads nor validates nor carries it: the handle stays
+  git/disk derived and accepts no subagent content (M-6).
+- **`work_orders_owing_tdd`, `work_orders_without_tdd`, `work_orders_bad_tdd`** on the
+  build-critique record. The last is present on a pass as well as a failure, so an empty list
+  reads as checked-and-clean rather than as never-looked.
+- **`--tdd-file <path>` on `wo-run-state.sh collect`.** Eight distinct refusals, each exit 2 with
+  the sidecar untouched: unsafe path, absent, not a regular file, unreadable, empty, not JSON, not
+  an object. No `--tdd-file` leaves no `tdd` key; nothing is ever auto-filled, because an invented
+  default makes a build that ran no test indistinguishable from one that did.
+
+### Changed
+- **One judge, two paths.** `tdd_block_problems` in `scripts/accept-verdict.sh` is now the single
+  authority on what a sound `tdd` block is, and both the in-session and work-order branches call
+  it. The first cut of the delegated branch called `has()` on four keys and stopped, under a
+  comment claiming the two paths could not disagree; they could, and a block with five unexplained
+  first-run passes passed one and failed the other. Verified after the change on 17 identical
+  blocks: 17/17 agree.
+- **`tdd-companion` no longer calls a first-run pass a violation by itself.** Only an unexplained
+  one blocks, which is what the gate has always enforced. v5.46.0 corrected the same rule in
+  `gate-audit-schema.md` and `commands/implement.md` and missed this file, which is the copy an
+  agent has loaded while building.
+- `references/build-critique.md` and `references/gate-audit-schema.md` said in as many words that
+  the work-order path carried no RED evidence and was not asked for any. Both now describe what
+  the gate does.
+
+### Fixed
+- **`wo-run-state.sh` hung forever on a valueless trailing flag.** `shift 2` with one argument left
+  shifts nothing and returns 1, so the argument loop re-read the same token indefinitely. It
+  affected every flag in all three argument loops, and predates this release.
+
 ## [5.47.0] - 2026-09-02
 
 ### Changed

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.47.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.48.0**.
 
 ## License
 

--- a/ai-dev-assistant/references/build-critique.md
+++ b/ai-dev-assistant/references/build-critique.md
@@ -726,13 +726,25 @@ components named. It is also not the same as a single component's empty diff, wh
   `uncritiqued[]` row is what makes that visible rather than silent.
 - **An architecture with no acceptance criteria per component** leaves `meets-ac` with
   nothing to check. The critique still runs; the row records the criteria were absent.
-- **The work-order build path carries no RED evidence at all.** The `tdd` block lives on
-  `_build-critique.json`, and only `/implement`'s in-session path writes that record. A build
-  that went through `/run-work-orders` owes `work-orders/wo-NN._critique.json` instead, and
-  nothing in that shape carries `red_observed`, `passed_first_run`, `ratified`, or `unobserved`. The
-  RED-observation half is not degraded on that path — it is entirely absent, and
-  `build-critique-assert.sh` does not ask it to be present, because the file it would live in
-  is never expected to exist there. Documented as not covered, not as covered-and-passing.
+- **The work-order build path owes RED evidence too, per work-order (v5.48.0+).** It did not
+  until then, and the paragraph that stood here said so: the `tdd` block lived on
+  `_build-critique.json`, only `/implement`'s in-session path wrote that record, and a
+  `/run-work-orders` build owed `work-orders/wo-NN._critique.json` instead, which carried nothing
+  equivalent. Since the orchestration rules route real builds to delegated agents, following them
+  routed every real build around this rung by construction. Measured on a live build: three
+  components built, reviewed and merged with no TDD record of any kind, every downstream check
+  satisfied, because each one read a record nobody was asked to write.
+
+  Now the unit of the record is the WORK-ORDER. The delegated builder writes
+  `work-orders/wo-NN.tdd.json`, the loop collects it into `wo-NN.run.json` via
+  `wo-run-state.sh collect --tdd-file`, and `build-critique-assert.sh` judges the `tdd` block on
+  that run record with the SAME function the in-session branch uses (`tdd_block_problems` in
+  `accept-verdict.sh`), so a record satisfies both paths or neither. A work-order that owes a
+  record and has none fails the review, fail-closed and `unresolved`. Which work-orders owe one is
+  a union: a run record exists, or a critique exists, or the status is anything but `ready` or
+  `blocked`. The full path end to end is in `references/tdd-workflow.md`, "When the build is
+  delegated". Evidence keys: `work_orders_owing_tdd`, `work_orders_without_tdd`,
+  `work_orders_bad_tdd`.
 - **A recorded `observed` is a report of an observation, not proof of one.** Nothing in this
   rung, or in `/review`, captures the test runner's actual exit code. The record is whatever
   Claude typed into the `tdd` block after the fact. A criterion whose test never ran, or whose

--- a/ai-dev-assistant/references/gate-audit-schema.md
+++ b/ai-dev-assistant/references/gate-audit-schema.md
@@ -957,9 +957,10 @@ folding it into `overall_verdict`:
 unknown — the record says which kind of test it was. Everything else that is wrong about the
 block, an unexplained first-run pass included, reads as "could not tell," which is why
 it is `unresolved: true`; a real, named violation does not get filed the same way as a gap in
-the record. **Covers the in-session build path only** — `/implement` writes this record; a
-build that went through `/run-work-orders` has no `_build-critique.json` and owes
-`work-orders/wo-NN._critique.json` instead, which carries no RED-observation equivalent. Full
+the record. **This record covers the in-session build path** — `/implement` writes it. A build
+that went through `/run-work-orders` has no `_build-critique.json`; since v5.48.0 it owes a `tdd`
+block per work-order on `wo-NN.run.json`, judged by the same function, rather than owing no
+RED-observation equivalent at all (see the enforcement paragraph below). Full
 enforcement rationale and the who-runs-the-test-by-`run_mode` rule: `references/tdd-workflow.md`
 ("Who runs the tests, and what has to be recorded") and `references/build-critique.md`.
 
@@ -981,7 +982,15 @@ is a hard-block gate input, not documentation: `verdict: "critical"`, any compon
 `blocking: true`, `verdict: "unresolved"`, a payload missing the three count keys, a
 malformed or absent `tdd` block (table above), and a `skipped` with no reason all fail the
 review. The absence of the record fails it too, unless `work-orders/wo-NN._critique.json`
-files show the build went through `/run-work-orders` and owes those instead. An override is
+files show the build went through `/run-work-orders` — and since v5.48.0 that path owes its own
+per-work-order TDD record rather than owing nothing: a `tdd` block on `wo-NN.run.json`, written by
+the loop from the builder's `wo-NN.tdd.json` sidecar and judged by the same `tdd_block_problems`
+that judges the in-session block. A work-order that owes one and has none fails the review,
+fail-closed and `unresolved`; a work-order owes one when a run record exists, or a critique
+exists, or its status is anything but `ready` or `blocked`. The gate reports this in three
+evidence keys — `work_orders_owing_tdd` (int), `work_orders_without_tdd` (array of work-order
+ids) and `work_orders_bad_tdd` (array of `{work_order, problems[]}`), the last present on a pass
+too, so an empty list reads as checked-and-clean rather than as never-looked. An override is
 a `bypass_reason` on this record, which the writer hoists to the envelope and the gate
 surfaces rather than absorbs.
 

--- a/ai-dev-assistant/references/tdd-workflow.md
+++ b/ai-dev-assistant/references/tdd-workflow.md
@@ -87,6 +87,62 @@ matching row. Neither row is a licence to skip the observation.
 | `interactive` (default) | The user, unless they have said otherwise for this project | Claude gives the exact command; the user runs it and reports the result back |
 | `autonomous` | The agent, because there is nobody else | The agent runs the command itself and keeps the exit code |
 
+### When the build is delegated (v5.48.0+)
+
+Everything above reads as though a build is something the main context does. Often it is not. A
+`/run-work-orders` build hands each unit to a fresh subagent, and that subagent inherits none of
+this: not the methodology floor `/implement` loads, not the activated `tdd-companion`, not the
+loop that records an outcome per criterion. **The discipline was not weak on that path. It was
+absent**, and the framework demanded a TDD record of the in-session record and of nothing else,
+so following an orchestration rule that says the main loop coordinates rather than builds routed
+every real build around this rung by construction. Measured on a live build: three components
+built, reviewed and merged with no TDD record of any kind, every downstream check satisfied,
+because each one reads a record nobody was asked to write.
+
+**The unit of the record is the unit of work, not the phase.** A delegated builder writes its own
+record and the orchestrator collects rather than authoring on its behalf. The whole path, end to
+end:
+
+1. **`skills/work-order-builder`** states the obligation in the prompt it hands the subagent and
+   names one absolute path to write it to: `<WO_DIR>/wo-NN.tdd.json`, beside that work-order's
+   `wo-NN.run.json` and `wo-NN._critique.json`. It is the only file the BUILDER writes outside its
+   build root; the atom separately flips `status:` on `wo-NN.md` in the same directory, before any
+   code is mutated.
+2. **The builder** writes ONE JSON object there: `{red_observed, passed_first_run, ratified,
+   unobserved[], reason}` — the same shape an in-session `_build-critique.json` carries, so
+   `/review` reads one record and not two.
+3. **The build atom does nothing with it.** It does not read the file, validate it, or carry it in
+   the handle. The handle is derived from git and disk and structurally accepts no subagent content
+   (M-6), which is exactly why the record travels beside it rather than inside it.
+4. **The loop** (`work-order-loop`, `work-order-loop-parallel`) computes the same path from the
+   work-order id it is already looping over and runs `wo-run-state.sh collect --tdd-file <path>`
+   when the file is there. No file ⇒ no flag ⇒ no `tdd` key, and nothing invents a default.
+   `wo-run-state.sh` parses and type-checks the content before storing it and refuses a malformed
+   one outright, because the content is subagent output even though the channel is a file.
+5. **`/review`'s build-critique gate** fails a work-order whose run record carries no `tdd` block,
+   fail-closed and unresolved.
+
+**A file, not a line in the builder's reply.** Every other subagent-produced value in this plugin
+already moves this way — `wo-critic` writes `wo-NN._critique.json`, `architecture-validator` writes
+`_arch-validate-<slug>.json`, `distill-agent` writes `_distill.json` — and `commands/review.md`
+step 5.0 records the measurement behind it: an agent whose report was its Task response alone had
+that response truncate in transit repeatedly, and the session had to improvise a scratchpad file
+mid-review to recover it. A record asked for as a trailing line in a reply has no reader and no
+path. On a file, both ends derive the path from data they already hold, so a truncated reply costs
+nothing.
+
+`run_mode` still decides who runs the test, by the table above. A delegated builder is running
+unattended by definition, so its rows are the `autonomous` ones: it runs the command and keeps the
+exit code. What it must not do is infer a RED it did not watch, which is the same rule as
+everywhere else here and is why `unobserved[]` is a value it can return rather than a failure.
+
+**What this does not fix.** The record is a self-report, exactly as the in-session one is. Moving
+it from a reply to a file fixed the delivery, not the trust: the builder still writes its own
+numbers, nothing captures the runner's exit code into the record, and a builder that writes nothing
+is caught only downstream, by a gate that fails on the absence. This closes the gap between
+recorded and unrecorded on a path where nothing was recorded at all. It does not close the gap
+between recorded and true.
+
 **A targeted run is part of the cycle, not a test-suite sweep.** A project instruction along the
 lines of "I run the test suites, not you" is about unattended whole-suite runs; a single
 `--filter`-scoped invocation whose entire purpose is to watch one new test fail is the RED step

--- a/ai-dev-assistant/scripts/accept-verdict.sh
+++ b/ai-dev-assistant/scripts/accept-verdict.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# accept-verdict.sh — the 7 pure decisions behind the repair accept verdict block in
+# accept-verdict.sh — the 7 pure decisions behind the repair accept verdict block, plus one
+# shared tdd-block judge (see its own banner below), in
 # build-critique-assert.sh (the section commented "the repair accept verdict (v5.42.0+)").
 #
 # SOURCE this file (do not execute it). Each function takes the record's PAYLOAD as $1 and
@@ -155,5 +156,53 @@ accept_escalation_reason() {
                    else ([(.rounds // [])[] | (.resolution // empty) | tostring | trim]
                          | map(select(. != "")) | last // "")
                    end' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
+  printf '%s' "$out"
+}
+
+# =====================================================================================
+# THE TDD BLOCK JUDGE — one function, two callers (v5.48.0+)
+#
+# NOT part of the accept verdict. It lives here because this file is where
+# build-critique-assert.sh keeps the pure decisions it makes twice, and this is the second
+# one: the in-session branch reads `.tdd` off `_build-critique.json` and the work-order
+# branch reads `.tdd` off each `wo-NN.run.json`, and the two have to reach the same answer
+# or the delegated path becomes the cheap way to satisfy a rung.
+#
+# THE DEFECT THIS EXISTS FOR. The work-order branch shipped calling has() on four keys and
+# stopping, with a comment claiming it demanded "the same three counts and the same array
+# the in-session branch demands, so one path cannot be satisfied by a record the other would
+# refuse". That was false: the in-session branch additionally blocks on two VALUE
+# judgements, so
+#   {"red_observed":0,"passed_first_run":5,"ratified":0,"unobserved":["A","B","C"],"reason":null}
+# returned pass on the delegated path and fail on the in-session one. A comment asserting a
+# property the code does not enforce is the exact defect class the rung it guards exists to
+# catch.
+
+# tdd_block_problems <tdd-block-json>
+# The problems that BLOCK, as a compact JSON array of human-readable strings; `[]` when the
+# block is sound. Blocking only: the ratified-vs-red ratio line and the per-count surfacing
+# lines are reporting, they stay in the caller, and nothing here formats or emits.
+#
+# The four `omits` readings mirror the caller's own coercions verbatim rather than reading
+# has(): the in-session branch resolves each count through `(.x // -1)` and treats -1 as "the
+# block cannot say", so a key present-but-null is missing to it and has() would disagree.
+# `unobserved` is the exception, keyed on has() there and here, because an empty array and an
+# absent one are different answers and `// []` collapses them.
+tdd_block_problems() {
+  local out
+  out=$(jq -c '
+    def absent($v): (($v // -1) == -1);
+    def count($v): (($v // -1) | tonumber? // -1);
+    (((.reason // "") | tostring) as $r
+     | (($r == "") or ($r == "null")) as $noreason
+     | [ (if absent(.red_observed) then "omits red_observed" else empty end),
+         (if absent(.passed_first_run) then "omits passed_first_run" else empty end),
+         (if (has("unobserved") | not) then "omits unobserved[]" else empty end),
+         (if absent(.ratified) then "omits ratified" else empty end),
+         (if ((count(.passed_first_run) > 0) and $noreason)
+          then "passed_first_run > 0 with no reason recorded" else empty end),
+         (if ((((.unobserved // []) | length) > 0) and $noreason)
+          then "unobserved[] non-empty with no reason recorded" else empty end) ])
+  ' <<<"$1" 2>/dev/null) || { printf '%s' "$JQ_ERR"; return 0; }
   printf '%s' "$out"
 }

--- a/ai-dev-assistant/scripts/build-critique-assert.sh
+++ b/ai-dev-assistant/scripts/build-critique-assert.sh
@@ -83,6 +83,29 @@ emit() { # emit <verdict> <unresolved true|false> <bypass_reason or empty> <exit
   exit "$4"
 }
 
+# has_tdd_problem <problems-json> <problem string>
+# Membership in what `tdd_block_problems` returned. A lookup, not a judgement -- the judging is
+# already done by the time this is called, and it is done in one place for both build paths.
+has_tdd_problem() { jq -e --arg p "$2" 'index($p) != null' <<<"$1" >/dev/null 2>&1; }
+
+# wo_frontmatter_status <work-order.md>
+# The `status:` value in the leading `---` frontmatter block, lowercased, or empty when the file
+# has no frontmatter or no status line. Deliberately not a YAML parse: this reads one line of a
+# file this repo writes itself, and a YAML dependency for that is a dependency the gate would
+# then fail closed on when it is missing.
+wo_frontmatter_status() {
+  awk '
+    NR == 1 { if ($0 !~ /^---[[:space:]]*$/) exit; next }
+    /^---[[:space:]]*$/ { exit }
+    /^status:/ {
+      sub(/^status:[[:space:]]*/, "")
+      gsub(/[[:space:]"]/, "")
+      print tolower($0)
+      exit
+    }
+  ' "$1" 2>/dev/null
+}
+
 BUILD_PATH="none"
 
 if [ -z "$TASK_DIR" ] || [ ! -d "$TASK_DIR" ]; then
@@ -259,7 +282,19 @@ if [ -e "$REC" ]; then
   [ "$TDD_REASON" = "null" ] && TDD_REASON=""
   set_ev tdd "$TDD"
 
-  if [ "$RED_N" = "-1" ] || [ "$FIRSTRUN_N" = "-1" ] || ! jq -e 'has("unobserved")' <<<"$TDD" >/dev/null 2>&1; then
+  # Every blocking decision about this block comes from ONE function, `tdd_block_problems` in
+  # accept-verdict.sh, and the delegated branch at the bottom of this file calls the same one.
+  # The counts above stay because the NON-blocking lines below say them out loud, and saying a
+  # number is not judging it.
+  TDD_PROBLEMS=$(tdd_block_problems "$TDD")
+  if [ "$TDD_PROBLEMS" = "$JQ_ERR" ]; then
+    add_msg "the tdd block could not be read, so it cannot say what was watched failing before the code existed"
+    emit fail true "" 1
+  fi
+
+  if has_tdd_problem "$TDD_PROBLEMS" "omits red_observed" \
+     || has_tdd_problem "$TDD_PROBLEMS" "omits passed_first_run" \
+     || has_tdd_problem "$TDD_PROBLEMS" "omits unobserved[]"; then
     add_msg "the tdd block omits red_observed, passed_first_run or unobserved[], so it cannot say what it did not watch"
     emit fail true "" 1
   fi
@@ -283,7 +318,7 @@ if [ -e "$REC" ]; then
   # `ratified` key reads identically to a phase that ratified nothing, and those are different
   # answers. Measured on one build: 19 assertions across two fixes, 11 red and 8 green on
   # arrival, and nothing anywhere was counting the 8.
-  if [ "$RATIFIED_N" = "-1" ]; then
+  if has_tdd_problem "$TDD_PROBLEMS" "omits ratified"; then
     add_msg "the tdd block omits ratified, so it cannot say how many tests passed on arrival because the code they describe already existed"
     emit fail true "" 1
   fi
@@ -293,7 +328,7 @@ if [ -e "$REC" ]; then
     add_msg "this suite is ratifying more than it is constraining: $RATIFIED_N ratified against $RED_N red"
   fi
 
-  if [ "$FIRSTRUN_N" -gt 0 ] && [ -z "$TDD_REASON" ]; then
+  if has_tdd_problem "$TDD_PROBLEMS" "passed_first_run > 0 with no reason recorded"; then
     # Two different things pass on their first run and only one is a defect.
     #
     # A test written test-first that passes immediately is the blocking violation
@@ -313,7 +348,7 @@ if [ -e "$REC" ]; then
     add_msg "$FIRSTRUN_N test(s) passed on their first run: $TDD_REASON"
   fi
 
-  if [ "$UNOBS_N" -gt 0 ] && [ -z "$TDD_REASON" ]; then
+  if has_tdd_problem "$TDD_PROBLEMS" "unobserved[] non-empty with no reason recorded"; then
     # Recording `unobserved` is legal. Leaving it unexplained is not: with no reason it reads
     # identically to a run where nobody thought about it, which is the state this whole block
     # exists to make visible.
@@ -1167,6 +1202,115 @@ if [ "$CRIT_N" -gt 0 ]; then
     add_msg "work-order critique(s) with no evaluated blocking field: $(jq -r 'join(", ")' <<<"$UNREADABLE")"
     emit fail true "" 1
   fi
+  # ---------------------------------------- the delegated path owes a TDD record too (v5.48.0+)
+  #
+  # Until this version `tdd` was demanded of `_build-critique.json` and of nothing else, so a
+  # /run-work-orders build satisfied this gate on its critique files alone and owed no statement
+  # about whether any test was watched failing before the code existed. The rung that enforces
+  # test-first was reachable only on the path where the main context does the building, while
+  # the orchestration rules route real builds to delegated agents. Measured on a live build:
+  # three components built, reviewed and merged with no TDD record of any kind, every downstream
+  # check satisfied, because each one reads a record nobody was asked to write.
+  #
+  # The unit of the record is the WORK-ORDER, not the phase. A delegated builder returns one and
+  # the loop collects it into `wo-NN.run.json` via wo-run-state.sh; the orchestrator aggregates
+  # rather than authoring on the builder's behalf. Absence is `unresolved`, the same answer the
+  # in-session branch gives a record with no `tdd` key: nobody looked is not nothing was wrong.
+  # THE SUBJECT SET IS THE WORK-ORDERS, NOT THE CRITIQUE FILES. The first cut of this block
+  # iterated `$CRITIQUES`, so a compiled work-order carrying no `wo-NN._critique.json` was never
+  # examined at all. Measured on a three-work-order fixture, one critiqued and two with nothing
+  # on disk beside their `.md`: `verdict: pass`, `work_orders_without_tdd: []`, and the record's
+  # own evidence saying `work_orders: 3`. A check whose subject set is the evidence it is looking
+  # for cannot report the evidence missing.
+  #
+  # NOT EVERY COMPILED WORK-ORDER OWES A RECORD. One that was never dispatched built nothing, and
+  # demanding a TDD statement of it would make the honest answer the expensive one. The rule is
+  # decidable from disk and is a UNION on purpose:
+  #
+  #   owes a record IFF `wo-NN.run.json` exists,
+  #                  OR `wo-NN._critique.json` exists,
+  #                  OR the frontmatter `status:` is NOT one of `ready` / `blocked`
+  #
+  # The status half is stated as an EXCLUSION because the state machine in `wo-compile.sh`
+  # (`blocked→ready→in_progress→{done,needs_rework}→ready`) has exactly two statuses a work-order
+  # can hold without ever having been dispatched: `blocked` and `ready`. Every other status is
+  # reached by the atom's own `ready→in_progress` flip, which happens BEFORE it mutates code. The
+  # first cut named `done` alone, which excluded `in_progress` (the loop crashed after the flip)
+  # and `needs_rework` (a failing verdict sent it back) -- both built something, and both were
+  # skipped in silence rather than named. Listing the two that owe nothing cannot rot as the
+  # enum grows; listing the three that owe something can.
+  #
+  # A run record means the loop dispatched it. A critique means it was BUILT: `wo-critic` reads a
+  # diff and the gate envelopes, so it cannot have run over something nobody built. A status past
+  # `ready` means the atom flipped it and started. Each of the three catches a lost-record shape
+  # the others miss, which is why the subject set is their union and not any one of them. A
+  # work-order matching none is one nobody dispatched, and it owes nothing: demanding a TDD
+  # statement of a build that never happened makes the honest answer the expensive one.
+  #
+  # The critique disjunct was missing from the first cut of this rule, which is how a fixture
+  # carrying a critique and no run record went from failing to passing without anyone choosing
+  # that.
+  #
+  # THE ID SET IS THE UNION OF THREE GLOBS, NOT THE `.md` LIST. Iterating `wo-*.md` fixes the
+  # original defect (a work-order with no critique was never examined) and opens its mirror: a
+  # `wo-NN._critique.json` whose `.md` is gone becomes invisible, and the gate returns `pass` on a
+  # record whose own evidence says one critic ran and zero work-orders owed anything. Measured:
+  # `work_orders: 0, work_order_critiques: 1, work_orders_owing_tdd: 0, verdict: pass`. A subject
+  # set drawn from ONE artifact can always be emptied by deleting that artifact, so it is drawn
+  # from all three that name a work-order.
+  WO_NO_TDD='[]'
+  WO_BAD_TDD='[]'
+  WO_TDD_SUBJECTS=0
+  WO_IDS=$( { printf '%s\n' "$WOS" | sed -n 's#.*/\(wo-[^/]*\)\.md$#\1#p'
+              find "$WO_DIR" -maxdepth 1 -name 'wo-*.run.json' -type f 2>/dev/null \
+                | sed -n 's#.*/\(wo-[^/]*\)\.run\.json$#\1#p'
+              printf '%s\n' "$CRITIQUES" | sed -n 's#.*/\(wo-[^/]*\)\._critique\.json$#\1#p'
+            } | grep . | sort -u )
+  while IFS= read -r WO_ID; do
+    [ -z "$WO_ID" ] && continue
+    f="$WO_DIR/$WO_ID.md"
+    RUN_JSON="$WO_DIR/$WO_ID.run.json"
+    WO_ST=""
+    [ -f "$f" ] && WO_ST=$(wo_frontmatter_status "$f")
+    if [ ! -f "$RUN_JSON" ] \
+       && [ ! -f "$WO_DIR/$WO_ID._critique.json" ] \
+       && { [ -z "$WO_ST" ] || [ "$WO_ST" = "ready" ] || [ "$WO_ST" = "blocked" ]; }; then
+      continue
+    fi
+    WO_TDD_SUBJECTS=$((WO_TDD_SUBJECTS + 1))
+    if [ ! -f "$RUN_JSON" ] || ! jq -e 'has("tdd")' "$RUN_JSON" >/dev/null 2>&1; then
+      WO_NO_TDD=$(jq -c --arg n "$WO_ID" '. + [$n]' <<<"$WO_NO_TDD")
+      continue
+    fi
+    # ONE JUDGE, TWO PATHS. `tdd_block_problems` is the same function the in-session branch
+    # blocks on above, so this record either satisfies both paths or neither. The comment this
+    # replaces claimed that property while the code checked four has() calls and nothing else,
+    # and a block with `passed_first_run: 5` and no reason passed here and failed there.
+    WO_TDD_PROBLEMS=$(tdd_block_problems "$(jq -c '.tdd' "$RUN_JSON" 2>/dev/null || printf 'null')")
+    if [ "$WO_TDD_PROBLEMS" = "$JQ_ERR" ]; then
+      WO_TDD_PROBLEMS='["the tdd block could not be read"]'
+    fi
+    if [ "$(jq -r 'length' <<<"$WO_TDD_PROBLEMS")" -gt 0 ]; then
+      WO_BAD_TDD=$(jq -c --arg n "$WO_ID" --argjson p "$WO_TDD_PROBLEMS" \
+        '. + [{work_order:$n, problems:$p}]' <<<"$WO_BAD_TDD")
+    fi
+  done <<< "$WO_IDS"
+  # Both keys are set unconditionally. An evidence key that appears only on failure cannot be
+  # read as "checked and clean", and `work_orders_owing_tdd` is here so a reader can tell an
+  # empty list that means nothing was wrong from one that means nothing was a subject.
+  set_ev work_orders_owing_tdd "$WO_TDD_SUBJECTS"
+  set_ev work_orders_without_tdd "$WO_NO_TDD"
+  set_ev work_orders_bad_tdd "$WO_BAD_TDD"
+  if [ "$(jq -r 'length' <<<"$WO_NO_TDD")" -gt 0 ]; then
+    add_msg "work-order(s) with no tdd block in their run record: $(jq -r 'join(", ")' <<<"$WO_NO_TDD")"
+    add_msg "a delegated build owes the same statement an in-session build owes: what was watched failing before the code existed, and what was not"
+    emit fail true "" 1
+  fi
+  if [ "$(jq -r 'length' <<<"$WO_BAD_TDD")" -gt 0 ]; then
+    add_msg "work-order tdd block(s) the in-session branch would also refuse: $(jq -r '[.[] | .work_order + " (" + (.problems | join("; ")) + ")"] | join(", ")' <<<"$WO_BAD_TDD")"
+    emit fail true "" 1
+  fi
+
   add_msg "the build was challenged through /run-work-orders: $CRIT_N work-order critique(s), none blocking"
   emit pass false "" 0
 fi

--- a/ai-dev-assistant/scripts/wo-run-state.sh
+++ b/ai-dev-assistant/scripts/wo-run-state.sh
@@ -9,14 +9,41 @@
 # Usage:
 #   wo-run-state.sh dispatch <run-json> --checkpoint-before <sha> [--cap <n=3>]
 #   wo-run-state.sh collect  <run-json> --override-used <bool> --halt-reason <r|null> \
-#                            --build-returned <bool> [--checkpoint-after <sha>]
+#                            --build-returned <bool> [--checkpoint-after <sha>] [--tdd-file <path>]
 #   wo-run-state.sh read     <run-json>
 #   wo-run-state.sh halt     <run-json> --reason <r>
 #
 # Sidecar shape:
 #   { "wo":"wo-NN", "attempts":<int>, "checkpoint_before":"<sha>", "dispatched_at":"<iso8601>",
 #     "halted":false, "halt_reason":null, "override_used":null, "build_returned":null,
-#     "checkpoint_after":null }
+#     "checkpoint_after":null, "tdd":{...} }
+#
+# `tdd` (v5.48.0+) is OPTIONAL HERE and REQUIRED THERE. This kernel stores what it is handed and
+# never invents one: no `--tdd-file` leaves no key, because an auto-filled default would make a
+# delegated build that never ran a test indistinguishable from one that did.
+# `scripts/build-critique-assert.sh` is what refuses the absence, at `/review`, on the
+# work-order branch. It demands of a delegated record exactly what it demands of an in-session
+# `_build-critique.json`, because BOTH call one function -- `tdd_block_problems` in
+# accept-verdict.sh, which is the authority on what a sound block is. That is presence of the
+# three counts and the array, AND two judgements on their values: a `passed_first_run` above zero
+# owes a reason, and a non-empty `unobserved[]` owes a reason. Do not read this comment as the
+# spec; the first version of this rung said "the same three counts and the same array" and shipped
+# a work-order branch that checked presence only, which a record with five unexplained first-run
+# passes satisfied on one path and failed on the other. Before that version the TDD rung was reachable only on the path where
+# the main context does the building, so delegating a build routed around it by construction.
+#
+# `--tdd-file` names the sidecar the delegated builder WROTE, `<WO_DIR>/wo-NN.tdd.json`, beside
+# the run record and the critique verdict. It is a file rather than a transcript value for the
+# reason `commands/review.md` step 5.0 records: an agent whose report was its Task response alone
+# had that response truncate in transit repeatedly. The file's CONTENT is still subagent output,
+# so it is parsed and type-checked before it is stored and a bad one is refused with the sidecar
+# untouched — a run record carrying half a TDD block would satisfy the gate's has() checks while
+# saying nothing true. Refusals, all exit 2: an option-shaped or newline-bearing path
+# (tdd_file_unsafe_path), a named file that is absent (tdd_file_absent) or is not a regular file
+# (tdd_file_not_regular) or is unreadable (tdd_file_unreadable) or is empty (tdd_file_empty),
+# content that is not JSON (tdd_not_json), and JSON that is not an object (tdd_not_an_object).
+# The path itself never reaches a command as an argument: the file is read by `<` redirection,
+# which does no option parsing at all.
 #
 # All JSON via jq --arg/--argjson (injection-inert; untrusted --checkpoint-before/--reason data-only).
 # All writes: temp-file + mv (crash-atomic; partial write never replaces the live sidecar).
@@ -44,6 +71,19 @@ atomic_write() {
   cat > "$tmpf" && mv "$tmpf" "$target"
 }
 
+# tdd_refuse: emit the refusal JSON + a stderr line and exit 2, leaving the sidecar untouched.
+# Every --tdd-file rejection routes through here so "refused" is one exit code and one shape.
+tdd_refuse() {
+  jq -nc --arg r "$1" '{"ok":false,"reason":$r}'
+  printf 'wo-run-state collect bad-tdd wo=%s reason=%s\n' "$WO" "$1" >&2
+  exit 2
+}
+
+# Arg-loop shifting below reads `shift; [ "$#" -gt 0 ] && shift` rather than `shift 2`. On a
+# TRAILING flag with no value left, `shift 2` shifts nothing and returns 1, and the enclosing
+# while-loop then spins forever on the same argument — measured, a real hang, on every flag in
+# this file. wo-compile.sh cmd_collect_handle already shifts the pair this way.
+
 case "$MODE" in
 
   # -------------------------------------------------------------------------
@@ -53,8 +93,8 @@ case "$MODE" in
     shift 2
     while [ "$#" -gt 0 ]; do
       case "$1" in
-        --checkpoint-before) CHECKPOINT_BEFORE="${2:-}"; shift 2 ;;
-        --cap)               CAP="${2:-3}";              shift 2 ;;
+        --checkpoint-before) CHECKPOINT_BEFORE="${2:-}"; shift; [ "$#" -gt 0 ] && shift ;;
+        --cap)               CAP="${2:-3}";              shift; [ "$#" -gt 0 ] && shift ;;
         *)                   shift ;;
       esac
     done
@@ -114,13 +154,16 @@ case "$MODE" in
   # collect: post-build merge of handle-snapshot fields; attempts preserved.
   collect)
     OV_USED="false"; HALT_REASON="null"; BUILD_RET="false"; CP_AFTER="null"
+    TDD_FILE=""; TDD_NAMED=0; TDD_BLOCK=""
     shift 2
     while [ "$#" -gt 0 ]; do
       case "$1" in
-        --override-used)    OV_USED="${2:-false}";    shift 2 ;;
-        --halt-reason)      HALT_REASON="${2:-null}"; shift 2 ;;
-        --build-returned)   BUILD_RET="${2:-false}";  shift 2 ;;
-        --checkpoint-after) CP_AFTER="${2:-null}";    shift 2 ;;
+        --override-used)    OV_USED="${2:-false}";    shift; [ "$#" -gt 0 ] && shift ;;
+        --halt-reason)      HALT_REASON="${2:-null}"; shift; [ "$#" -gt 0 ] && shift ;;
+        --build-returned)   BUILD_RET="${2:-false}";  shift; [ "$#" -gt 0 ] && shift ;;
+        --checkpoint-after) CP_AFTER="${2:-null}";    shift; [ "$#" -gt 0 ] && shift ;;
+        --tdd-file)         TDD_FILE="${2:-}"; TDD_NAMED=1
+                            shift; [ "$#" -gt 0 ] && shift ;;
         *)                  shift ;;
       esac
     done
@@ -148,6 +191,39 @@ case "$MODE" in
     if [ "$CP_AFTER" = "null" ]; then CA_JSON="null"
     else CA_JSON="$(jq -cn --arg v "$CP_AFTER" '$v')"; fi
 
+    # tdd: read the builder's sidecar, <WO_DIR>/wo-NN.tdd.json, named by the loop. The file is
+    # written by a subagent, so its content is untrusted: parsed and type-checked before it is
+    # stored, and refused rather than written when it is anything else. Refused = exit 2 with the
+    # live sidecar untouched, because a run record carrying half a TDD block would satisfy the
+    # gate's has() checks while saying nothing true. Naming a file and not producing one is a
+    # caller bug, not an absent record: the loop passes NO flag when the builder wrote nothing,
+    # and that path leaves no `tdd` key for /review to fail on.
+    if [ "$TDD_NAMED" = 1 ]; then
+      # Path safety, same posture as wo-compile.sh cmd_collect_handle: an option-shaped token
+      # must never be able to reach a command as a real option, and no path we accept has a
+      # newline in it. Reject both outright rather than trying to quote around them.
+      case "$TDD_FILE" in
+        "")  tdd_refuse tdd_file_unsafe_path ;;
+        -*)  tdd_refuse tdd_file_unsafe_path ;;
+      esac
+      [ "$TDD_FILE" = "${TDD_FILE%%$'\n'*}" ] || tdd_refuse tdd_file_unsafe_path
+
+      [ -e "$TDD_FILE" ] || tdd_refuse tdd_file_absent
+      [ -f "$TDD_FILE" ] || tdd_refuse tdd_file_not_regular
+      [ -r "$TDD_FILE" ] || tdd_refuse tdd_file_unreadable
+
+      # Read by REDIRECTION: `<` does no option parsing, so the path is never an argument.
+      TDD_BLOCK="$(cat < "$TDD_FILE")" || tdd_refuse tdd_file_unreadable
+      [ -n "${TDD_BLOCK//[[:space:]]/}" ] || tdd_refuse tdd_file_empty
+
+      # Parse, then type-check, as two refusals: "that is not JSON" and "that is JSON but not a
+      # record" are different caller mistakes and a shared reason string hides which one it was.
+      # `jq -e 'type'` and not `jq -e '.'`: the latter exits 1 on a well-formed `null` or
+      # `false` document, which would report a parse failure for content that parsed fine.
+      jq -e 'type' >/dev/null 2>&1 <<<"$TDD_BLOCK" || tdd_refuse tdd_not_json
+      jq -e 'type == "object"' >/dev/null 2>&1 <<<"$TDD_BLOCK" || tdd_refuse tdd_not_an_object
+    fi
+
     JSON="$(jq -c \
       --argjson override_used    "$OV_JSON" \
       --argjson halt_reason      "$HR_JSON" \
@@ -156,6 +232,10 @@ case "$MODE" in
       '. + {override_used:$override_used, halt_reason:$halt_reason,
             build_returned:$build_returned, checkpoint_after:$checkpoint_after}' \
       "$RUN_JSON")"
+
+    if [ "$TDD_NAMED" = 1 ]; then
+      JSON="$(jq -c --argjson tdd "$TDD_BLOCK" '. + {tdd:$tdd}' <<<"$JSON")"
+    fi
 
     printf '%s\n' "$JSON" | atomic_write "$RUN_JSON"
     printf '%s\n' "$JSON"
@@ -195,7 +275,7 @@ case "$MODE" in
     shift 2
     while [ "$#" -gt 0 ]; do
       case "$1" in
-        --reason) REASON="${2:-}"; shift 2 ;;
+        --reason) REASON="${2:-}"; shift; [ "$#" -gt 0 ] && shift ;;
         *)        shift ;;
       esac
     done

--- a/ai-dev-assistant/skills/tdd-companion/SKILL.md
+++ b/ai-dev-assistant/skills/tdd-companion/SKILL.md
@@ -161,9 +161,33 @@ STOP and enforce:
 
 **These BLOCK implementation:**
 - Writing implementation before test exists
-- Test passes on first run (test might be wrong)
+- **An UNEXPLAINED** test passing on first run
 - Adding untested features
 - Skipping RED phase confirmation
+
+**A test passing on first run is not a violation by itself, and this file said it was until
+v5.48.0.** `scripts/build-critique-assert.sh` passes `passed_first_run` whenever a reason is
+recorded and fails only an unexplained one. v5.46.0 corrected the two documents that stated the
+blanket rule, `references/gate-audit-schema.md` and `commands/implement.md`; this file states the
+same rule and was missed. It is the copy an agent has loaded while building, so it was the one
+most likely to be acted on.
+
+**There are two legitimate reasons a test passes immediately**, and neither is the violation:
+
+- **`ratified` (v5.46.0+).** The behaviour it describes already existed, so the test locks in what
+  the code already did. Legitimate as a characterization or regression test. It owes no reason.
+  Report it under `ratified`, never under `passed_first_run`, and never as a violation. A `tdd`
+  block omitting the count fails closed, because absence and zero are different answers.
+- **A test whose expectation is that nothing happens.** A malformed input is not recognised, a
+  near-miss is not matched, a non-matching directory still exits 0. Authored test-first from the
+  criterion, against no implementation, and green from the first run because the default state
+  already satisfies them. Measured on one build: 11 of 21 tests. **These are the tests most likely
+  to be insensitive**, since they pass in every state until something fires, so verify them by
+  temporarily making the thing happen and watching each one fail at its own assertion.
+
+The violation is the third case: a test-first test that passes because it asserts nothing, or
+asserts something already true for a reason unrelated to the behaviour. That one owes the reason,
+and the gate is what refuses a blank one.
 
 ## Integration with Quality Gates
 

--- a/ai-dev-assistant/skills/work-order-builder/SKILL.md
+++ b/ai-dev-assistant/skills/work-order-builder/SKILL.md
@@ -143,7 +143,7 @@ The re-gate passed (RC==0), so the WO is still `status: ready`. Flip it **now** 
 checkpoint/spawn/commit below — so every code mutation happens under `in_progress`:
 
 ```bash
-bash "$KERNEL" set-status "$WO" in_progress      # ready→in_progress (legal); the ONLY memory-repo write
+bash "$KERNEL" set-status "$WO" in_progress      # ready→in_progress (legal); the atom's ONLY memory-repo write
 ```
 
 This runs **only on a passing re-gate** (a refused gate already `return`ed at step 1, leaving the WO
@@ -172,6 +172,51 @@ the **Task** tool:
   to the prompt as clearly-demarcated trusted runtime context, separated from the WO body (the build
   brief) — e.g. a `BUILD ROOT (write all changes under this absolute path): <abs>` header line, a
   delimiter, then the verbatim WO body.
+- **Give the builder the test-first obligation, and a file to record it in (v5.48.0+).** A
+  delegated builder inherits no methodology floor and no activated `tdd-companion`: both happen in
+  the main context, on the `/implement` path, and this atom is the other path. Until this version
+  the framework demanded a TDD record of an in-session build and of nothing else, so the
+  orchestration rule that says the main loop coordinates rather than builds routed every real
+  build around the test-first rung by construction. Measured on a live build: three components
+  built, reviewed and merged with no TDD record of any kind, and every downstream check satisfied,
+  because each one reads a record nobody was asked to write.
+
+  So state the obligation in the prompt as trusted runtime context beside `BUILD ROOT`, **and name
+  the file the builder writes the record to** — a **third** anchor line, because the builder is
+  otherwise told to write everything under `BUILD ROOT` and this one file does not go there:
+
+  `TDD RECORD (write ONE JSON object to this absolute path, in addition to your build output under BUILD ROOT): <abs $WO_DIR>/<wo-NN>.tdd.json`
+
+  where `<wo-NN>` is the work-order id, so the file lands beside `wo-NN.run.json` and
+  `wo-NN._critique.json` in the **same `$WO_DIR`** the `../`-resolution anchor below already names.
+  It is one directory with two roles for the builder, read and write, not two notions of the same
+  path. The object:
+
+  `{"red_observed": <n>, "passed_first_run": <n>, "ratified": <n>, "unobserved": [<criterion>, ...], "reason": "<why, when unobserved is non-empty>"}`
+
+  What each value means is `references/tdd-workflow.md`, which the prompt should point at rather
+  than restate. The two that get conflated: `red_observed` counts tests run before the
+  implementation existed AND watched failing, and `ratified` counts tests that passed the moment
+  they were written because the behaviour was already there. A test authored while reading the
+  implementation and then run against a reverted tree fails identically to a test-first one, so
+  the count cannot separate them and the builder has to.
+
+  **A file, and NOT a line in the response, because a response is not a delivery channel.** This
+  plugin already routes every subagent-produced value through a file it names in advance —
+  `wo-critic` writes `wo-NN._critique.json`, `architecture-validator` writes
+  `_arch-validate-<slug>.json`, `distill-agent` writes `_distill.json` — and `commands/review.md`
+  step 5.0 records why: an agent whose report was its Task response alone had that response
+  truncate in transit repeatedly, and the session had to improvise a scratchpad file mid-review to
+  recover it. A record asked for as a trailing transcript line has no reader and no path; on a file
+  the path is derivable from first-party data at both ends, so a truncated builder response costs
+  nothing here. **The atom does not read the response for this.**
+
+  **The file's CONTENT is still untrusted subagent output.** ③ collects it with
+  `wo-run-state.sh collect --tdd-file <that same path>`, which parses and type-checks before it
+  stores and refuses a malformed one with the run record untouched. `/review` judges what was
+  stored and fails a work-order whose run record carries no `tdd` block, fail-closed. Nothing here
+  parses the file to decide control flow.
+
 - **Give the builder the WO_DIR second anchor — a body's `../` refs live in the MEMORY repo, not the
   worktree.** A self-contained WO body should inline what it needs, but a body legitimately carries two
   kinds of relative path: **worktree-relative** (`## Files to touch`, resolved against `BUILD ROOT`)
@@ -184,9 +229,15 @@ the **Task** tool:
   trusted-runtime-context anchor alongside `BUILD ROOT`:
   `WO_DIR (resolve any ../ reference in this work-order — e.g. ../task.md, ../coverage-map.json —
   against this absolute path, NOT against BUILD ROOT): <abs $WO_DIR>`. The builder's Read tool already
-  reaches absolute paths; it just needs to be told where the WO's siblings live. Keep the two anchors
-  visually distinct so the builder never writes build output under `$WO_DIR` (read-only) nor reads
-  inputs from under `BUILD ROOT`.
+  reaches absolute paths; it just needs to be told where the WO's siblings live. Keep the anchors
+  visually distinct so the builder never writes **build output** under `$WO_DIR` nor reads inputs from
+  under `BUILD ROOT`. `$WO_DIR` is the same directory the TDD-record line above names. **Two files under
+  it are written during a build, and they have different authors:** the atom flips `status:` on
+  `wo-NN.md` at step 2, and the builder writes `wo-NN.tdd.json`. Neither is build output. Do not read
+  the TDD-record instruction as a claim that the status flip does not happen — it is the crash-safety
+  hinge, it happens before any code is mutated, and `work-order-loop` step 7 depends on it to tell a
+  `spawn_failed` (flip happened, WO `in_progress`) from a refused re-gate (no flip, WO still `ready`).
+  One directory, two stated roles — not a second notion of the same path.
 - **Standard, not forked.** Do **not** set `CLAUDE_CODE_FORK_SUBAGENT` — a forked subagent inherits
   the parent conversation and defeats the load-bearing fresh-context guarantee. The builder must start
   in **clean context** with no parent narrative.
@@ -236,6 +287,15 @@ bash "$KERNEL" collect-handle "$WORKTREE" "$WO" \
 `git`/disk — the transcript is structurally unreachable to it. **Return the handle JSON** to ③ and
 stop.
 
+**The atom does nothing at all about `<wo-NN>.tdd.json`.** It does not read it, does not validate it,
+does not check whether the builder wrote one, and does not mention it in the handle. It has no reason
+to: the builder wrote it at a path ③ computes for itself from the work-order id it is already looping
+over, so neither side needs the other to carry it. Do **not** add a key to the handle for it and do
+**not** add a flag to `wo-compile.sh collect-handle` — that sub-command accepts no argument that could
+carry subagent content, which is the structural half of M-6, and it stays that way. An absent file is
+③'s and ②'s to notice: ③ passes no `--tdd-file`, the run record gets no `tdd` key, and `/review` fails
+the work-order fail-closed.
+
 ## The handle (the seam shape — built from git/disk, no transcript echo)
 
 ```json
@@ -249,8 +309,12 @@ stop.
 ```
 
 **No `verdict`** (②'s), **no `next`** (③'s), **no `status`** field (the `ready→in_progress` flip is a
-direct `set-status` at step 2, not a handle field; ③ owns every OTHER status write — H-3). Those
-deliberate omissions *are* the boundary made concrete. `halt_reason` is drawn **only** from the frozen
+direct `set-status` at step 2, not a handle field; ③ owns every OTHER status write — H-3), and **no
+TDD record** — that one is absent for a different reason than the other three, so read it separately.
+The first three are withheld because they carry authority this atom does not have. The TDD record is
+withheld because the handle is built from git and disk and structurally cannot carry subagent content
+(M-6); it did not go missing, it went to `<WO_DIR>/<wo-NN>.tdd.json`, where ③ reads it off disk
+(`work-order-loop` step 7) without this atom carrying it. Those deliberate omissions *are* the boundary made concrete. `halt_reason` is drawn **only** from the frozen
 enum above — step 1 **maps** the kernel's `assert-dispatchable` reason onto it (`status_not_ready:*` →
 `sequencing_error`, `frontmatter_unreadable:*` → `frontmatter_unreadable`), never forwarding a raw
 kernel string. `produced_changes` (git-derived, `checkpoint_after == null ⟺ produced_changes ==

--- a/ai-dev-assistant/skills/work-order-loop-parallel/SKILL.md
+++ b/ai-dev-assistant/skills/work-order-loop-parallel/SKILL.md
@@ -227,8 +227,26 @@ Read each verdict as a **scalar via `jq -r`** (`.gate_specific.overall_verdict` 
   ov=$(jq -r '.override_used  // false'  <wo-NN.run.json>)
   br=$(jq -r '.build_returned // false'  <wo-NN.run.json>)
   hr=$(jq -r '.halt_reason    // "null"' <wo-NN.run.json>)
-  wo-run-state.sh collect <wo-NN.run.json> --override-used "$ov" --build-returned "$br" \
-    --halt-reason "$hr" --checkpoint-after "$msha"
+  # --tdd-file (v5.48.0+): the builder WROTE its TDD record to <WO_DIR>/wo-NN.tdd.json, beside
+  #     wo-NN.run.json — the same path work-order-builder names in the prompt it hands the
+  #     subagent. You compute it from the WO id you are already looping over; the atom does not
+  #     hand it to you, and the handle could not carry it (M-6: git/disk derived, no subagent
+  #     content, because it carries the verdict and the status — a TDD record carries neither).
+  #     A file and not a returned value for the reason commands/review.md step 5.0 records: an
+  #     agent whose report was its Task response alone had that response truncate in transit.
+  #     PER-WORK-ORDER PATH, which is what makes this safe here: builds run CONCURRENTLY in this
+  #     skill, and wo-NN in the name is what keeps two builders off one file.
+  #     Present ⇒ pass it. Absent ⇒ pass NO flag: the run record gets no tdd key and /review
+  #     fails this WO fail-closed. Never synthesise one. Content is untrusted subagent output;
+  #     wo-run-state.sh parses and type-checks it and refuses a malformed one with exit 2.
+  tddf=<WO_DIR>/wo-NN.tdd.json
+  if [ -f "$tddf" ]; then
+    wo-run-state.sh collect <wo-NN.run.json> --override-used "$ov" --build-returned "$br" \
+      --halt-reason "$hr" --checkpoint-after "$msha" --tdd-file "$tddf"
+  else
+    wo-run-state.sh collect <wo-NN.run.json> --override-used "$ov" --build-returned "$br" \
+      --halt-reason "$hr" --checkpoint-after "$msha"
+  fi
 
   # (4) Undeclared-co-edit detector (step 7a) — runs HERE, BEFORE set-status done.
   #     N1: an up-to-date / no-op merge-back (zero-commit build) leaves msha == pre_merge_head ⇒ nothing

--- a/ai-dev-assistant/skills/work-order-loop/SKILL.md
+++ b/ai-dev-assistant/skills/work-order-loop/SKILL.md
@@ -154,12 +154,53 @@ deps are all `done`, or a `needs_rework` WO — step 2 promotes both to `ready`)
    **The loop never writes `in_progress`** (single owner = the builder), so a committed build is never left
    under `status: ready`.
 7. **Persist the handle snapshot.** `wo-run-state.sh collect <wo-NN.run.json> --override-used <…>
-   --halt-reason <…> --build-returned <…> --checkpoint-after <…>` (from the handle). If the handle's
+   --halt-reason <…> --build-returned <…> --checkpoint-after <…>` (from the handle), plus
+   `--tdd-file <…>` (v5.48.0+) when the builder wrote its TDD record. If the handle's
    `halt_reason != null` — the builder's re-gate **refused** (no flip happened ⇒ WO still `ready`) or
    `spawn_failed` (the flip already happened ⇒ WO `in_progress`) — ⇒ write `wo-NN.HALT` (reason = the
    handle `halt_reason`), mark the sidecar `wo-run-state.sh halt`, escalate. The WO is now TERMINAL
    (terminal keys off the HALT marker, regardless of `ready`/`in_progress` status). Otherwise the WO is
    already `in_progress` (the builder flipped it) — proceed to review.
+
+   **The TDD record is required, it comes off DISK, and it is NOT part of the handle (v5.48.0+).**
+   The handle is built from git and disk and accepts no subagent content (M-6), because it carries
+   authority: the verdict and the status. A TDD record carries none. It is the builder's report of
+   what it watched fail before the code existed, `/review` judges it, and the framework already
+   says in as many words that a recorded `observed` is a report of an observation and not proof of
+   one. So it travels as explicitly untrusted data into the state sidecar, never into the handle.
+
+   **The builder WROTE it to a file; you read the file.** The path is
+   `<WO_DIR>/wo-NN.tdd.json`, beside `wo-NN.run.json` and `wo-NN._critique.json` in the same
+   work-order directory — the same path `work-order-builder` names in the prompt it hands the
+   subagent. You do not need the atom to tell you: you are looping over work-order ids in that
+   directory, so you compute it, exactly as you already compute `wo-NN.run.json`. A file rather
+   than a value the atom hands back, for the reason `commands/review.md` step 5.0 records — an
+   agent whose report was its Task response alone had that response truncate in transit
+   repeatedly — and because the handle could not have carried it anyway.
+
+   ```bash
+   tddf="<WO_DIR>/wo-NN.tdd.json"
+   if [ -f "$tddf" ]; then
+     wo-run-state.sh collect <wo-NN.run.json> --override-used "$ov" --build-returned "$br" \
+       --halt-reason "$hr" --checkpoint-after "$cpa" --tdd-file "$tddf"
+   else
+     # No file ⇒ pass NO flag. The run record gets no `tdd` key, and /review fails this
+     # work-order fail-closed. Never synthesise one: an invented default makes a build that
+     # ran no test indistinguishable from one that did.
+     wo-run-state.sh collect <wo-NN.run.json> --override-used "$ov" --build-returned "$br" \
+       --halt-reason "$hr" --checkpoint-after "$cpa"
+   fi
+   ```
+
+   The file's shape is `{red_observed, passed_first_run, ratified, unobserved[], reason}`, the same
+   an in-session `_build-critique.json` carries. Its content is untrusted subagent output:
+   `wo-run-state.sh` parses and type-checks it before storing and **refuses** a malformed one with
+   exit 2 and the run record untouched — treat that as a hard error, not a reason to retry without
+   the flag. **Skipping the flag on a file that exists is not a shortcut.** `/review`'s
+   build-critique gate fails a work-order whose run record has no `tdd` block, fail-closed and
+   unresolved, exactly as it fails an in-session record with no `tdd` key. Until v5.48.0 it
+   demanded one from the in-session record and from nothing else, so delegating a build routed
+   around the test-first rung by construction.
 8. **Per-WO review (run for EVERY dispatched WO).** Run `/review --headless --dry-run --base <base> <task-folder>`
    **inline from cwd=`<worktree>`** (command-prose, not a callable; `/review` derives the change from
    `git diff $(git merge-base main HEAD)..HEAD` in its cwd, so it MUST run in the worktree where the build

--- a/ai-dev-assistant/tests/build-critique-gate-spec.sh
+++ b/ai-dev-assistant/tests/build-critique-gate-spec.sh
@@ -191,11 +191,258 @@ verdict_is fail "an unparseable _build-critique.json fails rather than being ign
 D=$(mktask wo_clean); mkdir -p "$D/work-orders" >/dev/null 2>&1
 printf '# wo\n' > "$D/work-orders/wo-01.md"
 printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+# The run record joined this fixture in v5.48.0, when the delegated path started owing a tdd
+# block. The assertion is unchanged: this cell is about resolving the build path from disk with
+# no _build-critique.json present, and it still is.
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
 run "$D"
 verdict_is pass "a /run-work-orders build passes on its per-work-order critiques with no _build-critique.json"
+# --- the delegated build path owes a TDD record too ---------------------------------------
+# THE DEFECT THIS DEFENDS AGAINST. `tdd` is demanded of the in-session record and of nothing
+# else. A /run-work-orders build satisfied this gate on its critique files alone and owed no
+# statement about whether any test was watched failing before the code existed. So the rung
+# that enforces test-first was reachable only on the path where the main context does the
+# building, while the orchestration rules route real builds to delegated agents. Measured on a
+# live build: three components built, reviewed and merged with no TDD record of any kind, and
+# every downstream check satisfied, because each one reads a record nobody was asked to write.
+#
+# Absence is the failure, not a skip. A work-order that recorded no TDD block is `unresolved`,
+# the same answer an in-session record with no `tdd` key gets, and for the same reason: nobody
+# looked is not the same answer as nothing was wrong.
+
+D=$(mktask wo_no_tdd); mkdir -p "$D/work-orders" >/dev/null 2>&1
+printf '# wo\n' > "$D/work-orders/wo-01.md"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true}' > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order build whose run record carries no tdd block fails"
+[ "$(printf '%s' "$OUT" | jq -r '.unresolved')" = "true" ] \
+  && pass_check "a missing work-order tdd block is a could-not-tell, not a clean pass" \
+  || fail_check "a work-order build with no tdd record was resolved rather than left unresolved"
+printf '%s' "$OUT" | jq -r '.messages|join(" ")' | grep -q 'wo-01' \
+  && pass_check "the message names the work-order that owes the record" \
+  || fail_check "the message does not say which work-order is missing its tdd block"
+
+D=$(mktask wo_with_tdd); mkdir -p "$D/work-orders" >/dev/null 2>&1
+printf '# wo\n' > "$D/work-orders/wo-01.md"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":2,"passed_first_run":0,"ratified":1,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is pass "a work-order build that recorded its tdd block passes"
+
+D=$(mktask wo_partial_tdd); mkdir -p "$D/work-orders" >/dev/null 2>&1
+printf '# wo\n' > "$D/work-orders/wo-01.md"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":2}}' > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order tdd block missing a sibling count fails like the in-session one"
+
 [ "$(printf '%s' "$OUT" | jq -r '.build_path')" = "work-orders" ] \
   && pass_check "the work-order build path is resolved from disk, not from prose" \
   || fail_check "the work-order build path was not resolved from the files on disk"
+
+# --- one cell per required key, each omitting EXACTLY that one key -------------------------
+# WHY ONE CELL PER KEY. The fixture above (`wo_partial_tdd`) omits three keys at once, so it
+# cannot say which of them is load-bearing. Measured before these cells existed: deleting
+# `has("unobserved")` from the gate, and separately deleting `has("passed_first_run")`, changed
+# the gate's behaviour and NO cell in either spec noticed. A single fixture missing everything
+# ratifies the check rather than constraining it.
+
+# mkwo <folder> <wo id> <status> — a compiled work-order with frontmatter the subject rule reads.
+mkwo() {
+  mkdir -p "$1/work-orders" >/dev/null 2>&1
+  printf -- '---\nid: %s\nstatus: %s\n---\n# wo\n' "$2" "$3" > "$1/work-orders/$2.md"
+}
+
+for key in red_observed passed_first_run ratified unobserved; do
+  D=$(mktask "wo_omit_$key"); mkwo "$D" wo-01 "done"
+  printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+  printf '%s' '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":2,"passed_first_run":0,"ratified":1,"unobserved":[],"reason":null}}' \
+    | jq -c --arg k "$key" 'del(.tdd[$k])' > "$D/work-orders/wo-01.run.json"
+  run "$D"
+  verdict_is fail "a work-order tdd block omitting only $key fails"
+  printf '%s' "$OUT" | jq -r '.evidence.work_orders_bad_tdd[0].problems | join(" ")' | grep -q "$key" \
+    && pass_check "the gate names $key specifically as the problem, not a generic omission" \
+    || fail_check "the gate failed without naming $key (evidence: $(printf '%s' "$OUT" | jq -c '.evidence.work_orders_bad_tdd'))"
+done
+
+# --- the two VALUE judgements, which are what C1 was about ---------------------------------
+# THE DEFECT THESE DEFEND AGAINST. The delegated branch called has() on four keys and stopped,
+# under a comment claiming it demanded exactly what the in-session branch demands. The
+# in-session branch additionally BLOCKS on two value judgements, so this exact block --
+# {"red_observed":0,"passed_first_run":5,"ratified":0,"unobserved":["A","B","C"],"reason":null}
+# -- returned pass on the delegated path and fail on the in-session one. Both paths now call
+# one function, so a record satisfies both or neither.
+
+# The MESSAGE has to name the problems too, not just the evidence object. Replacing this message
+# with a generic "a work-order tdd block was refused" survived a mutation sweep: every naming
+# assertion here read `.evidence`, and a person reading /review output reads the message.
+D=$(mktask wo_firstrun_no_reason); mkwo "$D" wo-01 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":0,"passed_first_run":5,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order recording passed_first_run > 0 with no reason fails, as the in-session path does"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_bad_tdd[0].problems | join(" ")' | grep -q 'passed_first_run > 0' \
+  && pass_check "the delegated path says the reason is what is missing, not the count" \
+  || fail_check "the delegated path failed without naming the unreasoned passed_first_run"
+printf '%s' "$OUT" | jq -r '.messages | join(" | ")' | grep -q 'wo-01 (passed_first_run > 0' \
+  && pass_check "the message names the work-order AND the problem, not just that something was refused" \
+  || fail_check "the message does not carry the problem names ($(printf '%s' "$OUT" | jq -c '.messages'))"
+
+D=$(mktask wo_firstrun_with_reason); mkwo "$D" wo-01 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":0,"passed_first_run":5,"ratified":0,"unobserved":[],"reason":"characterization tests written against existing code"}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is pass "a work-order recording passed_first_run > 0 WITH a reason passes, so the honest answer is not the expensive one"
+
+D=$(mktask wo_unobs_no_reason); mkwo "$D" wo-01 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":["A","B"],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order recording unobserved criteria with no reason fails, as the in-session path does"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_bad_tdd[0].problems | join(" ")' | grep -q 'unobserved' \
+  && pass_check "the delegated path names the unexplained unobserved[] entries" \
+  || fail_check "the delegated path failed without naming the unexplained unobserved[]"
+
+D=$(mktask wo_unobs_with_reason); mkwo "$D" wo-01 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":["A","B"],"reason":"both need a live payment gateway"}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is pass "a work-order recording unobserved criteria WITH a reason passes"
+
+# --- the subject set is the work-orders, not the critique files ----------------------------
+# THE DEFECT THIS DEFENDS AGAINST. The block iterated the critique files, so a compiled
+# work-order carrying no `wo-NN._critique.json` was never examined. Measured on three compiled
+# work-orders, one with a critique and a TDD record and two with nothing at all: `verdict: pass`,
+# `work_orders_without_tdd: []`, while the record's own evidence said `work_orders: 3`.
+
+# wo-02 is `pending` on purpose, so ONLY the run-record disjunct makes it a subject: no critique
+# file, not marked done. Measured before this line said `pending`: deleting the run-record
+# disjunct from the subject rule turned NOTHING red, because every fixture carrying a run record
+# also carried a critique or a `done` status. A disjunct no cell can kill is not being tested.
+# The shape is real -- the loop dispatched wo-02 and wrote its run record, and no critic has run
+# on it and nothing has marked it finished.
+D=$(mktask wo_no_critique_still_judged); mkwo "$D" wo-01 "done"; mkwo "$D" wo-02 pending
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+printf '{"wo":"wo-02","build_returned":true}' > "$D/work-orders/wo-02.run.json"
+run "$D"
+verdict_is fail "a dispatched work-order with a run record and NO critique file is still judged for its tdd block"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_without_tdd | join(" ")' | grep -q 'wo-02' \
+  && pass_check "the work-order with no critique file of its own is named as owing a record" \
+  || fail_check "the uncritiqued work-order was never examined (without_tdd: $(printf '%s' "$OUT" | jq -c '.evidence.work_orders_without_tdd'))"
+[ "$(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd')" = "2" ] \
+  && pass_check "the subject count is the work-orders that owe a record, not the critique files" \
+  || fail_check "the subject count did not follow the work-orders (got $(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd'))"
+
+D=$(mktask wo_never_dispatched); mkwo "$D" wo-01 "done"; mkwo "$D" wo-02 ready
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is pass "a compiled work-order with neither a run record nor status: done is not a subject: it built nothing"
+[ "$(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd')" = "1" ] \
+  && pass_check "the never-dispatched work-order is excluded from the subject count, and the count says so" \
+  || fail_check "the never-dispatched work-order was counted as owing a record"
+
+# `ready` and `blocked` are the ONLY two statuses reachable without a dispatch, so the exclusion
+# names those two rather than listing the three that owe. An unrecognised status is not evidence
+# that nothing happened: it fails closed and is named, which is what keeps the exclusion from
+# becoming a way to opt out by writing something the enum does not contain.
+D=$(mktask wo_unknown_status); mkwo "$D" wo-01 "done"; mkwo "$D" wo-02 banana
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order carrying a status outside the enum owes a record rather than being skipped"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_without_tdd | join(" ")' | grep -q 'wo-02' \
+  && pass_check "the unrecognised-status work-order is named, not silently excluded" \
+  || fail_check "an unrecognised status excluded the work-order in silence"
+
+# `done` with no run record is the lost-record half of the union, and it must not pass.
+D=$(mktask wo_done_no_run); mkwo "$D" wo-01 "done"; mkwo "$D" wo-02 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order marked done with no run record at all fails rather than passing silently"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_without_tdd | join(" ")' | grep -q 'wo-02' \
+  && pass_check "the done-but-recordless work-order is named" \
+  || fail_check "the done-but-recordless work-order was not named"
+
+# A critique is BUILD EVIDENCE: `wo-critic` reads a diff and the gate envelopes, so it cannot have
+# run over something nobody built. wo-02 below is `pending` with no run record, so ONLY the
+# critique disjunct makes it a subject. The first cut of the subject rule omitted that disjunct and
+# this shape passed.
+D=$(mktask wo_critique_no_run); mkwo "$D" wo-01 "done"; mkwo "$D" wo-02 pending
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+printf '{"blocking":false}' > "$D/work-orders/wo-02._critique.json"
+run "$D"
+verdict_is fail "a critiqued work-order with no run record fails: it was built, and its record is lost"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_without_tdd | join(" ")' | grep -q 'wo-02' \
+  && pass_check "the critiqued-but-recordless work-order is named" \
+  || fail_check "the critiqued-but-recordless work-order was not named"
+[ "$(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd')" = "2" ] \
+  && pass_check "a critique alone makes a work-order a subject" \
+  || fail_check "the critique disjunct did not make it a subject (count $(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd'))"
+
+# THE MIRROR OF THE ORIGINAL DEFECT. Iterating `wo-*.md` fixes "a work-order with no critique was
+# never examined" and opens "a critique whose .md is gone is never examined". Before the id set
+# became a union of all three globs this returned pass, with the record's own evidence saying one
+# critic ran and zero work-orders owed anything.
+D=$(mktask wo_critique_no_md); mkdir -p "$D/work-orders" >/dev/null 2>&1
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+run "$D"
+verdict_is fail "a critique whose work-order .md is gone is still a subject: the critic ran on something"
+[ "$(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd')" = "1" ] \
+  && pass_check "the subject set survives the deletion of the .md it was drawn from" \
+  || fail_check "a deleted .md emptied the subject set (owing $(printf '%s' "$OUT" | jq -r '.evidence.work_orders_owing_tdd'))"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_without_tdd | join(" ")' | grep -q 'wo-01' \
+  && pass_check "the orphaned critique's work-order is named as owing a record" \
+  || fail_check "the orphaned critique's work-order was not named"
+
+# A `tdd` THAT IS NOT AN OBJECT is the JQ_ERR path, and it is reachable rather than defensive:
+# the key is present, so the has("tdd") check passes, and every reading below it errors. Both
+# branches treat that as could-not-read, never as nothing-wrong. Without these two cells the
+# JQ_ERR handling on both paths survived a mutation that deleted it.
+D=$(mktask wo_tdd_not_object); mkwo "$D" wo-01 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":5}' > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is fail "a work-order whose tdd block is not an object fails rather than reading as sound"
+printf '%s' "$OUT" | jq -r '.evidence.work_orders_bad_tdd[0].problems | join(" ")' | grep -q 'could not be read' \
+  && pass_check "an unreadable work-order tdd block says it could not be read" \
+  || fail_check "an unreadable work-order tdd block was reported as some other problem"
+
+D=$(mktask tdd_not_object); write_record "$D" '.tdd=5'
+run "$D"
+verdict_is fail "an in-session tdd block that is not an object fails"
+[ "$(printf '%s' "$OUT" | jq -r '.unresolved')" = "true" ] \
+  && pass_check "an unreadable in-session tdd block is unresolved, not a settled violation" \
+  || fail_check "an unreadable in-session tdd block was reported as resolved"
+printf '%s' "$OUT" | jq -r '.messages | join(" | ")' | grep -q 'could not be read' \
+  && pass_check "the in-session path says the block could not be read" \
+  || fail_check "the in-session path failed without saying the block was unreadable"
+
+# An evidence key that appears only on failure cannot be read as "checked and clean".
+D=$(mktask wo_evidence_on_pass); mkwo "$D" wo-01 "done"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is pass "a delegated build with a sound tdd record passes"
+[ "$(printf '%s' "$OUT" | jq -r '.evidence | has("work_orders_bad_tdd")')" = "true" ] \
+  && pass_check "work_orders_bad_tdd is present on a pass, so an empty list means checked-and-clean" \
+  || fail_check "work_orders_bad_tdd only appears on failure, so its absence cannot be read"
 
 D=$(mktask wo_uncritiqued); mkdir -p "$D/work-orders" >/dev/null 2>&1
 printf '# wo\n' > "$D/work-orders/wo-01.md"

--- a/ai-dev-assistant/tests/tdd-red-observation-spec.sh
+++ b/ai-dev-assistant/tests/tdd-red-observation-spec.sh
@@ -171,27 +171,51 @@ unresolved_is true "a tdd block missing unobserved[] is unresolved"
 rc_is 1 "a tdd block missing unobserved[] exits 1"
 msg_has "omits red_observed, passed_first_run or unobserved" "the message names what the block cannot say (missing unobserved)"
 
-# ---------------------------------------------- 7. the work-order path is unaffected
+# ------------------------------------- 7. the work-order path owes its own tdd record
 #
-# No _build-critique.json at all: the build went through /run-work-orders, which owes
-# wo-NN._critique.json instead. The tdd block lives only inside _build-critique.json, so
-# this path must pass on its own record and never evaluate — or even mention — tdd.
+# THIS SECTION USED TO ASSERT THE OPPOSITE, AND THAT IS THE POINT. Until v5.48.0 it was
+# titled "the work-order path is unaffected" and required that this path "pass on its own
+# record and never evaluate — or even mention — tdd". Written in v5.34.0 that was a true
+# statement of what the change touched. It then sat here as a REQUIREMENT that the delegated
+# build path stay exempt, so closing the hole turned this file red and the file looked like
+# the authority. It was not. A spec can require a defect, not merely miss one.
+#
+# What it froze: the TDD rung was reachable only where the main context does the building,
+# while the orchestration rules route real builds to delegated agents. Measured on a live
+# build, three components were built, reviewed and merged with no TDD record of any kind and
+# every downstream check was satisfied, because each one reads a record nobody was asked to
+# write.
+#
+# The build-path resolution assertions below are unchanged and still matter. What changed is
+# that a work-order which recorded nothing is now a fail rather than a pass.
 
-D=$(mktask wo_unaffected); mkdir -p "$D/work-orders" >/dev/null 2>&1
-printf '# wo\n' > "$D/work-orders/wo-01.md"
+# `status: done` with NO run record at all is the lost-record case, and it is deliberately the
+# fixture here rather than a run record with the key missing. The loop marked this work-order
+# finished; the record of what it watched failing is nowhere. That has to fail, or "the file is
+# gone" becomes the cheapest way to satisfy the rung.
+D=$(mktask wo_no_tdd_record); mkdir -p "$D/work-orders" >/dev/null 2>&1
+printf -- '---\nid: wo-01\nstatus: done\n---\n# wo\n' > "$D/work-orders/wo-01.md"
 printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
 run "$D"
-verdict_is pass "a work-order build with no _build-critique.json still passes"
-rc_is 0 "the work-order path exits 0 with no tdd block anywhere on disk"
+verdict_is fail "a work-order marked done with no run record at all fails"
+[ "$(printf '%s' "$OUT" | jq -r '.unresolved')" = "true" ] \
+  && pass_check "a delegated build with no tdd record is a could-not-tell, not a clean pass" \
+  || fail_check "a delegated build with no tdd record was resolved rather than left unresolved"
+printf '%s' "$OUT" | jq -r '.messages|join(" ")' | grep -qi 'tdd' \
+  && pass_check "the work-order path says out loud that a tdd block is missing" \
+  || fail_check "the work-order path failed without saying the tdd record is what is missing"
+
+D=$(mktask wo_with_tdd_record); mkdir -p "$D/work-orders" >/dev/null 2>&1
+printf '# wo\n' > "$D/work-orders/wo-01.md"
+printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
+run "$D"
+verdict_is pass "a work-order build that recorded its tdd block passes with no _build-critique.json"
+rc_is 0 "the work-order path exits 0 once the record it owes is present"
 [ "$(printf '%s' "$OUT" | jq -r '.build_path')" = "work-orders" ] \
   && pass_check "the work-order build path is resolved, not the in-session one" \
   || fail_check "the work-order build path was not resolved from disk"
-[ "$(printf '%s' "$OUT" | jq -r '.evidence.tdd // "absent"')" = "absent" ] \
-  && pass_check "the work-order path records no tdd evidence at all" \
-  || fail_check "the work-order path unexpectedly carries tdd evidence"
-printf '%s' "$OUT" | jq -r '.messages|join(" ")' | grep -qi 'tdd' \
-  && fail_check "the work-order path's messages mention the RED-observation check" \
-  || pass_check "the work-order path's messages never mention the RED-observation check"
 
 # ------------------------------------------ 8. red_observed: 0, unobserved: [] (actual
 # behavior, read off the script rather than assumed): nothing here requires red_observed
@@ -284,16 +308,20 @@ printf '%s' "$OUT" | jq -r '.messages|join(" ")' | grep -q 'ratifying' \
   && fail_check "the ratifying-suite message fired on a suite that constrained more than it ratified" \
   || pass_check "a ratified count below red_observed does not fire the ratifying-suite message"
 
-# --- the work-order path is still untouched ------------------------------------------
+# --- the work-order path owes `ratified` too ------------------------------------------
+#
+# Same correction as section 7. This asserted that a delegated build "with no tdd block
+# anywhere still passes", which is the exemption, not a property worth keeping. The gate
+# demands the same four fields on both paths, so a record cannot satisfy one and be refused
+# by the other.
 
 D=$(mktask wo_no_ratified); mkdir -p "$D/work-orders" >/dev/null 2>&1
 printf '# wo\n' > "$D/work-orders/wo-01.md"
 printf '{"blocking":false}' > "$D/work-orders/wo-01._critique.json"
+printf '{"wo":"wo-01","build_returned":true,"tdd":{"red_observed":1,"passed_first_run":0,"unobserved":[],"reason":null}}' \
+  > "$D/work-orders/wo-01.run.json"
 run "$D"
-verdict_is pass "a work-order build with no tdd block anywhere still passes"
-printf '%s' "$OUT" | jq -r '.messages|join(" ")' | grep -qi 'ratified' \
-  && fail_check "the work-order path's messages mention the ratified count" \
-  || pass_check "the work-order path never mentions the ratified count"
+verdict_is fail "a work-order tdd block omitting ratified fails, as the in-session one does"
 
 # ===================================================================================
 # 11. the wiring: the value implement.md tells a builder to record is a value the gate,
@@ -308,6 +336,7 @@ printf '%s' "$OUT" | jq -r '.messages|join(" ")' | grep -qi 'ratified' \
 CMD="${PLUGIN_ROOT}/commands/implement.md"
 SCHEMA="${PLUGIN_ROOT}/references/gate-audit-schema.md"
 WORKFLOW="${PLUGIN_ROOT}/references/tdd-workflow.md"
+COMPANION="${PLUGIN_ROOT}/skills/tdd-companion/SKILL.md"
 REVIEW="${PLUGIN_ROOT}/commands/review.md"
 for f in "$CMD" "$SCHEMA" "$WORKFLOW" "$REVIEW"; do
   [ -f "$f" ] || { printf 'FAIL: %s missing\n' "$f" >&2; exit 1; }
@@ -379,6 +408,21 @@ PFR_ROW=$(grep '^| `passed_first_run` |' "$WORKFLOW" | head -1)
 printf '%s' "$PFR_ROW" | grep -qi 'characterization' \
   && fail_check "the passed_first_run row still claims the characterization case ratified now owns" \
   || pass_check "the passed_first_run row no longer claims the case ratified owns"
+
+# --- the THIRD copy of the rule, the one an agent is actually holding (v5.48.0+) ----------
+#
+# v5.46.0 corrected gate-audit-schema.md and implement.md, both asserted above, and missed
+# skills/tdd-companion/SKILL.md, which stated the same blanket rule for two more releases.
+# That file is the one `/implement` activates at step 65, so it is the copy most likely to be
+# acted on while building. Two documents were paired to the script and the third drifted,
+# which is why this assertion exists rather than a third careful edit.
+grep -q 'Test passes on first run (test might be wrong)' "$COMPANION" \
+  && fail_check "tdd-companion still calls any first-run pass a blocking violation, which the gate does not" \
+  || pass_check "tdd-companion no longer calls every first-run pass a blocking violation"
+
+grep -qi 'ratified' "$COMPANION" \
+  && pass_check "tdd-companion names ratified, so the skill an agent holds knows the fourth value" \
+  || fail_check "tdd-companion does not mention ratified, so a builder reports it as a violation"
 
 # /review step 5.0f: run the literal invocation the command body states, against a record
 # with a ratified count, and assert the gate really hands back what 5.0f promises to copy

--- a/ai-dev-assistant/tests/wo-run-state-spec.sh
+++ b/ai-dev-assistant/tests/wo-run-state-spec.sh
@@ -104,6 +104,159 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# T5b–T5j: collect --tdd-file — the delegated builder's TDD record.
+#
+# The builder WRITES <WO_DIR>/wo-NN.tdd.json and the loop names that file here. It is a file and
+# not a value carried back through the build handle because the handle is git/disk derived and
+# structurally accepts no subagent content (M-6), and because commands/review.md step 5.0 records
+# a report-as-Task-response truncating in transit repeatedly. The file's CONTENT is still subagent
+# output, so every one of these cells is about refusing a bad one WITHOUT touching the live
+# sidecar: a run record carrying half a TDD block would satisfy the gate's has() checks while
+# saying nothing true.
+#
+# mktdd: write $2 to a wo-01.tdd.json beside the run record and echo the path.
+mktdd() { local f; f="$(dirname "$1")/wo-01.tdd.json"; printf '%s' "$2" > "$f"; echo "$f"; }
+
+# Every refusal below asserts the same three things: exit 2, the named reason, and the sidecar
+# left exactly as it was seeded (no tdd key, attempts untouched).
+refuse_check() { # $1=label $2=expected-reason $3=run-json
+  if [ "$RC" -eq 2 ] \
+    && [ "$(jq -r '.reason' <<<"$OUT" 2>/dev/null)" = "$2" ] \
+    && [ "$(jq -r 'has("tdd")' "$3" 2>/dev/null)" = "false" ] \
+    && [ "$(jq -r '.attempts' "$3" 2>/dev/null)" = "1" ]; then
+    pass_check "$1"
+  else
+    fail_check "$1" "rc=$RC reason=$(jq -r '.reason' <<<"$OUT" 2>/dev/null) sidecar=$(cat "$3" 2>/dev/null)"
+  fi
+}
+
+# T5b: the success path — a well-formed record is stored VERBATIM, attempts preserved.
+#      Until v5.48.0 there was nowhere for a delegated build to record whether any test was
+#      watched failing before the code existed, so scripts/build-critique-assert.sh demanded one
+#      from the in-session record and from nothing else.
+RUN="$(mkrun t5b)"; seed "$RUN" 1
+TDDF="$(mktdd "$RUN" '{"red_observed":2,"passed_first_run":0,"ratified":1,"unobserved":["ac-3"],"reason":"suite offline"}')"
+krun collect "$RUN" \
+  --override-used false --halt-reason null --build-returned true --tdd-file "$TDDF"
+if [ "$RC" -eq 0 ] \
+  && [ "$(jq -r '.tdd.red_observed'      <<<"$OUT")" = "2" ] \
+  && [ "$(jq -r '.tdd.passed_first_run'  <<<"$OUT")" = "0" ] \
+  && [ "$(jq -r '.tdd.ratified'          <<<"$OUT")" = "1" ] \
+  && [ "$(jq -r '.tdd.unobserved[0]'     <<<"$OUT")" = "ac-3" ] \
+  && [ "$(jq -r '.tdd.reason'            <<<"$OUT")" = "suite offline" ] \
+  && [ "$(jq -c '.tdd' "$RUN")" = "$(jq -c '.' "$TDDF")" ] \
+  && [ "$(jq -r '.attempts'              <<<"$OUT")" = "1" ]; then
+  pass_check "T5b collect --tdd-file stores the record verbatim and preserves attempts"
+else
+  fail_check "T5b collect --tdd-file stores the record verbatim and preserves attempts" "out=$OUT rc=$RC"
+fi
+
+# T5c: no --tdd-file leaves no tdd key. Absence has to stay absent so the gate can tell "nobody
+# recorded one" from "one was recorded and is empty". An auto-filled default would make a
+# delegated build that never ran a test indistinguishable from one that did.
+RUN="$(mkrun t5c)"; seed "$RUN" 1
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true
+if [ "$RC" -eq 0 ] && [ "$(jq -r 'has("tdd")' <<<"$OUT")" = "false" ]; then
+  pass_check "T5c collect without --tdd-file writes no tdd key rather than an empty one"
+else
+  fail_check "T5c collect without --tdd-file writes no tdd key rather than an empty one" "out=$OUT rc=$RC"
+fi
+
+# T5d: content that is not JSON at all → tdd_not_json.
+RUN="$(mkrun t5d)"; seed "$RUN" 1
+TDDF="$(mktdd "$RUN" 'not json at all')"
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true --tdd-file "$TDDF"
+refuse_check "T5d --tdd-file with non-JSON content exits 2 and stores nothing" tdd_not_json "$RUN"
+
+# T5e: valid JSON that is not an OBJECT → tdd_not_an_object, a separate reason from T5d because
+# "that is not JSON" and "that is JSON but not a record" are different caller mistakes. An array
+# parses fine and would land in the sidecar as a tdd key the gate's has() check accepts.
+RUN="$(mkrun t5e)"; seed "$RUN" 1
+TDDF="$(mktdd "$RUN" '[1,2,3]')"
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true --tdd-file "$TDDF"
+refuse_check "T5e --tdd-file holding a JSON array exits 2 and stores nothing" tdd_not_an_object "$RUN"
+
+# T5f: a bare JSON `null` parses but is not a record. It is called out separately from T5e because
+# a `jq -e '.'` parse check exits 1 on `null`, which would misreport a parsed document as
+# unparseable and hide which half of the contract the caller broke.
+RUN="$(mkrun t5f)"; seed "$RUN" 1
+TDDF="$(mktdd "$RUN" 'null')"
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true --tdd-file "$TDDF"
+refuse_check "T5f --tdd-file holding JSON null exits 2 as not-an-object, not as not-JSON" tdd_not_an_object "$RUN"
+
+# T5g: named but absent. The loop's contract is present ⇒ pass the flag, absent ⇒ pass NO flag, so
+# naming a file that is not there is a caller bug and must NOT be read as "no record". Silently
+# treating it as absence is how a delegated build that recorded nothing would reach /review green.
+RUN="$(mkrun t5g)"; seed "$RUN" 1
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true \
+  --tdd-file "$(dirname "$RUN")/does-not-exist.tdd.json"
+refuse_check "T5g --tdd-file naming an absent file exits 2, never silently 'no record'" tdd_file_absent "$RUN"
+
+# T5h: present but EMPTY. A zero-byte file is what a builder that crashed mid-write leaves.
+RUN="$(mkrun t5h)"; seed "$RUN" 1
+TDDF="$(mktdd "$RUN" '')"
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true --tdd-file "$TDDF"
+refuse_check "T5h --tdd-file on an empty file exits 2 and stores nothing" tdd_file_empty "$RUN"
+
+# T5i: an OPTION-SHAPED path. wo-compile.sh cmd_collect_handle documents the same defence for
+# --checkpoint-before: a dash-leading token must never be able to reach a command as a real
+# option. Refused on the shape of the path, before anything touches the filesystem.
+RUN="$(mkrun t5i)"; seed "$RUN" 1
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true \
+  --tdd-file '--output=/tmp/PWNED'
+# The reason string IS the assertion: tdd_file_unsafe_path means it was refused on the SHAPE of
+# the path; tdd_file_absent would mean the guard was gone and the token had been carried on to a
+# stat. (There is deliberately no "and /tmp/PWNED was not created" cell here: the file is read by
+# `<` redirection, so no mutation of this script makes the path reach a command as an option, and
+# an assertion with no reachable failure mode is not a check.)
+refuse_check "T5i --tdd-file with an option-shaped path is refused on the path shape, before any stat" tdd_file_unsafe_path "$RUN"
+
+# T5j: a DIRECTORY at the named path is not a regular file. Distinguished from absent because the
+# caller mistakes differ: nothing was written vs something else is in the way.
+RUN="$(mkrun t5j)"; seed "$RUN" 1
+mkdir -p "$(dirname "$RUN")/wo-01.tdd.json"
+krun collect "$RUN" --override-used false --halt-reason null --build-returned true \
+  --tdd-file "$(dirname "$RUN")/wo-01.tdd.json"
+refuse_check "T5j --tdd-file naming a directory exits 2 as not-a-regular-file" tdd_file_not_regular "$RUN"
+
+# T5k: present but UNREADABLE (mode 000). Skipped as root, where -r is always true and the cell
+# would assert a refusal that cannot happen — a check that cannot fail is not a check.
+if [ "$(id -u)" != "0" ]; then
+  RUN="$(mkrun t5k)"; seed "$RUN" 1
+  TDDF="$(mktdd "$RUN" '{"red_observed":1,"passed_first_run":0,"ratified":0,"unobserved":[],"reason":null}')"
+  chmod 000 "$TDDF"
+  krun collect "$RUN" --override-used false --halt-reason null --build-returned true --tdd-file "$TDDF"
+  refuse_check "T5k --tdd-file on an unreadable file exits 2 and stores nothing" tdd_file_unreadable "$RUN"
+  chmod 644 "$TDDF"
+else
+  echo "SKIP T5k unreadable-file cell (running as root: [ -r ] is always true)"
+fi
+
+# T5l: a TRAILING --tdd-file with no value must not hang. `shift 2` on a valueless trailing flag
+# shifts nothing and returns 1, and the arg loop then spins on the same token forever — measured
+# on this script before v5.48.0, on every flag it takes. `timeout` is the assertion: without the
+# fix this cell never returns rather than failing.
+RUN="$(mkrun t5l)"; seed "$RUN" 1
+OUT="$(timeout 10 bash "$SUT" collect "$RUN" --override-used false --build-returned true --tdd-file 2>/dev/null)"; RC=$?
+if [ "$RC" -ne 124 ] && [ "$RC" -eq 2 ] \
+  && [ "$(jq -r '.reason' <<<"$OUT" 2>/dev/null)" = "tdd_file_unsafe_path" ]; then
+  pass_check "T5l a valueless trailing --tdd-file refuses instead of spinning forever"
+else
+  fail_check "T5l a valueless trailing --tdd-file refuses instead of spinning forever" \
+    "rc=$RC (124 = still hangs) reason=$(jq -r '.reason' <<<"$OUT" 2>/dev/null)"
+fi
+
+# T5m: the same hang on a PRE-EXISTING flag. The fix was applied to every flag in the file, not
+# just the one this change added, so assert one of the others too.
+RUN="$(mkrun t5m)"; seed "$RUN" 1
+timeout 10 bash "$SUT" collect "$RUN" --checkpoint-after >/dev/null 2>&1; RC=$?
+if [ "$RC" -ne 124 ]; then
+  pass_check "T5m a valueless trailing --checkpoint-after terminates too"
+else
+  fail_check "T5m a valueless trailing --checkpoint-after terminates too" "rc=124 (still hangs)"
+fi
+
+# ---------------------------------------------------------------------------
 # T6: read absent sidecar → ok:false, reason=missing_run_state, exit ≠0
 RUN="$(mkrun t6)"
 krun read "$RUN"


### PR DESCRIPTION
A build run by a delegated agent never had to say whether any test was watched failing before the code existed. The check only read the record an in-session build writes, so routing work to subagents skipped it entirely — and the orchestration rules tell you to route work to subagents. A live build shipped three components with no such record and satisfied every check on the way, because each one read a record nobody had been asked to write.

The record now travels as a file: the builder writes one JSON object beside its other per-job artifacts, the loop collects it, and review judges it with the same function that judges the in-session one.

**Look at `scripts/accept-verdict.sh` first.** `tdd_block_problems` is now the single authority both paths call. It replaces a comment I wrote claiming the two paths could not disagree — they could, and a record with five unexplained first-run passes passed one and failed the other. After the change, 17 identical records agree 17 times out of 17.

**The risk is intentional and worth stating plainly: this fails builds that passed yesterday.** Anything built by a delegated agent without the new record now fails review rather than passing silently.

Two holes turned up during review and both are fixed with a test that dies to its own cause: a critique whose work-order file has been deleted, and a build left part-way at `in_progress` or `needs_rework`. Both came from drawing the subject set out of a single artifact, which can always be emptied by deleting that artifact. It is now a union of three signals.

Unrelated to the feature, and it predates this release: `shift 2` on a valueless trailing flag shifts nothing and returns 1, so `wo-run-state.sh` re-read the same token forever. It affected every flag in all three of its argument loops.

**To verify:** `make test` (155 passed, 0 failed, 0 skipped), `make lint` (exit 0, no new warnings), and `make manifests outputs setup-doc-check claims validate`.

**Not done.** The in-session path leaks five `jq` error lines to stderr before it correctly fails on a malformed record; the exit code and the JSON on stdout are right, and fixing it means touching five lines whose behaviour three specs pin. Three older fixtures also describe a state the compiler cannot produce; they pass for an unrelated reason and predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
