### PR TITLE
A suppressed finding is not asked for back (ai-dev-assistant 5.50.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.72"
+    "version": "2.0.73"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.50.0",
+      "version": "5.50.1",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.50.0",
+  "version": "5.50.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [5.50.1] - 2026-09-03
+
+The first review phase this task has ever had found that the rule shipped in 5.50.0 was undone one
+line after it was made, and that the halt shipped alongside it could be switched off by passing an
+empty list. Three fresh readers, none of them allowed to read the build's own account of itself;
+two reached the first defect independently from opposite directions.
+
+### Fixed
+- **A finding the kernel suppressed is no longer asked for back by the next reader.** The kernel
+  drops a finding marked `design_change: true` from `effective`, so no repair round opens for it.
+  `commands/implement.md` then rebuilt the list of files a repair had to touch from the raw critics
+  array, selecting on severity alone, and handed the design site to `repair-scope-check.sh` anyway.
+  A repair that obeyed the rule and left the file alone was reported `unaddressed` and said out loud
+  as a shortfall; one that rewrote the design mid-build came back clean. The only deterministic
+  reading of a repair rewarded the forbidden move. `out_of_range` had the identical hole and
+  predates 5.50.0 — the design route copied the routing pattern and inherited its defect. Both are
+  excluded now, on the JSON literal `true` only, matching the kernel's own test.
+- **An empty `--test-globs` no longer accepts a repair that modified a test.**
+  `--test-globs-source` defaulted to `determined`, so `--test-globs '[]'` with the flag omitted
+  classified no path as a test path, left every motion array empty, and still returned `accepted`
+  with "the test motion raised nothing unanswered" — a positive claim about a comparison that never
+  ran, and enough to switch off the modified-test halt that 5.50.0 exists to install. Omitting the
+  flag is not an assertion, so it is now `cannot_judge`. An explicit `--test-globs-source
+  determined` still means the project has no test paths, and a non-empty list still decides with the
+  flag omitted.
+- **The repair's test globs are derived, not typed.** The call site carried the free-text
+  placeholder `--test-globs '<test paths, JSON array>'`, which is what made an empty list reachable.
+  It now reuses the `oracle-globs.sh` result step 2c already computed for that component.
+- **`references/build-critique.md`'s aggregate invocation was missing `--component-files-from`.**
+  A builder following the file that calls itself the full instructions got a range check that
+  reported `not_run` and suppressed nothing, while the same file said 320 lines later that the
+  kernel is handed that list.
+
+### Changed
+- `tests/design-finding-route-spec.sh` follows the value past the envelope. Its 48 assertions all
+  stopped at the aggregate output and all passed on the broken version, so the route was verified
+  where it was built and nowhere it was read. D10 lifts the site expression and the scope
+  invocation out of the command body and runs them, the way `build-critique-gate-spec.sh` does.
+  Each suppression is isolated by its own fixture: the first version of these cells used one
+  finding carrying both flags, and the design half alone was enough to make them pass.
+- `tests/repair-accept-check-spec.sh` no longer pins the empty-globs default as `accepted`. That
+  cell asserted the defect, with a fixture that is visibly a test file.
+
 ## [5.50.0] - 2026-09-03
 
 One criterion, both halves. A build finding gets fixed by changing the code, never by moving what

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.50.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.50.1**.
 
 ## License
 

--- a/ai-dev-assistant/commands/implement.md
+++ b/ai-dev-assistant/commands/implement.md
@@ -278,30 +278,30 @@ REP=$(${CLAUDE_PLUGIN_ROOT}/scripts/build-checkpoint.sh capture --repo <codePath
         --label <component>.repaired | jq -r .sha)
 git -C <codePath> diff --name-status $AFTER..$REP > "$CD/<component>.repair.txt"
 ${CLAUDE_PLUGIN_ROOT}/scripts/repair-accept-check.sh --suite <green|red|not_run> \
-  --test-motion-from "$CD/<component>.repair.txt" --test-globs '<test paths, JSON array>' \
-  [--test-globs-source undetermined] [--modification-reason "<why a test file changed>"]
+  --test-motion-from "$CD/<component>.repair.txt" --test-globs "$(jq -c .globs <<<"$G")" "$GF" "$GV" \
+  [--modification-reason "<why a test file changed>"]   # $G/$GF/$GV: step 2c's, same component
 
 # And the scope half, from the SAME repair diff. Copy it verbatim, every value is computed here.
 # TWO sets come back: `unnamed`, a file the repair touched that no finding named, and `unaddressed`,
-# a site a finding named that the repair never touched. `blocks` is false on both.
+# a site a finding named and the repair skipped. `blocks` false on both. A finding the kernel
+# SUPPRESSED is not a site: asking a repair for it back is how the design route was defeated.
 ${CLAUDE_PLUGIN_ROOT}/scripts/repair-scope-check.sh \
-  --finding-sites "$(jq -c '[(.critics[]?, .) | (.findings // [])[]? | select((.severity // "") == "critical" or (.severity // "") == "concern") | (.where // [])[]? | (.file // empty)] | unique' "$CD/<component>.critique.json" 2>/dev/null || echo '[]')" \
+  --finding-sites "$(jq -c '[(.critics[]?, .) | (.findings // [])[]? | select((.severity // "") == "critical" or (.severity // "") == "concern") | select((.design_change != true) and (.out_of_range != true)) | (.where // [])[]? | (.file // empty)] | unique' "$CD/<component>.critique.json" 2>/dev/null || echo '[]')" \
   --touched-files "$(awk -F'\t' 'NF>1{for(i=2;i<=NF;i++) if($i!="") print $i}' "$CD/<component>.repair.txt" 2>/dev/null | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')" \
   --touched-files-source "$([ -s "$CD/<component>.repair.txt" ] && echo determined || echo undetermined)" \
   > "$CD/<component>.scope.json"
 jq -r '"scope: \(.action): touched-unnamed [\(.unnamed|join(", "))] site-unaddressed [\(.unaddressed|join(", "))]"' "$CD/<component>.scope.json"  # SAY IT
 ```
 
-`repair-scope-check.sh` ran once per task at `/review` and nowhere else, so its only verdict landed
-after every repair was over. An unreadable critique yields `[]` sites and `cannot_judge`, never
-`in_scope`; a 0-byte repair diff is `undetermined`, the abstention the accept kernel makes on one.
+`repair-scope-check.sh` ran once per task at `/review`, so its only verdict landed after every repair was over.
+An unreadable critique yields `[]` sites and `cannot_judge`, never `in_scope`; a 0-byte repair diff is `undetermined`.
 
 `--suite` is a RESULT you hand in; the kernel runs nothing. Who runs it is settled by `run_mode`
 (`references/tdd-workflow.md:85-88`): the person interactive, you autonomous. Per repair the suite is
 the specs that read the files in `<component>.files.txt`, named in the record; `make` targets run once,
 when the PR is final, never per repair. With no suite over the repaired tree, `not_run` is the honest
 value and returns `cannot_judge`, not a pass. `--test-globs` is where this project's tests live; when that
-cannot be established pass `--test-globs-source undetermined`, never `[]`, the claim that no test path was touched.
+cannot be established pass `--test-globs-source undetermined`; `[]` alone is `cannot_judge`, and `[] determined` claims there are none.
 
 **Both ends of that diff are shas**, the same way the phase range at Step 12 is. A checkpoint
 label is not a revision, so handing one to `git diff` leaves an empty file rather than an error

--- a/ai-dev-assistant/references/build-critique.md
+++ b/ai-dev-assistant/references/build-critique.md
@@ -179,6 +179,7 @@ fail closed into `high` / non-blocking respectively when a required flag is abse
    ```
    wo-critique-aggregate.sh --wo "<component>" --tier "<risk_tier>" --mode fanout \
      --expected <lens count> --critics-dir "<...>/<component>.critics" \
+     --component-files-from "<...>/<component>.files.txt" \
      --evaluated true --required [--diff-empty] \
      > <task_folder>/build-critique/<component>.critique.json
    ```
@@ -351,6 +352,19 @@ never touched. One critic round per component is what that buys: the two questio
 was there to answer are now asked on every repair, by something that cannot be talked out of its
 answer.
 
+**A finding the kernel suppressed is not one of those sites.** The sites come from
+`commands/implement.md`'s `--finding-sites` expression, and it excludes any finding carrying
+`design_change: true` or `out_of_range: true` before it reads `where[]`. Without that exclusion the
+suppression is undone one line after it is made: the kernel drops the finding from `effective` so no
+repair round opens, and then the scope comparison asks the repair for the same file anyway. That
+shipped. A repair that obeyed the design rule and left the file alone was reported `unaddressed` and
+said out loud as a shortfall, while one that rewrote the design mid-build came back clean, so the
+only deterministic reading of a repair rewarded the forbidden move. Both suppressions read the JSON
+literal `true` only, matching `wo-critique-aggregate.sh`'s own test, so a string or a `1` still
+counts as a site. `tests/design-finding-route-spec.sh` D10 lifts the expression and the invocation
+out of the command body and runs them, because a spec that stops at the envelope cannot see this:
+the 48 assertions that shipped with the route all passed on the broken version.
+
 What the trade costs is stated in `agents/wo-critic.md` and is not re-argued here. A set
 comparison sees paths, never intent: it cannot tell a named site the repair deliberately left
 alone from one it forgot, and it cannot see a repair that edited the right file and fixed
@@ -370,11 +384,21 @@ always converges. The tripwire still does not judge the change, and nothing here
 moves the decision to somebody who is not the author, through the halt `/implement` already offers
 as `[f]ix` or `[o]verride`, which an autonomous run may not take for itself. Adds and deletes pass
 silently. `cannot_judge` has three causes: the
-motion file was zero bytes, no suite was run over the repaired tree, or the caller could not
-establish what a test path is here. The first exists because an empty diff carries no claim. A
-caller who knows there are no test paths says `--test-globs '[]'`, and one who cannot tell says
+motion file was zero bytes, no suite was run over the repaired tree, the caller could not establish
+what a test path is here, or the glob list was empty and nothing said which of those two it meant.
+The first exists because an empty diff carries no claim. A caller who knows there are no test paths
+says `--test-globs '[]' --test-globs-source determined`, and one who cannot tell says
 `--test-globs-source undetermined`, so a file with nothing in it means either the diff failed or the
 repair changed nothing, and neither is a repair that moved no test.
+
+**An empty list with the source flag omitted is the fourth cause, and it used to be a pass.** The
+flag defaulted to `determined`, so `--test-globs '[]'` on its own classified no path as a test path,
+left all three motion arrays empty, and returned `accepted` with the reason "the test motion raised
+nothing unanswered" over a diff that modified a test file. That is a positive claim about a
+comparison that never ran, and it switched off the modified-test halt entirely for any caller who
+passed an empty list. Omitting the flag is not the caller asserting anything, so it now gets its own
+`cannot_judge`. A non-empty list with the flag omitted still decides, because handing over the paths
+is itself the determination.
 
 **`cannot_judge` is not a pass.** It is the answer for nobody looked, and folding that into a clean
 result is the defect this framework has now found at five layers. Nothing halts on it: `blocks` is

--- a/ai-dev-assistant/scripts/repair-accept-check.sh
+++ b/ai-dev-assistant/scripts/repair-accept-check.sh
@@ -31,7 +31,10 @@
 #                    when no such file exists on disk. That is deliberate. A deleted test file is
 #                    exactly the motion this kernel most needs to see, and it is gone from disk by
 #                    the time anyone asks.
-#   --test-globs-source <determined|undetermined>  OPTIONAL, default determined. `undetermined` means
+#   --test-globs-source <determined|undetermined>  OPTIONAL, default determined WHEN --test-globs is
+#                    non-empty; an EMPTY list with this flag omitted is cannot_judge, because nothing
+#                    then separates "this project has no test paths" from "the caller never looked".
+#                    `undetermined` means
 #                    the caller could not establish what a test path is in this project, and forces
 #                    cannot_judge. An empty array cannot carry both "this repair touched no test
 #                    path" and "I do not know what a test path is here"; repair-scope-check.sh had to
@@ -60,7 +63,8 @@
 #                                self-issued permit, and a repair loop that may edit the standard
 #                                always converges. Adds and deletes still pass silently.
 #                 cannot_judge = --test-motion-from named a ZERO-BYTE file, OR --suite was not_run,
-#                                OR --test-globs-source was undetermined.
+#                                OR --test-globs-source was undetermined, OR --test-globs was empty
+#                                with --test-globs-source omitted.
 #                                UNMEASURED, never "fine". cannot_judge is NEVER accepted. Folding
 #                                "I could not look" into a pass is the defect this repo keeps
 #                                re-finding (mechanism-disposition.sh's `not_searched`,
@@ -121,14 +125,14 @@ require_value() {
   esac
 }
 
-SUITE=""; MOTION_FROM=""; TEST_GLOBS=""; GLOBS_SOURCE="determined"; GLOBS_ORIGIN=""; MOD_REASON=""; MOD_REASON_SET=0
+SUITE=""; MOTION_FROM=""; TEST_GLOBS=""; GLOBS_SOURCE="determined"; GLOBS_SOURCE_SET=0; GLOBS_ORIGIN=""; MOD_REASON=""; MOD_REASON_SET=0
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/lib/glob-to-regex.sh"
 while [ $# -gt 0 ]; do
   case "$1" in
     --suite) [ "$#" -ge 2 ] || { echo "repair-accept-check: --suite needs a value" >&2; exit 2; }; require_value --suite "$2"; SUITE="$2"; shift 2 ;;
     --test-motion-from) [ "$#" -ge 2 ] || { echo "repair-accept-check: --test-motion-from needs a value" >&2; exit 2; }; require_value --test-motion-from "$2"; MOTION_FROM="$2"; shift 2 ;;
     --test-globs) [ "$#" -ge 2 ] || { echo "repair-accept-check: --test-globs needs a value" >&2; exit 2; }; require_value --test-globs "$2"; TEST_GLOBS="$2"; shift 2 ;;
-    --test-globs-source) [ "$#" -ge 2 ] || { echo "repair-accept-check: --test-globs-source needs a value" >&2; exit 2; }; require_value --test-globs-source "$2"; GLOBS_SOURCE="$2"; shift 2 ;;
+    --test-globs-source) [ "$#" -ge 2 ] || { echo "repair-accept-check: --test-globs-source needs a value" >&2; exit 2; }; require_value --test-globs-source "$2"; GLOBS_SOURCE="$2"; GLOBS_SOURCE_SET=1; shift 2 ;;
     --test-globs-origin) [ "$#" -ge 2 ] || { echo "repair-accept-check: --test-globs-origin needs a value" >&2; exit 2; }; require_value --test-globs-origin "$2"; GLOBS_ORIGIN="$2"; shift 2 ;;
     --modification-reason) [ "$#" -ge 2 ] || { echo "repair-accept-check: --modification-reason needs a value" >&2; exit 2; }; require_value --modification-reason "$2"; MOD_REASON="$2"; MOD_REASON_SET=1; shift 2 ;;
     *) echo "repair-accept-check: unknown arg: $1" >&2; exit 2 ;;
@@ -207,6 +211,18 @@ if [ "$GLOBS_SOURCE" = "undetermined" ]; then
   # The caller could not establish what a test path is here. Every path would have to be classified
   # against a set nobody has, so the motion arrays stay empty rather than reporting a guess.
   REASONS+=("--test-globs-source was undetermined, so no path could be classified as a test path")
+  emit cannot_judge none "$EMPTY_MOTION"
+  exit 0
+fi
+
+# An EMPTY glob list is only an answer when the caller said so. Omitting --test-globs-source used to
+# default to `determined`, so `--test-globs '[]'` with no source flag classified nothing, left every
+# motion array empty, and still returned "the test motion raised nothing unanswered" over a modified
+# test file: a positive claim about a comparison that never ran, and enough to switch off the whole
+# modified-test halt. Absence is not the caller's assertion, so it gets its own verdict. A NON-empty
+# list still decides with the flag omitted, because handing over the paths IS the determination.
+if [ "$GLOBS_SOURCE_SET" -eq 0 ] && [ "$(jq -r 'length' <<<"$TEST_GLOBS")" = "0" ]; then
+  REASONS+=("--test-globs was an empty list and --test-globs-source was omitted, so nothing establishes whether this project has no test paths or whether the caller never looked; pass --test-globs-source determined to state that it has none")
   emit cannot_judge none "$EMPTY_MOTION"
   exit 0
 fi

--- a/ai-dev-assistant/tests/design-finding-route-spec.sh
+++ b/ai-dev-assistant/tests/design-finding-route-spec.sh
@@ -208,7 +208,85 @@ ok "D9 clean_returns is untouched by the route"     "1" "$(jq -r '.clean_returns
 ok "D9 and the finding count is untouched"          "1" "$(jq -r '[.critics[].findings[]] | length' <<<"$out")"
 ok "D9 the marked file itself still reads pass"     "pass" "$(jq -r '.critics[1].effective' <<<"$out")"
 
+# =============================================================================
+# D10 — THE SUPPRESSION HAS TO SURVIVE ITS NEXT READER
+# =============================================================================
+#
+# Every cell above stops at the aggregate envelope. Phase 4 (2026-09-03) found that one line further
+# on, `commands/implement.md` rebuilds the list of files a repair must touch from the RAW critics
+# array, selecting on severity alone, and hands the design site to repair-scope-check.sh anyway. So
+# a repair that obeyed the rule and left the design file alone was reported `unaddressed` -- named
+# out loud as a shortfall -- while one that rewrote it mid-build came back clean. The deterministic
+# reading rewarded the forbidden repair. Suppressing a finding from `effective` is not the whole
+# rule; the rule is that no downstream reader may ask for it back.
+#
+# So this block does not assert on the envelope. It runs the aggregate for real, lifts the site
+# expression and the invocation OUT of the command body the way build-critique-gate-spec does, and
+# executes them. A grep for `design_change` in the body would have passed on the broken version.
+IMPL="$ROOT/commands/implement.md"
+d="$(newdir)"
+critic "$d" 1 "$(filev critical "$(f critical dsg '[{"file":"src/DESIGN.php","line":3}]' true)" "$(f concern ord '[{"file":"src/ORD.php","line":4}]')")"
+ENV_OUT="$(run --tier high --expected 1 --critics-dir "$d" --required)"
+CJ="$TMP/d10.critique.json"; printf '%s' "$ENV_OUT" > "$CJ"
+
+# The site expression, lifted verbatim from the body rather than restated here: a copy in this file
+# would agree with itself forever while the shipped one drifted.
+SITE_JQ="$(awk '/--finding-sites /{ sub(/^.*--finding-sites "\$\(jq -c /,""); sub(/" \$\{?CD.*$/,""); sub(/ "\$CD.*$/,""); print; exit }' "$IMPL" | sed "s/^'//; s/'\$//")"
+if [ -z "$SITE_JQ" ]; then
+  FAIL=$((FAIL+1)); echo "FAIL D10: no --finding-sites expression could be lifted from implement.md"
+else
+  PASS=$((PASS+1))
+  SITES="$(jq -c "$SITE_JQ" "$CJ" 2>/dev/null)"
+  ok "D10 the ordinary finding is still asked for"  "true"  "$(jq -r 'index("src/ORD.php") != null' <<<"$SITES")"
+  ok "D10 the design site is NOT asked for"         "false" "$(jq -r 'index("src/DESIGN.php") != null' <<<"$SITES")"
+  # The OTHER suppression, tested on its own. Both disjuncts went into the fix together and only one
+  # had a cell: dropping the out_of_range half left this block at 55/55 under mutation. A rule looks
+  # covered when its sibling is.
+  # The off-range finding carries NO design_change, or the design half alone would suppress it and
+  # this cell could never isolate the range half. That is exactly how the first version of it passed.
+  dO="$(newdir)"
+  critic "$dO" 1 "$(filev critical "$(f critical off '[{"file":"src/OFF.php","line":7}]')" "$(f concern ord '[{"file":"src/ORD.php","line":4}]')")"
+  RJ="$(rangef src/ORD.php)"
+  ENV_OOR="$(run --tier high --expected 1 --critics-dir "$dO" --required --component-files-from "$RJ")"
+  SITES_OOR="$(jq -c "$SITE_JQ" <<<"$ENV_OOR" 2>/dev/null)"
+  ok "D10 the range check marked the off-range site" "true" "$(jq -r '[.out_of_range[].id] | index("off") != null' <<<"$ENV_OOR")"
+  ok "D10 an out-of-range site is NOT asked for"     "false" "$(jq -r 'index("src/OFF.php") != null' <<<"$SITES_OOR")"
+  ok "D10 while the in-range site still is"          "true"  "$(jq -r 'index("src/ORD.php") != null' <<<"$SITES_OOR")"
+  # And the design half isolated the same way: in range, so only the flag can suppress it.
+  RJ2="$(rangef src/ORD.php src/DESIGN.php)"
+  S2="$(jq -c "$SITE_JQ" <<<"$(run --tier high --expected 1 --critics-dir "$d" --required --component-files-from "$RJ2")" 2>/dev/null)"
+  ok "D10 an in-range design site is still NOT asked for" "false" "$(jq -r 'index("src/DESIGN.php") != null' <<<"$S2")"
+  ok "D10 and the in-range ordinary site still is"        "true"  "$(jq -r 'index("src/ORD.php") != null' <<<"$S2")"
+fi
+
+# And the same thing again through the real checker, because the site list is an input nobody reads
+# directly: what a builder is told is repair-scope-check.sh's verdict.
+LIT="$TMP/d10-scope.sh"
+awk 'index($0, "/scripts/repair-scope-check.sh") { s=1 }
+     s { print; if ($0 !~ /\\[[:space:]]*$/) exit }' "$IMPL" | sed 's/<component>/main/g' > "$LIT"
+if [ ! -s "$LIT" ]; then
+  FAIL=$((FAIL+1)); echo "FAIL D10: implement.md carries no repair-scope-check.sh invocation to run"
+else
+  PASS=$((PASS+1))
+  CD10="$TMP/d10cd"; mkdir -p "$CD10"
+  cp "$CJ" "$CD10/main.critique.json"
+  # THE COMPLIANT REPAIR: it fixes the ordinary finding and leaves the design file alone, which is
+  # exactly what the criterion demands of it.
+  printf 'M\tsrc/ORD.php\n' > "$CD10/main.repair.txt"
+  ( CLAUDE_PLUGIN_ROOT="$ROOT" CD="$CD10" bash "$LIT" ) >/dev/null 2>&1
+  ok "D10 the compliant repair is not told it missed the design site" "false" \
+     "$(jq -r '(.unaddressed // []) | index("src/DESIGN.php") != null' "$CD10/main.scope.json" 2>/dev/null)"
+  ok "D10 and it is not told it missed anything at all"               "0" \
+     "$(jq -r '(.unaddressed // []) | length' "$CD10/main.scope.json" 2>/dev/null)"
+  # THE INVERSE, so the cell above cannot be satisfied by a checker that reports nothing ever: a
+  # repair that DOES rewrite the design site is now touching a file no finding asked it to.
+  printf 'M\tsrc/ORD.php\nM\tsrc/DESIGN.php\n' > "$CD10/main.repair.txt"
+  ( CLAUDE_PLUGIN_ROOT="$ROOT" CD="$CD10" bash "$LIT" ) >/dev/null 2>&1
+  ok "D10 the repair that rewrites the design site is flagged, not cleared" "true" \
+     "$(jq -r '(.unnamed // []) | index("src/DESIGN.php") != null' "$CD10/main.scope.json" 2>/dev/null)"
+fi
+
 # --- guard: exact count, so a silently-skipped block cannot pass as green ---
-[ "$((PASS + FAIL))" -eq 48 ] || { echo "design-finding-route-spec: expected 48 assertions, ran $((PASS + FAIL))"; exit 2; }
+[ "$((PASS + FAIL))" -eq 60 ] || { echo "design-finding-route-spec: expected 60 assertions, ran $((PASS + FAIL))"; exit 2; }
 
 echo "----"; echo "design-finding-route-spec: $PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/ai-dev-assistant/tests/repair-accept-check-spec.sh
+++ b/ai-dev-assistant/tests/repair-accept-check-spec.sh
@@ -148,8 +148,22 @@ q "R3 empty globs + source undetermined -> cannot_judge" .action cannot_judge \
 # "an empty glob list determined by the caller means 'no test paths here', which is a real answer"
 q "R3 empty globs + source determined + green -> accepted" .action accepted \
   --suite green --test-motion-from "$MODTEST" --test-globs '[]' --test-globs-source determined
-q "R3 empty globs + source omitted + green -> accepted" .action accepted \
+# An OMITTED source is not a caller's assertion. Found by Phase 4 2026-09-03: this cell asserted
+# `accepted`, so `--test-globs '[]'` with no source flag classified nothing, left every motion array
+# empty, and still returned "the test motion raised nothing unanswered" over a MODIFIED test file.
+# That is a positive claim about a comparison that never ran, and it switched off the whole halt.
+# Absence gets its own answer; only an explicit `determined` makes an empty list mean something.
+q "R3 empty globs + source omitted -> cannot_judge, absence is not an assertion" .action cannot_judge \
   --suite green --test-motion-from "$MODTEST" --test-globs '[]'
+q "R3 empty globs + source omitted names the empty list, not the suite" \
+  '[.reasons[] | select(test("empty"))] | length > 0' true \
+  --suite green --test-motion-from "$MODTEST" --test-globs '[]'
+q "R3 empty globs + source omitted carries decided_by none" .decided_by none \
+  --suite green --test-motion-from "$MODTEST" --test-globs '[]'
+# The exclusion, so the rule above cannot be satisfied by refusing everything: a NON-empty glob list
+# with no source flag is still a determination, and still decides.
+q "R3 non-empty globs + source omitted still decides" .action not_accepted \
+  --suite green --test-motion-from "$MODTEST" --test-globs "$GLOBS"
 # "every cannot_judge result carries decided_by 'none' and a non-empty reasons[]"
 q "R3 not_run cannot_judge carries decided_by none" .decided_by none \
   --suite not_run --test-motion-from "$NOTEST" --test-globs "$GLOBS"
@@ -352,7 +366,7 @@ q "a path matching a glob but absent from disk still counts" '.motion.modified |
 #      + 3 suite-echo + 3 glob.
 # Asserted rather than trusted: a block that fails to run, or a helper that returns early, subtracts
 # assertions silently and the run still prints "0 failed", which reads as green.
-EXPECTED=83
+EXPECTED=86
 TOTAL=$((PASS + FAIL))
 [ "$TOTAL" -eq "$EXPECTED" ] && ok || no "expected $EXPECTED assertions, ran $TOTAL (a skipped block reads as green)"
 


### PR DESCRIPTION
The first review phase this task has ever had found that the rule shipped in 5.50.0 was undone one line after it was made. The kernel drops a design finding so no repair round opens, and then `implement.md` rebuilt the list of files a repair had to touch from the raw critics array, filtering on severity alone, and asked for the design site anyway. A repair that obeyed the rule was reported as having missed something; one that broke it came back clean. `out_of_range` had the same hole and predates 5.50.0.

Two more in the same criterion: `--test-globs '[]'` with the source flag omitted classified nothing as a test path and still returned `accepted` over a modified test, which switched off the halt 5.50.0 exists to install; and the repair call site typed its glob list as free text instead of reusing the value already derived for that component.

The 48 assertions that shipped with the design route all stopped at the aggregate envelope and all passed on the broken version, so the route was verified where it was built and nowhere it was read. The new cells lift the expression and the invocation out of the command body and run them, with each suppression isolated by its own fixture. 6 mutations, all applied and confirmed, 0 survivors. 156 tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)