### PR TITLE
The stack list is discovered, not written down (ai-dev-assistant 5.54.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.76"
+    "version": "2.0.77"
   },
   "plugins": [
     {
@@ -38,7 +38,7 @@
     {
       "name": "plugin-creation-tools",
       "source": "./plugin-creation-tools",
-      "description": "Authoring toolkit and quality gate for Claude Code plugins. Scaffolds and audits every component — skills, commands, agents, hooks, MCP servers, themes, dependencies, userConfig, and Routines — with a deterministic `validate` command (opt-in auto-fix), a pre-publish containment scan that catches leaked home paths and secrets, and the `plugin-creation` authoring skill. Tracks the current plugin spec: hook handler types and pre-spawn filters, exec-form args, JSON output controls, subfolder agent scoping, single-skill auto-discovery, and cross-marketplace dependencies.",
+      "description": "Authoring toolkit and quality gate for Claude Code plugins. Scaffolds and audits every component \u2014 skills, commands, agents, hooks, MCP servers, themes, dependencies, userConfig, and Routines \u2014 with a deterministic `validate` command (opt-in auto-fix), a pre-publish containment scan that catches leaked home paths and secrets, and the `plugin-creation` authoring skill. Tracks the current plugin spec: hook handler types and pre-spawn filters, exec-form args, JSON output controls, subfolder agent scoping, single-skill auto-discovery, and cross-marketplace dependencies.",
       "version": "3.12.1",
       "author": {
         "name": "camoa"
@@ -59,8 +59,8 @@
     {
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
-      "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research → Architecture → Implementation → Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.53.0",
+      "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
+      "version": "5.54.0",
       "author": {
         "name": "camoa"
       },
@@ -84,7 +84,7 @@
     {
       "name": "drupal-dev-framework",
       "source": "./drupal-dev-framework",
-      "description": "DEPRECATED — renamed to ai-dev-assistant. Installable only to run a one-time upgrade that repoints your project store at the new plugin and re-stamps per-project session-remembrance hooks, then is safe to uninstall. An opt-in --permissions flag also re-points stale Skill(drupal-dev-framework:*) grants. The shell exposes only /drupal-dev-framework:upgrade; install ai-dev-assistant going forward.",
+      "description": "DEPRECATED \u2014 renamed to ai-dev-assistant. Installable only to run a one-time upgrade that repoints your project store at the new plugin and re-stamps per-project session-remembrance hooks, then is safe to uninstall. An opt-in --permissions flag also re-points stale Skill(drupal-dev-framework:*) grants. The shell exposes only /drupal-dev-framework:upgrade; install ai-dev-assistant going forward.",
       "version": "4.24.2",
       "author": {
         "name": "camoa"
@@ -175,7 +175,7 @@
     {
       "name": "code-paper-test",
       "source": "./code-paper-test",
-      "description": "Systematically test code, skills, commands, and configs through mental execution — trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase (50–300), or a 3-agent competing team in isolated worktrees (300+, security-critical, skills). Verifies external calls for both existence and behavioral contracts (return-shape/nullability diffing, chained-object tracing, taint-stance fallback for closed-source). Supports `--json` for CI.",
+      "description": "Systematically test code, skills, commands, and configs through mental execution \u2014 trace logic line-by-line with concrete values to find bugs, AI hallucinations, edge cases, and contract violations. Smart routing: quick trace (<50 lines), structured 3-phase (50\u2013300), or a 3-agent competing team in isolated worktrees (300+, security-critical, skills). Verifies external calls for both existence and behavioral contracts (return-shape/nullability diffing, chained-object tracing, taint-stance fallback for closed-source). Supports `--json` for CI.",
       "version": "0.11.2",
       "author": {
         "name": "camoa"
@@ -200,7 +200,7 @@
     {
       "name": "brand-content-design",
       "source": "./brand-content-design",
-      "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, a style-recommendation engine, 26 visual styles, 114 infographic templates, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF, PPTX, and Google Slides output (canonical PPTX→Slides import via Drive for design fidelity), HTML composition, and infographic rendering.",
+      "description": "Create branded visual content (presentations, carousels, infographics, HTML pages) with Aaker personality-driven design, a style-recommendation engine, 26 visual styles, 114 infographic templates, design systems, visual components, and Presentation Zen principles. Routes to specialized skills for PDF, PPTX, and Google Slides output (canonical PPTX\u2192Slides import via Drive for design fidelity), HTML composition, and infographic rendering.",
       "version": "3.5.2",
       "author": {
         "name": "camoa"

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
-  "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research → Architecture → Implementation → Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.53.0",
+  "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
+  "version": "5.54.0",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [5.54.0] - 2026-09-04
+
+The stack axis of the gate-report contract is discovered instead of listed. `ai-dev-assistant` no
+longer carries a list of `code-quality-tools`' stacks.
+
+### Changed
+- **`gate-verdict-resolve.sh --field-paths` declares a producer LAYOUT, not producer paths.** Each
+  gate used to name `skills/code-quality-audit/scripts/drupal/<gate>-check.sh` as its producer with
+  an `also` block naming the `nextjs/` equivalent, so the set of stacks the suite could see was
+  whatever somebody had remembered to add. It was not remembered. Only the Drupal half of each gate
+  was declared until cqt 3.10.1, and the Next.js SOLID emitter — carrying no coverage fields at all —
+  was checked against nothing while its all-analyzers-absent run resolved `pass`. The declaration now
+  gives the root, the excluded directories and the filename per gate, and the spec walks
+  `code-quality-tools` to find the stacks. A stack added to that plugin is checked here on the next
+  run with no edit to this one.
+
+  The layout is that plugin's own convention, not a new one: `core/detect-project.sh` prints `drupal`
+  or `nextjs` as the project type, and that string is the directory name under the audit `scripts/`
+  root.
+
+- **Field paths are declared once per gate rather than once per producer.** The `also` blocks
+  repeated each gate's list a second time, which is what let a second stack be declared with a
+  shorter list than the first. `required` is what every discovered producer must emit; `optional` is
+  what one may lack, and every entry is bounded and checked in both directions, because an
+  unbounded `optional` is how a check like this stops being able to fail:
+  - `when_producer_lacks: "changed-mode"` — the path exists only in a `--changed` run, so a producer
+    with no `--changed)` arm cannot emit it. Derived from the producer, naming no stack: give
+    `nextjs/solid-check.sh` a changed mode and the path becomes required of it automatically. Four
+    of the five exemptions.
+  - `absent_in: [...]` — one entry, `solid`'s `.tools_skipped` in `drupal/solid-check.sh`, which has
+    no observable to derive from. The spec fails when a producer NOT on the list omits the path, and
+    equally when a producer that IS on it starts emitting the path, so the exemption cannot outlive
+    its reason.
+
+- **The layer-name check discovers its roots too.** It ran a second `find` over a hardcoded
+  `drupal` + `nextjs` pair near the end of the same spec, with the identical exposure: a new stack
+  could push an unclassified tool name into a coverage list and be read by nothing.
+
+### Fixed
+- **`nextjs/security-check.sh` is reached by the suite.** It was a declared producer of nothing and
+  was checked against nothing; `code-quality-tools`' own changelog recorded that and it stayed
+  unowned across three releases. It passes the 7 required security paths. The 3 it does not emit are
+  the changed-mode set, exempted by the derived rule because it has no `--changed` arm at all.
+
+### Coverage
+- Producer checking went from 6 declared path-lists over 4 gates to **42 required-path checks across
+  6 producers, plus 10 optional-path comparisons in both directions.** Discovery has its own
+  negative cells: zero stacks fails, a stack whose producers are all missing fails, an excluded
+  directory is not a stack, a newly added directory is found, and a discovered stack shipping an
+  incomplete producer is caught rather than skipped.
+
+### Not changed
+- The runtime resolver's decision logic. It was re-measured before this work and carries no stack
+  literal outside the comments recording what used to be there — the `phpcpd` half of the original
+  finding shipped in 5.37.0, and the stack reasoning is gone.
+- `## Code-quality extensions` in the review recipe. Producer paths in a recipe would be the same
+  list in a different file.
+
 ## [5.53.0] - 2026-09-03
 
 The second halves of four tasks that had shipped a first half and stopped. Each was a specific named

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.53.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.54.0**.
 
 ## License
 

--- a/ai-dev-assistant/references/validation-gate-result.md
+++ b/ai-dev-assistant/references/validation-gate-result.md
@@ -150,6 +150,15 @@ about a producer, checkable only by reading the producer, and
 resolver declares, plus fixture reports for each state of each mode. A table in
 a command file cannot be run, so it was never checked, so it was wrong.
 
+The producers it reads are **discovered, not listed**. The resolver declares a
+layout — the root under `code-quality-tools`, the directories that are not
+stacks, the filename per gate — and the spec walks that plugin to find the rest.
+Naming them was the same failure one level up: only the Drupal half of each gate
+was declared until cqt 3.10.1, so the Next.js emitters were checked against
+nothing, and `nextjs/security-check.sh` was still reached by nothing at 5.53.0.
+A stack added to that plugin is checked here on the next run with no edit to
+this one.
+
 **When it applies.** Whenever the gate was invoked and could not check the thing
 it exists to check. The resolver reads the gate's **JSON report**, located with
 `scripts/core/report-dir.sh --latest` — never the console text, and never a

--- a/ai-dev-assistant/scripts/gate-verdict-resolve.sh
+++ b/ai-dev-assistant/scripts/gate-verdict-resolve.sh
@@ -98,53 +98,110 @@ set -eu
 die() { printf 'gate-verdict-resolve: %s\n' "$1" >&2; exit 2; }
 
 # ---------------------------------------------------------------------------------------
-# THE FIELD PATHS, AND THE SCRIPT THAT MUST EMIT EACH ONE.
+# THE FIELD PATHS, AND THE PRODUCERS THAT MUST EMIT EACH ONE.
 #
 # This is the machine-readable half of the contract. `tests/gate-verdict-resolve-spec.sh`
-# reads it with `--field-paths` and checks every path against the named producer's own JSON
+# reads it with `--field-paths` and checks every path against each producer's own JSON
 # emitter, at the right nesting depth. A path added here without being emitted there fails
 # the suite; a path READ below but not declared here is caught by the same spec, which
 # greps this file's jq programs for `.`-paths and requires each to be declared.
 #
-# `optional_in` names a path that exists in only one of a gate's two report modes. It is
-# still checked for existence in the producer — the mode difference is about whether the
-# resolver may rely on it, not about whether it is real.
+# THE STACK AXIS IS DISCOVERED, NOT LISTED. Until 5.54.0 this block named
+# `scripts/drupal/<gate>-check.sh` as each gate's producer and carried `nextjs/` as an
+# `also` block beside it, so the set of stacks the spec could see was a list somebody had
+# to remember to extend. It was not extended: only the Drupal half of each gate was
+# declared until cqt 3.10.1, and the Next.js SOLID emitter — which carried no coverage
+# fields at all — was checked against nothing, so its all-analyzers-absent run resolved to
+# `pass`. `nextjs/security-check.sh` was still undeclared as of 5.53.0, and three paths
+# this file reads are not emitted by it.
 #
-# `also` names a SECOND producer for the same gate and the subset of paths it emits. A
-# gate has one resolver but a stack per framework, and until 3.10.1 only the Drupal half
-# was declared here — so the Next.js SOLID emitter, which carried no coverage fields at
-# all, was checked against nothing and its all-analyzers-absent run resolved to `pass`.
-# A stack whose producer is not declared is a stack this file cannot be held to.
+# `producer_layout` replaces the list with the convention code-quality-tools already owns
+# and already publishes: `core/detect-project.sh` emits `drupal` or `nextjs`, and the value
+# it emits IS the directory name under the audit `scripts/` root. So a stack is any
+# directory there that is not `core` or `tests`, and a producer is `<stack>/<file>`. Add a
+# stack to that plugin and this spec checks it on the next run with no edit here.
+#
+# What stays written down is the GATE axis, which this file resolves and therefore owns
+# (see the `case "$GATE" in` below), and the one gate whose filename breaks the pattern.
+#
+# `required` is what every discovered producer must emit. `optional` is what one may lack,
+# and each entry has to say WHY in a form that can be checked, or `optional` becomes the
+# escape hatch that makes this whole block unable to fail:
+#
+#   `when_producer_lacks: "changed-mode"` — the path exists only in a `--changed` run, so a
+#     producer with no `--changed` arm cannot emit it. DERIVED from the producer, naming no
+#     stack: give `nextjs/solid-check.sh` a changed mode and the path becomes required of it
+#     automatically.
+#   `absent_in: [...]` — a named exemption, for a per-producer fact with no observable to
+#     derive from. Falsifiable in BOTH directions: the spec fails when a producer NOT named
+#     lacks the path, and equally when a producer that IS named now emits it, so an
+#     exemption cannot outlive the reason it was written.
+#
+# `optional_in` is a different axis and is unchanged: it names a path that exists in only
+# one of a gate's two RUNTIME report modes. It is still required of the producer — the mode
+# difference is about whether the resolver may rely on the value, not about whether the
+# emitter has the field.
 # ---------------------------------------------------------------------------------------
 emit_field_paths() {
   cat <<'FIELDPATHS'
 {
-  "dry": {
-    "producer": "skills/code-quality-audit/scripts/drupal/dry-check.sh",
-    "paths": [".status", ".rating", ".mode", ".measured", ".skip_reason", ".tools_absent", ".generated_at"],
-    "also": {
-      "skills/code-quality-audit/scripts/nextjs/dry-check.sh": [".status", ".rating", ".mode", ".measured", ".skip_reason", ".tools_absent", ".generated_at"]
+  "producer_layout": {
+    "plugin": "code-quality-tools",
+    "root": "skills/code-quality-audit/scripts",
+    "exclude_dirs": ["core", "tests"],
+    "file_for_gate": {
+      "dry": "dry-check.sh",
+      "solid": "solid-check.sh",
+      "security": "security-check.sh",
+      "tdd": "tdd-workflow.sh"
     },
-    "note": "dry-report.json emits NO tools_failed and NO tools_unmeasured. Do not read them."
+    "changed_mode_probe": "a `--changed)` arm in the producer's own argument parsing",
+    "note": "A stack is a directory under root that is not in exclude_dirs. The names are code-quality-tools' own: core/detect-project.sh prints the directory name as the project type."
   },
-  "solid": {
-    "producer": "skills/code-quality-audit/scripts/drupal/solid-check.sh",
-    "paths": [".status", ".mode", ".analyzers_ran", ".binary_analyzers", ".tools_absent", ".tools_failed", ".tools_unmeasured", ".generated_at"],
-    "also": {
-      "skills/code-quality-audit/scripts/nextjs/solid-check.sh": [".status", ".analyzers_ran", ".binary_analyzers", ".tools_absent", ".tools_failed", ".tools_unmeasured", ".tools_skipped", ".generated_at"]
+  "gates": {
+    "dry": {
+      "required": [".status", ".rating", ".mode", ".measured", ".skip_reason", ".tools_absent", ".generated_at"],
+      "optional": {},
+      "note": "dry-report.json emits NO tools_failed and NO tools_unmeasured. Do not read them."
     },
-    "note": "analyzers_ran counts CHECKS, not analyzers: the always-on \\Drupal:: grep needs no binary and increments it. Never the coverage test. binary_analyzers[] is the producer naming the analyzers that DO need installing, so this file does not carry those names as a literal of its own."
-  },
-  "security": {
-    "producer": "skills/code-quality-audit/scripts/drupal/security-check.sh",
-    "paths": [".summary.overall_status", ".meta", ".meta.timestamp", ".meta.mode", ".meta.skip_reason", ".meta.tools_absent", ".meta.tools_failed", ".meta.tools_unmeasured", ".meta.tools_skipped", ".meta.analyzers_ran"],
-    "optional_in": {".meta.analyzers_ran": "changed", ".meta.mode": "changed", ".meta.skip_reason": "changed", ".meta.tools_skipped": "changed"},
-    "note": "There is NO top-level .status. meta.tools[] is whole-project-only AND its literal disagrees with the names the code pushes, so it is deliberately not read. meta.tools_absent[] means ONE thing since cqt 3.10.1 — the binary is not installed; layers the changed set scoped out are in meta.tools_skipped[] and are NOT a coverage gap."
-  },
-  "tdd": {
-    "producer": "skills/code-quality-audit/scripts/drupal/tdd-workflow.sh",
-    "paths": [],
-    "note": "Writes no JSON report on any path and says so in its own source. Resolved from the exit code alone."
+    "solid": {
+      "required": [".status", ".analyzers_ran", ".binary_analyzers", ".tools_absent", ".tools_failed", ".tools_unmeasured", ".generated_at"],
+      "optional": {
+        ".mode": {
+          "when_producer_lacks": "changed-mode",
+          "why": "A producer with no --changed arm always runs whole-project and records no mode. The resolver defaults MODE to whole-project, which is the right reading for exactly that producer."
+        },
+        ".tools_skipped": {
+          "absent_in": ["drupal/solid-check.sh"],
+          "why": "tools_skipped[] is the producer naming an analyzer it declined to run BY DESIGN. The Drupal solid gate declines none, so it emits no such list; the resolver reads it as `// []`, which is the same statement. Not derivable from a --changed arm: this producer HAS one."
+        }
+      },
+      "note": "analyzers_ran counts CHECKS, not analyzers: the always-on \\Drupal:: grep needs no binary and increments it. Never the coverage test. binary_analyzers[] is the producer naming the analyzers that DO need installing, so this file does not carry those names as a literal of its own."
+    },
+    "security": {
+      "required": [".summary.overall_status", ".meta", ".meta.timestamp", ".meta.tools_absent", ".meta.tools_failed", ".meta.tools_unmeasured", ".meta.tools_skipped"],
+      "optional": {
+        ".meta.mode": {
+          "when_producer_lacks": "changed-mode",
+          "why": "Same rule as solid's .mode. nextjs/security-check.sh has no --changed arm, so it records no mode and the whole-project default is correct for it."
+        },
+        ".meta.skip_reason": {
+          "when_producer_lacks": "changed-mode",
+          "why": "A skip_reason exists to say which layers a changed set scoped out. A whole-project-only producer scopes nothing out and has nothing to name."
+        },
+        ".meta.analyzers_ran": {
+          "when_producer_lacks": "changed-mode",
+          "why": "Emitted by the changed-mode envelope only. Its absence is safe here because coverage on this gate comes from the tool lists, never from a count of checks."
+        }
+      },
+      "optional_in": {".meta.analyzers_ran": "changed", ".meta.mode": "changed", ".meta.skip_reason": "changed", ".meta.tools_skipped": "changed"},
+      "note": "There is NO top-level .status. meta.tools[] is whole-project-only AND its literal disagrees with the names the code pushes, so it is deliberately not read. meta.tools_absent[] means ONE thing since cqt 3.10.1 — the binary is not installed; layers the changed set scoped out are in meta.tools_skipped[] and are NOT a coverage gap."
+    },
+    "tdd": {
+      "required": [],
+      "optional": {},
+      "note": "Writes no JSON report on any path and says so in its own source. Resolved from the exit code alone."
+    }
   }
 }
 FIELDPATHS

--- a/ai-dev-assistant/tests/gate-verdict-resolve-spec.sh
+++ b/ai-dev-assistant/tests/gate-verdict-resolve-spec.sh
@@ -95,64 +95,204 @@ else
   exit 1
 fi
 
-GATES=$(printf '%s' "$DECL" | jq -r 'keys[]')
+# ------------------------------------------------------------------------------------------
+# 1a. DISCOVER THE PRODUCERS. The resolver declares a LAYOUT, not a list of stacks, so this
+# walks code-quality-tools and finds them. Until 5.54.0 the declaration named
+# `drupal/<gate>-check.sh` with `nextjs/` as an `also` block, and the set of stacks this spec
+# could see was whatever somebody had remembered to add. It was not remembered: the Next.js
+# SOLID emitter went undeclared until cqt 3.10.1 and was checked against nothing while an
+# all-analyzers-absent run of it resolved `pass`, and `nextjs/security-check.sh` was still
+# undeclared at 5.53.0 with three read paths it does not emit.
+#
+# Discovering means a stack added to that plugin is checked here on the next run, with no
+# edit to this repo. It also means the discovery itself has to be able to fail: zero stacks,
+# or a stack with no producers, is not a pass. Section 1c mutates the tree and requires red.
+# ------------------------------------------------------------------------------------------
+LAYOUT=$(printf '%s' "$DECL" | jq -c '.producer_layout')
+SROOT="${CQT}/$(printf '%s' "$LAYOUT" | jq -r '.root')"
+mapfile -t EXCLUDES < <(printf '%s' "$LAYOUT" | jq -r '.exclude_dirs[]?')
+
+# discover_stacks <scripts-root> — prints one stack directory name per line.
+discover_stacks() {
+  local root="$1" d base skip x
+  [ -d "$root" ] || return 0
+  for d in "$root"/*/; do
+    [ -d "$d" ] || continue
+    base=$(basename "$d")
+    skip=0
+    for x in "${EXCLUDES[@]+"${EXCLUDES[@]}"}"; do
+      [ "$base" = "$x" ] && skip=1
+    done
+    [ "$skip" -eq 1 ] || printf '%s\n' "$base"
+  done
+}
+
+# producer_has_changed_mode <file> — the `--changed)` arm in its own argument parsing. This
+# is the observable behind every `when_producer_lacks: changed-mode` exemption, so an
+# exemption is derived from the producer rather than from a stack name somebody wrote down.
+producer_has_changed_mode() {
+  sed 's/#.*//' "$1" 2>/dev/null | grep -qE -- '--changed[[:space:]]*\)'
+}
+
+mapfile -t STACKS < <(discover_stacks "$SROOT")
+if [ "${#STACKS[@]}" -eq 0 ]; then
+  fail_check "no stack directories discovered under $SROOT — the field-path check has no producers and is checking nothing"
+  printf '\ngate-verdict-resolve-spec: FAILURES\n' >&2
+  exit 1
+fi
+pass_check "discovered ${#STACKS[@]} producer stacks under $(printf '%s' "$LAYOUT" | jq -r '.root') (${STACKS[*]})"
+
+# ------------------------------------------------------------------------------------------
+# 1b. EVERY DISCOVERED PRODUCER EMITS EVERY REQUIRED PATH.
+# ------------------------------------------------------------------------------------------
+GATES=$(printf '%s' "$DECL" | jq -r '.gates | keys[]')
 CHECKED_PATHS=0
+PRODUCERS_SEEN=0
 for gate in $GATES; do
-  PRODUCER=$(printf '%s' "$DECL" | jq -r --arg g "$gate" '.[$g].producer')
-  PFILE="${CQT}/${PRODUCER}"
-  if [ ! -f "$PFILE" ]; then
-    fail_check "$gate: declared producer $PRODUCER does not exist — the paths below are checked against nothing"
+  GFILE=$(printf '%s' "$LAYOUT" | jq -r --arg g "$gate" '.file_for_gate[$g] // empty')
+  if [ -z "$GFILE" ]; then
+    fail_check "$gate: the layout names no producer filename for this gate — it is resolved by the resolver and checked by nothing"
     continue
   fi
-  mapfile -t PLIST < <(printf '%s' "$DECL" | jq -r --arg g "$gate" '.[$g].paths[]?')
-  if [ "${#PLIST[@]}" -eq 0 ]; then
-    # tdd declares none, deliberately: it writes no report. That is a claim too.
-    if printf '%s' "$DECL" | jq -er --arg g "$gate" '.[$g].note' 2>/dev/null | grep -qi 'no JSON report'; then
+  mapfile -t REQ < <(printf '%s' "$DECL" | jq -r --arg g "$gate" '.gates[$g].required[]?')
+
+  # A gate declaring no required paths has to say why, or it is a gate that reads nothing.
+  if [ "${#REQ[@]}" -eq 0 ]; then
+    if printf '%s' "$DECL" | jq -er --arg g "$gate" '.gates[$g].note' 2>/dev/null | grep -qi 'no JSON report'; then
       pass_check "$gate declares no field paths and says why (it writes no report)"
     else
       fail_check "$gate declares no field paths and gives no reason — a gate that reads nothing decides on nothing"
     fi
     continue
   fi
-  if OUT=$(python3 "$PATHS_TOOL" "$PFILE" "${PLIST[@]}" 2>&1); then
-    pass_check "$gate: all ${#PLIST[@]} declared paths are emitted by $(basename "$PRODUCER")"
-    CHECKED_PATHS=$((CHECKED_PATHS + ${#PLIST[@]}))
-  else
-    fail_check "$gate: declared paths NOT emitted by $(basename "$PRODUCER") — $(printf '%s' "$OUT" | tr '\n' ' ')"
-  fi
 
-  # SECOND PRODUCERS. One resolver, one stack per framework. Only the Drupal half of
-  # each gate was declared until cqt 3.10.1, so the Next.js SOLID emitter — which carried
-  # no coverage fields at all, printed "[SKIP] madge not installed" and then set status
-  # "pass" — was checked against nothing, and a Next.js project with every analyzer
-  # missing resolved to pass / unresolved:false / coverage_partial:false. That is the
-  # original defect of this whole branch, surviving in the directory nobody declared.
-  mapfile -t ALSO < <(printf '%s' "$DECL" | jq -r --arg g "$gate" '.[$g].also // {} | keys[]?')
-  for other in "${ALSO[@]+"${ALSO[@]}"}"; do
-    OFILE="${CQT}/${other}"
-    mapfile -t OLIST < <(printf '%s' "$DECL" | jq -r --arg g "$gate" --arg o "$other" '.[$g].also[$o][]?')
-    if [ ! -f "$OFILE" ]; then
-      fail_check "$gate: declared second producer $other does not exist"
-      continue
-    fi
-    if [ "${#OLIST[@]}" -eq 0 ]; then
-      fail_check "$gate: second producer $other is declared with no paths — it is checked against nothing"
-      continue
-    fi
-    if OUT=$(python3 "$PATHS_TOOL" "$OFILE" "${OLIST[@]}" 2>&1); then
-      pass_check "$gate: all ${#OLIST[@]} declared paths are emitted by $(basename "$other") (the Next.js producer)"
-      CHECKED_PATHS=$((CHECKED_PATHS + ${#OLIST[@]}))
+  GATE_PRODUCERS=0
+  for stack in "${STACKS[@]}"; do
+    PFILE="${SROOT}/${stack}/${GFILE}"
+    # A stack need not implement every gate. It must implement at least one, which 1c checks.
+    [ -f "$PFILE" ] || continue
+    GATE_PRODUCERS=$((GATE_PRODUCERS + 1))
+    PRODUCERS_SEEN=$((PRODUCERS_SEEN + 1))
+    if OUT=$(python3 "$PATHS_TOOL" "$PFILE" "${REQ[@]}" 2>&1); then
+      pass_check "$gate/$stack: all ${#REQ[@]} required paths are emitted by $GFILE"
+      CHECKED_PATHS=$((CHECKED_PATHS + ${#REQ[@]}))
     else
-      fail_check "$gate: $(basename "$other") does not emit its declared paths — $(printf '%s' "$OUT" | tr '\n' ' ')"
+      fail_check "$gate/$stack: required paths NOT emitted by $GFILE — $(printf '%s' "$OUT" | tr '\n' ' ')"
+    fi
+  done
+  if [ "$GATE_PRODUCERS" -eq 0 ]; then
+    fail_check "$gate: no discovered stack ships $GFILE — this gate's paths were checked against nothing"
+  fi
+done
+
+# ------------------------------------------------------------------------------------------
+# 1b-ii. THE OPTIONAL PATHS, FALSIFIABLE IN BOTH DIRECTIONS.
+#
+# `optional` is where a check like this goes to die: make absence acceptable and every
+# producer passes by emitting nothing. So each optional path is checked twice.
+#
+#   `when_producer_lacks: changed-mode` — REQUIRED of every producer that has a --changed
+#     arm, and merely allowed to be absent in one that does not. Give a whole-project-only
+#     producer a changed mode and the path becomes required of it with no edit here.
+#   `absent_in: [...]` — allowed absent ONLY in the producers named. Absent anywhere else is
+#     a failure, AND present in a named one is also a failure, because an exemption that
+#     outlives its reason is how the old `also` blocks went stale in the first place.
+# ------------------------------------------------------------------------------------------
+OPT_CHECKED=0
+for gate in $GATES; do
+  GFILE=$(printf '%s' "$LAYOUT" | jq -r --arg g "$gate" '.file_for_gate[$g] // empty')
+  [ -n "$GFILE" ] || continue
+  mapfile -t OPTS < <(printf '%s' "$DECL" | jq -r --arg g "$gate" '.gates[$g].optional // {} | keys[]?')
+  for opath in "${OPTS[@]+"${OPTS[@]}"}"; do
+    RULE=$(printf '%s' "$DECL" | jq -c --arg g "$gate" --arg p "$opath" '.gates[$g].optional[$p]')
+    WHY=$(printf '%s' "$RULE" | jq -r '.why // ""')
+    if [ -z "$WHY" ]; then
+      fail_check "$gate: optional path $opath carries no reason — an unexplained exemption is an opt-out from this check"
+      continue
+    fi
+    LACKS=$(printf '%s' "$RULE" | jq -r '.when_producer_lacks // ""')
+    mapfile -t ABSENT_IN < <(printf '%s' "$RULE" | jq -r '.absent_in[]?')
+    if [ -z "$LACKS" ] && [ "${#ABSENT_IN[@]}" -eq 0 ]; then
+      fail_check "$gate: optional path $opath names neither when_producer_lacks nor absent_in — nothing bounds who may omit it"
+      continue
+    fi
+    BAD=""
+    for stack in "${STACKS[@]}"; do
+      PFILE="${SROOT}/${stack}/${GFILE}"
+      [ -f "$PFILE" ] || continue
+      EMITS=0
+      python3 "$PATHS_TOOL" "$PFILE" "$opath" >/dev/null 2>&1 && EMITS=1
+      if [ "$LACKS" = "changed-mode" ]; then
+        if producer_has_changed_mode "$PFILE"; then
+          [ "$EMITS" -eq 1 ] || BAD="${BAD} ${stack}/${GFILE}:has-a---changed-arm-but-omits-${opath}"
+        fi
+      else
+        NAMED=0
+        for n in "${ABSENT_IN[@]+"${ABSENT_IN[@]}"}"; do
+          [ "$n" = "${stack}/${GFILE}" ] && NAMED=1
+        done
+        if [ "$NAMED" -eq 1 ] && [ "$EMITS" -eq 1 ]; then
+          BAD="${BAD} ${stack}/${GFILE}:exempted-from-${opath}-but-now-emits-it"
+        elif [ "$NAMED" -eq 0 ] && [ "$EMITS" -eq 0 ]; then
+          BAD="${BAD} ${stack}/${GFILE}:omits-${opath}-and-is-not-on-its-absent_in-list"
+        fi
+      fi
+      OPT_CHECKED=$((OPT_CHECKED + 1))
+    done
+    if [ -z "$BAD" ]; then
+      pass_check "$gate: optional $opath holds in both directions across every discovered producer"
+    else
+      fail_check "$gate: optional $opath —$BAD"
     fi
   done
 done
 
-if [ "$CHECKED_PATHS" -ge 15 ]; then
-  pass_check "field-path check covered $CHECKED_PATHS paths across the producers"
+if [ "$PRODUCERS_SEEN" -ge 4 ] && [ "$CHECKED_PATHS" -ge 15 ] && [ "$OPT_CHECKED" -ge 1 ]; then
+  pass_check "field-path check covered $CHECKED_PATHS required paths across $PRODUCERS_SEEN producers, plus $OPT_CHECKED optional-path comparisons"
 else
-  fail_check "field-path check only covered $CHECKED_PATHS paths — it is not looking at enough to mean anything"
+  fail_check "field-path check covered $CHECKED_PATHS paths / $PRODUCERS_SEEN producers / $OPT_CHECKED optional comparisons — it is not looking at enough to mean anything"
 fi
+
+# ------------------------------------------------------------------------------------------
+# 1c. THE DISCOVERY ITSELF MUST BE ABLE TO FAIL. A check that found nothing has not passed,
+# and a discovery walk is exactly the kind that silently finds nothing. Point it at an empty
+# tree and at a tree whose only stack ships no producers, and require both to come back with
+# nothing found rather than with a clean result.
+# ------------------------------------------------------------------------------------------
+TMPD=$(mktemp -d)
+trap 'rm -rf "$TMPD"' EXIT
+mkdir -p "$TMPD/empty"
+mapfile -t GOT < <(discover_stacks "$TMPD/empty")
+if [ "${#GOT[@]}" -eq 0 ]; then
+  pass_check "discovery finds zero stacks in an empty tree (the caller fails on that, it is not a pass)"
+else
+  fail_check "discovery invented ${#GOT[@]} stacks in an empty tree"
+fi
+mkdir -p "$TMPD/only-excluded/core" "$TMPD/only-excluded/tests"
+mapfile -t GOT < <(discover_stacks "$TMPD/only-excluded")
+if [ "${#GOT[@]}" -eq 0 ]; then
+  pass_check "discovery excludes core/ and tests/ and reports no stack when they are all there is"
+else
+  fail_check "discovery counted an excluded directory as a stack (${GOT[*]})"
+fi
+mkdir -p "$TMPD/added/core" "$TMPD/added/python"
+mapfile -t GOT < <(discover_stacks "$TMPD/added")
+if [ "${#GOT[@]}" -eq 1 ] && [ "${GOT[0]}" = "python" ]; then
+  pass_check "a stack directory added to the plugin is discovered with no edit to the resolver's declaration"
+else
+  fail_check "a newly added stack directory was not discovered (got: ${GOT[*]-none})"
+fi
+# And an incomplete producer in a discovered stack is caught, not skipped.
+mkdir -p "$TMPD/added/python"
+printf '#!/usr/bin/env bash\njq -n "{status: 1}"\n' > "$TMPD/added/python/solid-check.sh"
+mapfile -t SREQ < <(printf '%s' "$DECL" | jq -r '.gates.solid.required[]?')
+if python3 "$PATHS_TOOL" "$TMPD/added/python/solid-check.sh" "${SREQ[@]}" >/dev/null 2>&1; then
+  fail_check "the path checker accepted a producer emitting only .status against solid's ${#SREQ[@]} required paths — a new stack could ship blind"
+else
+  pass_check "a discovered stack shipping an incomplete producer fails the required-path check"
+fi
+
+
 
 # The checker itself must be able to FAIL, or the block above is decoration. Ask it for
 # the three paths that burned us and require it to reject each one.
@@ -1004,7 +1144,7 @@ fi
 # reads BOTH: the helper calls with their full jq programs, and the quoted path arguments
 # on require_shape's continuation lines. Over-matching is safe — a path picked up that is
 # not really read still has to be declared and still gets checked against the producer.
-ALL_DECLARED=$(printf '%s' "$DECL" | jq -r '[.[].paths[]?, (.[].also // {} | .[][]?)] | unique | .[]')
+ALL_DECLARED=$(printf '%s' "$DECL" | jq -r '[.gates[].required[]?, (.gates[].optional // {} | keys[]?)] | unique | .[]')
 USED=$(sed -n "/jq\(r\|v\|c\|len\|join\) '/p; /^ *'\.[A-Za-z_]/p" "$R" \
        | grep -oE "\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*" | sort -u)
 NUSED=$(printf '%s\n' "$USED" | grep -c . || true)
@@ -1446,8 +1586,13 @@ trap 'rm -f "$CATALOG_NAMES" "$REPORTED_NAMES"' EXIT
 if [ -f "$CATALOG" ]; then
   jq -r '((.tools // {}) | keys[]), ((.layers // {}) | keys[])' "$CATALOG" | sort -u > "$CATALOG_NAMES"
 fi
-GATE_SCRIPTS=$(find "${CQT}/skills/code-quality-audit/scripts/drupal" \
-                    "${CQT}/skills/code-quality-audit/scripts/nextjs" \
+# DISCOVERED, not listed — the same reason section 1a discovers. This walk named `drupal`
+# and `nextjs` until 5.54.0, so a stack added to code-quality-tools could push an
+# unclassified tool name into a coverage list and never be read here. The roots come from
+# the resolver's declared layout, so there is one place that knows where stacks live.
+GATE_ROOTS=()
+for stack in "${STACKS[@]}"; do GATE_ROOTS+=("${SROOT}/${stack}"); done
+GATE_SCRIPTS=$(find "${GATE_ROOTS[@]}" \
                     -name '*-check.sh' -o -name '*-workflow.sh' 2>/dev/null | sort)
 if [ -z "$GATE_SCRIPTS" ]; then
   fail_check "found no gate scripts to read layer names out of — this check is looking at nothing"


### PR DESCRIPTION
`gate-verdict-resolve.sh` named `drupal/<gate>-check.sh` as each gate's producer with an `also` block for the `nextjs/` one, so the set of stacks the suite could check was whatever somebody had remembered to add — and it was not remembered. Only the Drupal half of each gate was declared until cqt 3.10.1, and `nextjs/security-check.sh` was still reached by nothing at 5.53.0.

The declaration now gives a layout and the spec walks `code-quality-tools` to find the stacks, which is that plugin's own convention rather than a new one. Field paths move to once per gate; the `optional` half is bounded so it cannot become an opt-out, with four exemptions derived from the producer and the one that cannot be derived failing in both directions.

Coverage goes from 6 declared lists to 42 required-path checks across 6 producers plus 10 optional comparisons. Three mutations, all killed. `make test` 158 passed, `make lint` clean, the five cheap checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)