### PR TITLE
A discovered stack that nothing reads is not a checked stack (ai-dev-assistant 5.55.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.78"
+    "version": "2.0.79"
   },
   "plugins": [
     {
@@ -60,7 +60,7 @@
       "name": "ai-dev-assistant",
       "source": "./ai-dev-assistant",
       "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. Most AI dev tools optimize for speed. This one keeps the work disciplined: understand the problem before coding, reuse what already exists, follow your standards, and verify. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review, with deterministic gates (SOLID, TDD, DRY, security, code-purposefulness, a Phase-4 review) the AI can't quietly skip, and grounds its decisions in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks. Under the hood it covers epic and sub-task hierarchy, scope contracts, change-impact dispatch, work-orders with adversarial critique and oracle integrity, two-stage dev-guides detection, the Playbook System, git-worktree awareness, agent-team validation, session-remembrance hooks, and committed-Playwright E2E, visual-regression, and visual-parity gates (framework-agnostic setup via process recipes; Drupal payload ships in dev-guides).",
-      "version": "5.55.0",
+      "version": "5.55.1",
       "author": {
         "name": "camoa"
       },

--- a/ai-dev-assistant/.claude-plugin/plugin.json
+++ b/ai-dev-assistant/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-dev-assistant",
   "description": "An AI assistant for developers that focuses on getting the process right, not just getting code out fast. It runs each task through Research \u2192 Architecture \u2192 Implementation \u2192 Review before code gets written, and checks the work against your standards (SOLID, TDD, DRY, security) with gates the AI can't quietly skip. Decisions stay grounded in best-practice guides instead of whatever the model guessed. Stack-agnostic, so stack specifics live in consumable dev-guides, recipes, and playbooks.",
-  "version": "5.55.0",
+  "version": "5.55.1",
   "author": {
     "name": "camoa"
   },

--- a/ai-dev-assistant/CHANGELOG.md
+++ b/ai-dev-assistant/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [5.55.1] - 2026-09-04
+
+Three holes in 5.54.0's discovery, found by a fresh reader running the artifact rather than reading
+about it. The suite stayed green through all of them.
+
+### Fixed
+- **A discovered stack could still be checked against nothing** — 5.54.0's own goal statement, still
+  true after 5.54.0. Discovery answers "what stacks exist"; it never answered "did we check them".
+  `file_for_gate` names four filenames and the loop skips a path that is not there, so a stack whose
+  producers are named anything else was discovered, announced in a passing line as a producer stack,
+  and read by nothing. A real `python/` directory holding one off-pattern file made the suite print
+  `discovered 3 producer stacks` and `42 required paths across 6 producers` in the same green run.
+
+  Producers are now counted per stack and asserted after the gate loop. Zero fails, and the message
+  names both repairs: a stack with genuinely no gates belongs in `exclude_dirs`, and a stack using
+  different filenames means `file_for_gate` is out of date.
+
+  **The comment on that line asserted the check existed.** It read "It must implement at least one,
+  which 1c checks", and 1c checks a synthetic `mktemp` tree, never the real discovered set. A claim
+  with nothing behind it, in the release whose subject is claims with nothing behind them.
+
+- **The changed-mode derivation was bypassable by ordinary shell style.** It is the sole observable
+  behind four of the five `optional` exemptions, and it recognised only the literal `--changed)`. A
+  producer writing `--changed|--only-changed)` or `--changed=*)` or `[ "$1" = "--changed" ]` kept a
+  working changed mode, was silently moved into the exempt set, and stopped being required to emit
+  the fields the resolver reads. Demonstrated on a real producer: the arm rewritten, the `mode`
+  emitters renamed, suite still green. All four forms are now recognised, and they classify the six
+  shipped producers identically.
+
+- **The coverage budget had room for two whole producers to vanish.** `>= 4` producers and `>= 15`
+  paths against an actual 6 and 42. Deleting `nextjs/dry-check.sh` left that line green at 35 paths
+  across 5 producers; the run only went red through the older hardcoded assertions this change set
+  out to replace. The expected count is now derived from the discovered tree, so a lost producer
+  fails on its own line.
+
+- **The section 1c `EXIT` trap never ran and leaked a temp directory every invocation.** Bash keeps
+  one EXIT trap and two later sections replace it. Cleanup is now explicit where the directory is
+  finished with.
+
+- **A `why` string named a producer in prose nothing checks.** It asserted that
+  `nextjs/security-check.sh` has no `--changed` arm. The rule is derived, so the moment that
+  producer gained one the derivation would correctly start requiring the path while the prose kept
+  asserting the opposite. The producers are no longer named there.
+
+### Coverage
+- Three mutations, each verified applied, each killed on its own message: an off-pattern stack
+  directory, a producer whose changed arm is written as an alternation while losing `.mode`, and a
+  deleted producer. `make test` 159 passed.
+
+### Known deviation
+- The contract scoped `.meta.tools_skipped` as an optional security path; it ships as required.
+  Stricter than scoped and both producers emit it, so nothing is lost — recorded so it is not later
+  read as the contract having been met verbatim.
+
 ## [5.55.0] - 2026-09-04
 
 The material a task is captured with has somewhere to live, and research reads it.

--- a/ai-dev-assistant/README.md
+++ b/ai-dev-assistant/README.md
@@ -213,7 +213,7 @@ A passing gate means the disciplined step ran (the tests exist and pass, the sta
 - **Philosophy:** [PHILOSOPHY.md](../PHILOSOPHY.md). Why the framework works the way it does.
 - **Deeper how-to:** [docs/usage.md](docs/usage.md). Prerequisites, "it's working if", reading the trace, autonomous runs, the full command reference.
 - **Upgrading from v2.x:** run `/next` after upgrading (it offers to migrate old tasks), or `/ai-dev-assistant:migrate-tasks`. See [MIGRATION.md](./MIGRATION.md).
-- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.55.0**.
+- **Changelog:** [CHANGELOG.md](./CHANGELOG.md). Current version: **5.55.1**.
 
 ## License
 

--- a/ai-dev-assistant/scripts/gate-verdict-resolve.sh
+++ b/ai-dev-assistant/scripts/gate-verdict-resolve.sh
@@ -183,7 +183,7 @@ emit_field_paths() {
       "optional": {
         ".meta.mode": {
           "when_producer_lacks": "changed-mode",
-          "why": "Same rule as solid's .mode. nextjs/security-check.sh has no --changed arm, so it records no mode and the whole-project default is correct for it."
+          "why": "Same rule as solid's .mode. A producer with no --changed arm records no mode, and the resolver's whole-project default is the right reading for exactly that producer. Which producers those are is derived, never named here: a name in this string is a claim nothing checks, and it would keep asserting the old answer after the producer gained a changed arm."
         },
         ".meta.skip_reason": {
           "when_producer_lacks": "changed-mode",

--- a/ai-dev-assistant/tests/gate-verdict-resolve-spec.sh
+++ b/ai-dev-assistant/tests/gate-verdict-resolve-spec.sh
@@ -131,7 +131,14 @@ discover_stacks() {
 # is the observable behind every `when_producer_lacks: changed-mode` exemption, so an
 # exemption is derived from the producer rather than from a stack name somebody wrote down.
 producer_has_changed_mode() {
-  sed 's/#.*//' "$1" 2>/dev/null | grep -qE -- '--changed[[:space:]]*\)'
+  # Four ways to write the same working argument arm. Until 5.56.0 only the first was
+  # recognised, so `--changed|--only-changed)` or `--changed=*)` moved a producer that HAS a
+  # changed mode into the exempt set, and the paths the resolver reads stopped being required of
+  # it. That is the escape hatch `optional` exists to close, reachable by ordinary shell style.
+  #   case arm:        --changed)   |   --changed|--x)   |   --changed=*)
+  #   explicit test:   [ "$1" = "--changed" ]  /  [[ $1 == --changed ]]
+  sed 's/#.*//' "$1" 2>/dev/null \
+    | grep -qE -- '(--changed([[:space:]]*\||=|[[:space:]]*\))|["'"'"']--changed["'"'"']|=[[:space:]]*--changed([[:space:]]|$))'
 }
 
 mapfile -t STACKS < <(discover_stacks "$SROOT")
@@ -148,6 +155,8 @@ pass_check "discovered ${#STACKS[@]} producer stacks under $(printf '%s' "$LAYOU
 GATES=$(printf '%s' "$DECL" | jq -r '.gates | keys[]')
 CHECKED_PATHS=0
 PRODUCERS_SEEN=0
+declare -A STACK_PRODUCERS=()
+for stack in "${STACKS[@]}"; do STACK_PRODUCERS["$stack"]=0; done
 for gate in $GATES; do
   GFILE=$(printf '%s' "$LAYOUT" | jq -r --arg g "$gate" '.file_for_gate[$g] // empty')
   if [ -z "$GFILE" ]; then
@@ -169,8 +178,15 @@ for gate in $GATES; do
   GATE_PRODUCERS=0
   for stack in "${STACKS[@]}"; do
     PFILE="${SROOT}/${stack}/${GFILE}"
-    # A stack need not implement every gate. It must implement at least one, which 1c checks.
+    # A stack need not implement every gate. Whether it implements ANY is counted per stack in
+    # STACK_PRODUCERS and asserted after this loop — see the block below, and read its comment
+    # before removing this line. Until 5.56.0 this comment claimed "which 1c checks", and 1c
+    # checks a synthetic mktemp tree, never the real discovered set. So a real stack whose files
+    # were named anything but the four literals below was announced as a discovered producer
+    # stack and checked against nothing, which is the exact scenario this whole change exists to
+    # end. A comment is not a check.
     [ -f "$PFILE" ] || continue
+    STACK_PRODUCERS["$stack"]=$(( ${STACK_PRODUCERS["$stack"]:-0} + 1 ))
     GATE_PRODUCERS=$((GATE_PRODUCERS + 1))
     PRODUCERS_SEEN=$((PRODUCERS_SEEN + 1))
     if OUT=$(python3 "$PATHS_TOOL" "$PFILE" "${REQ[@]}" 2>&1); then
@@ -182,6 +198,29 @@ for gate in $GATES; do
   done
   if [ "$GATE_PRODUCERS" -eq 0 ]; then
     fail_check "$gate: no discovered stack ships $GFILE — this gate's paths were checked against nothing"
+  fi
+done
+
+# EVERY DISCOVERED STACK SHIPS AT LEAST ONE PRODUCER THIS FILE CAN READ.
+#
+# Discovery answers "what stacks exist"; it does not answer "did we check them". `file_for_gate`
+# still names four filenames, and the loop above skips a path that is not there, so a stack whose
+# producers are named anything else contributes zero checks in silence — discovered, announced,
+# and read by nothing. That is indistinguishable from the pre-5.54.0 state for that stack.
+#
+# Found by a fresh reader who made a real `python/` directory holding one off-pattern file: the
+# suite exited 0 and printed "discovered 3 producer stacks" and "42 required paths across 6
+# producers" in the same run. The gate-level GATE_PRODUCERS guard cannot see it — that one fires
+# only when NO stack ships a given gate's file.
+#
+# The fix is loud rather than silent because the two ways to reach it need different answers: a
+# stack code-quality-tools genuinely has no gates for should be excluded in the declaration, and a
+# stack whose files are named differently means `file_for_gate` is out of date.
+for stack in "${STACKS[@]}"; do
+  if [ "${STACK_PRODUCERS["$stack"]:-0}" -gt 0 ]; then
+    pass_check "stack $stack: ${STACK_PRODUCERS["$stack"]} producer(s) this file knows how to read"
+  else
+    fail_check "stack $stack was discovered and checked against NOTHING — it ships none of the filenames file_for_gate names ($(printf '%s' "$LAYOUT" | jq -r '.file_for_gate | to_entries | map(.value) | join(", ")')). Either add it to exclude_dirs, or teach file_for_gate the names it uses"
   fi
 done
 
@@ -247,7 +286,16 @@ for gate in $GATES; do
   done
 done
 
-if [ "$PRODUCERS_SEEN" -ge 4 ] && [ "$CHECKED_PATHS" -ge 15 ] && [ "$OPT_CHECKED" -ge 1 ]; then
+# The budget equals what the discovered tree actually yields, not a floor beneath it. A floor of
+# 4 producers against an actual 6 let two whole producers and 27 path checks disappear with this
+# line still green, which is the repo's own recorded lesson about a check with slack. Deriving it
+# means deleting a producer fails HERE, on its own message, rather than incidentally elsewhere.
+EXPECT_PRODUCERS=0
+for stack in "${STACKS[@]}"; do
+  EXPECT_PRODUCERS=$(( EXPECT_PRODUCERS + ${STACK_PRODUCERS["$stack"]:-0} ))
+done
+if [ "$PRODUCERS_SEEN" -eq "$EXPECT_PRODUCERS" ] && [ "$PRODUCERS_SEEN" -ge 4 ] \
+   && [ "$CHECKED_PATHS" -ge 15 ] && [ "$OPT_CHECKED" -ge 1 ]; then
   pass_check "field-path check covered $CHECKED_PATHS required paths across $PRODUCERS_SEEN producers, plus $OPT_CHECKED optional-path comparisons"
 else
   fail_check "field-path check covered $CHECKED_PATHS paths / $PRODUCERS_SEEN producers / $OPT_CHECKED optional comparisons — it is not looking at enough to mean anything"
@@ -259,8 +307,9 @@ fi
 # tree and at a tree whose only stack ships no producers, and require both to come back with
 # nothing found rather than with a clean result.
 # ------------------------------------------------------------------------------------------
+# Bash keeps ONE EXIT trap and two later sections replace this one, so a `trap ... EXIT` here
+# never runs and this directory leaked on every invocation. Cleaned up where it is finished with.
 TMPD=$(mktemp -d)
-trap 'rm -rf "$TMPD"' EXIT
 mkdir -p "$TMPD/empty"
 mapfile -t GOT < <(discover_stacks "$TMPD/empty")
 if [ "${#GOT[@]}" -eq 0 ]; then
@@ -291,6 +340,7 @@ if python3 "$PATHS_TOOL" "$TMPD/added/python/solid-check.sh" "${SREQ[@]}" >/dev/
 else
   pass_check "a discovered stack shipping an incomplete producer fails the required-path check"
 fi
+rm -rf "$TMPD"
 
 
 


### PR DESCRIPTION
Three holes in 5.54.0's discovery, found by a fresh reader running the artifact rather than reading about it. The suite stayed green through all three.

The serious one is 5.54.0's own goal statement, still true after 5.54.0: discovery answered "what stacks exist" and never answered "did we check them". A real `python/` directory holding one off-pattern filename was discovered, announced in a passing line as a producer stack, and read by nothing — the suite printed `discovered 3 producer stacks` and `42 required paths across 6 producers` in the same green run. The comment on that line asserted a check that did not exist.

Also: the changed-mode derivation recognised only the literal `--changed)`, so ordinary shell style silently moved a producer into the exempt set; and the coverage budget had room for two producers to disappear while green.

Three mutations, each verified applied, each killed on its own message. `make test` 159 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)