### PR TITLE
code-quality-tools 3.11.0: the debate commands could not run, and were not debates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for AI-assisted development workflow (stack-agnostic, Drupal-flavored reference), dev-guides navigator, HTMX/AJAX migration, AI-assisted Drupal contribution quality, brand content creation, code quality auditing, paper testing, and plugin development",
-    "version": "2.0.81"
+    "version": "2.0.82"
   },
   "renames": {
     "plugin-creation-tools": "claude-plugin-checks"
@@ -145,7 +145,7 @@
       "name": "code-quality-tools",
       "source": "./code-quality-tools",
       "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-      "version": "3.10.5",
+      "version": "3.11.0",
       "author": {
         "name": "camoa"
       },

--- a/code-quality-tools/.claude-plugin/plugin.json
+++ b/code-quality-tools/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-tools",
   "description": "Code quality and security auditing for Drupal (PHPStan, Psalm, PHPMD, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Provides full audits with cross-tool synthesis, rubric-scored code review, 3-agent security and architecture debates, REVIEW.md v2 generation, a /code-review ultra cloud-review wrapper with a headless CLI gating path, optional LSP code-intelligence for deeper SOLID/DRY/review analysis, watch-mode linting, scheduled sweeps, and --json output for CI pipelines.",
-  "version": "3.10.5",
+  "version": "3.11.0",
   "author": {
     "name": "camoa"
   },

--- a/code-quality-tools/CHANGELOG.md
+++ b/code-quality-tools/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.0] - 2026-09-06
+
+### Fixed
+
+- **Both debate commands were written against tools Claude Code deleted.** `security-debate` and `architecture-debate` each said "Verify agent teams are available by attempting to create a team" and "Create a team and these tasks". `TeamCreate` and `TeamDelete` were removed in v2.1.178, and `team_name` on the Agent tool is now accepted and ignored. Agent teams are also experimental and off unless `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, and the Task tools that once enforced the `Depends on` column are excluded by default on current models from v2.1.233. Three separate reasons the documented mechanism could not run. Both commands now dispatch ordinary subagents with the Agent tool, which needs no team, no experimental flag and no Task tools — every analyst already delivered by writing a file rather than by replying, so nothing was lost in the change. Where ordering matters the commands now say plainly that the orchestrator sequences the rounds and that nothing in the harness enforces it.
+- **The cross-challenge round was promised and never happened.** Both task tables listed "Cross-challenge — debate severity / trade-offs" as a step, and both frontmatter descriptions said the agents "debate" and "cross-challenge". Steps 5 and 6 went straight from spawning to synthesis. Three agents wrote independent reports and the lead merged them, which is a panel rather than a debate, and a "consensus" drawn from it was three opinions that happened to agree. There is now a real round 2: each analyst reads its own round-1 file and both others, and writes a challenge naming what it disputes, where it changed position, and whether unanimity is consensus or a shared blind spot. The synthesis reads all six files and reports a missing challenge rather than skipping it.
+- **The spawn prompts told the analysts to message each other.** All six ended with "Message the other teammates". Plain subagents have no channel between them, so the instruction was unfollowable and the coordination it stood in for never occurred. Round 2 replaces it, and the prompts now say the file is the delivery and there is no channel.
+- **The skill's hook scoping was justified by a mechanism that no longer exists.** `SKILL.md` said "both hooks auto-disable when the skill isn't active" and `CONVENTIONS.md` said the hooks are "active only while the skill is loaded". Skill-frontmatter hooks are registered on invocation and keep running for the rest of the session. The conclusion still holds for a better reason, now stated: skill scope gates whether a hook ever arms, it does not disarm it afterwards, and a plugin-scoped `FileChanged` would be live from session start for people who never asked for an audit. `once: true` is documented alongside, including why it does not suit watch-mode linting.
+
 ## [3.10.5] - 2026-09-06
 
 ### Fixed

--- a/code-quality-tools/CONVENTIONS.md
+++ b/code-quality-tools/CONVENTIONS.md
@@ -36,7 +36,7 @@ Two scopes in use:
 **Plugin-scoped** (`hooks/hooks.json` — session-global, always on when plugin enabled):
 - **PreCompact** — `hooks/pre-compact.sh` — Preserves audit context before conversation compaction
 
-**Skill-scoped** (declared in `skills/code-quality-audit/SKILL.md` frontmatter — active only while the skill is loaded):
+**Skill-scoped** (declared in `skills/code-quality-audit/SKILL.md` frontmatter — registered when the skill is invoked, then running for the rest of the session; skill scope gates whether they ever arm, it does not disarm them afterwards):
 - **FileChanged** — `hooks/lint-changed.sh` — Watch-mode linting on linter-config edits. Matcher enumerates literal filenames (per Hooks Reference, FileChanged matcher values are literal filenames, NOT globs): `composer.json`, `package.json`, `phpstan.neon`, `phpstan.neon.dist`, `psalm.xml`, `eslint.config.js`, `eslint.config.mjs`, `.eslintrc.json`, `tsconfig.json`. Source-file watching requires populating `watchPaths` dynamically. Force-disable: `CLAUDE_CODE_QUALITY_WATCH=0`.
 - **PermissionDenied** — returns `{retry: true}` scoped to `Read|Grep|Glob` only. Prevents audit flows from stalling on auto-mode classifier denials for read-only tools.
 

--- a/code-quality-tools/commands/architecture-debate.md
+++ b/code-quality-tools/commands/architecture-debate.md
@@ -1,12 +1,12 @@
 ---
-description: Debate architecture and SOLID findings with competing agent team (Pragmatist + Purist + Maintainer). Use when user says "debate architecture", "SOLID debate", "is this over-engineered", "should I refactor", "architecture review with debate", "code structure debate", "design review". Best for contentious design decisions where reasonable people disagree.
+description: Debate architecture and SOLID findings with three competing subagents (Pragmatist + Purist + Maintainer) across two rounds. Use when user says "debate architecture", "SOLID debate", "is this over-engineered", "should I refactor", "architecture review with debate", "code structure debate", "design review". Best for contentious design decisions where reasonable people disagree.
 allowed-tools: Read, Write, Glob, Grep, Bash
 argument-hint: <file-or-directory-path>
 ---
 
 # Architecture Debate
 
-Analyze code architecture from 3 competing perspectives using an agent team. A Pragmatist defends shipping, a Purist advocates clean architecture, and a Maintainer focuses on long-term readability. They debate and produce a balanced assessment.
+Analyze code architecture from 3 competing perspectives. A Pragmatist defends shipping, a Purist advocates clean architecture, and a Maintainer focuses on long-term readability. A second round has each of them dispute the other two, and the synthesis reports where they disagreed and where all three agreed.
 
 ## Usage
 
@@ -16,7 +16,7 @@ Analyze code architecture from 3 competing perspectives using an agent team. A P
 
 ## What This Does
 
-Spawns a 3-teammate agent team that debates the architecture of the specified code. Each teammate analyzes from a different perspective, then they cross-challenge. The lead synthesizes a balanced `architecture-debate.md` in the run's report directory, with agreed improvements and accepted trade-offs.
+Dispatches 3 competing subagents that debate the architecture of the specified code, in two rounds: each analyzes from a different perspective, then each reads and disputes the other two. The lead synthesizes a balanced `architecture-debate.md` in the run's report directory, with agreed improvements and accepted trade-offs.
 
 ## Instructions
 
@@ -31,7 +31,7 @@ REPORT_DIR="$(bash "${CLAUDE_PLUGIN_ROOT}/skills/code-quality-audit/scripts/core
   && REPORT_DIR="$(cd "$REPORT_DIR" && pwd)" && echo "$REPORT_DIR"
 ```
 
-Use that value as `{report_dir}` everywhere below, including in the spawn prompts. It must be **absolute**: teammates run in isolated worktrees, so a relative path would give each teammate its own private directory and the lead would find nothing to synthesize. The `cd`/`pwd` above is what guarantees that. `--ensure` creates the directory with the 0700 that keeps quoted source and matched-secret filenames off a shared machine, so do not `mkdir` it yourself.
+Use that value as `{report_dir}` everywhere below, including in the spawn prompts. It must be **absolute**: the analysts run in isolated worktrees, so a relative path would give each its own private directory, and neither the challenge round nor the lead would find anything to read. The `cd`/`pwd` above is what guarantees that. `--ensure` creates the directory with the 0700 that keeps quoted source and matched-secret filenames off a shared machine, so do not `mkdir` it yourself.
 
 ### Step 1 — Check Target Exists
 
@@ -49,9 +49,13 @@ If path doesn't exist:
 
 ### Step 2 — Check Prerequisites
 
-Verify agent teams are available by attempting to create a team. If creation fails:
+Nothing beyond the target itself. This command dispatches ordinary subagents with the Agent
+tool, which is always available; it needs no agent team, no experimental flag and no Task
+tools.
 
-> Agent teams are not available in this environment.
+If the Agent tool is unavailable in this session:
+
+> Subagents are not available in this environment.
 >
 > **Fallback:** Use `/code-quality-tools:solid` for automated SOLID analysis, or ask Claude to "review architecture of {path}".
 
@@ -67,42 +71,98 @@ If fewer than 30 lines total:
 
 Continue if user confirms or if 30+ lines.
 
-### Step 4 — Create Shared Task List
+### Step 4 — Plan the two rounds
 
-Create a team and these tasks:
+The debate runs in two rounds, and **you sequence them** — dispatch round 2 only after all
+three of round 1 have written their files. Nothing in the harness enforces this ordering.
+The shared task list that once did requires the Task tools, which current models exclude by
+default (v2.1.233+), so the order is yours to keep.
 
-| # | Task | Assign to | Depends on |
-|---|------|-----------|------------|
-| 1 | Defend current architecture — identify what works, why it ships | Pragmatist | — |
-| 2 | Identify SOLID/DRY violations — propose clean architecture | Purist | — |
-| 3 | Assess maintainability — what confuses a new developer in 6 months | Maintainer | — |
-| 4 | Cross-challenge — debate trade-offs, find consensus on what to fix | All three | 1, 2, 3 |
-| 5 | Synthesize balanced architecture assessment | Lead | 4 |
+| Round | Work | Who | Reads |
+|---|---|---|---|
+| 1 | Defend the current architecture — what works, why it ships | Pragmatist | the code |
+| 1 | Identify SOLID/DRY violations, propose clean architecture | Purist | the code |
+| 1 | Assess maintainability — what confuses a new developer in 6 months | Maintainer | the code |
+| 2 | Cross-challenge — dispute trade-offs, find real consensus on what to fix | all three, in parallel | their own round-1 file plus the other two |
+| 3 | Synthesize the balanced assessment | you | all six files |
 
-**Quality Gate:** Each agent must address ALL aspects of their perspective. If an agent skips areas (e.g., Purist only checks SRP but ignores OCP/LSP/ISP/DIP), the lead flags incomplete analysis.
+**Quality Gate:** Each agent must address ALL aspects of their perspective. If an agent skips areas (e.g., Purist only checks SRP but ignores OCP/LSP/ISP/DIP), note that in the synthesis and name what was not covered.
 
-### Step 5 — Spawn Teammates
+### Step 5 — Round 1: dispatch the three analysts
 
-Spawn 3 teammates using the prompt templates below. After spawning:
+Dispatch all three in **one message**, so they run concurrently. Each is an ordinary
+subagent: call the Agent tool with the prompt template below, `model: sonnet`, and
+`isolation: "worktree"`. Do **not** pass `name` — a `name` makes the agent a teammate, which
+needs `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and buys nothing here, because every analyst
+delivers by writing a file rather than by replying.
 
-1. Tell the user: "Team spawned. Teammates are debating — I'll synthesize when they finish."
-2. Do NOT perform analysis yourself — wait for all teammates to complete.
+After dispatching:
 
-**Teammate model & monitoring.** Each spawn prompt pins `**Model:** sonnet` — explicit per-spawn values are intentional, and naming the model in the prompt is the documented way to set a team's model. There is no global setting: `teammateDefaultModel` was removed in Claude Code v2.1.234 and a leftover value is ignored. To force one model across every subagent instead, set `CLAUDE_CODE_SUBAGENT_MODEL` together with `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1` (v2.1.257+) — the second is a boolean that promotes the first above the per-spawn value, which otherwise wins. Watch teammate progress with `claude agents` or `/tasks`. Do **not** dispatch the whole debate as a background session (`claude --bg`): the teammates already run in worktree isolation, so a backgrounded debate is a worktree-of-worktrees plus permission-auto-deny scenario that is untested — run debates in the foreground.
+1. Tell the user: "Three analysts are working — I'll run the challenge round when they finish."
+2. Do NOT analyze anything yourself. Wait for all three.
+3. Confirm each file exists before continuing. An agent that returns prose but writes no file has delivered nothing, and reads exactly like one that found nothing.
+
+**Model & monitoring.** Each prompt below pins `**Model:** sonnet`; naming the model per dispatch is how it is set. There is no global default setting — `teammateDefaultModel` was removed in Claude Code v2.1.234 and a leftover value is ignored. To force one model across every subagent, set `CLAUDE_CODE_SUBAGENT_MODEL` with `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1` (v2.1.257+); the second is a boolean that promotes the first above the per-dispatch value, which otherwise wins. Watch progress with `/tasks`. Do **not** run the whole debate as a background session (`claude --bg`): the analysts already run in worktree isolation, so that is a worktree-of-worktrees plus permission-auto-deny scenario that is untested.
+
+### Step 5b — Round 2: the cross-challenge
+
+This is the round that makes it a debate rather than three reports side by side. Dispatch all three again in one message, same models and isolation, each with this prompt:
+
+```
+You are the {role} in an architecture debate. Round 1 is finished.
+
+YOUR OWN ROUND-1 ANALYSIS:
+  {report_dir}/{your-file}.md
+
+THE OTHER TWO ANALYSES:
+  {report_dir}/{other-file-1}.md
+  {report_dir}/{other-file-2}.md
+
+YOUR MISSION:
+Read all three. Then dispute them.
+
+1. Which of their recommendations would you refuse to make, and why? Name the file and
+   the change.
+2. Where has one of them changed your own round-1 position? Say which, and why.
+3. Which proposed refactor costs more than the problem it solves? Which cheap fix did
+   they all miss?
+4. Where do all three of you agree? Agreement across a pragmatist, a purist and a
+   maintainer is either a genuine consensus or a shared blind spot. Say which, and why.
+
+Disagreement is the product here. If you find nothing to dispute, say so explicitly and
+explain why the other two were right. Do not manufacture a dispute, and do not stay quiet
+to avoid one.
+
+WRITE to: {report_dir}/{your-role}-challenge.md
+
+Format:
+# {Role} Challenge
+
+## Recommendations I would refuse
+| Their proposal | Why I refuse | What I would do instead |
+
+## Positions I changed
+## Unanimous — consensus or blind spot?
+## Summary
+```
+
+Wait for all three challenge files before synthesizing.
 
 ### Step 6 — Synthesize
 
-When all teammates finish:
+When all six files exist:
 
-- Read `{report_dir}/pragmatist-analysis.md`, `{report_dir}/purist-analysis.md`, `{report_dir}/maintainer-analysis.md`
-- Write `{report_dir}/architecture-debate.md` using the Output Format below
+- Read the three round-1 analyses: `{report_dir}/pragmatist-analysis.md`, `{report_dir}/purist-analysis.md`, `{report_dir}/maintainer-analysis.md`
+- Read the three round-2 challenges: `{report_dir}/pragmatist-challenge.md`, `{report_dir}/purist-challenge.md`, `{report_dir}/maintainer-challenge.md`
+- Write `{report_dir}/architecture-debate.md` using the Output Format below. Consensus, Accepted Trade-offs and Disputed Findings all come from round 2 — a "consensus" drawn from round 1 alone is three independent opinions that happen to agree, which is not the same thing.
+- A missing challenge file is reported, never silently skipped: say which lens did not challenge, so a reader knows the assessment rests on two perspectives rather than three.
 - Tell the user: "Architecture debate complete. Assessment saved to `{report_dir}/architecture-debate.md`"
 
 ---
 
 ## Spawn Prompts
 
-### Teammate 1: Pragmatist
+### Analyst 1: Pragmatist
 
 **Model:** sonnet
 **MaxTurns:** 10
@@ -160,11 +220,12 @@ Use this format:
 - Would push back on: {N}
 
 WHEN DONE:
-Message the other teammates: "Pragmatist analysis complete. Review pragmatist-analysis.md"
+When the file is written, you are done. Do not message anyone — the lead reads your
+file and dispatches the challenge round; there is no channel between you and the other two.
 Mark your task as completed.
 ```
 
-### Teammate 2: Purist
+### Analyst 2: Purist
 
 **Model:** sonnet
 **MaxTurns:** 10
@@ -241,11 +302,12 @@ Use this format:
 - Architecture score: {total}/35
 
 WHEN DONE:
-Message the other teammates: "Purist analysis complete. Review purist-analysis.md"
+When the file is written, you are done. Do not message anyone — the lead reads your
+file and dispatches the challenge round; there is no channel between you and the other two.
 Mark your task as completed.
 ```
 
-### Teammate 3: Maintainer
+### Analyst 3: Maintainer
 
 **Model:** sonnet
 **MaxTurns:** 10
@@ -322,7 +384,8 @@ Use this format:
 - Overall maintenance rating: {rating}
 
 WHEN DONE:
-Message the other teammates: "Maintainer analysis complete. Review maintainer-analysis.md"
+When the file is written, you are done. Do not message anyone — the lead reads your
+file and dispatches the challenge round; there is no channel between you and the other two.
 Mark your task as completed.
 ```
 
@@ -333,7 +396,8 @@ Mark your task as completed.
 Writes into `{report_dir}`, the audit report directory this run resolves:
 
 - `architecture-debate.md` — the lead's synthesis
-- `pragmatist-analysis.md`, `purist-analysis.md`, `maintainer-analysis.md` — one per teammate, left in place as the evidence behind the synthesis
+- `pragmatist-analysis.md`, `purist-analysis.md`, `maintainer-analysis.md` — one per analyst, round 1
+- `pragmatist-challenge.md`, `purist-challenge.md`, `maintainer-challenge.md` — one per analyst, round 2; left in place as the evidence behind the synthesis
 
 ## Output Format
 
@@ -346,7 +410,7 @@ The lead synthesizes into `{report_dir}/architecture-debate.md`:
 {file/directory path, total lines, total files}
 
 ## Debate Method
-Agent team with 3 competing perspectives.
+Three competing subagents, two rounds.
 Source: [pragmatist-analysis.md] | [purist-analysis.md] | [maintainer-analysis.md]
 
 ## Summary

--- a/code-quality-tools/commands/security-debate.md
+++ b/code-quality-tools/commands/security-debate.md
@@ -1,12 +1,12 @@
 ---
-description: Debate security audit findings with competing agent team (Defender + Red Team + Compliance). Use when user says "debate security", "security from 3 perspectives", "is this vulnerability real", "security team review", "red team this", "challenge security findings", "false positive check". Best for 10+ findings where severity needs validation. Each agent runs in isolated worktree.
+description: Debate security audit findings with three competing subagents (Defender + Red Team + Compliance) across two rounds. Use when user says "debate security", "security from 3 perspectives", "is this vulnerability real", "security team review", "red team this", "challenge security findings", "false positive check". Best for 10+ findings where severity needs validation. Each agent runs in isolated worktree.
 allowed-tools: Read, Write, Glob, Grep, WebSearch, WebFetch, Bash
 argument-hint: optional|project-path
 ---
 
 # Security Debate
 
-Analyze security audit results from 3 competing perspectives using an agent team. A Defender validates findings, a Red Team Attacker finds gaps, and a Compliance Checker maps to standards. They debate severity and produce a challenged assessment.
+Analyze security audit results from 3 competing perspectives. A Defender validates findings, a Red Team Attacker finds gaps, and a Compliance Checker maps to standards. A second round has each of them dispute the other two, and the synthesis reports where they disagreed and where all three agreed.
 
 ## Usage
 
@@ -16,7 +16,7 @@ Analyze security audit results from 3 competing perspectives using an agent team
 
 ## What This Does
 
-Spawns a 3-teammate agent team that debates the results of a prior security audit. Each teammate writes their analysis to a separate file. The lead synthesizes a final `security-debate.md` in the audit's report directory, with debated severity ratings, attack scenarios, false positives, and OWASP coverage.
+Dispatches 3 competing subagents that debate the results of a prior security audit, in two rounds: independent analysis, then a cross-challenge in which each reads and disputes the other two. Each writes to its own file. The lead synthesizes a final `security-debate.md` in the audit's report directory, with debated severity ratings, attack scenarios, false positives, and OWASP coverage.
 
 ## Instructions
 
@@ -31,7 +31,7 @@ REPORT_DIR="$(bash "${CLAUDE_PLUGIN_ROOT}/skills/code-quality-audit/scripts/core
   && REPORT_DIR="$(cd "$REPORT_DIR" && pwd)" && echo "$REPORT_DIR"
 ```
 
-Use that value as `{report_dir}` everywhere below, including in the spawn prompts. It must be **absolute**: teammates run in isolated worktrees, so a relative path would give each teammate its own private directory and the lead would find nothing to synthesize. The `cd`/`pwd` above is what guarantees that.
+Use that value as `{report_dir}` everywhere below, including in the spawn prompts. It must be **absolute**: the analysts run in isolated worktrees, so a relative path would give each its own private directory, and neither the challenge round nor the lead would find anything to read. The `cd`/`pwd` above is what guarantees that.
 
 A non-zero exit means no audit has ever been run here — not that one came back clean:
 
@@ -52,9 +52,13 @@ Stop here if not found.
 
 ### Step 2 — Check Prerequisites
 
-Verify agent teams are available by attempting to create a team. If creation fails:
+Nothing beyond the report itself. This command dispatches ordinary subagents with the Agent
+tool, which is always available; it needs no agent team, no experimental flag and no Task
+tools.
 
-> Agent teams are not available in this environment.
+If the Agent tool is unavailable in this session:
+
+> Subagents are not available in this environment.
 >
 > **Fallback:** Your security audit results are in `{report_dir}/security-report.json`. Run `/code-quality-tools:security` for standard single-pass analysis.
 
@@ -66,7 +70,7 @@ Read `{report_dir}/security-report.json` and count findings.
 
 If fewer than 10 findings:
 > Found {N} findings. For small reports, single-agent analysis may be sufficient.
-> Continue with agent team debate? (The team adds most value with 10+ findings.)
+> Continue with the debate? (It adds most value with 10+ findings.)
 
 Continue if user confirms or if 10+ findings.
 
@@ -81,45 +85,98 @@ If the project is Drupal, WebFetch relevant security guides to provide richer co
 5. **If findings include CSRF:** `https://camoa.github.io/dev-guides/drupal/security/csrf-protection/index.md`
 6. **If findings include input validation:** `https://camoa.github.io/dev-guides/drupal/security/input-validation-and-sanitization/index.md`
 
-Save fetched content to `{report_dir}/security-context.md` and include its path in the spawn prompts so teammates can reference it.
+Save fetched content to `{report_dir}/security-context.md` and include its path in the dispatch prompts so the analysts can reference it.
 
-### Step 4 — Create Shared Task List
+### Step 4 — Plan the two rounds
 
-Create a team and these tasks:
+The debate runs in two rounds, and **you sequence them** — dispatch round 2 only after all
+three of round 1 have written their files. Nothing in the harness enforces this ordering.
+The shared task list that once did requires the Task tools, which current models exclude by
+default (v2.1.233+), so the order is yours to keep.
 
-| # | Task | Assign to | Depends on |
-|---|------|-----------|------------|
-| 1 | Validate findings — identify false positives, assess exploitability | Defender | — |
-| 2 | Construct attack scenarios — chain findings, find gaps audit missed | Red Team Attacker | — |
-| 3 | Map findings to OWASP Top 10 / CWE standards, identify coverage gaps | Compliance Checker | — |
-| 4 | Cross-challenge — debate severity, exploitability, priorities | All three | 1, 2, 3 |
-| 5 | Synthesize challenged security assessment | Lead | 4 |
+| Round | Work | Who | Reads |
+|---|---|---|---|
+| 1 | Validate findings — identify false positives, assess exploitability | Defender | the report |
+| 1 | Construct attack scenarios — chain findings, find gaps the audit missed | Red Team Attacker | the report |
+| 1 | Map findings to OWASP Top 10 / CWE, identify coverage gaps | Compliance Checker | the report |
+| 2 | Cross-challenge — dispute severity, exploitability and priorities | all three, in parallel | their own round-1 file plus the other two |
+| 3 | Synthesize the challenged assessment | you | all six files |
 
-**Quality Gate:** Each agent must address ALL findings in the report. If an agent skips findings (e.g., Defender only validates 5 of 20 findings), the lead flags incomplete analysis and notes which findings were not reviewed.
+**Quality Gate:** Each agent must address ALL findings in the report. If an agent skips findings (e.g., Defender only validates 5 of 20 findings), note that in the synthesis and name which findings were not reviewed.
 
-### Step 5 — Spawn Teammates
+### Step 5 — Round 1: dispatch the three analysts
 
-Spawn 3 teammates using the prompt templates below. After spawning:
+Dispatch all three in **one message**, so they run concurrently. Each is an ordinary
+subagent: call the Agent tool with the prompt template below, `model: sonnet`, and
+`isolation: "worktree"`. Do **not** pass `name` — a `name` makes the agent a teammate, which
+needs `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and buys nothing here, because every analyst
+delivers by writing a file rather than by replying.
 
-1. Tell the user: "Team spawned. Teammates are working — I'll synthesize when they finish."
-2. If running inside tmux, teammates appear in split panes (visible output). Otherwise they run in-process (background).
-3. Do NOT perform analysis yourself — wait for all teammates to complete before proceeding.
+After dispatching:
 
-**Teammate model & monitoring.** Each spawn prompt pins `**Model:** sonnet` — explicit per-spawn values are intentional, and naming the model in the prompt is the documented way to set a team's model. There is no global setting: `teammateDefaultModel` was removed in Claude Code v2.1.234 and a leftover value is ignored. To force one model across every subagent instead, set `CLAUDE_CODE_SUBAGENT_MODEL` together with `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1` (v2.1.257+) — the second is a boolean that promotes the first above the per-spawn value, which otherwise wins. Watch teammate progress with `claude agents` or `/tasks`. Do **not** dispatch the whole debate as a background session (`claude --bg`): the teammates already run in worktree isolation, so a backgrounded debate is a worktree-of-worktrees plus permission-auto-deny scenario that is untested — run debates in the foreground.
+1. Tell the user: "Three analysts are working — I'll run the challenge round when they finish."
+2. Do NOT analyze anything yourself. Wait for all three.
+3. Confirm each file exists before continuing. An agent that returns prose but writes no file has delivered nothing, and reads exactly like one that found nothing.
+
+**Model & monitoring.** Each prompt below pins `**Model:** sonnet`; naming the model per dispatch is how it is set. There is no global default setting — `teammateDefaultModel` was removed in Claude Code v2.1.234 and a leftover value is ignored. To force one model across every subagent, set `CLAUDE_CODE_SUBAGENT_MODEL` with `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1` (v2.1.257+); the second is a boolean that promotes the first above the per-dispatch value, which otherwise wins. Watch progress with `/tasks`. Do **not** run the whole debate as a background session (`claude --bg`): the analysts already run in worktree isolation, so that is a worktree-of-worktrees plus permission-auto-deny scenario that is untested.
+
+### Step 5b — Round 2: the cross-challenge
+
+This is the round that makes it a debate rather than three reports side by side. Dispatch all three again in one message, same models and isolation, each with this prompt:
+
+```
+You are the {role} in a security audit debate. Round 1 is finished.
+
+YOUR OWN ROUND-1 ANALYSIS:
+  {report_dir}/{your-file}.md
+
+THE OTHER TWO ANALYSES:
+  {report_dir}/{other-file-1}.md
+  {report_dir}/{other-file-2}.md
+
+YOUR MISSION:
+Read all three. Then dispute them.
+
+1. Where do you DISAGREE with the other two, and on what evidence? Name the finding.
+2. Where has one of them changed your own round-1 position? Say which, and why.
+3. Which severities are wrong, in either direction — overstated or understated?
+4. Where do all three of you agree? Agreement across three lenses is either a real
+   consensus or a shared blind spot. Say which you think it is, and why.
+
+Disagreement is the product here. If you find nothing to dispute, say so explicitly and
+explain why the other two were right. Do not manufacture a dispute, and do not stay quiet
+to avoid one.
+
+WRITE to: {report_dir}/{your-role}-challenge.md
+
+Format:
+# {Role} Challenge
+
+## Disputed — severity or exploitability
+| Finding | Their position | My position | Evidence |
+
+## Positions I changed
+## Unanimous — consensus or blind spot?
+## Summary
+```
+
+Wait for all three challenge files before synthesizing.
 
 ### Step 6 — Synthesize
 
-When all teammates finish:
+When all six files exist:
 
-- Read `{report_dir}/defender-analysis.md`, `{report_dir}/red-team-analysis.md`, `{report_dir}/compliance-analysis.md`
-- Write `{report_dir}/security-debate.md` using the Output Format below
+- Read the three round-1 analyses: `{report_dir}/defender-analysis.md`, `{report_dir}/red-team-analysis.md`, `{report_dir}/compliance-analysis.md`
+- Read the three round-2 challenges: `{report_dir}/defender-challenge.md`, `{report_dir}/red-team-challenge.md`, `{report_dir}/compliance-challenge.md`
+- Write `{report_dir}/security-debate.md` using the Output Format below. The Debate Log section is drawn from round 2 — where they disagreed, who moved position, and what all three agreed on.
+- A missing challenge file is reported, never silently skipped: say which lens did not challenge, so a reader knows the assessment rests on two perspectives rather than three.
 - Tell the user: "Security debate complete. Assessment saved to `{report_dir}/security-debate.md`"
 
 ---
 
 ## Spawn Prompts
 
-### Teammate 1: Defender
+### Analyst 1: Defender
 
 **Model:** sonnet
 **MaxTurns:** 10
@@ -175,11 +232,12 @@ Use this format:
 - False Positive: {N}
 
 WHEN DONE:
-Message the other teammates: "Defender analysis complete. Review defender-analysis.md"
+When the file is written, you are done. Do not message anyone — the lead reads your
+file and dispatches the challenge round; there is no channel between you and the other two.
 Mark your task as completed.
 ```
 
-### Teammate 2: Red Team Attacker
+### Analyst 2: Red Team Attacker
 
 **Model:** sonnet
 **MaxTurns:** 10
@@ -239,11 +297,12 @@ Use this format:
 - CVEs matched: {N}
 
 WHEN DONE:
-Message the other teammates: "Red Team analysis complete. Review red-team-analysis.md"
+When the file is written, you are done. Do not message anyone — the lead reads your
+file and dispatches the challenge round; there is no channel between you and the other two.
 Mark your task as completed.
 ```
 
-### Teammate 3: Compliance Checker
+### Analyst 3: Compliance Checker
 
 **Model:** sonnet
 **MaxTurns:** 10
@@ -305,7 +364,8 @@ Use this format:
 - CWE corrections made: {N}
 
 WHEN DONE:
-Message the other teammates: "Compliance analysis complete. Review compliance-analysis.md"
+When the file is written, you are done. Do not message anyone — the lead reads your
+file and dispatches the challenge round; there is no channel between you and the other two.
 Mark your task as completed.
 ```
 
@@ -316,8 +376,9 @@ Mark your task as completed.
 Writes into `{report_dir}`, the directory holding the `security-report.json` this run debates:
 
 - `security-debate.md` — the lead's synthesis
-- `defender-analysis.md`, `red-team-analysis.md`, `compliance-analysis.md` — one per teammate, left in place as the evidence behind the synthesis
-- `security-context.md` — the dev-guides content fetched for this run, saved so the teammates can read it. `OUTPUTS.md` notes this as a write no rule covers: fetched guide content otherwise belongs in the navigator's shared store.
+- `defender-analysis.md`, `red-team-analysis.md`, `compliance-analysis.md` — one per analyst, round 1
+- `defender-challenge.md`, `red-team-challenge.md`, `compliance-challenge.md` — one per analyst, round 2; left in place as the evidence behind the synthesis
+- `security-context.md` — the dev-guides content fetched for this run, saved so the analysts can read it. `OUTPUTS.md` notes this as a write no rule covers: fetched guide content otherwise belongs in the navigator's shared store.
 
 It does not modify `security-report.json`.
 

--- a/code-quality-tools/skills/code-quality-audit/SKILL.md
+++ b/code-quality-tools/skills/code-quality-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-quality-audit
 description: Use when checking code quality, running security audits, testing coverage, finding SOLID/DRY violations, or setting up quality tools. Use when user says "audit this code", "check security", "run PHPStan", "code quality", "find violations", "SOLID check", "DRY check", "test coverage", "lint this", "security review", "is this production ready", "check for vulnerabilities", "code review", "grade this code", "watch mode lint", "deep review", "ultrareview", "schedule quality sweep". Supports Drupal (PHPStan, PHPMD, Psalm, Semgrep, Trivy, Gitleaks via DDEV) and Next.js (ESLint, Jest, Semgrep, Trivy, Gitleaks). Use proactively before deployment or after significant code changes.
-version: 3.10.5
+version: 3.11.0
 model: inherit
 allowed-tools: Read, Bash, Grep, Glob
 disallowed-tools: Write, Edit
@@ -56,7 +56,7 @@ This skill declares two skill-scoped hooks in its frontmatter — active ONLY wh
 | `FileChanged` | Linter config changes — exact filenames for common variants: `composer.json`, `package.json`, `phpstan.neon*` (3 variants), `phpcs.xml*` (3 variants), `psalm.xml*` (2 variants), `eslint.config.{js,mjs,cjs}`, `.eslintrc.{js,json,yml,yaml}`, `tsconfig.json` | Runs `hooks/lint-changed.sh` — re-lints on config change; lints single file on source-file change when watchPaths include it |
 | `PermissionDenied` | `Read`, `Grep`, `Glob` denied in auto mode | Returns `{retry: true}` — retries non-destructive classifier denials during audits |
 
-**Scope discipline:** both hooks auto-disable when the skill isn't active. A `FileChanged` handler at plugin scope would fire on every file change across every conversation — noise, not value. Audit-contextual behaviors belong here.
+**Scope discipline:** these hooks are registered when the skill is invoked and keep running for the rest of the session — they do **not** switch off when the skill goes inactive. What skill scope buys is the invocation gate, not an off switch: a `FileChanged` handler at plugin scope is live from session start in every conversation where the plugin is enabled, firing on file changes for people who never asked for an audit. Declared here, nothing fires until somebody actually invokes the skill. Use `CLAUDE_CODE_QUALITY_WATCH=0` below to stop watch-mode within a session, and `once: true` on a hook handler if you want Claude Code to remove it after its first successful run — `once` is honored only in skill frontmatter, and is a poor fit for watch-mode linting, which is meant to fire repeatedly.
 
 **FileChanged matcher is literal, not glob.** Per the Hooks Reference, `FileChanged` matcher values are split on `|` and registered as **literal filenames** — not globs. To watch arbitrary source files (`*.php`, `*.tsx`), populate `watchPaths` dynamically from a `CwdChanged` hook, or add specific absolute paths to your project's `.claude/settings.json`. The default watch list here covers linter-config churn; broaden it in your settings if you want per-file watch on source edits.
 
@@ -68,7 +68,7 @@ export CLAUDE_CODE_QUALITY_WATCH=0
 
 Unset the variable (or set to anything other than `0`) to re-enable.
 
-**Why this isn't in `hooks/hooks.json`:** session-global hooks stay at plugin scope (only `PreCompact` there). Audit behaviors scoped to skill-active sessions avoid polluting unrelated work.
+**Why this isn't in `hooks/hooks.json`:** a plugin-scope hook needs no invocation — it is armed in every session the plugin is enabled in. Only `PreCompact` belongs there, because it should apply whether or not anyone ran an audit. Watch-mode linting should not fire for someone who never asked for it, which is what declaring it here prevents.
 
 ### Known limitations
 


### PR DESCRIPTION
Checking a narrow question from the gaps document — do the debate commands say what happens when the Task tools are off? — turned up that the mechanism underneath had been replaced. Three defects.

**They were written against deleted tools.** Both commands said to verify agent teams "by attempting to create a team" and then to "create a team and these tasks". `TeamCreate` and `TeamDelete` were removed in v2.1.178, and `team_name` on the Agent tool is now accepted and ignored. Agent teams are separately experimental and off unless `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, and the Task tools that enforced the `Depends on` column are excluded by default on current models since v2.1.233. Any one of those alone would have stopped it. Both commands now dispatch ordinary subagents — no team, no flag, no Task tools — and nothing was lost, because every analyst already delivered by writing a file rather than by replying.

**The cross-challenge round was promised and never ran.** Both task tables listed it and both descriptions claimed the agents debate, while steps 5 and 6 went straight from spawning to synthesis. Three independent reports merged by the lead is a panel, and a "consensus" from it is three opinions that happen to agree. Round 2 now exists: each analyst reads its own file and the other two, then writes what it disputes, where it changed position, and whether unanimity is real consensus or a shared blind spot.

**All six spawn prompts told the analysts to message each other.** Plain subagents have no channel between them, so that instruction could not be followed and the coordination it stood for never happened.

Also corrects the skill's hook-scoping justification. Skill-frontmatter hooks are registered on invocation and run for the rest of the session — they do not auto-disable when the skill goes inactive, which is what `SKILL.md` and `CONVENTIONS.md` both said. The conclusion holds for a better reason, now stated: skill scope decides whether a hook ever arms, not whether it disarms later.

`make manifests outputs setup-doc-check claims validate` pass, `make test-code-quality-tools` is 6/6, and the root claim-check spec is 118/118. The rewritten commands have not been run end to end — that needs a real audit report to debate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)